### PR TITLE
fix(python): emit Pydantic field aliases to fix nested field validation

### DIFF
--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -116,9 +116,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -161,9 +162,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -1,9 +1,9 @@
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
-import inspect
 import pydantic
 
 IS_PYDANTIC_V2 = pydantic.VERSION.startswith("2.")

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -55,8 +55,6 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,7 +68,6 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -87,6 +87,42 @@ class UniversalBaseModel(pydantic.BaseModel):
             protected_namespaces=(),
         )
 
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
+
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
             serialized = self.dict()  # type: ignore[attr-defined]
@@ -98,6 +134,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -55,6 +55,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -68,6 +70,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/generators/python/core_utilities/shared/unchecked_base_model.py
+++ b/generators/python/core_utilities/shared/unchecked_base_model.py
@@ -17,7 +17,7 @@ from .pydantic_utilities import (
     parse_datetime,
     parse_obj_as,
 )
-from .serialization import convert_and_respect_annotation_metadata, get_field_to_alias_mapping
+from .serialization import get_field_to_alias_mapping
 from pydantic_core import PydanticUndefined
 
 
@@ -38,26 +38,6 @@ class UncheckedBaseModel(UniversalBaseModel):
 
         class Config:
             extra = pydantic.Extra.allow
-
-    if IS_PYDANTIC_V2:
-
-        @classmethod
-        def model_validate(
-            cls: typing.Type["Model"],
-            obj: typing.Any,
-            *args: typing.Any,
-            **kwargs: typing.Any,
-        ) -> "Model":
-            """
-            Ensure that when using Pydantic v2's `model_validate` entrypoint we still
-            respect our FieldMetadata-based aliasing.
-            """
-            dealiased_obj = convert_and_respect_annotation_metadata(
-                object_=obj,
-                annotation=cls,
-                direction="read",
-            )
-            return super().model_validate(dealiased_obj, *args, **kwargs)  # type: ignore[misc]
 
     @classmethod
     def model_construct(

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -20,6 +20,9 @@ from typing_extensions import TypeAlias
 T = TypeVar("T")
 Model = TypeVar("Model", bound=pydantic.BaseModel)
 
+_PYDANTIC_V1 = getattr(pydantic, "v1", pydantic)
+_PYDANTIC_V1_BASE_MODEL = getattr(_PYDANTIC_V1, "BaseModel", pydantic.BaseModel)
+
 PydanticField = Union[ModelField, pydantic.fields.FieldInfo]
 
 
@@ -30,7 +33,7 @@ def parse_obj_as(type_: Type[T], object_: Any) -> T:
     # the model encodes aliasing:
     # - If the model uses real Pydantic aliases (Field(alias=...)), pass wire keys through unchanged.
     # - If the model encodes aliasing only via FieldMetadata, pre-dealias before validation.
-    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+    if inspect.isclass(type_) and issubclass(type_, _PYDANTIC_V1_BASE_MODEL):
         has_pydantic_aliases = False
         for field in getattr(type_, "__fields__", {}).values():
             alias = getattr(field, "alias", None)

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -1,9 +1,9 @@
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
-import inspect
 import pydantic
 from .datetime_utils import serialize_datetime
 from .serialization import convert_and_respect_annotation_metadata

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -85,9 +85,10 @@ class UniversalBaseModel(pydantic.v1.BaseModel):
                     "Provide the explicit alias key to disambiguate."
                 )
 
+        original_keys = set(values.keys())
         rewritten: Dict[str, Any] = dict(values)
         for name, alias in name_to_alias.items():
-            if alias != name and name in rewritten and alias not in rewritten:
+            if alias != name and name in original_keys and alias not in rewritten:
                 rewritten[alias] = rewritten.pop(name)
 
         return rewritten

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+
+- version: 4.46.7-rc2
+  changelogEntry:
+    - summary: Fixed Python SDK generation to use native Pydantic field aliases and improved core parsing so wire-key and nested/union validation works correctly across Pydantic v1/v2.
+      type: fix
+  createdAt: "2026-01-07"
+  irVersion: 62
+
 - version: 4.46.7-rc1
   changelogEntry:
     - summary: Update Dockerfile CVE patches to work with newer generator-cli package structures.

--- a/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
+++ b/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
@@ -121,7 +121,7 @@ class PydanticModel:
         )
 
         initializer = get_field_name_initializer(
-            alias=field.json_field_name if (is_aliased and self._use_pydantic_field_aliases) else None,
+            alias=field.json_field_name if is_aliased else None,
             default_factory=field.default_factory,
             description=field.description,
             default=default_value,

--- a/generators/python/tests/utils/test_pydantic_v1_on_v2_template_is_hardened.py
+++ b/generators/python/tests/utils/test_pydantic_v1_on_v2_template_is_hardened.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+def test_v1_on_v2_parse_obj_as_uses_v1_base_model_check() -> None:
+    """
+    Regression test (source-level):
+
+    The v1-on-v2 core utility templates are *copied* into the generated SDK's core package.
+    They are not importable directly from their template location.
+
+    We still want to ensure the template is hardened to detect v1-on-v2 models correctly:
+    it must not check `issubclass(..., pydantic.BaseModel)` (v2 hierarchy), and instead must
+    check against a resolved v1 BaseModel (`pydantic.v1.BaseModel`).
+    """
+
+    template_path = (
+        Path(__file__).resolve().parents[2]
+        / "core_utilities"
+        / "shared"
+        / "with_pydantic_v1_on_v2"
+        / "pydantic_utilities.py"
+    )
+    contents = template_path.read_text(encoding="utf-8")
+
+    assert "_PYDANTIC_V1_BASE_MODEL" in contents
+    assert "issubclass(type_, _PYDANTIC_V1_BASE_MODEL)" in contents
+    assert "issubclass(type_, pydantic.BaseModel)" not in contents

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -562,7 +562,7 @@ async function convertGenerator({
             maybeTopLevelReviewers
         }),
         keywords: generator.keywords,
-        smartCasing: generator["smart-casing"] ?? true,
+        smartCasing: generator["smart-casing"] ?? false, // Temp change to `false` to allow accurate local testing. DO NOT MERGE THIS.
         disableExamples: generator["disable-examples"] ?? false,
         absolutePathToLocalOutput:
             generator.output?.location === "local-file-system"

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -562,7 +562,7 @@ async function convertGenerator({
             maybeTopLevelReviewers
         }),
         keywords: generator.keywords,
-        smartCasing: generator["smart-casing"] ?? false, // Temp change to `false` to allow accurate local testing. DO NOT MERGE THIS.
+        smartCasing: generator["smart-casing"] ?? true,
         disableExamples: generator["disable-examples"] ?? false,
         absolutePathToLocalOutput:
             generator.output?.location === "local-file-system"

--- a/seed/python-sdk/accept-header/poetry.lock
+++ b/seed/python-sdk/accept-header/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/accept-header/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/accept-header/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/accept-header/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/accept-header/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/accept-header/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/accept-header/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/alias-extends/no-custom-config/poetry.lock
+++ b/seed/python-sdk/alias-extends/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/alias/poetry.lock
+++ b/seed/python-sdk/alias/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/alias/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/alias/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/alias/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/alias/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/any-auth/poetry.lock
+++ b/seed/python-sdk/any-auth/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/any-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/any-auth/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/any-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/any-auth/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/any-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/any-auth/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/api-wide-base-path/poetry.lock
+++ b/seed/python-sdk/api-wide-base-path/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/audiences/poetry.lock
+++ b/seed/python-sdk/audiences/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/audiences/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/audiences/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/audiences/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/audiences/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/audiences/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/audiences/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/basic-auth-environment-variables/poetry.lock
+++ b/seed/python-sdk/basic-auth-environment-variables/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/basic-auth/poetry.lock
+++ b/seed/python-sdk/basic-auth/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/basic-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/basic-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/basic-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/bearer-token-environment-variable/poetry.lock
+++ b/seed/python-sdk/bearer-token-environment-variable/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/bytes-download/poetry.lock
+++ b/seed/python-sdk/bytes-download/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/bytes-download/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/bytes-download/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/bytes-download/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/bytes-upload/poetry.lock
+++ b/seed/python-sdk/bytes-upload/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/bytes-upload/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/bytes-upload/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/bytes-upload/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/circular-references/no-custom-config/poetry.lock
+++ b/seed/python-sdk/circular-references/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/client-side-params/poetry.lock
+++ b/seed/python-sdk/client-side-params/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/client-side-params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/client-side-params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/client-side-params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/client-side-params/src/seed/types/types/client.py
+++ b/seed/python-sdk/client-side-params/src/seed/types/types/client.py
@@ -34,7 +34,7 @@ class Client(UniversalBaseModel):
     """
 
     global_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="global")] = pydantic.Field(
-        default=None
+        alias="global", default=None
     )
     """
     Whether this is a global client

--- a/seed/python-sdk/content-type/poetry.lock
+++ b/seed/python-sdk/content-type/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/content-type/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/content-type/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/content-type/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/content-type/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/content-type/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/content-type/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/cross-package-type-names/poetry.lock
+++ b/seed/python-sdk/cross-package-type-names/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/dollar-string-examples/poetry.lock
+++ b/seed/python-sdk/dollar-string-examples/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/empty-clients/poetry.lock
+++ b/seed/python-sdk/empty-clients/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/empty-clients/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/empty-clients/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/empty-clients/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/empty-clients/src/seed/level_1/level_2/types/types/address.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/level_2/types/types/address.py
@@ -9,8 +9,10 @@ from .....core.serialization import FieldMetadata
 
 
 class Address(UniversalBaseModel):
-    line_1: typing_extensions.Annotated[str, FieldMetadata(alias="line1")]
-    line_2: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="line2")] = None
+    line_1: typing_extensions.Annotated[str, FieldMetadata(alias="line1")] = pydantic.Field(alias="line1")
+    line_2: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="line2")] = pydantic.Field(
+        alias="line2", default=None
+    )
     city: str
     state: str
     zip: str

--- a/seed/python-sdk/empty-clients/src/seed/level_1/types/types/address.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/types/types/address.py
@@ -9,8 +9,10 @@ from ....core.serialization import FieldMetadata
 
 
 class Address(UniversalBaseModel):
-    line_1: typing_extensions.Annotated[str, FieldMetadata(alias="line1")]
-    line_2: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="line2")] = None
+    line_1: typing_extensions.Annotated[str, FieldMetadata(alias="line1")] = pydantic.Field(alias="line1")
+    line_2: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="line2")] = pydantic.Field(
+        alias="line2", default=None
+    )
     city: str
     state: str
     zip: str

--- a/seed/python-sdk/endpoint-security-auth/poetry.lock
+++ b/seed/python-sdk/endpoint-security-auth/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/enum/no-custom-config/poetry.lock
+++ b/seed/python-sdk/enum/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/enum/real-enum-forward-compat/poetry.lock
+++ b/seed/python-sdk/enum/real-enum-forward-compat/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/enum/real-enum/poetry.lock
+++ b/seed/python-sdk/enum/real-enum/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/enum/real-enum/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/enum/real-enum/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/enum/real-enum/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/enum/strenum/poetry.lock
+++ b/seed/python-sdk/enum/strenum/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/enum/strenum/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/enum/strenum/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/enum/strenum/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/error-property/poetry.lock
+++ b/seed/python-sdk/error-property/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/error-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/error-property/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/error-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/error-property/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/error-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/error-property/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/errors/poetry.lock
+++ b/seed/python-sdk/errors/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/errors/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/errors/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/errors/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/errors/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/errors/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/errors/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/client-filename/poetry.lock
+++ b/seed/python-sdk/examples/client-filename/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/examples/client-filename/src/seed/commons/types/types/event_info.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/commons/types/types/event_info.py
@@ -27,7 +27,9 @@ class EventInfo_Metadata(UniversalBaseModel):
     type: typing.Literal["metadata"] = "metadata"
     id: str
     data: typing.Optional[typing.Dict[str, str]] = None
-    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = None
+    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = pydantic.Field(
+        alias="jsonString", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/client-filename/src/seed/commons/types/types/metadata.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/commons/types/types/metadata.py
@@ -23,7 +23,9 @@ class Metadata(UniversalBaseModel):
 
     id: str
     data: typing.Optional[typing.Dict[str, str]] = None
-    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = None
+    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = pydantic.Field(
+        alias="jsonString", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/client-filename/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/client-filename/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/examples/client-filename/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/client-filename/src/seed/types/types/big_entity.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/types/big_entity.py
@@ -22,16 +22,20 @@ from .test import Test
 
 
 class BigEntity(UniversalBaseModel):
-    cast_member: typing_extensions.Annotated[typing.Optional[CastMember], FieldMetadata(alias="castMember")] = None
+    cast_member: typing_extensions.Annotated[typing.Optional[CastMember], FieldMetadata(alias="castMember")] = (
+        pydantic.Field(alias="castMember", default=None)
+    )
     extended_movie: typing_extensions.Annotated[
         typing.Optional[ExtendedMovie], FieldMetadata(alias="extendedMovie")
-    ] = None
+    ] = pydantic.Field(alias="extendedMovie", default=None)
     entity: typing.Optional[Entity] = None
     metadata: typing.Optional[types_types_metadata_Metadata] = None
     common_metadata: typing_extensions.Annotated[
         typing.Optional[commons_types_types_metadata_Metadata], FieldMetadata(alias="commonMetadata")
-    ] = None
-    event_info: typing_extensions.Annotated[typing.Optional[EventInfo], FieldMetadata(alias="eventInfo")] = None
+    ] = pydantic.Field(alias="commonMetadata", default=None)
+    event_info: typing_extensions.Annotated[typing.Optional[EventInfo], FieldMetadata(alias="eventInfo")] = (
+        pydantic.Field(alias="eventInfo", default=None)
+    )
     data: typing.Optional[Data] = None
     migration: typing.Optional[Migration] = None
     exception: typing.Optional[Exception] = None

--- a/seed/python-sdk/examples/client-filename/src/seed/types/types/exception.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/types/exception.py
@@ -24,9 +24,15 @@ class Exception_Generic(UniversalBaseModel):
     """
 
     type: typing.Literal["generic"] = "generic"
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/client-filename/src/seed/types/types/exception_info.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/types/exception_info.py
@@ -21,9 +21,15 @@ class ExceptionInfo(UniversalBaseModel):
     )
     """
 
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/client-filename/src/seed/types/types/extended_movie.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/types/extended_movie.py
@@ -36,7 +36,7 @@ class ExtendedMovie(UniversalBaseModel):
     id: MovieId
     prequel: typing.Optional[MovieId] = None
     title: str
-    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")]
+    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")] = pydantic.Field(alias="from")
     rating: float = pydantic.Field()
     """
     The rating scale is one to five stars

--- a/seed/python-sdk/examples/client-filename/src/seed/types/types/movie.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/types/movie.py
@@ -35,7 +35,7 @@ class Movie(UniversalBaseModel):
     id: MovieId
     prequel: typing.Optional[MovieId] = None
     title: str
-    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")]
+    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")] = pydantic.Field(alias="from")
     rating: float = pydantic.Field()
     """
     The rating scale is one to five stars

--- a/seed/python-sdk/examples/client-filename/src/seed/types/types/stunt_double.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/types/stunt_double.py
@@ -10,7 +10,9 @@ from ...core.serialization import FieldMetadata
 
 class StuntDouble(UniversalBaseModel):
     name: str
-    actor_or_actress_id: typing_extensions.Annotated[str, FieldMetadata(alias="actorOrActressId")]
+    actor_or_actress_id: typing_extensions.Annotated[str, FieldMetadata(alias="actorOrActressId")] = pydantic.Field(
+        alias="actorOrActressId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/legacy-wire-tests/poetry.lock
+++ b/seed/python-sdk/examples/legacy-wire-tests/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/types/types/event_info.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/types/types/event_info.py
@@ -27,7 +27,9 @@ class EventInfo_Metadata(UniversalBaseModel):
     type: typing.Literal["metadata"] = "metadata"
     id: str
     data: typing.Optional[typing.Dict[str, str]] = None
-    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = None
+    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = pydantic.Field(
+        alias="jsonString", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/types/types/metadata.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/types/types/metadata.py
@@ -23,7 +23,9 @@ class Metadata(UniversalBaseModel):
 
     id: str
     data: typing.Optional[typing.Dict[str, str]] = None
-    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = None
+    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = pydantic.Field(
+        alias="jsonString", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/big_entity.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/big_entity.py
@@ -22,16 +22,20 @@ from .test import Test
 
 
 class BigEntity(UniversalBaseModel):
-    cast_member: typing_extensions.Annotated[typing.Optional[CastMember], FieldMetadata(alias="castMember")] = None
+    cast_member: typing_extensions.Annotated[typing.Optional[CastMember], FieldMetadata(alias="castMember")] = (
+        pydantic.Field(alias="castMember", default=None)
+    )
     extended_movie: typing_extensions.Annotated[
         typing.Optional[ExtendedMovie], FieldMetadata(alias="extendedMovie")
-    ] = None
+    ] = pydantic.Field(alias="extendedMovie", default=None)
     entity: typing.Optional[Entity] = None
     metadata: typing.Optional[types_types_metadata_Metadata] = None
     common_metadata: typing_extensions.Annotated[
         typing.Optional[commons_types_types_metadata_Metadata], FieldMetadata(alias="commonMetadata")
-    ] = None
-    event_info: typing_extensions.Annotated[typing.Optional[EventInfo], FieldMetadata(alias="eventInfo")] = None
+    ] = pydantic.Field(alias="commonMetadata", default=None)
+    event_info: typing_extensions.Annotated[typing.Optional[EventInfo], FieldMetadata(alias="eventInfo")] = (
+        pydantic.Field(alias="eventInfo", default=None)
+    )
     data: typing.Optional[Data] = None
     migration: typing.Optional[Migration] = None
     exception: typing.Optional[Exception] = None

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/exception.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/exception.py
@@ -24,9 +24,15 @@ class Exception_Generic(UniversalBaseModel):
     """
 
     type: typing.Literal["generic"] = "generic"
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/exception_info.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/exception_info.py
@@ -21,9 +21,15 @@ class ExceptionInfo(UniversalBaseModel):
     )
     """
 
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/extended_movie.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/extended_movie.py
@@ -36,7 +36,7 @@ class ExtendedMovie(UniversalBaseModel):
     id: MovieId
     prequel: typing.Optional[MovieId] = None
     title: str
-    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")]
+    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")] = pydantic.Field(alias="from")
     rating: float = pydantic.Field()
     """
     The rating scale is one to five stars

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/movie.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/movie.py
@@ -35,7 +35,7 @@ class Movie(UniversalBaseModel):
     id: MovieId
     prequel: typing.Optional[MovieId] = None
     title: str
-    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")]
+    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")] = pydantic.Field(alias="from")
     rating: float = pydantic.Field()
     """
     The rating scale is one to five stars

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/stunt_double.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/stunt_double.py
@@ -10,7 +10,9 @@ from ...core.serialization import FieldMetadata
 
 class StuntDouble(UniversalBaseModel):
     name: str
-    actor_or_actress_id: typing_extensions.Annotated[str, FieldMetadata(alias="actorOrActressId")]
+    actor_or_actress_id: typing_extensions.Annotated[str, FieldMetadata(alias="actorOrActressId")] = pydantic.Field(
+        alias="actorOrActressId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/no-custom-config/poetry.lock
+++ b/seed/python-sdk/examples/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/examples/no-custom-config/src/seed/commons/types/types/event_info.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/commons/types/types/event_info.py
@@ -27,7 +27,9 @@ class EventInfo_Metadata(UniversalBaseModel):
     type: typing.Literal["metadata"] = "metadata"
     id: str
     data: typing.Optional[typing.Dict[str, str]] = None
-    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = None
+    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = pydantic.Field(
+        alias="jsonString", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/no-custom-config/src/seed/commons/types/types/metadata.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/commons/types/types/metadata.py
@@ -23,7 +23,9 @@ class Metadata(UniversalBaseModel):
 
     id: str
     data: typing.Optional[typing.Dict[str, str]] = None
-    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = None
+    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = pydantic.Field(
+        alias="jsonString", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/no-custom-config/src/seed/types/types/big_entity.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/types/types/big_entity.py
@@ -22,16 +22,20 @@ from .test import Test
 
 
 class BigEntity(UniversalBaseModel):
-    cast_member: typing_extensions.Annotated[typing.Optional[CastMember], FieldMetadata(alias="castMember")] = None
+    cast_member: typing_extensions.Annotated[typing.Optional[CastMember], FieldMetadata(alias="castMember")] = (
+        pydantic.Field(alias="castMember", default=None)
+    )
     extended_movie: typing_extensions.Annotated[
         typing.Optional[ExtendedMovie], FieldMetadata(alias="extendedMovie")
-    ] = None
+    ] = pydantic.Field(alias="extendedMovie", default=None)
     entity: typing.Optional[Entity] = None
     metadata: typing.Optional[types_types_metadata_Metadata] = None
     common_metadata: typing_extensions.Annotated[
         typing.Optional[commons_types_types_metadata_Metadata], FieldMetadata(alias="commonMetadata")
-    ] = None
-    event_info: typing_extensions.Annotated[typing.Optional[EventInfo], FieldMetadata(alias="eventInfo")] = None
+    ] = pydantic.Field(alias="commonMetadata", default=None)
+    event_info: typing_extensions.Annotated[typing.Optional[EventInfo], FieldMetadata(alias="eventInfo")] = (
+        pydantic.Field(alias="eventInfo", default=None)
+    )
     data: typing.Optional[Data] = None
     migration: typing.Optional[Migration] = None
     exception: typing.Optional[Exception] = None

--- a/seed/python-sdk/examples/no-custom-config/src/seed/types/types/exception.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/types/types/exception.py
@@ -24,9 +24,15 @@ class Exception_Generic(UniversalBaseModel):
     """
 
     type: typing.Literal["generic"] = "generic"
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/no-custom-config/src/seed/types/types/exception_info.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/types/types/exception_info.py
@@ -21,9 +21,15 @@ class ExceptionInfo(UniversalBaseModel):
     )
     """
 
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/no-custom-config/src/seed/types/types/movie.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/types/types/movie.py
@@ -35,7 +35,7 @@ class Movie(UniversalBaseModel):
     id: MovieId
     prequel: typing.Optional[MovieId] = None
     title: str
-    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")]
+    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")] = pydantic.Field(alias="from")
     rating: float = pydantic.Field()
     """
     The rating scale is one to five stars

--- a/seed/python-sdk/examples/no-custom-config/src/seed/types/types/stunt_double.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/types/types/stunt_double.py
@@ -10,7 +10,9 @@ from ...core.serialization import FieldMetadata
 
 class StuntDouble(UniversalBaseModel):
     name: str
-    actor_or_actress_id: typing_extensions.Annotated[str, FieldMetadata(alias="actorOrActressId")]
+    actor_or_actress_id: typing_extensions.Annotated[str, FieldMetadata(alias="actorOrActressId")] = pydantic.Field(
+        alias="actorOrActressId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/readme/poetry.lock
+++ b/seed/python-sdk/examples/readme/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/examples/readme/src/seed/commons/types/types/event_info.py
+++ b/seed/python-sdk/examples/readme/src/seed/commons/types/types/event_info.py
@@ -27,7 +27,9 @@ class EventInfo_Metadata(UniversalBaseModel):
     type: typing.Literal["metadata"] = "metadata"
     id: str
     data: typing.Optional[typing.Dict[str, str]] = None
-    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = None
+    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = pydantic.Field(
+        alias="jsonString", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/readme/src/seed/commons/types/types/metadata.py
+++ b/seed/python-sdk/examples/readme/src/seed/commons/types/types/metadata.py
@@ -23,7 +23,9 @@ class Metadata(UniversalBaseModel):
 
     id: str
     data: typing.Optional[typing.Dict[str, str]] = None
-    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = None
+    json_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="jsonString")] = pydantic.Field(
+        alias="jsonString", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/readme/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/readme/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/examples/readme/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/examples/readme/src/seed/types/types/big_entity.py
+++ b/seed/python-sdk/examples/readme/src/seed/types/types/big_entity.py
@@ -22,16 +22,20 @@ from .test import Test
 
 
 class BigEntity(UniversalBaseModel):
-    cast_member: typing_extensions.Annotated[typing.Optional[CastMember], FieldMetadata(alias="castMember")] = None
+    cast_member: typing_extensions.Annotated[typing.Optional[CastMember], FieldMetadata(alias="castMember")] = (
+        pydantic.Field(alias="castMember", default=None)
+    )
     extended_movie: typing_extensions.Annotated[
         typing.Optional[ExtendedMovie], FieldMetadata(alias="extendedMovie")
-    ] = None
+    ] = pydantic.Field(alias="extendedMovie", default=None)
     entity: typing.Optional[Entity] = None
     metadata: typing.Optional[types_types_metadata_Metadata] = None
     common_metadata: typing_extensions.Annotated[
         typing.Optional[commons_types_types_metadata_Metadata], FieldMetadata(alias="commonMetadata")
-    ] = None
-    event_info: typing_extensions.Annotated[typing.Optional[EventInfo], FieldMetadata(alias="eventInfo")] = None
+    ] = pydantic.Field(alias="commonMetadata", default=None)
+    event_info: typing_extensions.Annotated[typing.Optional[EventInfo], FieldMetadata(alias="eventInfo")] = (
+        pydantic.Field(alias="eventInfo", default=None)
+    )
     data: typing.Optional[Data] = None
     migration: typing.Optional[Migration] = None
     exception: typing.Optional[Exception] = None

--- a/seed/python-sdk/examples/readme/src/seed/types/types/exception.py
+++ b/seed/python-sdk/examples/readme/src/seed/types/types/exception.py
@@ -24,9 +24,15 @@ class Exception_Generic(UniversalBaseModel):
     """
 
     type: typing.Literal["generic"] = "generic"
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/readme/src/seed/types/types/exception_info.py
+++ b/seed/python-sdk/examples/readme/src/seed/types/types/exception_info.py
@@ -21,9 +21,15 @@ class ExceptionInfo(UniversalBaseModel):
     )
     """
 
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/examples/readme/src/seed/types/types/movie.py
+++ b/seed/python-sdk/examples/readme/src/seed/types/types/movie.py
@@ -35,7 +35,7 @@ class Movie(UniversalBaseModel):
     id: MovieId
     prequel: typing.Optional[MovieId] = None
     title: str
-    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")]
+    from_: typing_extensions.Annotated[str, FieldMetadata(alias="from")] = pydantic.Field(alias="from")
     rating: float = pydantic.Field()
     """
     The rating scale is one to five stars

--- a/seed/python-sdk/examples/readme/src/seed/types/types/stunt_double.py
+++ b/seed/python-sdk/examples/readme/src/seed/types/types/stunt_double.py
@@ -10,7 +10,9 @@ from ...core.serialization import FieldMetadata
 
 class StuntDouble(UniversalBaseModel):
     name: str
-    actor_or_actress_id: typing_extensions.Annotated[str, FieldMetadata(alias="actorOrActressId")]
+    actor_or_actress_id: typing_extensions.Annotated[str, FieldMetadata(alias="actorOrActressId")] = pydantic.Field(
+        alias="actorOrActressId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/additional_init_exports/poetry.lock
+++ b/seed/python-sdk/exhaustive/additional_init_exports/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/aliases_with_validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/aliases_without_validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/unchecked_base_model.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/unchecked_base_model.py
@@ -19,7 +19,7 @@ from .pydantic_utilities import (
     parse_datetime,
     parse_obj_as,
 )
-from .serialization import convert_and_respect_annotation_metadata, get_field_to_alias_mapping
+from .serialization import get_field_to_alias_mapping
 from pydantic_core import PydanticUndefined
 
 
@@ -40,26 +40,6 @@ class UncheckedBaseModel(UniversalBaseModel):
 
         class Config:
             extra = pydantic.Extra.allow
-
-    if IS_PYDANTIC_V2:
-
-        @classmethod
-        def model_validate(
-            cls: typing.Type["Model"],
-            obj: typing.Any,
-            *args: typing.Any,
-            **kwargs: typing.Any,
-        ) -> "Model":
-            """
-            Ensure that when using Pydantic v2's `model_validate` entrypoint we still
-            respect our FieldMetadata-based aliasing.
-            """
-            dealiased_obj = convert_and_respect_annotation_metadata(
-                object_=obj,
-                annotation=cls,
-                direction="read",
-            )
-            return super().model_validate(dealiased_obj, *args, **kwargs)  # type: ignore[misc]
 
     @classmethod
     def model_construct(

--- a/seed/python-sdk/exhaustive/eager-imports/poetry.lock
+++ b/seed/python-sdk/exhaustive/eager-imports/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dependencies/poetry.lock
+++ b/seed/python-sdk/exhaustive/extra_dependencies/poetry.lock
@@ -246,13 +246,13 @@ crt = ["awscrt (==0.19.12)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/poetry.lock
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/poetry.lock
@@ -79,13 +79,13 @@ crt = ["awscrt (==0.19.12)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/five-second-timeout/poetry.lock
+++ b/seed/python-sdk/exhaustive/five-second-timeout/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/poetry.lock
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/improved_imports/poetry.lock
+++ b/seed/python-sdk/exhaustive/improved_imports/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/infinite-timeout/poetry.lock
+++ b/seed/python-sdk/exhaustive/infinite-timeout/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline-path-params/poetry.lock
+++ b/seed/python-sdk/exhaustive/inline-path-params/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline_request_params/poetry.lock
+++ b/seed/python-sdk/exhaustive/inline_request_params/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/no-custom-config/poetry.lock
+++ b/seed/python-sdk/exhaustive/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/package-path/poetry.lock
+++ b/seed/python-sdk/exhaustive/package-path/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/poetry.lock
@@ -24,13 +24,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/nested_object_with_required_field.py
@@ -9,7 +9,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     class Config:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/types/cat.py
@@ -8,7 +8,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/types/dog.py
@@ -8,7 +8,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/poetry.lock
@@ -24,13 +24,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/nested_object_with_required_field.py
@@ -9,7 +9,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     class Config:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     class Config:
         frozen = True
@@ -24,7 +26,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/types/cat.py
@@ -8,7 +8,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/types/dog.py
@@ -8,7 +8,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1/poetry.lock
@@ -24,13 +24,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/nested_object_with_required_field.py
@@ -9,7 +9,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     class Config:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     class Config:
         frozen = True
@@ -24,7 +26,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/types/cat.py
@@ -8,7 +8,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/types/dog.py
@@ -8,7 +8,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     class Config:
         frozen = True

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/double_optional.py
@@ -12,6 +12,6 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,6 +13,6 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,6 +11,8 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,6 +9,8 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)
 
@@ -21,7 +23,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)
 

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/types/cat.py
@@ -10,6 +10,8 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/types/dog.py
@@ -10,6 +10,8 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/seed/python-sdk/exhaustive/pyproject_extras/poetry.lock
+++ b/seed/python-sdk/exhaustive/pyproject_extras/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/unchecked_base_model.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/unchecked_base_model.py
@@ -19,7 +19,7 @@ from .pydantic_utilities import (
     parse_datetime,
     parse_obj_as,
 )
-from .serialization import convert_and_respect_annotation_metadata, get_field_to_alias_mapping
+from .serialization import get_field_to_alias_mapping
 from pydantic_core import PydanticUndefined
 
 
@@ -40,26 +40,6 @@ class UncheckedBaseModel(UniversalBaseModel):
 
         class Config:
             extra = pydantic.Extra.allow
-
-    if IS_PYDANTIC_V2:
-
-        @classmethod
-        def model_validate(
-            cls: typing.Type["Model"],
-            obj: typing.Any,
-            *args: typing.Any,
-            **kwargs: typing.Any,
-        ) -> "Model":
-            """
-            Ensure that when using Pydantic v2's `model_validate` entrypoint we still
-            respect our FieldMetadata-based aliasing.
-            """
-            dealiased_obj = convert_and_respect_annotation_metadata(
-                object_=obj,
-                annotation=cls,
-                direction="read",
-            )
-            return super().model_validate(dealiased_obj, *args, **kwargs)  # type: ignore[misc]
 
     @classmethod
     def model_construct(

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/double_optional.py
@@ -13,7 +13,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UncheckedBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -14,7 +14,7 @@ class NestedObjectWithOptionalField(UncheckedBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/nested_object_with_required_field.py
@@ -12,7 +12,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UncheckedBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/object_with_map_of_map.py
@@ -10,7 +10,9 @@ from ....core.unchecked_base_model import UncheckedBaseModel
 
 
 class ObjectWithMapOfMap(UncheckedBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/object_with_optional_field.py
@@ -18,16 +18,30 @@ class ObjectWithOptionalField(UncheckedBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/types/animal.py
@@ -14,7 +14,9 @@ from ....core.unchecked_base_model import UncheckedBaseModel, UnionMetadata
 class Animal_Dog(UncheckedBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -29,7 +31,9 @@ class Animal_Dog(UncheckedBaseModel):
 class Animal_Cat(UncheckedBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/types/cat.py
@@ -11,7 +11,9 @@ from ....core.unchecked_base_model import UncheckedBaseModel
 
 class Cat(UncheckedBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/types/dog.py
@@ -11,7 +11,9 @@ from ....core.unchecked_base_model import UncheckedBaseModel
 
 class Dog(UncheckedBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/union-utils/poetry.lock
+++ b/seed/python-sdk/exhaustive/union-utils/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/poetry.lock
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/double_optional.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/double_optional.py
@@ -12,7 +12,7 @@ from .optional_alias import OptionalAlias
 class DoubleOptional(UniversalBaseModel):
     optional_alias: typing_extensions.Annotated[
         typing.Optional[OptionalAlias], FieldMetadata(alias="optionalAlias")
-    ] = None
+    ] = pydantic.Field(alias="optionalAlias", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/nested_object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/nested_object_with_optional_field.py
@@ -13,7 +13,7 @@ class NestedObjectWithOptionalField(UniversalBaseModel):
     string: typing.Optional[str] = None
     nested_object: typing_extensions.Annotated[
         typing.Optional[ObjectWithOptionalField], FieldMetadata(alias="NestedObject")
-    ] = None
+    ] = pydantic.Field(alias="NestedObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/nested_object_with_required_field.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/nested_object_with_required_field.py
@@ -11,7 +11,9 @@ from .object_with_optional_field import ObjectWithOptionalField
 
 class NestedObjectWithRequiredField(UniversalBaseModel):
     string: str
-    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")]
+    nested_object: typing_extensions.Annotated[ObjectWithOptionalField, FieldMetadata(alias="NestedObject")] = (
+        pydantic.Field(alias="NestedObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/object_with_map_of_map.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/object_with_map_of_map.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class ObjectWithMapOfMap(UniversalBaseModel):
-    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")]
+    map_: typing_extensions.Annotated[typing.Dict[str, typing.Dict[str, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/object_with_optional_field.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/object/types/object_with_optional_field.py
@@ -17,16 +17,30 @@ class ObjectWithOptionalField(UniversalBaseModel):
     """
 
     integer: typing.Optional[int] = None
-    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = None
+    long_: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="long")] = pydantic.Field(
+        alias="long", default=None
+    )
     double: typing.Optional[float] = None
-    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = None
+    bool_: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="bool")] = pydantic.Field(
+        alias="bool", default=None
+    )
     datetime: typing.Optional[dt.datetime] = None
     date: typing.Optional[dt.date] = None
-    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = None
-    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = None
-    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = None
-    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = None
-    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = None
+    uuid_: typing_extensions.Annotated[typing.Optional[uuid.UUID], FieldMetadata(alias="uuid")] = pydantic.Field(
+        alias="uuid", default=None
+    )
+    base_64: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="base64")] = pydantic.Field(
+        alias="base64", default=None
+    )
+    list_: typing_extensions.Annotated[typing.Optional[typing.List[str]], FieldMetadata(alias="list")] = pydantic.Field(
+        alias="list", default=None
+    )
+    set_: typing_extensions.Annotated[typing.Optional[typing.Set[str]], FieldMetadata(alias="set")] = pydantic.Field(
+        alias="set", default=None
+    )
+    map_: typing_extensions.Annotated[typing.Optional[typing.Dict[int, str]], FieldMetadata(alias="map")] = (
+        pydantic.Field(alias="map", default=None)
+    )
     bigint: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/union/types/animal.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/union/types/animal.py
@@ -13,7 +13,9 @@ from ....core.serialization import FieldMetadata
 class Animal_Dog(UniversalBaseModel):
     animal: typing.Literal["dog"] = "dog"
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -28,7 +30,9 @@ class Animal_Dog(UniversalBaseModel):
 class Animal_Cat(UniversalBaseModel):
     animal: typing.Literal["cat"] = "cat"
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/union/types/cat.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/union/types/cat.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Cat(UniversalBaseModel):
     name: str
-    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")]
+    likes_to_meow: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToMeow")] = pydantic.Field(
+        alias="likesToMeow"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/union/types/dog.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/types/union/types/dog.py
@@ -10,7 +10,9 @@ from ....core.serialization import FieldMetadata
 
 class Dog(UniversalBaseModel):
     name: str
-    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")]
+    likes_to_woof: typing_extensions.Annotated[bool, FieldMetadata(alias="likesToWoof")] = pydantic.Field(
+        alias="likesToWoof"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/extends/poetry.lock
+++ b/seed/python-sdk/extends/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/extends/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/extends/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/extends/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/extends/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/extends/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/extends/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/extra-properties/poetry.lock
+++ b/seed/python-sdk/extra-properties/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/extra-properties/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/extra-properties/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/extra-properties/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-download/default-chunk-size/poetry.lock
+++ b/seed/python-sdk/file-download/default-chunk-size/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-download/no-custom-config/poetry.lock
+++ b/seed/python-sdk/file-download/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload-openapi/poetry.lock
+++ b/seed/python-sdk/file-upload-openapi/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/poetry.lock
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/service/types/my_object_with_optional.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/service/types/my_object_with_optional.py
@@ -10,7 +10,9 @@ from ...core.serialization import FieldMetadata
 
 class MyObjectWithOptional(UniversalBaseModel):
     prop: str
-    optional_prop: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalProp")] = None
+    optional_prop: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalProp")] = (
+        pydantic.Field(alias="optionalProp", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/file-upload/no-custom-config/poetry.lock
+++ b/seed/python-sdk/file-upload/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/service/types/my_object_with_optional.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/service/types/my_object_with_optional.py
@@ -10,7 +10,9 @@ from ...core.serialization import FieldMetadata
 
 class MyObjectWithOptional(UniversalBaseModel):
     prop: str
-    optional_prop: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalProp")] = None
+    optional_prop: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalProp")] = (
+        pydantic.Field(alias="optionalProp", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/file-upload/use_typeddict_requests/poetry.lock
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/types/my_object_with_optional.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/types/my_object_with_optional.py
@@ -10,7 +10,9 @@ from ...core.serialization import FieldMetadata
 
 class MyObjectWithOptional(UniversalBaseModel):
     prop: str
-    optional_prop: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalProp")] = None
+    optional_prop: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalProp")] = (
+        pydantic.Field(alias="optionalProp", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/folders/poetry.lock
+++ b/seed/python-sdk/folders/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/folders/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/folders/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/folders/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/folders/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/folders/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/folders/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/header-auth-environment-variable/poetry.lock
+++ b/seed/python-sdk/header-auth-environment-variable/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/header-auth/poetry.lock
+++ b/seed/python-sdk/header-auth/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/header-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/header-auth/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/header-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/header-auth/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/header-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/header-auth/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/http-head/poetry.lock
+++ b/seed/python-sdk/http-head/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/http-head/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/http-head/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/http-head/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/http-head/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/http-head/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/http-head/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/idempotency-headers/poetry.lock
+++ b/seed/python-sdk/idempotency-headers/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/idempotency-headers/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/idempotency-headers/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/idempotency-headers/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/imdb/poetry.lock
+++ b/seed/python-sdk/imdb/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/imdb/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-explicit/poetry.lock
+++ b/seed/python-sdk/inferred-auth-explicit/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-implicit-api-key/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-implicit-reference/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-reference/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-implicit/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/license/poetry.lock
+++ b/seed/python-sdk/license/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/license/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/license/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/license/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/license/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/license/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/license/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/literal/no-custom-config/poetry.lock
+++ b/seed/python-sdk/literal/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/literal/no-custom-config/src/seed/inlined/types/a_nested_literal.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/inlined/types/a_nested_literal.py
@@ -10,7 +10,7 @@ from ...core.serialization import FieldMetadata
 
 class ANestedLiteral(UniversalBaseModel):
     my_literal: typing_extensions.Annotated[typing.Literal["How super cool"], FieldMetadata(alias="myLiteral")] = (
-        "How super cool"
+        pydantic.Field(alias="myLiteral", default="How super cool")
     )
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/inlined/types/a_top_level_literal.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/inlined/types/a_top_level_literal.py
@@ -10,7 +10,9 @@ from .a_nested_literal import ANestedLiteral
 
 
 class ATopLevelLiteral(UniversalBaseModel):
-    nested_literal: typing_extensions.Annotated[ANestedLiteral, FieldMetadata(alias="nestedLiteral")]
+    nested_literal: typing_extensions.Annotated[ANestedLiteral, FieldMetadata(alias="nestedLiteral")] = pydantic.Field(
+        alias="nestedLiteral"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/literal/no-custom-config/src/seed/reference/types/container_object.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/reference/types/container_object.py
@@ -12,7 +12,7 @@ from .nested_object_with_literals import NestedObjectWithLiterals
 class ContainerObject(UniversalBaseModel):
     nested_objects: typing_extensions.Annotated[
         typing.List[NestedObjectWithLiterals], FieldMetadata(alias="nestedObjects")
-    ]
+    ] = pydantic.Field(alias="nestedObjects")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/literal/no-custom-config/src/seed/reference/types/nested_object_with_literals.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/reference/types/nested_object_with_literals.py
@@ -9,9 +9,13 @@ from ...core.serialization import FieldMetadata
 
 
 class NestedObjectWithLiterals(UniversalBaseModel):
-    literal_1: typing_extensions.Annotated[typing.Literal["literal1"], FieldMetadata(alias="literal1")] = "literal1"
-    literal_2: typing_extensions.Annotated[typing.Literal["literal2"], FieldMetadata(alias="literal2")] = "literal2"
-    str_prop: typing_extensions.Annotated[str, FieldMetadata(alias="strProp")]
+    literal_1: typing_extensions.Annotated[typing.Literal["literal1"], FieldMetadata(alias="literal1")] = (
+        pydantic.Field(alias="literal1", default="literal1")
+    )
+    literal_2: typing_extensions.Annotated[typing.Literal["literal2"], FieldMetadata(alias="literal2")] = (
+        pydantic.Field(alias="literal2", default="literal2")
+    )
+    str_prop: typing_extensions.Annotated[str, FieldMetadata(alias="strProp")] = pydantic.Field(alias="strProp")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/literal/no-custom-config/src/seed/reference/types/send_request.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/reference/types/send_request.py
@@ -16,8 +16,12 @@ class SendRequest(UniversalBaseModel):
     stream: typing.Literal[False] = False
     ending: typing.Literal["$ending"] = "$ending"
     context: SomeLiteral = "You're super wise"
-    maybe_context: typing_extensions.Annotated[typing.Optional[SomeLiteral], FieldMetadata(alias="maybeContext")] = None
-    container_object: typing_extensions.Annotated[ContainerObject, FieldMetadata(alias="containerObject")]
+    maybe_context: typing_extensions.Annotated[typing.Optional[SomeLiteral], FieldMetadata(alias="maybeContext")] = (
+        pydantic.Field(alias="maybeContext", default=None)
+    )
+    container_object: typing_extensions.Annotated[ContainerObject, FieldMetadata(alias="containerObject")] = (
+        pydantic.Field(alias="containerObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/literal/use_typeddict_requests/poetry.lock
+++ b/seed/python-sdk/literal/use_typeddict_requests/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/types/a_nested_literal.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/types/a_nested_literal.py
@@ -10,7 +10,7 @@ from ...core.serialization import FieldMetadata
 
 class ANestedLiteral(UniversalBaseModel):
     my_literal: typing_extensions.Annotated[typing.Literal["How super cool"], FieldMetadata(alias="myLiteral")] = (
-        "How super cool"
+        pydantic.Field(alias="myLiteral", default="How super cool")
     )
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/types/a_top_level_literal.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/types/a_top_level_literal.py
@@ -10,7 +10,9 @@ from .a_nested_literal import ANestedLiteral
 
 
 class ATopLevelLiteral(UniversalBaseModel):
-    nested_literal: typing_extensions.Annotated[ANestedLiteral, FieldMetadata(alias="nestedLiteral")]
+    nested_literal: typing_extensions.Annotated[ANestedLiteral, FieldMetadata(alias="nestedLiteral")] = pydantic.Field(
+        alias="nestedLiteral"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/types/container_object.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/types/container_object.py
@@ -12,7 +12,7 @@ from .nested_object_with_literals import NestedObjectWithLiterals
 class ContainerObject(UniversalBaseModel):
     nested_objects: typing_extensions.Annotated[
         typing.List[NestedObjectWithLiterals], FieldMetadata(alias="nestedObjects")
-    ]
+    ] = pydantic.Field(alias="nestedObjects")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/types/nested_object_with_literals.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/types/nested_object_with_literals.py
@@ -9,9 +9,13 @@ from ...core.serialization import FieldMetadata
 
 
 class NestedObjectWithLiterals(UniversalBaseModel):
-    literal_1: typing_extensions.Annotated[typing.Literal["literal1"], FieldMetadata(alias="literal1")] = "literal1"
-    literal_2: typing_extensions.Annotated[typing.Literal["literal2"], FieldMetadata(alias="literal2")] = "literal2"
-    str_prop: typing_extensions.Annotated[str, FieldMetadata(alias="strProp")]
+    literal_1: typing_extensions.Annotated[typing.Literal["literal1"], FieldMetadata(alias="literal1")] = (
+        pydantic.Field(alias="literal1", default="literal1")
+    )
+    literal_2: typing_extensions.Annotated[typing.Literal["literal2"], FieldMetadata(alias="literal2")] = (
+        pydantic.Field(alias="literal2", default="literal2")
+    )
+    str_prop: typing_extensions.Annotated[str, FieldMetadata(alias="strProp")] = pydantic.Field(alias="strProp")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/types/send_request.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/types/send_request.py
@@ -16,8 +16,12 @@ class SendRequest(UniversalBaseModel):
     stream: typing.Literal[False] = False
     ending: typing.Literal["$ending"] = "$ending"
     context: SomeLiteral = "You're super wise"
-    maybe_context: typing_extensions.Annotated[typing.Optional[SomeLiteral], FieldMetadata(alias="maybeContext")] = None
-    container_object: typing_extensions.Annotated[ContainerObject, FieldMetadata(alias="containerObject")]
+    maybe_context: typing_extensions.Annotated[typing.Optional[SomeLiteral], FieldMetadata(alias="maybeContext")] = (
+        pydantic.Field(alias="maybeContext", default=None)
+    )
+    container_object: typing_extensions.Annotated[ContainerObject, FieldMetadata(alias="containerObject")] = (
+        pydantic.Field(alias="containerObject")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/literals-unions/poetry.lock
+++ b/seed/python-sdk/literals-unions/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/literals-unions/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/literals-unions/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/literals-unions/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/mixed-case/poetry.lock
+++ b/seed/python-sdk/mixed-case/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/mixed-case/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/mixed-case/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/mixed-case/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/mixed-case/src/seed/service/types/nested_user.py
+++ b/seed/python-sdk/mixed-case/src/seed/service/types/nested_user.py
@@ -25,8 +25,10 @@ class NestedUser(UniversalBaseModel):
     )
     """
 
-    name: typing_extensions.Annotated[str, FieldMetadata(alias="Name")]
-    nested_user: typing_extensions.Annotated[User, FieldMetadata(alias="NestedUser")]
+    name: typing_extensions.Annotated[str, FieldMetadata(alias="Name")] = pydantic.Field(alias="Name")
+    nested_user: typing_extensions.Annotated[User, FieldMetadata(alias="NestedUser")] = pydantic.Field(
+        alias="NestedUser"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/mixed-case/src/seed/service/types/resource.py
+++ b/seed/python-sdk/mixed-case/src/seed/service/types/resource.py
@@ -50,9 +50,11 @@ class Resource_User(Base):
     """
 
     resource_type: typing.Literal["user"] = "user"
-    user_name: typing_extensions.Annotated[str, FieldMetadata(alias="userName")]
+    user_name: typing_extensions.Annotated[str, FieldMetadata(alias="userName")] = pydantic.Field(alias="userName")
     metadata_tags: typing.List[str]
-    extra_properties: typing_extensions.Annotated[typing.Dict[str, str], FieldMetadata(alias="EXTRA_PROPERTIES")]
+    extra_properties: typing_extensions.Annotated[typing.Dict[str, str], FieldMetadata(alias="EXTRA_PROPERTIES")] = (
+        pydantic.Field(alias="EXTRA_PROPERTIES")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/mixed-case/src/seed/service/types/user.py
+++ b/seed/python-sdk/mixed-case/src/seed/service/types/user.py
@@ -21,9 +21,11 @@ class User(UniversalBaseModel):
     )
     """
 
-    user_name: typing_extensions.Annotated[str, FieldMetadata(alias="userName")]
+    user_name: typing_extensions.Annotated[str, FieldMetadata(alias="userName")] = pydantic.Field(alias="userName")
     metadata_tags: typing.List[str]
-    extra_properties: typing_extensions.Annotated[typing.Dict[str, str], FieldMetadata(alias="EXTRA_PROPERTIES")]
+    extra_properties: typing_extensions.Annotated[typing.Dict[str, str], FieldMetadata(alias="EXTRA_PROPERTIES")] = (
+        pydantic.Field(alias="EXTRA_PROPERTIES")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/poetry.lock
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/poetry.lock
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multi-line-docs/poetry.lock
+++ b/seed/python-sdk/multi-line-docs/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/multi-line-docs/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multi-line-docs/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/multi-line-docs/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multi-url-environment-no-default/poetry.lock
+++ b/seed/python-sdk/multi-url-environment-no-default/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multi-url-environment/poetry.lock
+++ b/seed/python-sdk/multi-url-environment/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/multi-url-environment/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multi-url-environment/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/multi-url-environment/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multiple-request-bodies/poetry.lock
+++ b/seed/python-sdk/multiple-request-bodies/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/multiple-request-bodies/src/seed/types/document_upload_result.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/types/document_upload_result.py
@@ -9,7 +9,9 @@ from ..core.serialization import FieldMetadata
 
 
 class DocumentUploadResult(UniversalBaseModel):
-    file_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="fileId")] = None
+    file_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="fileId")] = pydantic.Field(
+        alias="fileId", default=None
+    )
     status: typing.Optional[str] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/no-environment/poetry.lock
+++ b/seed/python-sdk/no-environment/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/no-environment/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/no-environment/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/no-environment/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/no-environment/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/no-environment/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/no-environment/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/no-retries/poetry.lock
+++ b/seed/python-sdk/no-retries/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/no-retries/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/no-retries/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/no-retries/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/no-retries/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/no-retries/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/no-retries/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable-allof-extends/poetry.lock
+++ b/seed/python-sdk/nullable-allof-extends/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable-allof-extends/src/seed/types/normal_object.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/types/normal_object.py
@@ -13,7 +13,9 @@ class NormalObject(UniversalBaseModel):
     A standard object with no nullable issues.
     """
 
-    normal_field: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="normalField")] = None
+    normal_field: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="normalField")] = (
+        pydantic.Field(alias="normalField", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-allof-extends/src/seed/types/nullable_object.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/types/nullable_object.py
@@ -13,7 +13,9 @@ class NullableObject(UniversalBaseModel):
     This schema has nullable:true at the top level.
     """
 
-    nullable_field: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="nullableField")] = None
+    nullable_field: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="nullableField")] = (
+        pydantic.Field(alias="nullableField", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/poetry.lock
+++ b/seed/python-sdk/nullable-optional/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/nullable-optional/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable-optional/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/nullable-optional/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/address.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/address.py
@@ -18,10 +18,14 @@ class Address(UniversalBaseModel):
     street: str
     city: typing.Optional[str] = None
     state: typing.Optional[str] = None
-    zip_code: typing_extensions.Annotated[str, FieldMetadata(alias="zipCode")]
+    zip_code: typing_extensions.Annotated[str, FieldMetadata(alias="zipCode")] = pydantic.Field(alias="zipCode")
     country: typing.Optional[str] = None
-    building_id: typing_extensions.Annotated[NullableUserId, FieldMetadata(alias="buildingId")]
-    tenant_id: typing_extensions.Annotated[OptionalUserId, FieldMetadata(alias="tenantId")]
+    building_id: typing_extensions.Annotated[NullableUserId, FieldMetadata(alias="buildingId")] = pydantic.Field(
+        alias="buildingId"
+    )
+    tenant_id: typing_extensions.Annotated[OptionalUserId, FieldMetadata(alias="tenantId")] = pydantic.Field(
+        alias="tenantId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/complex_profile.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/complex_profile.py
@@ -19,56 +19,60 @@ class ComplexProfile(UniversalBaseModel):
     """
 
     id: str
-    nullable_role: typing_extensions.Annotated[typing.Optional[UserRole], FieldMetadata(alias="nullableRole")] = None
-    optional_role: typing_extensions.Annotated[typing.Optional[UserRole], FieldMetadata(alias="optionalRole")] = None
+    nullable_role: typing_extensions.Annotated[typing.Optional[UserRole], FieldMetadata(alias="nullableRole")] = (
+        pydantic.Field(alias="nullableRole", default=None)
+    )
+    optional_role: typing_extensions.Annotated[typing.Optional[UserRole], FieldMetadata(alias="optionalRole")] = (
+        pydantic.Field(alias="optionalRole", default=None)
+    )
     optional_nullable_role: typing_extensions.Annotated[
         typing.Optional[UserRole], FieldMetadata(alias="optionalNullableRole")
-    ] = None
+    ] = pydantic.Field(alias="optionalNullableRole", default=None)
     nullable_status: typing_extensions.Annotated[typing.Optional[UserStatus], FieldMetadata(alias="nullableStatus")] = (
-        None
+        pydantic.Field(alias="nullableStatus", default=None)
     )
     optional_status: typing_extensions.Annotated[typing.Optional[UserStatus], FieldMetadata(alias="optionalStatus")] = (
-        None
+        pydantic.Field(alias="optionalStatus", default=None)
     )
     optional_nullable_status: typing_extensions.Annotated[
         typing.Optional[UserStatus], FieldMetadata(alias="optionalNullableStatus")
-    ] = None
+    ] = pydantic.Field(alias="optionalNullableStatus", default=None)
     nullable_notification: typing_extensions.Annotated[
         typing.Optional[NotificationMethod], FieldMetadata(alias="nullableNotification")
-    ] = None
+    ] = pydantic.Field(alias="nullableNotification", default=None)
     optional_notification: typing_extensions.Annotated[
         typing.Optional[NotificationMethod], FieldMetadata(alias="optionalNotification")
-    ] = None
+    ] = pydantic.Field(alias="optionalNotification", default=None)
     optional_nullable_notification: typing_extensions.Annotated[
         typing.Optional[NotificationMethod], FieldMetadata(alias="optionalNullableNotification")
-    ] = None
+    ] = pydantic.Field(alias="optionalNullableNotification", default=None)
     nullable_search_result: typing_extensions.Annotated[
         typing.Optional[SearchResult], FieldMetadata(alias="nullableSearchResult")
-    ] = None
+    ] = pydantic.Field(alias="nullableSearchResult", default=None)
     optional_search_result: typing_extensions.Annotated[
         typing.Optional[SearchResult], FieldMetadata(alias="optionalSearchResult")
-    ] = None
+    ] = pydantic.Field(alias="optionalSearchResult", default=None)
     nullable_array: typing_extensions.Annotated[
         typing.Optional[typing.List[str]], FieldMetadata(alias="nullableArray")
-    ] = None
+    ] = pydantic.Field(alias="nullableArray", default=None)
     optional_array: typing_extensions.Annotated[
         typing.Optional[typing.List[str]], FieldMetadata(alias="optionalArray")
-    ] = None
+    ] = pydantic.Field(alias="optionalArray", default=None)
     optional_nullable_array: typing_extensions.Annotated[
         typing.Optional[typing.List[str]], FieldMetadata(alias="optionalNullableArray")
-    ] = None
+    ] = pydantic.Field(alias="optionalNullableArray", default=None)
     nullable_list_of_nullables: typing_extensions.Annotated[
         typing.Optional[typing.List[typing.Optional[str]]], FieldMetadata(alias="nullableListOfNullables")
-    ] = None
+    ] = pydantic.Field(alias="nullableListOfNullables", default=None)
     nullable_map_of_nullables: typing_extensions.Annotated[
         typing.Optional[typing.Dict[str, typing.Optional[Address]]], FieldMetadata(alias="nullableMapOfNullables")
-    ] = None
+    ] = pydantic.Field(alias="nullableMapOfNullables", default=None)
     nullable_list_of_unions: typing_extensions.Annotated[
         typing.Optional[typing.List[NotificationMethod]], FieldMetadata(alias="nullableListOfUnions")
-    ] = None
+    ] = pydantic.Field(alias="nullableListOfUnions", default=None)
     optional_map_of_enums: typing_extensions.Annotated[
         typing.Optional[typing.Dict[str, UserRole]], FieldMetadata(alias="optionalMapOfEnums")
-    ] = None
+    ] = pydantic.Field(alias="optionalMapOfEnums", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/deserialization_test_request.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/deserialization_test_request.py
@@ -19,30 +19,42 @@ class DeserializationTestRequest(UniversalBaseModel):
     Request body for testing deserialization of null values
     """
 
-    required_string: typing_extensions.Annotated[str, FieldMetadata(alias="requiredString")]
-    nullable_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="nullableString")] = None
-    optional_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalString")] = None
+    required_string: typing_extensions.Annotated[str, FieldMetadata(alias="requiredString")] = pydantic.Field(
+        alias="requiredString"
+    )
+    nullable_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="nullableString")] = (
+        pydantic.Field(alias="nullableString", default=None)
+    )
+    optional_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalString")] = (
+        pydantic.Field(alias="optionalString", default=None)
+    )
     optional_nullable_string: typing_extensions.Annotated[
         typing.Optional[str], FieldMetadata(alias="optionalNullableString")
-    ] = None
-    nullable_enum: typing_extensions.Annotated[typing.Optional[UserRole], FieldMetadata(alias="nullableEnum")] = None
-    optional_enum: typing_extensions.Annotated[typing.Optional[UserStatus], FieldMetadata(alias="optionalEnum")] = None
+    ] = pydantic.Field(alias="optionalNullableString", default=None)
+    nullable_enum: typing_extensions.Annotated[typing.Optional[UserRole], FieldMetadata(alias="nullableEnum")] = (
+        pydantic.Field(alias="nullableEnum", default=None)
+    )
+    optional_enum: typing_extensions.Annotated[typing.Optional[UserStatus], FieldMetadata(alias="optionalEnum")] = (
+        pydantic.Field(alias="optionalEnum", default=None)
+    )
     nullable_union: typing_extensions.Annotated[
         typing.Optional[NotificationMethod], FieldMetadata(alias="nullableUnion")
-    ] = None
+    ] = pydantic.Field(alias="nullableUnion", default=None)
     optional_union: typing_extensions.Annotated[typing.Optional[SearchResult], FieldMetadata(alias="optionalUnion")] = (
-        None
+        pydantic.Field(alias="optionalUnion", default=None)
     )
     nullable_list: typing_extensions.Annotated[
         typing.Optional[typing.List[str]], FieldMetadata(alias="nullableList")
-    ] = None
+    ] = pydantic.Field(alias="nullableList", default=None)
     nullable_map: typing_extensions.Annotated[
         typing.Optional[typing.Dict[str, int]], FieldMetadata(alias="nullableMap")
-    ] = None
-    nullable_object: typing_extensions.Annotated[typing.Optional[Address], FieldMetadata(alias="nullableObject")] = None
+    ] = pydantic.Field(alias="nullableMap", default=None)
+    nullable_object: typing_extensions.Annotated[typing.Optional[Address], FieldMetadata(alias="nullableObject")] = (
+        pydantic.Field(alias="nullableObject", default=None)
+    )
     optional_object: typing_extensions.Annotated[
         typing.Optional[Organization], FieldMetadata(alias="optionalObject")
-    ] = None
+    ] = pydantic.Field(alias="optionalObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/deserialization_test_response.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/deserialization_test_response.py
@@ -16,9 +16,13 @@ class DeserializationTestResponse(UniversalBaseModel):
     """
 
     echo: DeserializationTestRequest
-    processed_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="processedAt")]
-    null_count: typing_extensions.Annotated[int, FieldMetadata(alias="nullCount")]
-    present_fields_count: typing_extensions.Annotated[int, FieldMetadata(alias="presentFieldsCount")]
+    processed_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="processedAt")] = pydantic.Field(
+        alias="processedAt"
+    )
+    null_count: typing_extensions.Annotated[int, FieldMetadata(alias="nullCount")] = pydantic.Field(alias="nullCount")
+    present_fields_count: typing_extensions.Annotated[int, FieldMetadata(alias="presentFieldsCount")] = pydantic.Field(
+        alias="presentFieldsCount"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/email_notification.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/email_notification.py
@@ -9,9 +9,13 @@ from ...core.serialization import FieldMetadata
 
 
 class EmailNotification(UniversalBaseModel):
-    email_address: typing_extensions.Annotated[str, FieldMetadata(alias="emailAddress")]
+    email_address: typing_extensions.Annotated[str, FieldMetadata(alias="emailAddress")] = pydantic.Field(
+        alias="emailAddress"
+    )
     subject: str
-    html_content: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="htmlContent")] = None
+    html_content: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="htmlContent")] = (
+        pydantic.Field(alias="htmlContent", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/notification_method.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/notification_method.py
@@ -16,9 +16,13 @@ class NotificationMethod_Email(UniversalBaseModel):
     """
 
     type: typing.Literal["email"] = "email"
-    email_address: typing_extensions.Annotated[str, FieldMetadata(alias="emailAddress")]
+    email_address: typing_extensions.Annotated[str, FieldMetadata(alias="emailAddress")] = pydantic.Field(
+        alias="emailAddress"
+    )
     subject: str
-    html_content: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="htmlContent")] = None
+    html_content: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="htmlContent")] = (
+        pydantic.Field(alias="htmlContent", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -36,9 +40,13 @@ class NotificationMethod_Sms(UniversalBaseModel):
     """
 
     type: typing.Literal["sms"] = "sms"
-    phone_number: typing_extensions.Annotated[str, FieldMetadata(alias="phoneNumber")]
+    phone_number: typing_extensions.Annotated[str, FieldMetadata(alias="phoneNumber")] = pydantic.Field(
+        alias="phoneNumber"
+    )
     message: str
-    short_code: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="shortCode")] = None
+    short_code: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="shortCode")] = pydantic.Field(
+        alias="shortCode", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -56,7 +64,9 @@ class NotificationMethod_Push(UniversalBaseModel):
     """
 
     type: typing.Literal["push"] = "push"
-    device_token: typing_extensions.Annotated[str, FieldMetadata(alias="deviceToken")]
+    device_token: typing_extensions.Annotated[str, FieldMetadata(alias="deviceToken")] = pydantic.Field(
+        alias="deviceToken"
+    )
     title: str
     body: str
     badge: typing.Optional[int] = None

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/organization.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/organization.py
@@ -12,7 +12,9 @@ class Organization(UniversalBaseModel):
     id: str
     name: str
     domain: typing.Optional[str] = None
-    employee_count: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="employeeCount")] = None
+    employee_count: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="employeeCount")] = (
+        pydantic.Field(alias="employeeCount", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/push_notification.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/push_notification.py
@@ -9,7 +9,9 @@ from ...core.serialization import FieldMetadata
 
 
 class PushNotification(UniversalBaseModel):
-    device_token: typing_extensions.Annotated[str, FieldMetadata(alias="deviceToken")]
+    device_token: typing_extensions.Annotated[str, FieldMetadata(alias="deviceToken")] = pydantic.Field(
+        alias="deviceToken"
+    )
     title: str
     body: str
     badge: typing.Optional[int] = None

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/search_result.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/search_result.py
@@ -22,8 +22,12 @@ class SearchResult_User(UniversalBaseModel):
     username: str
     email: typing.Optional[str] = None
     phone: typing.Optional[str] = None
-    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="createdAt")]
-    updated_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="updatedAt")] = None
+    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="createdAt")] = pydantic.Field(
+        alias="createdAt"
+    )
+    updated_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="updatedAt")] = (
+        pydantic.Field(alias="updatedAt", default=None)
+    )
     address: typing.Optional[Address] = None
 
     if IS_PYDANTIC_V2:
@@ -45,7 +49,9 @@ class SearchResult_Organization(UniversalBaseModel):
     id: str
     name: str
     domain: typing.Optional[str] = None
-    employee_count: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="employeeCount")] = None
+    employee_count: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="employeeCount")] = (
+        pydantic.Field(alias="employeeCount", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/sms_notification.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/sms_notification.py
@@ -9,9 +9,13 @@ from ...core.serialization import FieldMetadata
 
 
 class SmsNotification(UniversalBaseModel):
-    phone_number: typing_extensions.Annotated[str, FieldMetadata(alias="phoneNumber")]
+    phone_number: typing_extensions.Annotated[str, FieldMetadata(alias="phoneNumber")] = pydantic.Field(
+        alias="phoneNumber"
+    )
     message: str
-    short_code: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="shortCode")] = None
+    short_code: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="shortCode")] = pydantic.Field(
+        alias="shortCode", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/user_profile.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/user_profile.py
@@ -17,34 +17,54 @@ class UserProfile(UniversalBaseModel):
 
     id: str
     username: str
-    nullable_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="nullableString")] = None
-    nullable_integer: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="nullableInteger")] = None
-    nullable_boolean: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="nullableBoolean")] = None
-    nullable_date: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="nullableDate")] = None
-    nullable_object: typing_extensions.Annotated[typing.Optional[Address], FieldMetadata(alias="nullableObject")] = None
+    nullable_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="nullableString")] = (
+        pydantic.Field(alias="nullableString", default=None)
+    )
+    nullable_integer: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="nullableInteger")] = (
+        pydantic.Field(alias="nullableInteger", default=None)
+    )
+    nullable_boolean: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="nullableBoolean")] = (
+        pydantic.Field(alias="nullableBoolean", default=None)
+    )
+    nullable_date: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="nullableDate")] = (
+        pydantic.Field(alias="nullableDate", default=None)
+    )
+    nullable_object: typing_extensions.Annotated[typing.Optional[Address], FieldMetadata(alias="nullableObject")] = (
+        pydantic.Field(alias="nullableObject", default=None)
+    )
     nullable_list: typing_extensions.Annotated[
         typing.Optional[typing.List[str]], FieldMetadata(alias="nullableList")
-    ] = None
+    ] = pydantic.Field(alias="nullableList", default=None)
     nullable_map: typing_extensions.Annotated[
         typing.Optional[typing.Dict[str, str]], FieldMetadata(alias="nullableMap")
-    ] = None
-    optional_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalString")] = None
-    optional_integer: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="optionalInteger")] = None
-    optional_boolean: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="optionalBoolean")] = None
-    optional_date: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="optionalDate")] = None
-    optional_object: typing_extensions.Annotated[typing.Optional[Address], FieldMetadata(alias="optionalObject")] = None
+    ] = pydantic.Field(alias="nullableMap", default=None)
+    optional_string: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="optionalString")] = (
+        pydantic.Field(alias="optionalString", default=None)
+    )
+    optional_integer: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="optionalInteger")] = (
+        pydantic.Field(alias="optionalInteger", default=None)
+    )
+    optional_boolean: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="optionalBoolean")] = (
+        pydantic.Field(alias="optionalBoolean", default=None)
+    )
+    optional_date: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="optionalDate")] = (
+        pydantic.Field(alias="optionalDate", default=None)
+    )
+    optional_object: typing_extensions.Annotated[typing.Optional[Address], FieldMetadata(alias="optionalObject")] = (
+        pydantic.Field(alias="optionalObject", default=None)
+    )
     optional_list: typing_extensions.Annotated[
         typing.Optional[typing.List[str]], FieldMetadata(alias="optionalList")
-    ] = None
+    ] = pydantic.Field(alias="optionalList", default=None)
     optional_map: typing_extensions.Annotated[
         typing.Optional[typing.Dict[str, str]], FieldMetadata(alias="optionalMap")
-    ] = None
+    ] = pydantic.Field(alias="optionalMap", default=None)
     optional_nullable_string: typing_extensions.Annotated[
         typing.Optional[str], FieldMetadata(alias="optionalNullableString")
-    ] = None
+    ] = pydantic.Field(alias="optionalNullableString", default=None)
     optional_nullable_object: typing_extensions.Annotated[
         typing.Optional[Address], FieldMetadata(alias="optionalNullableObject")
-    ] = None
+    ] = pydantic.Field(alias="optionalNullableObject", default=None)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/user_response.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/user_response.py
@@ -15,8 +15,12 @@ class UserResponse(UniversalBaseModel):
     username: str
     email: typing.Optional[str] = None
     phone: typing.Optional[str] = None
-    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="createdAt")]
-    updated_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="updatedAt")] = None
+    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="createdAt")] = pydantic.Field(
+        alias="createdAt"
+    )
+    updated_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="updatedAt")] = (
+        pydantic.Field(alias="updatedAt", default=None)
+    )
     address: typing.Optional[Address] = None
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/nullable-request-body/poetry.lock
+++ b/seed/python-sdk/nullable-request-body/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/nullable-request-body/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable-request-body/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/nullable-request-body/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable/no-custom-config/poetry.lock
+++ b/seed/python-sdk/nullable/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/nullable/types/metadata.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/nullable/types/metadata.py
@@ -11,8 +11,12 @@ from .status import Status
 
 
 class Metadata(UniversalBaseModel):
-    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="createdAt")]
-    updated_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="updatedAt")]
+    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="createdAt")] = pydantic.Field(
+        alias="createdAt"
+    )
+    updated_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="updatedAt")] = pydantic.Field(
+        alias="updatedAt"
+    )
     avatar: typing.Optional[str] = None
     activated: typing.Optional[bool] = None
     status: Status

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/nullable/types/user.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/nullable/types/user.py
@@ -18,7 +18,9 @@ class User(UniversalBaseModel):
     tags: typing.Optional[typing.List[str]] = None
     metadata: typing.Optional[Metadata] = None
     email: Email
-    favorite_number: typing_extensions.Annotated[WeirdNumber, FieldMetadata(alias="favorite-number")]
+    favorite_number: typing_extensions.Annotated[WeirdNumber, FieldMetadata(alias="favorite-number")] = pydantic.Field(
+        alias="favorite-number"
+    )
     numbers: typing.Optional[typing.List[int]] = None
     strings: typing.Optional[typing.Dict[str, typing.Any]] = None
 

--- a/seed/python-sdk/nullable/use-typeddict-requests/poetry.lock
+++ b/seed/python-sdk/nullable/use-typeddict-requests/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/types/metadata.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/types/metadata.py
@@ -11,8 +11,12 @@ from .status import Status
 
 
 class Metadata(UniversalBaseModel):
-    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="createdAt")]
-    updated_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="updatedAt")]
+    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="createdAt")] = pydantic.Field(
+        alias="createdAt"
+    )
+    updated_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="updatedAt")] = pydantic.Field(
+        alias="updatedAt"
+    )
     avatar: typing.Optional[str] = None
     activated: typing.Optional[bool] = None
     status: Status

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/types/user.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/types/user.py
@@ -18,7 +18,9 @@ class User(UniversalBaseModel):
     tags: typing.Optional[typing.List[str]] = None
     metadata: typing.Optional[Metadata] = None
     email: Email
-    favorite_number: typing_extensions.Annotated[WeirdNumber, FieldMetadata(alias="favorite-number")]
+    favorite_number: typing_extensions.Annotated[WeirdNumber, FieldMetadata(alias="favorite-number")] = pydantic.Field(
+        alias="favorite-number"
+    )
     numbers: typing.Optional[typing.List[int]] = None
     strings: typing.Optional[typing.Dict[str, typing.Any]] = None
 

--- a/seed/python-sdk/oauth-client-credentials-custom/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-custom/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-default/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-default/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-nested-root/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-reference/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-reference/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-with-variables/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/object/poetry.lock
+++ b/seed/python-sdk/object/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/object/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/object/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/object/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/object/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/object/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/object/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/objects-with-imports/poetry.lock
+++ b/seed/python-sdk/objects-with-imports/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/objects-with-imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/objects-with-imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/objects-with-imports/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/optional/poetry.lock
+++ b/seed/python-sdk/optional/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/optional/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/optional/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/optional/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/optional/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/optional/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/optional/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/optional/src/seed/optional/types/deploy_params.py
+++ b/seed/python-sdk/optional/src/seed/optional/types/deploy_params.py
@@ -9,7 +9,9 @@ from ...core.serialization import FieldMetadata
 
 
 class DeployParams(UniversalBaseModel):
-    update_draft: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="updateDraft")] = None
+    update_draft: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="updateDraft")] = (
+        pydantic.Field(alias="updateDraft", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/package-yml/poetry.lock
+++ b/seed/python-sdk/package-yml/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/package-yml/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/package-yml/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/package-yml/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/package-yml/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/package-yml/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/package-yml/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/pagination-custom/poetry.lock
+++ b/seed/python-sdk/pagination-custom/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/pagination-custom/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/pagination-custom/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/pagination-custom/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/pagination/no-custom-config/poetry.lock
+++ b/seed/python-sdk/pagination/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/inline_users/types/list_users_pagination_response.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/inline_users/types/list_users_pagination_response.py
@@ -11,7 +11,9 @@ from .users import Users
 
 
 class ListUsersPaginationResponse(UniversalBaseModel):
-    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = None
+    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = (
+        pydantic.Field(alias="hasNextPage", default=None)
+    )
     page: typing.Optional[Page] = None
     total_count: int = pydantic.Field()
     """

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/users/types/list_users_optional_data_pagination_response.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/users/types/list_users_optional_data_pagination_response.py
@@ -11,7 +11,9 @@ from .user import User
 
 
 class ListUsersOptionalDataPaginationResponse(UniversalBaseModel):
-    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = None
+    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = (
+        pydantic.Field(alias="hasNextPage", default=None)
+    )
     page: typing.Optional[Page] = None
     total_count: int = pydantic.Field()
     """

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/users/types/list_users_pagination_response.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/users/types/list_users_pagination_response.py
@@ -11,7 +11,9 @@ from .user import User
 
 
 class ListUsersPaginationResponse(UniversalBaseModel):
-    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = None
+    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = (
+        pydantic.Field(alias="hasNextPage", default=None)
+    )
     page: typing.Optional[Page] = None
     total_count: int = pydantic.Field()
     """

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/inline_users/types/list_users_pagination_response.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/inline_users/types/list_users_pagination_response.py
@@ -11,7 +11,9 @@ from .users import Users
 
 
 class ListUsersPaginationResponse(UniversalBaseModel):
-    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = None
+    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = (
+        pydantic.Field(alias="hasNextPage", default=None)
+    )
     page: typing.Optional[Page] = None
     total_count: int = pydantic.Field()
     """

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/types/list_users_optional_data_pagination_response.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/types/list_users_optional_data_pagination_response.py
@@ -11,7 +11,9 @@ from .user import User
 
 
 class ListUsersOptionalDataPaginationResponse(UniversalBaseModel):
-    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = None
+    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = (
+        pydantic.Field(alias="hasNextPage", default=None)
+    )
     page: typing.Optional[Page] = None
     total_count: int = pydantic.Field()
     """

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/types/list_users_pagination_response.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/types/list_users_pagination_response.py
@@ -11,7 +11,9 @@ from .user import User
 
 
 class ListUsersPaginationResponse(UniversalBaseModel):
-    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = None
+    has_next_page: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="hasNextPage")] = (
+        pydantic.Field(alias="hasNextPage", default=None)
+    )
     page: typing.Optional[Page] = None
     total_count: int = pydantic.Field()
     """

--- a/seed/python-sdk/path-parameters/poetry.lock
+++ b/seed/python-sdk/path-parameters/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/path-parameters/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/path-parameters/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/path-parameters/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/plain-text/poetry.lock
+++ b/seed/python-sdk/plain-text/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/plain-text/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/plain-text/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/plain-text/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/plain-text/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/plain-text/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/plain-text/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/property-access/poetry.lock
+++ b/seed/python-sdk/property-access/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/property-access/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/property-access/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/property-access/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/property-access/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/property-access/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/property-access/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/property-access/src/seed/types/admin.py
+++ b/seed/python-sdk/property-access/src/seed/types/admin.py
@@ -14,7 +14,9 @@ class Admin(User):
     Admin user object
     """
 
-    admin_level: typing_extensions.Annotated[str, FieldMetadata(alias="adminLevel")] = pydantic.Field()
+    admin_level: typing_extensions.Annotated[str, FieldMetadata(alias="adminLevel")] = pydantic.Field(
+        alias="adminLevel"
+    )
     """
     The level of admin privileges.
     """

--- a/seed/python-sdk/public-object/poetry.lock
+++ b/seed/python-sdk/public-object/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/public-object/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/public-object/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/public-object/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/public-object/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/public-object/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/public-object/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/python-backslash-escape/poetry.lock
+++ b/seed/python-sdk/python-backslash-escape/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/query-parameters/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/request-parameters/poetry.lock
+++ b/seed/python-sdk/request-parameters/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/request-parameters/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/request-parameters/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/request-parameters/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/required-nullable/poetry.lock
+++ b/seed/python-sdk/required-nullable/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/required-nullable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/required-nullable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/required-nullable/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/reserved-keywords/poetry.lock
+++ b/seed/python-sdk/reserved-keywords/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/reserved-keywords/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/reserved-keywords/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/reserved-keywords/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/reserved-keywords/src/seed/package/types/record.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/package/types/record.py
@@ -10,7 +10,7 @@ from ...core.serialization import FieldMetadata
 
 class Record(UniversalBaseModel):
     foo: typing.Dict[str, str]
-    f_3_d: typing_extensions.Annotated[int, FieldMetadata(alias="3d")]
+    f_3_d: typing_extensions.Annotated[int, FieldMetadata(alias="3d")] = pydantic.Field(alias="3d")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/response-property/poetry.lock
+++ b/seed/python-sdk/response-property/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/response-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/response-property/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/response-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/response-property/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/response-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/response-property/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/server-sent-event-examples/poetry.lock
+++ b/seed/python-sdk/server-sent-event-examples/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/server-sent-events/with-wire-tests/poetry.lock
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/simple-api/poetry.lock
+++ b/seed/python-sdk/simple-api/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/simple-api/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/simple-api/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/simple-api/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/simple-api/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/simple-api/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/simple-api/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/single-url-environment-default/poetry.lock
+++ b/seed/python-sdk/single-url-environment-default/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/single-url-environment-no-default/poetry.lock
+++ b/seed/python-sdk/single-url-environment-no-default/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/streaming-parameter/poetry.lock
+++ b/seed/python-sdk/streaming-parameter/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/streaming-parameter/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/streaming-parameter/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/streaming-parameter/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/streaming/no-custom-config/poetry.lock
+++ b/seed/python-sdk/streaming/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/streaming/skip-pydantic-validation/poetry.lock
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/unchecked_base_model.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/unchecked_base_model.py
@@ -19,7 +19,7 @@ from .pydantic_utilities import (
     parse_datetime,
     parse_obj_as,
 )
-from .serialization import convert_and_respect_annotation_metadata, get_field_to_alias_mapping
+from .serialization import get_field_to_alias_mapping
 from pydantic_core import PydanticUndefined
 
 
@@ -40,26 +40,6 @@ class UncheckedBaseModel(UniversalBaseModel):
 
         class Config:
             extra = pydantic.Extra.allow
-
-    if IS_PYDANTIC_V2:
-
-        @classmethod
-        def model_validate(
-            cls: typing.Type["Model"],
-            obj: typing.Any,
-            *args: typing.Any,
-            **kwargs: typing.Any,
-        ) -> "Model":
-            """
-            Ensure that when using Pydantic v2's `model_validate` entrypoint we still
-            respect our FieldMetadata-based aliasing.
-            """
-            dealiased_obj = convert_and_respect_annotation_metadata(
-                object_=obj,
-                annotation=cls,
-                direction="read",
-            )
-            return super().model_validate(dealiased_obj, *args, **kwargs)  # type: ignore[misc]
 
     @classmethod
     def model_construct(

--- a/seed/python-sdk/trace/poetry.lock
+++ b/seed/python-sdk/trace/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/trace/src/seed/commons/types/binary_tree_node_and_tree_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/binary_tree_node_and_tree_value.py
@@ -11,8 +11,10 @@ from .node_id import NodeId
 
 
 class BinaryTreeNodeAndTreeValue(UniversalBaseModel):
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
-    full_tree: typing_extensions.Annotated[BinaryTreeValue, FieldMetadata(alias="fullTree")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
+    full_tree: typing_extensions.Annotated[BinaryTreeValue, FieldMetadata(alias="fullTree")] = pydantic.Field(
+        alias="fullTree"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/binary_tree_node_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/binary_tree_node_value.py
@@ -10,7 +10,7 @@ from .node_id import NodeId
 
 
 class BinaryTreeNodeValue(UniversalBaseModel):
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
     val: float
     right: typing.Optional[NodeId] = None
     left: typing.Optional[NodeId] = None

--- a/seed/python-sdk/trace/src/seed/commons/types/debug_map_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/debug_map_value.py
@@ -13,7 +13,7 @@ from ...core.serialization import FieldMetadata
 class DebugMapValue(UniversalBaseModel):
     key_value_pairs: typing_extensions.Annotated[
         typing.List["DebugKeyValuePairs"], FieldMetadata(alias="keyValuePairs")
-    ]
+    ] = pydantic.Field(alias="keyValuePairs")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/debug_variable_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/debug_variable_value.py
@@ -83,7 +83,7 @@ class DebugVariableValue_MapValue(UniversalBaseModel):
     type: typing.Literal["mapValue"] = "mapValue"
     key_value_pairs: typing_extensions.Annotated[
         typing.List["DebugKeyValuePairs"], FieldMetadata(alias="keyValuePairs")
-    ]
+    ] = pydantic.Field(alias="keyValuePairs")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -110,8 +110,10 @@ class DebugVariableValue_ListValue(UniversalBaseModel):
 
 class DebugVariableValue_BinaryTreeNodeValue(UniversalBaseModel):
     type: typing.Literal["binaryTreeNodeValue"] = "binaryTreeNodeValue"
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
-    full_tree: typing_extensions.Annotated[BinaryTreeValue, FieldMetadata(alias="fullTree")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
+    full_tree: typing_extensions.Annotated[BinaryTreeValue, FieldMetadata(alias="fullTree")] = pydantic.Field(
+        alias="fullTree"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -125,8 +127,10 @@ class DebugVariableValue_BinaryTreeNodeValue(UniversalBaseModel):
 
 class DebugVariableValue_SinglyLinkedListNodeValue(UniversalBaseModel):
     type: typing.Literal["singlyLinkedListNodeValue"] = "singlyLinkedListNodeValue"
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
-    full_list: typing_extensions.Annotated[SinglyLinkedListValue, FieldMetadata(alias="fullList")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
+    full_list: typing_extensions.Annotated[SinglyLinkedListValue, FieldMetadata(alias="fullList")] = pydantic.Field(
+        alias="fullList"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -140,8 +144,10 @@ class DebugVariableValue_SinglyLinkedListNodeValue(UniversalBaseModel):
 
 class DebugVariableValue_DoublyLinkedListNodeValue(UniversalBaseModel):
     type: typing.Literal["doublyLinkedListNodeValue"] = "doublyLinkedListNodeValue"
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
-    full_list: typing_extensions.Annotated[DoublyLinkedListValue, FieldMetadata(alias="fullList")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
+    full_list: typing_extensions.Annotated[DoublyLinkedListValue, FieldMetadata(alias="fullList")] = pydantic.Field(
+        alias="fullList"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -181,8 +187,12 @@ class DebugVariableValue_NullValue(UniversalBaseModel):
 
 class DebugVariableValue_GenericValue(UniversalBaseModel):
     type: typing.Literal["genericValue"] = "genericValue"
-    stringified_type: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="stringifiedType")] = None
-    stringified_value: typing_extensions.Annotated[str, FieldMetadata(alias="stringifiedValue")]
+    stringified_type: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="stringifiedType")] = (
+        pydantic.Field(alias="stringifiedType", default=None)
+    )
+    stringified_value: typing_extensions.Annotated[str, FieldMetadata(alias="stringifiedValue")] = pydantic.Field(
+        alias="stringifiedValue"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/doubly_linked_list_node_and_list_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/doubly_linked_list_node_and_list_value.py
@@ -11,8 +11,10 @@ from .node_id import NodeId
 
 
 class DoublyLinkedListNodeAndListValue(UniversalBaseModel):
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
-    full_list: typing_extensions.Annotated[DoublyLinkedListValue, FieldMetadata(alias="fullList")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
+    full_list: typing_extensions.Annotated[DoublyLinkedListValue, FieldMetadata(alias="fullList")] = pydantic.Field(
+        alias="fullList"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/doubly_linked_list_node_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/doubly_linked_list_node_value.py
@@ -10,7 +10,7 @@ from .node_id import NodeId
 
 
 class DoublyLinkedListNodeValue(UniversalBaseModel):
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
     val: float
     next: typing.Optional[NodeId] = None
     prev: typing.Optional[NodeId] = None

--- a/seed/python-sdk/trace/src/seed/commons/types/generic_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/generic_value.py
@@ -9,8 +9,12 @@ from ...core.serialization import FieldMetadata
 
 
 class GenericValue(UniversalBaseModel):
-    stringified_type: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="stringifiedType")] = None
-    stringified_value: typing_extensions.Annotated[str, FieldMetadata(alias="stringifiedValue")]
+    stringified_type: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="stringifiedType")] = (
+        pydantic.Field(alias="stringifiedType", default=None)
+    )
+    stringified_value: typing_extensions.Annotated[str, FieldMetadata(alias="stringifiedValue")] = pydantic.Field(
+        alias="stringifiedValue"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/list_type.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/list_type.py
@@ -11,9 +11,11 @@ from ...core.serialization import FieldMetadata
 
 
 class ListType(UniversalBaseModel):
-    value_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="valueType")]
+    value_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="valueType")] = pydantic.Field(
+        alias="valueType"
+    )
     is_fixed_length: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="isFixedLength")] = (
-        pydantic.Field(default=None)
+        pydantic.Field(alias="isFixedLength", default=None)
     )
     """
     Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false.

--- a/seed/python-sdk/trace/src/seed/commons/types/map_type.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/map_type.py
@@ -11,8 +11,12 @@ from ...core.serialization import FieldMetadata
 
 
 class MapType(UniversalBaseModel):
-    key_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="keyType")]
-    value_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="valueType")]
+    key_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="keyType")] = pydantic.Field(
+        alias="keyType"
+    )
+    value_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="valueType")] = pydantic.Field(
+        alias="valueType"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/map_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/map_value.py
@@ -11,7 +11,9 @@ from ...core.serialization import FieldMetadata
 
 
 class MapValue(UniversalBaseModel):
-    key_value_pairs: typing_extensions.Annotated[typing.List["KeyValuePair"], FieldMetadata(alias="keyValuePairs")]
+    key_value_pairs: typing_extensions.Annotated[typing.List["KeyValuePair"], FieldMetadata(alias="keyValuePairs")] = (
+        pydantic.Field(alias="keyValuePairs")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/singly_linked_list_node_and_list_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/singly_linked_list_node_and_list_value.py
@@ -11,8 +11,10 @@ from .singly_linked_list_value import SinglyLinkedListValue
 
 
 class SinglyLinkedListNodeAndListValue(UniversalBaseModel):
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
-    full_list: typing_extensions.Annotated[SinglyLinkedListValue, FieldMetadata(alias="fullList")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
+    full_list: typing_extensions.Annotated[SinglyLinkedListValue, FieldMetadata(alias="fullList")] = pydantic.Field(
+        alias="fullList"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/singly_linked_list_node_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/singly_linked_list_node_value.py
@@ -10,7 +10,7 @@ from .node_id import NodeId
 
 
 class SinglyLinkedListNodeValue(UniversalBaseModel):
-    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")]
+    node_id: typing_extensions.Annotated[NodeId, FieldMetadata(alias="nodeId")] = pydantic.Field(alias="nodeId")
     val: float
     next: typing.Optional[NodeId] = None
 

--- a/seed/python-sdk/trace/src/seed/commons/types/test_case_with_expected_result.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/test_case_with_expected_result.py
@@ -12,8 +12,10 @@ from .test_case import TestCase
 
 
 class TestCaseWithExpectedResult(UniversalBaseModel):
-    test_case: typing_extensions.Annotated[TestCase, FieldMetadata(alias="testCase")]
-    expected_result: typing_extensions.Annotated["VariableValue", FieldMetadata(alias="expectedResult")]
+    test_case: typing_extensions.Annotated[TestCase, FieldMetadata(alias="testCase")] = pydantic.Field(alias="testCase")
+    expected_result: typing_extensions.Annotated["VariableValue", FieldMetadata(alias="expectedResult")] = (
+        pydantic.Field(alias="expectedResult")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/variable_type.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/variable_type.py
@@ -77,8 +77,12 @@ class VariableType_CharType(UniversalBaseModel):
 
 class VariableType_ListType(UniversalBaseModel):
     type: typing.Literal["listType"] = "listType"
-    value_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="valueType")]
-    is_fixed_length: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="isFixedLength")] = None
+    value_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="valueType")] = pydantic.Field(
+        alias="valueType"
+    )
+    is_fixed_length: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="isFixedLength")] = (
+        pydantic.Field(alias="isFixedLength", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -92,8 +96,12 @@ class VariableType_ListType(UniversalBaseModel):
 
 class VariableType_MapType(UniversalBaseModel):
     type: typing.Literal["mapType"] = "mapType"
-    key_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="keyType")]
-    value_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="valueType")]
+    key_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="keyType")] = pydantic.Field(
+        alias="keyType"
+    )
+    value_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="valueType")] = pydantic.Field(
+        alias="valueType"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/commons/types/variable_value.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/variable_value.py
@@ -81,7 +81,9 @@ class VariableValue_CharValue(UniversalBaseModel):
 
 class VariableValue_MapValue(UniversalBaseModel):
     type: typing.Literal["mapValue"] = "mapValue"
-    key_value_pairs: typing_extensions.Annotated[typing.List["KeyValuePair"], FieldMetadata(alias="keyValuePairs")]
+    key_value_pairs: typing_extensions.Annotated[typing.List["KeyValuePair"], FieldMetadata(alias="keyValuePairs")] = (
+        pydantic.Field(alias="keyValuePairs")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/trace/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/trace/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/trace/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/trace/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/trace/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/trace/src/seed/playlist/types/playlist.py
+++ b/seed/python-sdk/trace/src/seed/playlist/types/playlist.py
@@ -13,7 +13,7 @@ from .playlist_id import PlaylistId
 
 class Playlist(PlaylistCreateRequest):
     playlist_id: PlaylistId
-    owner_id: typing_extensions.Annotated[UserId, FieldMetadata(alias="owner-id")]
+    owner_id: typing_extensions.Annotated[UserId, FieldMetadata(alias="owner-id")] = pydantic.Field(alias="owner-id")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/problem/types/create_problem_error.py
+++ b/seed/python-sdk/trace/src/seed/problem/types/create_problem_error.py
@@ -11,7 +11,9 @@ from ...core.serialization import FieldMetadata
 
 
 class CreateProblemError_Generic(UniversalBaseModel):
-    error_type: typing_extensions.Annotated[typing.Literal["generic"], FieldMetadata(alias="_type")] = "generic"
+    error_type: typing_extensions.Annotated[typing.Literal["generic"], FieldMetadata(alias="_type")] = pydantic.Field(
+        alias="_type", default="generic"
+    )
     message: str
     type: str
     stacktrace: str

--- a/seed/python-sdk/trace/src/seed/problem/types/create_problem_request.py
+++ b/seed/python-sdk/trace/src/seed/problem/types/create_problem_request.py
@@ -16,13 +16,23 @@ from .variable_type_and_name import VariableTypeAndName
 
 
 class CreateProblemRequest(UniversalBaseModel):
-    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")]
-    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")]
+    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")] = pydantic.Field(
+        alias="problemName"
+    )
+    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")] = (
+        pydantic.Field(alias="problemDescription")
+    )
     files: typing.Dict[Language, ProblemFiles]
-    input_params: typing_extensions.Annotated[typing.List[VariableTypeAndName], FieldMetadata(alias="inputParams")]
-    output_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="outputType")]
+    input_params: typing_extensions.Annotated[typing.List[VariableTypeAndName], FieldMetadata(alias="inputParams")] = (
+        pydantic.Field(alias="inputParams")
+    )
+    output_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="outputType")] = pydantic.Field(
+        alias="outputType"
+    )
     testcases: typing.List[TestCaseWithExpectedResult]
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/problem/types/problem_files.py
+++ b/seed/python-sdk/trace/src/seed/problem/types/problem_files.py
@@ -10,8 +10,12 @@ from ...core.serialization import FieldMetadata
 
 
 class ProblemFiles(UniversalBaseModel):
-    solution_file: typing_extensions.Annotated[FileInfo, FieldMetadata(alias="solutionFile")]
-    read_only_files: typing_extensions.Annotated[typing.List[FileInfo], FieldMetadata(alias="readOnlyFiles")]
+    solution_file: typing_extensions.Annotated[FileInfo, FieldMetadata(alias="solutionFile")] = pydantic.Field(
+        alias="solutionFile"
+    )
+    read_only_files: typing_extensions.Annotated[typing.List[FileInfo], FieldMetadata(alias="readOnlyFiles")] = (
+        pydantic.Field(alias="readOnlyFiles")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/problem/types/problem_info.py
+++ b/seed/python-sdk/trace/src/seed/problem/types/problem_info.py
@@ -17,16 +17,32 @@ from .variable_type_and_name import VariableTypeAndName
 
 
 class ProblemInfo(UniversalBaseModel):
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")]
-    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")]
-    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")] = (
+        pydantic.Field(alias="problemDescription")
+    )
+    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")] = pydantic.Field(
+        alias="problemName"
+    )
+    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")] = pydantic.Field(
+        alias="problemVersion"
+    )
     files: typing.Dict[Language, ProblemFiles]
-    input_params: typing_extensions.Annotated[typing.List[VariableTypeAndName], FieldMetadata(alias="inputParams")]
-    output_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="outputType")]
+    input_params: typing_extensions.Annotated[typing.List[VariableTypeAndName], FieldMetadata(alias="inputParams")] = (
+        pydantic.Field(alias="inputParams")
+    )
+    output_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="outputType")] = pydantic.Field(
+        alias="outputType"
+    )
     testcases: typing.List[TestCaseWithExpectedResult]
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
-    supports_custom_test_cases: typing_extensions.Annotated[bool, FieldMetadata(alias="supportsCustomTestCases")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
+    supports_custom_test_cases: typing_extensions.Annotated[bool, FieldMetadata(alias="supportsCustomTestCases")] = (
+        pydantic.Field(alias="supportsCustomTestCases")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/problem/types/update_problem_response.py
+++ b/seed/python-sdk/trace/src/seed/problem/types/update_problem_response.py
@@ -9,7 +9,9 @@ from ...core.serialization import FieldMetadata
 
 
 class UpdateProblemResponse(UniversalBaseModel):
-    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")]
+    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")] = pydantic.Field(
+        alias="problemVersion"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/problem/types/variable_type_and_name.py
+++ b/seed/python-sdk/trace/src/seed/problem/types/variable_type_and_name.py
@@ -11,7 +11,9 @@ from ...core.serialization import FieldMetadata
 
 
 class VariableTypeAndName(UniversalBaseModel):
-    variable_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="variableType")]
+    variable_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="variableType")] = pydantic.Field(
+        alias="variableType"
+    )
     name: str
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/actual_result.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/actual_result.py
@@ -27,9 +27,15 @@ class ActualResult_Value(UniversalBaseModel):
 
 class ActualResult_Exception(UniversalBaseModel):
     type: typing.Literal["exception"] = "exception"
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/building_executor_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/building_executor_response.py
@@ -11,7 +11,9 @@ from .submission_id import SubmissionId
 
 
 class BuildingExecutorResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     status: ExecutionSessionStatus
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/code_execution_update.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/code_execution_update.py
@@ -24,7 +24,9 @@ from .workspace_run_details import WorkspaceRunDetails
 
 class CodeExecutionUpdate_BuildingExecutor(UniversalBaseModel):
     type: typing.Literal["buildingExecutor"] = "buildingExecutor"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     status: ExecutionSessionStatus
 
     if IS_PYDANTIC_V2:
@@ -39,7 +41,9 @@ class CodeExecutionUpdate_BuildingExecutor(UniversalBaseModel):
 
 class CodeExecutionUpdate_Running(UniversalBaseModel):
     type: typing.Literal["running"] = "running"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     state: RunningSubmissionState
 
     if IS_PYDANTIC_V2:
@@ -54,8 +58,12 @@ class CodeExecutionUpdate_Running(UniversalBaseModel):
 
 class CodeExecutionUpdate_Errored(UniversalBaseModel):
     type: typing.Literal["errored"] = "errored"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    error_info: typing_extensions.Annotated[ErrorInfo, FieldMetadata(alias="errorInfo")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    error_info: typing_extensions.Annotated[ErrorInfo, FieldMetadata(alias="errorInfo")] = pydantic.Field(
+        alias="errorInfo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -69,7 +77,9 @@ class CodeExecutionUpdate_Errored(UniversalBaseModel):
 
 class CodeExecutionUpdate_Stopped(UniversalBaseModel):
     type: typing.Literal["stopped"] = "stopped"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -83,10 +93,12 @@ class CodeExecutionUpdate_Stopped(UniversalBaseModel):
 
 class CodeExecutionUpdate_Graded(UniversalBaseModel):
     type: typing.Literal["graded"] = "graded"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     test_cases: typing_extensions.Annotated[
         typing.Dict[str, TestCaseResultWithStdout], FieldMetadata(alias="testCases")
-    ]
+    ] = pydantic.Field(alias="testCases")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -100,8 +112,12 @@ class CodeExecutionUpdate_Graded(UniversalBaseModel):
 
 class CodeExecutionUpdate_GradedV2(UniversalBaseModel):
     type: typing.Literal["gradedV2"] = "gradedV2"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    test_cases: typing_extensions.Annotated[typing.Dict[TestCaseId, TestCaseGrade], FieldMetadata(alias="testCases")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    test_cases: typing_extensions.Annotated[
+        typing.Dict[TestCaseId, TestCaseGrade], FieldMetadata(alias="testCases")
+    ] = pydantic.Field(alias="testCases")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -115,8 +131,12 @@ class CodeExecutionUpdate_GradedV2(UniversalBaseModel):
 
 class CodeExecutionUpdate_WorkspaceRan(UniversalBaseModel):
     type: typing.Literal["workspaceRan"] = "workspaceRan"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    run_details: typing_extensions.Annotated[WorkspaceRunDetails, FieldMetadata(alias="runDetails")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    run_details: typing_extensions.Annotated[WorkspaceRunDetails, FieldMetadata(alias="runDetails")] = pydantic.Field(
+        alias="runDetails"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -130,13 +150,21 @@ class CodeExecutionUpdate_WorkspaceRan(UniversalBaseModel):
 
 class CodeExecutionUpdate_Recording(UniversalBaseModel):
     type: typing.Literal["recording"] = "recording"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    test_case_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="testCaseId")] = None
-    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    test_case_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="testCaseId")] = pydantic.Field(
+        alias="testCaseId", default=None
+    )
+    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")] = pydantic.Field(
+        alias="lineNumber"
+    )
     lightweight_stack_info: typing_extensions.Annotated[
         LightweightStackframeInformation, FieldMetadata(alias="lightweightStackInfo")
-    ]
-    traced_file: typing_extensions.Annotated[typing.Optional[TracedFile], FieldMetadata(alias="tracedFile")] = None
+    ] = pydantic.Field(alias="lightweightStackInfo")
+    traced_file: typing_extensions.Annotated[typing.Optional[TracedFile], FieldMetadata(alias="tracedFile")] = (
+        pydantic.Field(alias="tracedFile", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -150,9 +178,15 @@ class CodeExecutionUpdate_Recording(UniversalBaseModel):
 
 class CodeExecutionUpdate_Recorded(UniversalBaseModel):
     type: typing.Literal["recorded"] = "recorded"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")]
-    test_case_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="testCaseId")] = None
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")] = pydantic.Field(
+        alias="traceResponsesSize"
+    )
+    test_case_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="testCaseId")] = pydantic.Field(
+        alias="testCaseId", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -181,7 +215,9 @@ class CodeExecutionUpdate_InvalidRequest(UniversalBaseModel):
 
 class CodeExecutionUpdate_Finished(UniversalBaseModel):
     type: typing.Literal["finished"] = "finished"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/custom_test_cases_unsupported.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/custom_test_cases_unsupported.py
@@ -11,8 +11,12 @@ from .submission_id import SubmissionId
 
 
 class CustomTestCasesUnsupported(UniversalBaseModel):
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/error_info.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/error_info.py
@@ -41,7 +41,9 @@ class ErrorInfo_RuntimeError(UniversalBaseModel):
 
 class ErrorInfo_InternalError(UniversalBaseModel):
     type: typing.Literal["internalError"] = "internalError"
-    exception_info: typing_extensions.Annotated[ExceptionInfo, FieldMetadata(alias="exceptionInfo")]
+    exception_info: typing_extensions.Annotated[ExceptionInfo, FieldMetadata(alias="exceptionInfo")] = pydantic.Field(
+        alias="exceptionInfo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/errored_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/errored_response.py
@@ -11,8 +11,12 @@ from .submission_id import SubmissionId
 
 
 class ErroredResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    error_info: typing_extensions.Annotated[ErrorInfo, FieldMetadata(alias="errorInfo")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    error_info: typing_extensions.Annotated[ErrorInfo, FieldMetadata(alias="errorInfo")] = pydantic.Field(
+        alias="errorInfo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/exception_info.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/exception_info.py
@@ -9,9 +9,15 @@ from ...core.serialization import FieldMetadata
 
 
 class ExceptionInfo(UniversalBaseModel):
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/exception_v_2.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/exception_v_2.py
@@ -12,9 +12,15 @@ from ...core.serialization import FieldMetadata
 
 class ExceptionV2_Generic(UniversalBaseModel):
     type: typing.Literal["generic"] = "generic"
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/execution_session_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/execution_session_response.py
@@ -11,10 +11,10 @@ from .execution_session_status import ExecutionSessionStatus
 
 
 class ExecutionSessionResponse(UniversalBaseModel):
-    session_id: typing_extensions.Annotated[str, FieldMetadata(alias="sessionId")]
+    session_id: typing_extensions.Annotated[str, FieldMetadata(alias="sessionId")] = pydantic.Field(alias="sessionId")
     execution_session_url: typing_extensions.Annotated[
         typing.Optional[str], FieldMetadata(alias="executionSessionUrl")
-    ] = None
+    ] = pydantic.Field(alias="executionSessionUrl", default=None)
     language: Language
     status: ExecutionSessionStatus
 

--- a/seed/python-sdk/trace/src/seed/submission/types/execution_session_state.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/execution_session_state.py
@@ -12,15 +12,19 @@ from .execution_session_status import ExecutionSessionStatus
 
 class ExecutionSessionState(UniversalBaseModel):
     last_time_contacted: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="lastTimeContacted")] = (
-        None
+        pydantic.Field(alias="lastTimeContacted", default=None)
     )
-    session_id: typing_extensions.Annotated[str, FieldMetadata(alias="sessionId")] = pydantic.Field()
+    session_id: typing_extensions.Annotated[str, FieldMetadata(alias="sessionId")] = pydantic.Field(alias="sessionId")
     """
     The auto-generated session id. Formatted as a uuid.
     """
 
-    is_warm_instance: typing_extensions.Annotated[bool, FieldMetadata(alias="isWarmInstance")]
-    aws_task_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="awsTaskId")] = None
+    is_warm_instance: typing_extensions.Annotated[bool, FieldMetadata(alias="isWarmInstance")] = pydantic.Field(
+        alias="isWarmInstance"
+    )
+    aws_task_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="awsTaskId")] = pydantic.Field(
+        alias="awsTaskId", default=None
+    )
     language: Language
     status: ExecutionSessionStatus
 

--- a/seed/python-sdk/trace/src/seed/submission/types/existing_submission_executing.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/existing_submission_executing.py
@@ -10,7 +10,9 @@ from .submission_id import SubmissionId
 
 
 class ExistingSubmissionExecuting(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/finished_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/finished_response.py
@@ -10,7 +10,9 @@ from .submission_id import SubmissionId
 
 
 class FinishedResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/get_execution_session_state_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/get_execution_session_state_response.py
@@ -13,8 +13,10 @@ class GetExecutionSessionStateResponse(UniversalBaseModel):
     states: typing.Dict[str, ExecutionSessionState]
     num_warming_instances: typing_extensions.Annotated[
         typing.Optional[int], FieldMetadata(alias="numWarmingInstances")
-    ] = None
-    warming_session_ids: typing_extensions.Annotated[typing.List[str], FieldMetadata(alias="warmingSessionIds")]
+    ] = pydantic.Field(alias="numWarmingInstances", default=None)
+    warming_session_ids: typing_extensions.Annotated[typing.List[str], FieldMetadata(alias="warmingSessionIds")] = (
+        pydantic.Field(alias="warmingSessionIds")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/get_submission_state_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/get_submission_state_response.py
@@ -15,11 +15,13 @@ from .submission_type_state import SubmissionTypeState
 
 class GetSubmissionStateResponse(UniversalBaseModel):
     time_submitted: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="timeSubmitted")] = (
-        None
+        pydantic.Field(alias="timeSubmitted", default=None)
     )
     submission: str
     language: Language
-    submission_type_state: typing_extensions.Annotated[SubmissionTypeState, FieldMetadata(alias="submissionTypeState")]
+    submission_type_state: typing_extensions.Annotated[
+        SubmissionTypeState, FieldMetadata(alias="submissionTypeState")
+    ] = pydantic.Field(alias="submissionTypeState")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/graded_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/graded_response.py
@@ -13,10 +13,12 @@ from .test_case_result_with_stdout import TestCaseResultWithStdout
 
 
 class GradedResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     test_cases: typing_extensions.Annotated[
         typing.Dict[str, TestCaseResultWithStdout], FieldMetadata(alias="testCases")
-    ]
+    ] = pydantic.Field(alias="testCases")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/graded_response_v_2.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/graded_response_v_2.py
@@ -14,8 +14,12 @@ from .test_case_grade import TestCaseGrade
 
 
 class GradedResponseV2(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    test_cases: typing_extensions.Annotated[typing.Dict[TestCaseId, TestCaseGrade], FieldMetadata(alias="testCases")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    test_cases: typing_extensions.Annotated[
+        typing.Dict[TestCaseId, TestCaseGrade], FieldMetadata(alias="testCases")
+    ] = pydantic.Field(alias="testCases")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/graded_test_case_update.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/graded_test_case_update.py
@@ -13,7 +13,9 @@ from .test_case_grade import TestCaseGrade
 
 
 class GradedTestCaseUpdate(UniversalBaseModel):
-    test_case_id: typing_extensions.Annotated[TestCaseId, FieldMetadata(alias="testCaseId")]
+    test_case_id: typing_extensions.Annotated[TestCaseId, FieldMetadata(alias="testCaseId")] = pydantic.Field(
+        alias="testCaseId"
+    )
     grade: TestCaseGrade
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/initialize_problem_request.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/initialize_problem_request.py
@@ -10,8 +10,12 @@ from ...core.serialization import FieldMetadata
 
 
 class InitializeProblemRequest(UniversalBaseModel):
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_version: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="problemVersion")] = None
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_version: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="problemVersion")] = (
+        pydantic.Field(alias="problemVersion", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/internal_error.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/internal_error.py
@@ -10,7 +10,9 @@ from .exception_info import ExceptionInfo
 
 
 class InternalError(UniversalBaseModel):
-    exception_info: typing_extensions.Annotated[ExceptionInfo, FieldMetadata(alias="exceptionInfo")]
+    exception_info: typing_extensions.Annotated[ExceptionInfo, FieldMetadata(alias="exceptionInfo")] = pydantic.Field(
+        alias="exceptionInfo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/invalid_request_cause.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/invalid_request_cause.py
@@ -15,7 +15,9 @@ from .submission_id import SubmissionId
 
 class InvalidRequestCause_SubmissionIdNotFound(UniversalBaseModel):
     type: typing.Literal["submissionIdNotFound"] = "submissionIdNotFound"
-    missing_submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="missingSubmissionId")]
+    missing_submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="missingSubmissionId")] = (
+        pydantic.Field(alias="missingSubmissionId")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -29,8 +31,12 @@ class InvalidRequestCause_SubmissionIdNotFound(UniversalBaseModel):
 
 class InvalidRequestCause_CustomTestCasesUnsupported(UniversalBaseModel):
     type: typing.Literal["customTestCasesUnsupported"] = "customTestCasesUnsupported"
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -44,8 +50,12 @@ class InvalidRequestCause_CustomTestCasesUnsupported(UniversalBaseModel):
 
 class InvalidRequestCause_UnexpectedLanguage(UniversalBaseModel):
     type: typing.Literal["unexpectedLanguage"] = "unexpectedLanguage"
-    expected_language: typing_extensions.Annotated[Language, FieldMetadata(alias="expectedLanguage")]
-    actual_language: typing_extensions.Annotated[Language, FieldMetadata(alias="actualLanguage")]
+    expected_language: typing_extensions.Annotated[Language, FieldMetadata(alias="expectedLanguage")] = pydantic.Field(
+        alias="expectedLanguage"
+    )
+    actual_language: typing_extensions.Annotated[Language, FieldMetadata(alias="actualLanguage")] = pydantic.Field(
+        alias="actualLanguage"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/lightweight_stackframe_information.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/lightweight_stackframe_information.py
@@ -9,8 +9,12 @@ from ...core.serialization import FieldMetadata
 
 
 class LightweightStackframeInformation(UniversalBaseModel):
-    num_stack_frames: typing_extensions.Annotated[int, FieldMetadata(alias="numStackFrames")]
-    top_stack_frame_method_name: typing_extensions.Annotated[str, FieldMetadata(alias="topStackFrameMethodName")]
+    num_stack_frames: typing_extensions.Annotated[int, FieldMetadata(alias="numStackFrames")] = pydantic.Field(
+        alias="numStackFrames"
+    )
+    top_stack_frame_method_name: typing_extensions.Annotated[str, FieldMetadata(alias="topStackFrameMethodName")] = (
+        pydantic.Field(alias="topStackFrameMethodName")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/recorded_response_notification.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/recorded_response_notification.py
@@ -10,9 +10,15 @@ from .submission_id import SubmissionId
 
 
 class RecordedResponseNotification(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")]
-    test_case_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="testCaseId")] = None
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")] = pydantic.Field(
+        alias="traceResponsesSize"
+    )
+    test_case_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="testCaseId")] = pydantic.Field(
+        alias="testCaseId", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/recorded_test_case_update.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/recorded_test_case_update.py
@@ -10,8 +10,12 @@ from ...v_2.problem.types.test_case_id import TestCaseId
 
 
 class RecordedTestCaseUpdate(UniversalBaseModel):
-    test_case_id: typing_extensions.Annotated[TestCaseId, FieldMetadata(alias="testCaseId")]
-    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")]
+    test_case_id: typing_extensions.Annotated[TestCaseId, FieldMetadata(alias="testCaseId")] = pydantic.Field(
+        alias="testCaseId"
+    )
+    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")] = pydantic.Field(
+        alias="traceResponsesSize"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/recording_response_notification.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/recording_response_notification.py
@@ -12,13 +12,21 @@ from .traced_file import TracedFile
 
 
 class RecordingResponseNotification(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    test_case_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="testCaseId")] = None
-    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    test_case_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="testCaseId")] = pydantic.Field(
+        alias="testCaseId", default=None
+    )
+    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")] = pydantic.Field(
+        alias="lineNumber"
+    )
     lightweight_stack_info: typing_extensions.Annotated[
         LightweightStackframeInformation, FieldMetadata(alias="lightweightStackInfo")
-    ]
-    traced_file: typing_extensions.Annotated[typing.Optional[TracedFile], FieldMetadata(alias="tracedFile")] = None
+    ] = pydantic.Field(alias="lightweightStackInfo")
+    traced_file: typing_extensions.Annotated[typing.Optional[TracedFile], FieldMetadata(alias="tracedFile")] = (
+        pydantic.Field(alias="tracedFile", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/running_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/running_response.py
@@ -11,7 +11,9 @@ from .submission_id import SubmissionId
 
 
 class RunningResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     state: RunningSubmissionState
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/stack_frame.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/stack_frame.py
@@ -12,8 +12,12 @@ from .scope import Scope
 
 
 class StackFrame(UniversalBaseModel):
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
-    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
+    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")] = pydantic.Field(
+        alias="lineNumber"
+    )
     scopes: typing.List[Scope]
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/stack_information.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/stack_information.py
@@ -12,9 +12,11 @@ from .stack_frame import StackFrame
 
 
 class StackInformation(UniversalBaseModel):
-    num_stack_frames: typing_extensions.Annotated[int, FieldMetadata(alias="numStackFrames")]
+    num_stack_frames: typing_extensions.Annotated[int, FieldMetadata(alias="numStackFrames")] = pydantic.Field(
+        alias="numStackFrames"
+    )
     top_stack_frame: typing_extensions.Annotated[typing.Optional[StackFrame], FieldMetadata(alias="topStackFrame")] = (
-        None
+        pydantic.Field(alias="topStackFrame", default=None)
     )
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/stderr_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/stderr_response.py
@@ -10,7 +10,9 @@ from .submission_id import SubmissionId
 
 
 class StderrResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     stderr: str
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/stdout_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/stdout_response.py
@@ -10,7 +10,9 @@ from .submission_id import SubmissionId
 
 
 class StdoutResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     stdout: str
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/stop_request.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/stop_request.py
@@ -10,7 +10,9 @@ from .submission_id import SubmissionId
 
 
 class StopRequest(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/stopped_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/stopped_response.py
@@ -10,7 +10,9 @@ from .submission_id import SubmissionId
 
 
 class StoppedResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/submission_id_not_found.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/submission_id_not_found.py
@@ -10,7 +10,9 @@ from .submission_id import SubmissionId
 
 
 class SubmissionIdNotFound(UniversalBaseModel):
-    missing_submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="missingSubmissionId")]
+    missing_submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="missingSubmissionId")] = (
+        pydantic.Field(alias="missingSubmissionId")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/submission_request.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/submission_request.py
@@ -16,8 +16,12 @@ from .submission_id import SubmissionId
 
 class SubmissionRequest_InitializeProblemRequest(UniversalBaseModel):
     type: typing.Literal["initializeProblemRequest"] = "initializeProblemRequest"
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_version: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="problemVersion")] = None
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_version: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="problemVersion")] = (
+        pydantic.Field(alias="problemVersion", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -44,14 +48,22 @@ class SubmissionRequest_InitializeWorkspaceRequest(UniversalBaseModel):
 
 class SubmissionRequest_SubmitV2(UniversalBaseModel):
     type: typing.Literal["submitV2"] = "submitV2"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     language: Language
     submission_files: typing_extensions.Annotated[
         typing.List[SubmissionFileInfo], FieldMetadata(alias="submissionFiles")
-    ]
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_version: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="problemVersion")] = None
-    user_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="userId")] = None
+    ] = pydantic.Field(alias="submissionFiles")
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_version: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="problemVersion")] = (
+        pydantic.Field(alias="problemVersion", default=None)
+    )
+    user_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="userId")] = pydantic.Field(
+        alias="userId", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -65,12 +77,16 @@ class SubmissionRequest_SubmitV2(UniversalBaseModel):
 
 class SubmissionRequest_WorkspaceSubmit(UniversalBaseModel):
     type: typing.Literal["workspaceSubmit"] = "workspaceSubmit"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     language: Language
     submission_files: typing_extensions.Annotated[
         typing.List[SubmissionFileInfo], FieldMetadata(alias="submissionFiles")
-    ]
-    user_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="userId")] = None
+    ] = pydantic.Field(alias="submissionFiles")
+    user_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="userId")] = pydantic.Field(
+        alias="userId", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -84,7 +100,9 @@ class SubmissionRequest_WorkspaceSubmit(UniversalBaseModel):
 
 class SubmissionRequest_Stop(UniversalBaseModel):
     type: typing.Literal["stop"] = "stop"
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/submission_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/submission_response.py
@@ -53,9 +53,15 @@ class SubmissionResponse_WorkspaceInitialized(UniversalBaseModel):
 
 class SubmissionResponse_ServerErrored(UniversalBaseModel):
     type: typing.Literal["serverErrored"] = "serverErrored"
-    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")]
-    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")]
-    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")]
+    exception_type: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionType")] = pydantic.Field(
+        alias="exceptionType"
+    )
+    exception_message: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionMessage")] = pydantic.Field(
+        alias="exceptionMessage"
+    )
+    exception_stacktrace: typing_extensions.Annotated[str, FieldMetadata(alias="exceptionStacktrace")] = pydantic.Field(
+        alias="exceptionStacktrace"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/submission_status_for_test_case.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/submission_status_for_test_case.py
@@ -44,7 +44,9 @@ class SubmissionStatusForTestCase_GradedV2(UniversalBaseModel):
 class SubmissionStatusForTestCase_Traced(UniversalBaseModel):
     type: typing.Literal["traced"] = "traced"
     result: TestCaseResultWithStdout
-    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")]
+    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")] = pydantic.Field(
+        alias="traceResponsesSize"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/submission_status_v_2.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/submission_status_v_2.py
@@ -17,9 +17,15 @@ from .workspace_submission_update import WorkspaceSubmissionUpdate
 class SubmissionStatusV2_Test(UniversalBaseModel):
     type: typing.Literal["test"] = "test"
     updates: typing.List[TestSubmissionUpdate]
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")]
-    problem_info: typing_extensions.Annotated[ProblemInfoV2, FieldMetadata(alias="problemInfo")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")] = pydantic.Field(
+        alias="problemVersion"
+    )
+    problem_info: typing_extensions.Annotated[ProblemInfoV2, FieldMetadata(alias="problemInfo")] = pydantic.Field(
+        alias="problemInfo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/submission_type_state.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/submission_type_state.py
@@ -16,9 +16,15 @@ from .workspace_submission_status import WorkspaceSubmissionStatus
 
 class SubmissionTypeState_Test(UniversalBaseModel):
     type: typing.Literal["test"] = "test"
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    default_test_cases: typing_extensions.Annotated[typing.List[TestCase], FieldMetadata(alias="defaultTestCases")]
-    custom_test_cases: typing_extensions.Annotated[typing.List[TestCase], FieldMetadata(alias="customTestCases")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    default_test_cases: typing_extensions.Annotated[typing.List[TestCase], FieldMetadata(alias="defaultTestCases")] = (
+        pydantic.Field(alias="defaultTestCases")
+    )
+    custom_test_cases: typing_extensions.Annotated[typing.List[TestCase], FieldMetadata(alias="customTestCases")] = (
+        pydantic.Field(alias="customTestCases")
+    )
     status: TestSubmissionStatus
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/submit_request_v_2.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/submit_request_v_2.py
@@ -13,14 +13,22 @@ from .submission_id import SubmissionId
 
 
 class SubmitRequestV2(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     language: Language
     submission_files: typing_extensions.Annotated[
         typing.List[SubmissionFileInfo], FieldMetadata(alias="submissionFiles")
-    ]
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_version: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="problemVersion")] = None
-    user_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="userId")] = None
+    ] = pydantic.Field(alias="submissionFiles")
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_version: typing_extensions.Annotated[typing.Optional[int], FieldMetadata(alias="problemVersion")] = (
+        pydantic.Field(alias="problemVersion", default=None)
+    )
+    user_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="userId")] = pydantic.Field(
+        alias="userId", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/test_case_grade.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/test_case_grade.py
@@ -30,7 +30,7 @@ class TestCaseGrade_NonHidden(UniversalBaseModel):
     passed: bool
     actual_result: typing_extensions.Annotated[
         typing.Optional["VariableValue"], FieldMetadata(alias="actualResult")
-    ] = None
+    ] = pydantic.Field(alias="actualResult", default=None)
     exception: typing.Optional[ExceptionV2] = None
     stdout: str
 

--- a/seed/python-sdk/trace/src/seed/submission/types/test_case_non_hidden_grade.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/test_case_non_hidden_grade.py
@@ -15,7 +15,7 @@ class TestCaseNonHiddenGrade(UniversalBaseModel):
     passed: bool
     actual_result: typing_extensions.Annotated[
         typing.Optional["VariableValue"], FieldMetadata(alias="actualResult")
-    ] = None
+    ] = pydantic.Field(alias="actualResult", default=None)
     exception: typing.Optional[ExceptionV2] = None
     stdout: str
 

--- a/seed/python-sdk/trace/src/seed/submission/types/test_case_result.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/test_case_result.py
@@ -12,8 +12,12 @@ from .actual_result import ActualResult
 
 
 class TestCaseResult(UniversalBaseModel):
-    expected_result: typing_extensions.Annotated["VariableValue", FieldMetadata(alias="expectedResult")]
-    actual_result: typing_extensions.Annotated[ActualResult, FieldMetadata(alias="actualResult")]
+    expected_result: typing_extensions.Annotated["VariableValue", FieldMetadata(alias="expectedResult")] = (
+        pydantic.Field(alias="expectedResult")
+    )
+    actual_result: typing_extensions.Annotated[ActualResult, FieldMetadata(alias="actualResult")] = pydantic.Field(
+        alias="actualResult"
+    )
     passed: bool
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/test_submission_state.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/test_submission_state.py
@@ -14,9 +14,15 @@ from .test_submission_status import TestSubmissionStatus
 
 
 class TestSubmissionState(UniversalBaseModel):
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    default_test_cases: typing_extensions.Annotated[typing.List[TestCase], FieldMetadata(alias="defaultTestCases")]
-    custom_test_cases: typing_extensions.Annotated[typing.List[TestCase], FieldMetadata(alias="customTestCases")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    default_test_cases: typing_extensions.Annotated[typing.List[TestCase], FieldMetadata(alias="defaultTestCases")] = (
+        pydantic.Field(alias="defaultTestCases")
+    )
+    custom_test_cases: typing_extensions.Annotated[typing.List[TestCase], FieldMetadata(alias="customTestCases")] = (
+        pydantic.Field(alias="customTestCases")
+    )
     status: TestSubmissionStatus
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/submission/types/test_submission_status_v_2.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/test_submission_status_v_2.py
@@ -15,9 +15,15 @@ from .test_submission_update import TestSubmissionUpdate
 
 class TestSubmissionStatusV2(UniversalBaseModel):
     updates: typing.List[TestSubmissionUpdate]
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")]
-    problem_info: typing_extensions.Annotated[ProblemInfoV2, FieldMetadata(alias="problemInfo")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")] = pydantic.Field(
+        alias="problemVersion"
+    )
+    problem_info: typing_extensions.Annotated[ProblemInfoV2, FieldMetadata(alias="problemInfo")] = pydantic.Field(
+        alias="problemInfo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/test_submission_update.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/test_submission_update.py
@@ -13,8 +13,12 @@ from .test_submission_update_info import TestSubmissionUpdateInfo
 
 
 class TestSubmissionUpdate(UniversalBaseModel):
-    update_time: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="updateTime")]
-    update_info: typing_extensions.Annotated[TestSubmissionUpdateInfo, FieldMetadata(alias="updateInfo")]
+    update_time: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="updateTime")] = pydantic.Field(
+        alias="updateTime"
+    )
+    update_info: typing_extensions.Annotated[TestSubmissionUpdateInfo, FieldMetadata(alias="updateInfo")] = (
+        pydantic.Field(alias="updateInfo")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/test_submission_update_info.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/test_submission_update_info.py
@@ -55,7 +55,9 @@ class TestSubmissionUpdateInfo_Errored(UniversalBaseModel):
 
 class TestSubmissionUpdateInfo_GradedTestCase(UniversalBaseModel):
     type: typing.Literal["gradedTestCase"] = "gradedTestCase"
-    test_case_id: typing_extensions.Annotated[TestCaseId, FieldMetadata(alias="testCaseId")]
+    test_case_id: typing_extensions.Annotated[TestCaseId, FieldMetadata(alias="testCaseId")] = pydantic.Field(
+        alias="testCaseId"
+    )
     grade: TestCaseGrade
 
     if IS_PYDANTIC_V2:
@@ -70,8 +72,12 @@ class TestSubmissionUpdateInfo_GradedTestCase(UniversalBaseModel):
 
 class TestSubmissionUpdateInfo_RecordedTestCase(UniversalBaseModel):
     type: typing.Literal["recordedTestCase"] = "recordedTestCase"
-    test_case_id: typing_extensions.Annotated[TestCaseId, FieldMetadata(alias="testCaseId")]
-    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")]
+    test_case_id: typing_extensions.Annotated[TestCaseId, FieldMetadata(alias="testCaseId")] = pydantic.Field(
+        alias="testCaseId"
+    )
+    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")] = pydantic.Field(
+        alias="traceResponsesSize"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/trace_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/trace_response.py
@@ -14,14 +14,18 @@ from .submission_id import SubmissionId
 
 
 class TraceResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")] = pydantic.Field(
+        alias="lineNumber"
+    )
     return_value: typing_extensions.Annotated[
         typing.Optional["DebugVariableValue"], FieldMetadata(alias="returnValue")
-    ] = None
+    ] = pydantic.Field(alias="returnValue", default=None)
     expression_location: typing_extensions.Annotated[
         typing.Optional[ExpressionLocation], FieldMetadata(alias="expressionLocation")
-    ] = None
+    ] = pydantic.Field(alias="expressionLocation", default=None)
     stack: StackInformation
     stdout: typing.Optional[str] = None
 

--- a/seed/python-sdk/trace/src/seed/submission/types/trace_response_v_2.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/trace_response_v_2.py
@@ -15,15 +15,19 @@ from .traced_file import TracedFile
 
 
 class TraceResponseV2(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    line_number: typing_extensions.Annotated[int, FieldMetadata(alias="lineNumber")] = pydantic.Field(
+        alias="lineNumber"
+    )
     file: TracedFile
     return_value: typing_extensions.Annotated[
         typing.Optional["DebugVariableValue"], FieldMetadata(alias="returnValue")
-    ] = None
+    ] = pydantic.Field(alias="returnValue", default=None)
     expression_location: typing_extensions.Annotated[
         typing.Optional[ExpressionLocation], FieldMetadata(alias="expressionLocation")
-    ] = None
+    ] = pydantic.Field(alias="expressionLocation", default=None)
     stack: StackInformation
     stdout: typing.Optional[str] = None
 

--- a/seed/python-sdk/trace/src/seed/submission/types/trace_responses_page.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/trace_responses_page.py
@@ -18,7 +18,9 @@ class TraceResponsesPage(UniversalBaseModel):
     The offset is the id of the next trace response to load.
     """
 
-    trace_responses: typing_extensions.Annotated[typing.List[TraceResponse], FieldMetadata(alias="traceResponses")]
+    trace_responses: typing_extensions.Annotated[typing.List[TraceResponse], FieldMetadata(alias="traceResponses")] = (
+        pydantic.Field(alias="traceResponses")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/trace_responses_page_v_2.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/trace_responses_page_v_2.py
@@ -18,7 +18,9 @@ class TraceResponsesPageV2(UniversalBaseModel):
     The offset is the id of the next trace response to load.
     """
 
-    trace_responses: typing_extensions.Annotated[typing.List[TraceResponseV2], FieldMetadata(alias="traceResponses")]
+    trace_responses: typing_extensions.Annotated[
+        typing.List[TraceResponseV2], FieldMetadata(alias="traceResponses")
+    ] = pydantic.Field(alias="traceResponses")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/traced_test_case.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/traced_test_case.py
@@ -13,7 +13,9 @@ from .test_case_result_with_stdout import TestCaseResultWithStdout
 
 class TracedTestCase(UniversalBaseModel):
     result: TestCaseResultWithStdout
-    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")]
+    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")] = pydantic.Field(
+        alias="traceResponsesSize"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/unexpected_language_error.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/unexpected_language_error.py
@@ -10,8 +10,12 @@ from ...core.serialization import FieldMetadata
 
 
 class UnexpectedLanguageError(UniversalBaseModel):
-    expected_language: typing_extensions.Annotated[Language, FieldMetadata(alias="expectedLanguage")]
-    actual_language: typing_extensions.Annotated[Language, FieldMetadata(alias="actualLanguage")]
+    expected_language: typing_extensions.Annotated[Language, FieldMetadata(alias="expectedLanguage")] = pydantic.Field(
+        alias="expectedLanguage"
+    )
+    actual_language: typing_extensions.Annotated[Language, FieldMetadata(alias="actualLanguage")] = pydantic.Field(
+        alias="actualLanguage"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_files.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_files.py
@@ -10,8 +10,10 @@ from ...core.serialization import FieldMetadata
 
 
 class WorkspaceFiles(UniversalBaseModel):
-    main_file: typing_extensions.Annotated[FileInfo, FieldMetadata(alias="mainFile")]
-    read_only_files: typing_extensions.Annotated[typing.List[FileInfo], FieldMetadata(alias="readOnlyFiles")]
+    main_file: typing_extensions.Annotated[FileInfo, FieldMetadata(alias="mainFile")] = pydantic.Field(alias="mainFile")
+    read_only_files: typing_extensions.Annotated[typing.List[FileInfo], FieldMetadata(alias="readOnlyFiles")] = (
+        pydantic.Field(alias="readOnlyFiles")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_ran_response.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_ran_response.py
@@ -11,8 +11,12 @@ from .workspace_run_details import WorkspaceRunDetails
 
 
 class WorkspaceRanResponse(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
-    run_details: typing_extensions.Annotated[WorkspaceRunDetails, FieldMetadata(alias="runDetails")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
+    run_details: typing_extensions.Annotated[WorkspaceRunDetails, FieldMetadata(alias="runDetails")] = pydantic.Field(
+        alias="runDetails"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_run_details.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_run_details.py
@@ -11,7 +11,9 @@ from .exception_v_2 import ExceptionV2
 
 
 class WorkspaceRunDetails(UniversalBaseModel):
-    exception_v_2: typing_extensions.Annotated[typing.Optional[ExceptionV2], FieldMetadata(alias="exceptionV2")] = None
+    exception_v_2: typing_extensions.Annotated[typing.Optional[ExceptionV2], FieldMetadata(alias="exceptionV2")] = (
+        pydantic.Field(alias="exceptionV2", default=None)
+    )
     exception: typing.Optional[ExceptionInfo] = None
     stdout: str
 

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_starter_files_response_v_2.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_starter_files_response_v_2.py
@@ -11,7 +11,9 @@ from ...v_2.problem.types.files import Files
 
 
 class WorkspaceStarterFilesResponseV2(UniversalBaseModel):
-    files_by_language: typing_extensions.Annotated[typing.Dict[Language, Files], FieldMetadata(alias="filesByLanguage")]
+    files_by_language: typing_extensions.Annotated[
+        typing.Dict[Language, Files], FieldMetadata(alias="filesByLanguage")
+    ] = pydantic.Field(alias="filesByLanguage")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_submission_status.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_submission_status.py
@@ -55,7 +55,9 @@ class WorkspaceSubmissionStatus_Running(UniversalBaseModel):
 
 class WorkspaceSubmissionStatus_Ran(UniversalBaseModel):
     type: typing.Literal["ran"] = "ran"
-    exception_v_2: typing_extensions.Annotated[typing.Optional[ExceptionV2], FieldMetadata(alias="exceptionV2")] = None
+    exception_v_2: typing_extensions.Annotated[typing.Optional[ExceptionV2], FieldMetadata(alias="exceptionV2")] = (
+        pydantic.Field(alias="exceptionV2", default=None)
+    )
     exception: typing.Optional[ExceptionInfo] = None
     stdout: str
 
@@ -71,7 +73,9 @@ class WorkspaceSubmissionStatus_Ran(UniversalBaseModel):
 
 class WorkspaceSubmissionStatus_Traced(UniversalBaseModel):
     type: typing.Literal["traced"] = "traced"
-    exception_v_2: typing_extensions.Annotated[typing.Optional[ExceptionV2], FieldMetadata(alias="exceptionV2")] = None
+    exception_v_2: typing_extensions.Annotated[typing.Optional[ExceptionV2], FieldMetadata(alias="exceptionV2")] = (
+        pydantic.Field(alias="exceptionV2", default=None)
+    )
     exception: typing.Optional[ExceptionInfo] = None
     stdout: str
 

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_submission_update.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_submission_update.py
@@ -11,8 +11,12 @@ from .workspace_submission_update_info import WorkspaceSubmissionUpdateInfo
 
 
 class WorkspaceSubmissionUpdate(UniversalBaseModel):
-    update_time: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="updateTime")]
-    update_info: typing_extensions.Annotated[WorkspaceSubmissionUpdateInfo, FieldMetadata(alias="updateInfo")]
+    update_time: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="updateTime")] = pydantic.Field(
+        alias="updateTime"
+    )
+    update_info: typing_extensions.Annotated[WorkspaceSubmissionUpdateInfo, FieldMetadata(alias="updateInfo")] = (
+        pydantic.Field(alias="updateInfo")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_submission_update_info.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_submission_update_info.py
@@ -29,7 +29,9 @@ class WorkspaceSubmissionUpdateInfo_Running(UniversalBaseModel):
 
 class WorkspaceSubmissionUpdateInfo_Ran(UniversalBaseModel):
     type: typing.Literal["ran"] = "ran"
-    exception_v_2: typing_extensions.Annotated[typing.Optional[ExceptionV2], FieldMetadata(alias="exceptionV2")] = None
+    exception_v_2: typing_extensions.Annotated[typing.Optional[ExceptionV2], FieldMetadata(alias="exceptionV2")] = (
+        pydantic.Field(alias="exceptionV2", default=None)
+    )
     exception: typing.Optional[ExceptionInfo] = None
     stdout: str
 
@@ -71,7 +73,9 @@ class WorkspaceSubmissionUpdateInfo_Traced(UniversalBaseModel):
 
 class WorkspaceSubmissionUpdateInfo_TracedV2(UniversalBaseModel):
     type: typing.Literal["tracedV2"] = "tracedV2"
-    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")]
+    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")] = pydantic.Field(
+        alias="traceResponsesSize"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_submit_request.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_submit_request.py
@@ -12,12 +12,16 @@ from .submission_id import SubmissionId
 
 
 class WorkspaceSubmitRequest(UniversalBaseModel):
-    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")]
+    submission_id: typing_extensions.Annotated[SubmissionId, FieldMetadata(alias="submissionId")] = pydantic.Field(
+        alias="submissionId"
+    )
     language: Language
     submission_files: typing_extensions.Annotated[
         typing.List[SubmissionFileInfo], FieldMetadata(alias="submissionFiles")
-    ]
-    user_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="userId")] = None
+    ] = pydantic.Field(alias="submissionFiles")
+    user_id: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="userId")] = pydantic.Field(
+        alias="userId", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/submission/types/workspace_traced_update.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/workspace_traced_update.py
@@ -9,7 +9,9 @@ from ...core.serialization import FieldMetadata
 
 
 class WorkspaceTracedUpdate(UniversalBaseModel):
-    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")]
+    trace_responses_size: typing_extensions.Annotated[int, FieldMetadata(alias="traceResponsesSize")] = pydantic.Field(
+        alias="traceResponsesSize"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/assert_correctness_check.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/assert_correctness_check.py
@@ -17,7 +17,7 @@ class AssertCorrectnessCheck_DeepEquality(UniversalBaseModel):
     type: typing.Literal["deepEquality"] = "deepEquality"
     expected_value_parameter_id: typing_extensions.Annotated[
         ParameterId, FieldMetadata(alias="expectedValueParameterId")
-    ]
+    ] = pydantic.Field(alias="expectedValueParameterId")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -33,7 +33,7 @@ class AssertCorrectnessCheck_Custom(UniversalBaseModel):
     type: typing.Literal["custom"] = "custom"
     additional_parameters: typing_extensions.Annotated[
         typing.List[Parameter], FieldMetadata(alias="additionalParameters")
-    ]
+    ] = pydantic.Field(alias="additionalParameters")
     code: FunctionImplementationForMultipleLanguages
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/basic_custom_files.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/basic_custom_files.py
@@ -15,12 +15,16 @@ from .non_void_function_signature import NonVoidFunctionSignature
 
 
 class BasicCustomFiles(UniversalBaseModel):
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
     signature: NonVoidFunctionSignature
-    additional_files: typing_extensions.Annotated[typing.Dict[Language, Files], FieldMetadata(alias="additionalFiles")]
+    additional_files: typing_extensions.Annotated[
+        typing.Dict[Language, Files], FieldMetadata(alias="additionalFiles")
+    ] = pydantic.Field(alias="additionalFiles")
     basic_test_case_template: typing_extensions.Annotated[
         BasicTestCaseTemplate, FieldMetadata(alias="basicTestCaseTemplate")
-    ]
+    ] = pydantic.Field(alias="basicTestCaseTemplate")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/basic_test_case_template.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/basic_test_case_template.py
@@ -12,12 +12,14 @@ from .test_case_template_id import TestCaseTemplateId
 
 
 class BasicTestCaseTemplate(UniversalBaseModel):
-    template_id: typing_extensions.Annotated[TestCaseTemplateId, FieldMetadata(alias="templateId")]
+    template_id: typing_extensions.Annotated[TestCaseTemplateId, FieldMetadata(alias="templateId")] = pydantic.Field(
+        alias="templateId"
+    )
     name: str
     description: TestCaseImplementationDescription
     expected_value_parameter_id: typing_extensions.Annotated[
         ParameterId, FieldMetadata(alias="expectedValueParameterId")
-    ]
+    ] = pydantic.Field(alias="expectedValueParameterId")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/create_problem_request_v_2.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/create_problem_request_v_2.py
@@ -16,15 +16,23 @@ from .test_case_v_2 import TestCaseV2
 
 
 class CreateProblemRequestV2(UniversalBaseModel):
-    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")]
-    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")]
-    custom_files: typing_extensions.Annotated[CustomFiles, FieldMetadata(alias="customFiles")]
+    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")] = pydantic.Field(
+        alias="problemName"
+    )
+    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")] = (
+        pydantic.Field(alias="problemDescription")
+    )
+    custom_files: typing_extensions.Annotated[CustomFiles, FieldMetadata(alias="customFiles")] = pydantic.Field(
+        alias="customFiles"
+    )
     custom_test_case_templates: typing_extensions.Annotated[
         typing.List[TestCaseTemplate], FieldMetadata(alias="customTestCaseTemplates")
-    ]
+    ] = pydantic.Field(alias="customTestCaseTemplates")
     testcases: typing.List[TestCaseV2]
-    supported_languages: typing_extensions.Annotated[typing.Set[Language], FieldMetadata(alias="supportedLanguages")]
-    is_public: typing_extensions.Annotated[bool, FieldMetadata(alias="isPublic")]
+    supported_languages: typing_extensions.Annotated[
+        typing.Set[Language], FieldMetadata(alias="supportedLanguages")
+    ] = pydantic.Field(alias="supportedLanguages")
+    is_public: typing_extensions.Annotated[bool, FieldMetadata(alias="isPublic")] = pydantic.Field(alias="isPublic")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/custom_files.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/custom_files.py
@@ -16,12 +16,16 @@ from .non_void_function_signature import NonVoidFunctionSignature
 
 class CustomFiles_Basic(UniversalBaseModel):
     type: typing.Literal["basic"] = "basic"
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
     signature: NonVoidFunctionSignature
-    additional_files: typing_extensions.Annotated[typing.Dict[Language, Files], FieldMetadata(alias="additionalFiles")]
+    additional_files: typing_extensions.Annotated[
+        typing.Dict[Language, Files], FieldMetadata(alias="additionalFiles")
+    ] = pydantic.Field(alias="additionalFiles")
     basic_test_case_template: typing_extensions.Annotated[
         BasicTestCaseTemplate, FieldMetadata(alias="basicTestCaseTemplate")
-    ]
+    ] = pydantic.Field(alias="basicTestCaseTemplate")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/deep_equality_correctness_check.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/deep_equality_correctness_check.py
@@ -12,7 +12,7 @@ from .parameter_id import ParameterId
 class DeepEqualityCorrectnessCheck(UniversalBaseModel):
     expected_value_parameter_id: typing_extensions.Annotated[
         ParameterId, FieldMetadata(alias="expectedValueParameterId")
-    ]
+    ] = pydantic.Field(alias="expectedValueParameterId")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/default_provided_file.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/default_provided_file.py
@@ -13,7 +13,9 @@ from .file_info_v_2 import FileInfoV2
 
 class DefaultProvidedFile(UniversalBaseModel):
     file: FileInfoV2
-    related_types: typing_extensions.Annotated[typing.List["VariableType"], FieldMetadata(alias="relatedTypes")]
+    related_types: typing_extensions.Annotated[typing.List["VariableType"], FieldMetadata(alias="relatedTypes")] = (
+        pydantic.Field(alias="relatedTypes")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/function_implementation_for_multiple_languages.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/function_implementation_for_multiple_languages.py
@@ -13,7 +13,7 @@ from .function_implementation import FunctionImplementation
 class FunctionImplementationForMultipleLanguages(UniversalBaseModel):
     code_by_language: typing_extensions.Annotated[
         typing.Dict[Language, FunctionImplementation], FieldMetadata(alias="codeByLanguage")
-    ]
+    ] = pydantic.Field(alias="codeByLanguage")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/function_signature.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/function_signature.py
@@ -28,7 +28,9 @@ class FunctionSignature_Void(UniversalBaseModel):
 class FunctionSignature_NonVoid(UniversalBaseModel):
     type: typing.Literal["nonVoid"] = "nonVoid"
     parameters: typing.List[Parameter]
-    return_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="returnType")]
+    return_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="returnType")] = pydantic.Field(
+        alias="returnType"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -43,7 +45,9 @@ class FunctionSignature_NonVoid(UniversalBaseModel):
 class FunctionSignature_VoidThatTakesActualResult(UniversalBaseModel):
     type: typing.Literal["voidThatTakesActualResult"] = "voidThatTakesActualResult"
     parameters: typing.List[Parameter]
-    actual_result_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="actualResultType")]
+    actual_result_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="actualResultType")] = (
+        pydantic.Field(alias="actualResultType")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/generated_files.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/generated_files.py
@@ -13,10 +13,10 @@ from .files import Files
 class GeneratedFiles(UniversalBaseModel):
     generated_test_case_files: typing_extensions.Annotated[
         typing.Dict[Language, Files], FieldMetadata(alias="generatedTestCaseFiles")
-    ]
+    ] = pydantic.Field(alias="generatedTestCaseFiles")
     generated_template_files: typing_extensions.Annotated[
         typing.Dict[Language, Files], FieldMetadata(alias="generatedTemplateFiles")
-    ]
+    ] = pydantic.Field(alias="generatedTemplateFiles")
     other: typing.Dict[Language, Files]
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/get_basic_solution_file_request.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/get_basic_solution_file_request.py
@@ -12,7 +12,9 @@ from .non_void_function_signature import NonVoidFunctionSignature
 
 
 class GetBasicSolutionFileRequest(UniversalBaseModel):
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
     signature: NonVoidFunctionSignature
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/get_basic_solution_file_response.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/get_basic_solution_file_response.py
@@ -13,7 +13,7 @@ from .file_info_v_2 import FileInfoV2
 class GetBasicSolutionFileResponse(UniversalBaseModel):
     solution_file_by_language: typing_extensions.Annotated[
         typing.Dict[Language, FileInfoV2], FieldMetadata(alias="solutionFileByLanguage")
-    ]
+    ] = pydantic.Field(alias="solutionFileByLanguage")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/get_function_signature_request.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/get_function_signature_request.py
@@ -12,7 +12,9 @@ from .function_signature import FunctionSignature
 
 
 class GetFunctionSignatureRequest(UniversalBaseModel):
-    function_signature: typing_extensions.Annotated[FunctionSignature, FieldMetadata(alias="functionSignature")]
+    function_signature: typing_extensions.Annotated[FunctionSignature, FieldMetadata(alias="functionSignature")] = (
+        pydantic.Field(alias="functionSignature")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/get_function_signature_response.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/get_function_signature_response.py
@@ -12,7 +12,7 @@ from ....core.serialization import FieldMetadata
 class GetFunctionSignatureResponse(UniversalBaseModel):
     function_by_language: typing_extensions.Annotated[
         typing.Dict[Language, str], FieldMetadata(alias="functionByLanguage")
-    ]
+    ] = pydantic.Field(alias="functionByLanguage")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/get_generated_test_case_file_request.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/get_generated_test_case_file_request.py
@@ -14,7 +14,9 @@ from .test_case_v_2 import TestCaseV2
 
 class GetGeneratedTestCaseFileRequest(UniversalBaseModel):
     template: typing.Optional[TestCaseTemplate] = None
-    test_case: typing_extensions.Annotated[TestCaseV2, FieldMetadata(alias="testCase")]
+    test_case: typing_extensions.Annotated[TestCaseV2, FieldMetadata(alias="testCase")] = pydantic.Field(
+        alias="testCase"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/lightweight_problem_info_v_2.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/lightweight_problem_info_v_2.py
@@ -12,10 +12,18 @@ from ....core.serialization import FieldMetadata
 
 
 class LightweightProblemInfoV2(UniversalBaseModel):
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")]
-    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")]
-    variable_types: typing_extensions.Annotated[typing.List["VariableType"], FieldMetadata(alias="variableTypes")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")] = pydantic.Field(
+        alias="problemName"
+    )
+    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")] = pydantic.Field(
+        alias="problemVersion"
+    )
+    variable_types: typing_extensions.Annotated[typing.List["VariableType"], FieldMetadata(alias="variableTypes")] = (
+        pydantic.Field(alias="variableTypes")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/non_void_function_signature.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/non_void_function_signature.py
@@ -13,7 +13,9 @@ from .parameter import Parameter
 
 class NonVoidFunctionSignature(UniversalBaseModel):
     parameters: typing.List[Parameter]
-    return_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="returnType")]
+    return_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="returnType")] = pydantic.Field(
+        alias="returnType"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/parameter.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/parameter.py
@@ -12,9 +12,13 @@ from .parameter_id import ParameterId
 
 
 class Parameter(UniversalBaseModel):
-    parameter_id: typing_extensions.Annotated[ParameterId, FieldMetadata(alias="parameterId")]
+    parameter_id: typing_extensions.Annotated[ParameterId, FieldMetadata(alias="parameterId")] = pydantic.Field(
+        alias="parameterId"
+    )
     name: str
-    variable_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="variableType")]
+    variable_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="variableType")] = pydantic.Field(
+        alias="variableType"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/problem_info_v_2.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/problem_info_v_2.py
@@ -18,18 +18,32 @@ from .test_case_v_2 import TestCaseV2
 
 
 class ProblemInfoV2(UniversalBaseModel):
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")]
-    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")]
-    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")]
-    supported_languages: typing_extensions.Annotated[typing.Set[Language], FieldMetadata(alias="supportedLanguages")]
-    custom_files: typing_extensions.Annotated[CustomFiles, FieldMetadata(alias="customFiles")]
-    generated_files: typing_extensions.Annotated[GeneratedFiles, FieldMetadata(alias="generatedFiles")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")] = (
+        pydantic.Field(alias="problemDescription")
+    )
+    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")] = pydantic.Field(
+        alias="problemName"
+    )
+    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")] = pydantic.Field(
+        alias="problemVersion"
+    )
+    supported_languages: typing_extensions.Annotated[
+        typing.Set[Language], FieldMetadata(alias="supportedLanguages")
+    ] = pydantic.Field(alias="supportedLanguages")
+    custom_files: typing_extensions.Annotated[CustomFiles, FieldMetadata(alias="customFiles")] = pydantic.Field(
+        alias="customFiles"
+    )
+    generated_files: typing_extensions.Annotated[GeneratedFiles, FieldMetadata(alias="generatedFiles")] = (
+        pydantic.Field(alias="generatedFiles")
+    )
     custom_test_case_templates: typing_extensions.Annotated[
         typing.List[TestCaseTemplate], FieldMetadata(alias="customTestCaseTemplates")
-    ]
+    ] = pydantic.Field(alias="customTestCaseTemplates")
     testcases: typing.List[TestCaseV2]
-    is_public: typing_extensions.Annotated[bool, FieldMetadata(alias="isPublic")]
+    is_public: typing_extensions.Annotated[bool, FieldMetadata(alias="isPublic")] = pydantic.Field(alias="isPublic")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/test_case_expects.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/test_case_expects.py
@@ -9,7 +9,9 @@ from ....core.serialization import FieldMetadata
 
 
 class TestCaseExpects(UniversalBaseModel):
-    expected_stdout: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="expectedStdout")] = None
+    expected_stdout: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="expectedStdout")] = (
+        pydantic.Field(alias="expectedStdout", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/test_case_function.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/test_case_function.py
@@ -16,10 +16,12 @@ from .parameter import Parameter
 
 class TestCaseFunction_WithActualResult(UniversalBaseModel):
     type: typing.Literal["withActualResult"] = "withActualResult"
-    get_actual_result: typing_extensions.Annotated[NonVoidFunctionDefinition, FieldMetadata(alias="getActualResult")]
+    get_actual_result: typing_extensions.Annotated[
+        NonVoidFunctionDefinition, FieldMetadata(alias="getActualResult")
+    ] = pydantic.Field(alias="getActualResult")
     assert_correctness_check: typing_extensions.Annotated[
         AssertCorrectnessCheck, FieldMetadata(alias="assertCorrectnessCheck")
-    ]
+    ] = pydantic.Field(alias="assertCorrectnessCheck")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/test_case_template.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/test_case_template.py
@@ -13,7 +13,9 @@ from .test_case_template_id import TestCaseTemplateId
 
 
 class TestCaseTemplate(UniversalBaseModel):
-    template_id: typing_extensions.Annotated[TestCaseTemplateId, FieldMetadata(alias="templateId")]
+    template_id: typing_extensions.Annotated[TestCaseTemplateId, FieldMetadata(alias="templateId")] = pydantic.Field(
+        alias="templateId"
+    )
     name: str
     implementation: TestCaseImplementation
 

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/test_case_with_actual_result_implementation.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/test_case_with_actual_result_implementation.py
@@ -13,10 +13,12 @@ from .non_void_function_definition import NonVoidFunctionDefinition
 
 
 class TestCaseWithActualResultImplementation(UniversalBaseModel):
-    get_actual_result: typing_extensions.Annotated[NonVoidFunctionDefinition, FieldMetadata(alias="getActualResult")]
+    get_actual_result: typing_extensions.Annotated[
+        NonVoidFunctionDefinition, FieldMetadata(alias="getActualResult")
+    ] = pydantic.Field(alias="getActualResult")
     assert_correctness_check: typing_extensions.Annotated[
         AssertCorrectnessCheck, FieldMetadata(alias="assertCorrectnessCheck")
-    ]
+    ] = pydantic.Field(alias="assertCorrectnessCheck")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/void_function_definition_that_takes_actual_result.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/void_function_definition_that_takes_actual_result.py
@@ -19,7 +19,7 @@ class VoidFunctionDefinitionThatTakesActualResult(UniversalBaseModel):
 
     additional_parameters: typing_extensions.Annotated[
         typing.List[Parameter], FieldMetadata(alias="additionalParameters")
-    ]
+    ] = pydantic.Field(alias="additionalParameters")
     code: FunctionImplementationForMultipleLanguages
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/void_function_signature_that_takes_actual_result.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/void_function_signature_that_takes_actual_result.py
@@ -13,7 +13,9 @@ from .parameter import Parameter
 
 class VoidFunctionSignatureThatTakesActualResult(UniversalBaseModel):
     parameters: typing.List[Parameter]
-    actual_result_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="actualResultType")]
+    actual_result_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="actualResultType")] = (
+        pydantic.Field(alias="actualResultType")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/assert_correctness_check.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/assert_correctness_check.py
@@ -17,7 +17,7 @@ class AssertCorrectnessCheck_DeepEquality(UniversalBaseModel):
     type: typing.Literal["deepEquality"] = "deepEquality"
     expected_value_parameter_id: typing_extensions.Annotated[
         ParameterId, FieldMetadata(alias="expectedValueParameterId")
-    ]
+    ] = pydantic.Field(alias="expectedValueParameterId")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -33,7 +33,7 @@ class AssertCorrectnessCheck_Custom(UniversalBaseModel):
     type: typing.Literal["custom"] = "custom"
     additional_parameters: typing_extensions.Annotated[
         typing.List[Parameter], FieldMetadata(alias="additionalParameters")
-    ]
+    ] = pydantic.Field(alias="additionalParameters")
     code: FunctionImplementationForMultipleLanguages
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/basic_custom_files.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/basic_custom_files.py
@@ -15,12 +15,16 @@ from .non_void_function_signature import NonVoidFunctionSignature
 
 
 class BasicCustomFiles(UniversalBaseModel):
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
     signature: NonVoidFunctionSignature
-    additional_files: typing_extensions.Annotated[typing.Dict[Language, Files], FieldMetadata(alias="additionalFiles")]
+    additional_files: typing_extensions.Annotated[
+        typing.Dict[Language, Files], FieldMetadata(alias="additionalFiles")
+    ] = pydantic.Field(alias="additionalFiles")
     basic_test_case_template: typing_extensions.Annotated[
         BasicTestCaseTemplate, FieldMetadata(alias="basicTestCaseTemplate")
-    ]
+    ] = pydantic.Field(alias="basicTestCaseTemplate")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/basic_test_case_template.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/basic_test_case_template.py
@@ -12,12 +12,14 @@ from .test_case_template_id import TestCaseTemplateId
 
 
 class BasicTestCaseTemplate(UniversalBaseModel):
-    template_id: typing_extensions.Annotated[TestCaseTemplateId, FieldMetadata(alias="templateId")]
+    template_id: typing_extensions.Annotated[TestCaseTemplateId, FieldMetadata(alias="templateId")] = pydantic.Field(
+        alias="templateId"
+    )
     name: str
     description: TestCaseImplementationDescription
     expected_value_parameter_id: typing_extensions.Annotated[
         ParameterId, FieldMetadata(alias="expectedValueParameterId")
-    ]
+    ] = pydantic.Field(alias="expectedValueParameterId")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/create_problem_request_v_2.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/create_problem_request_v_2.py
@@ -16,15 +16,23 @@ from .test_case_v_2 import TestCaseV2
 
 
 class CreateProblemRequestV2(UniversalBaseModel):
-    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")]
-    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")]
-    custom_files: typing_extensions.Annotated[CustomFiles, FieldMetadata(alias="customFiles")]
+    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")] = pydantic.Field(
+        alias="problemName"
+    )
+    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")] = (
+        pydantic.Field(alias="problemDescription")
+    )
+    custom_files: typing_extensions.Annotated[CustomFiles, FieldMetadata(alias="customFiles")] = pydantic.Field(
+        alias="customFiles"
+    )
     custom_test_case_templates: typing_extensions.Annotated[
         typing.List[TestCaseTemplate], FieldMetadata(alias="customTestCaseTemplates")
-    ]
+    ] = pydantic.Field(alias="customTestCaseTemplates")
     testcases: typing.List[TestCaseV2]
-    supported_languages: typing_extensions.Annotated[typing.Set[Language], FieldMetadata(alias="supportedLanguages")]
-    is_public: typing_extensions.Annotated[bool, FieldMetadata(alias="isPublic")]
+    supported_languages: typing_extensions.Annotated[
+        typing.Set[Language], FieldMetadata(alias="supportedLanguages")
+    ] = pydantic.Field(alias="supportedLanguages")
+    is_public: typing_extensions.Annotated[bool, FieldMetadata(alias="isPublic")] = pydantic.Field(alias="isPublic")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/custom_files.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/custom_files.py
@@ -16,12 +16,16 @@ from .non_void_function_signature import NonVoidFunctionSignature
 
 class CustomFiles_Basic(UniversalBaseModel):
     type: typing.Literal["basic"] = "basic"
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
     signature: NonVoidFunctionSignature
-    additional_files: typing_extensions.Annotated[typing.Dict[Language, Files], FieldMetadata(alias="additionalFiles")]
+    additional_files: typing_extensions.Annotated[
+        typing.Dict[Language, Files], FieldMetadata(alias="additionalFiles")
+    ] = pydantic.Field(alias="additionalFiles")
     basic_test_case_template: typing_extensions.Annotated[
         BasicTestCaseTemplate, FieldMetadata(alias="basicTestCaseTemplate")
-    ]
+    ] = pydantic.Field(alias="basicTestCaseTemplate")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/deep_equality_correctness_check.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/deep_equality_correctness_check.py
@@ -12,7 +12,7 @@ from .parameter_id import ParameterId
 class DeepEqualityCorrectnessCheck(UniversalBaseModel):
     expected_value_parameter_id: typing_extensions.Annotated[
         ParameterId, FieldMetadata(alias="expectedValueParameterId")
-    ]
+    ] = pydantic.Field(alias="expectedValueParameterId")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/default_provided_file.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/default_provided_file.py
@@ -13,7 +13,9 @@ from .file_info_v_2 import FileInfoV2
 
 class DefaultProvidedFile(UniversalBaseModel):
     file: FileInfoV2
-    related_types: typing_extensions.Annotated[typing.List["VariableType"], FieldMetadata(alias="relatedTypes")]
+    related_types: typing_extensions.Annotated[typing.List["VariableType"], FieldMetadata(alias="relatedTypes")] = (
+        pydantic.Field(alias="relatedTypes")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/function_implementation_for_multiple_languages.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/function_implementation_for_multiple_languages.py
@@ -13,7 +13,7 @@ from .function_implementation import FunctionImplementation
 class FunctionImplementationForMultipleLanguages(UniversalBaseModel):
     code_by_language: typing_extensions.Annotated[
         typing.Dict[Language, FunctionImplementation], FieldMetadata(alias="codeByLanguage")
-    ]
+    ] = pydantic.Field(alias="codeByLanguage")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/function_signature.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/function_signature.py
@@ -28,7 +28,9 @@ class FunctionSignature_Void(UniversalBaseModel):
 class FunctionSignature_NonVoid(UniversalBaseModel):
     type: typing.Literal["nonVoid"] = "nonVoid"
     parameters: typing.List[Parameter]
-    return_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="returnType")]
+    return_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="returnType")] = pydantic.Field(
+        alias="returnType"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
@@ -43,7 +45,9 @@ class FunctionSignature_NonVoid(UniversalBaseModel):
 class FunctionSignature_VoidThatTakesActualResult(UniversalBaseModel):
     type: typing.Literal["voidThatTakesActualResult"] = "voidThatTakesActualResult"
     parameters: typing.List[Parameter]
-    actual_result_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="actualResultType")]
+    actual_result_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="actualResultType")] = (
+        pydantic.Field(alias="actualResultType")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/generated_files.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/generated_files.py
@@ -13,10 +13,10 @@ from .files import Files
 class GeneratedFiles(UniversalBaseModel):
     generated_test_case_files: typing_extensions.Annotated[
         typing.Dict[Language, Files], FieldMetadata(alias="generatedTestCaseFiles")
-    ]
+    ] = pydantic.Field(alias="generatedTestCaseFiles")
     generated_template_files: typing_extensions.Annotated[
         typing.Dict[Language, Files], FieldMetadata(alias="generatedTemplateFiles")
-    ]
+    ] = pydantic.Field(alias="generatedTemplateFiles")
     other: typing.Dict[Language, Files]
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_basic_solution_file_request.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_basic_solution_file_request.py
@@ -12,7 +12,9 @@ from .non_void_function_signature import NonVoidFunctionSignature
 
 
 class GetBasicSolutionFileRequest(UniversalBaseModel):
-    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")]
+    method_name: typing_extensions.Annotated[str, FieldMetadata(alias="methodName")] = pydantic.Field(
+        alias="methodName"
+    )
     signature: NonVoidFunctionSignature
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_basic_solution_file_response.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_basic_solution_file_response.py
@@ -13,7 +13,7 @@ from .file_info_v_2 import FileInfoV2
 class GetBasicSolutionFileResponse(UniversalBaseModel):
     solution_file_by_language: typing_extensions.Annotated[
         typing.Dict[Language, FileInfoV2], FieldMetadata(alias="solutionFileByLanguage")
-    ]
+    ] = pydantic.Field(alias="solutionFileByLanguage")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_function_signature_request.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_function_signature_request.py
@@ -12,7 +12,9 @@ from .function_signature import FunctionSignature
 
 
 class GetFunctionSignatureRequest(UniversalBaseModel):
-    function_signature: typing_extensions.Annotated[FunctionSignature, FieldMetadata(alias="functionSignature")]
+    function_signature: typing_extensions.Annotated[FunctionSignature, FieldMetadata(alias="functionSignature")] = (
+        pydantic.Field(alias="functionSignature")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_function_signature_response.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_function_signature_response.py
@@ -12,7 +12,7 @@ from .....core.serialization import FieldMetadata
 class GetFunctionSignatureResponse(UniversalBaseModel):
     function_by_language: typing_extensions.Annotated[
         typing.Dict[Language, str], FieldMetadata(alias="functionByLanguage")
-    ]
+    ] = pydantic.Field(alias="functionByLanguage")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_generated_test_case_file_request.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/get_generated_test_case_file_request.py
@@ -14,7 +14,9 @@ from .test_case_v_2 import TestCaseV2
 
 class GetGeneratedTestCaseFileRequest(UniversalBaseModel):
     template: typing.Optional[TestCaseTemplate] = None
-    test_case: typing_extensions.Annotated[TestCaseV2, FieldMetadata(alias="testCase")]
+    test_case: typing_extensions.Annotated[TestCaseV2, FieldMetadata(alias="testCase")] = pydantic.Field(
+        alias="testCase"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/lightweight_problem_info_v_2.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/lightweight_problem_info_v_2.py
@@ -12,10 +12,18 @@ from .....core.serialization import FieldMetadata
 
 
 class LightweightProblemInfoV2(UniversalBaseModel):
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")]
-    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")]
-    variable_types: typing_extensions.Annotated[typing.List["VariableType"], FieldMetadata(alias="variableTypes")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")] = pydantic.Field(
+        alias="problemName"
+    )
+    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")] = pydantic.Field(
+        alias="problemVersion"
+    )
+    variable_types: typing_extensions.Annotated[typing.List["VariableType"], FieldMetadata(alias="variableTypes")] = (
+        pydantic.Field(alias="variableTypes")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/non_void_function_signature.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/non_void_function_signature.py
@@ -13,7 +13,9 @@ from .parameter import Parameter
 
 class NonVoidFunctionSignature(UniversalBaseModel):
     parameters: typing.List[Parameter]
-    return_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="returnType")]
+    return_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="returnType")] = pydantic.Field(
+        alias="returnType"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/parameter.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/parameter.py
@@ -12,9 +12,13 @@ from .parameter_id import ParameterId
 
 
 class Parameter(UniversalBaseModel):
-    parameter_id: typing_extensions.Annotated[ParameterId, FieldMetadata(alias="parameterId")]
+    parameter_id: typing_extensions.Annotated[ParameterId, FieldMetadata(alias="parameterId")] = pydantic.Field(
+        alias="parameterId"
+    )
     name: str
-    variable_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="variableType")]
+    variable_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="variableType")] = pydantic.Field(
+        alias="variableType"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/problem_info_v_2.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/problem_info_v_2.py
@@ -18,18 +18,32 @@ from .test_case_v_2 import TestCaseV2
 
 
 class ProblemInfoV2(UniversalBaseModel):
-    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")]
-    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")]
-    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")]
-    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")]
-    supported_languages: typing_extensions.Annotated[typing.Set[Language], FieldMetadata(alias="supportedLanguages")]
-    custom_files: typing_extensions.Annotated[CustomFiles, FieldMetadata(alias="customFiles")]
-    generated_files: typing_extensions.Annotated[GeneratedFiles, FieldMetadata(alias="generatedFiles")]
+    problem_id: typing_extensions.Annotated[ProblemId, FieldMetadata(alias="problemId")] = pydantic.Field(
+        alias="problemId"
+    )
+    problem_description: typing_extensions.Annotated[ProblemDescription, FieldMetadata(alias="problemDescription")] = (
+        pydantic.Field(alias="problemDescription")
+    )
+    problem_name: typing_extensions.Annotated[str, FieldMetadata(alias="problemName")] = pydantic.Field(
+        alias="problemName"
+    )
+    problem_version: typing_extensions.Annotated[int, FieldMetadata(alias="problemVersion")] = pydantic.Field(
+        alias="problemVersion"
+    )
+    supported_languages: typing_extensions.Annotated[
+        typing.Set[Language], FieldMetadata(alias="supportedLanguages")
+    ] = pydantic.Field(alias="supportedLanguages")
+    custom_files: typing_extensions.Annotated[CustomFiles, FieldMetadata(alias="customFiles")] = pydantic.Field(
+        alias="customFiles"
+    )
+    generated_files: typing_extensions.Annotated[GeneratedFiles, FieldMetadata(alias="generatedFiles")] = (
+        pydantic.Field(alias="generatedFiles")
+    )
     custom_test_case_templates: typing_extensions.Annotated[
         typing.List[TestCaseTemplate], FieldMetadata(alias="customTestCaseTemplates")
-    ]
+    ] = pydantic.Field(alias="customTestCaseTemplates")
     testcases: typing.List[TestCaseV2]
-    is_public: typing_extensions.Annotated[bool, FieldMetadata(alias="isPublic")]
+    is_public: typing_extensions.Annotated[bool, FieldMetadata(alias="isPublic")] = pydantic.Field(alias="isPublic")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/test_case_expects.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/test_case_expects.py
@@ -9,7 +9,9 @@ from .....core.serialization import FieldMetadata
 
 
 class TestCaseExpects(UniversalBaseModel):
-    expected_stdout: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="expectedStdout")] = None
+    expected_stdout: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="expectedStdout")] = (
+        pydantic.Field(alias="expectedStdout", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/test_case_function.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/test_case_function.py
@@ -16,10 +16,12 @@ from .parameter import Parameter
 
 class TestCaseFunction_WithActualResult(UniversalBaseModel):
     type: typing.Literal["withActualResult"] = "withActualResult"
-    get_actual_result: typing_extensions.Annotated[NonVoidFunctionDefinition, FieldMetadata(alias="getActualResult")]
+    get_actual_result: typing_extensions.Annotated[
+        NonVoidFunctionDefinition, FieldMetadata(alias="getActualResult")
+    ] = pydantic.Field(alias="getActualResult")
     assert_correctness_check: typing_extensions.Annotated[
         AssertCorrectnessCheck, FieldMetadata(alias="assertCorrectnessCheck")
-    ]
+    ] = pydantic.Field(alias="assertCorrectnessCheck")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/test_case_template.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/test_case_template.py
@@ -13,7 +13,9 @@ from .test_case_template_id import TestCaseTemplateId
 
 
 class TestCaseTemplate(UniversalBaseModel):
-    template_id: typing_extensions.Annotated[TestCaseTemplateId, FieldMetadata(alias="templateId")]
+    template_id: typing_extensions.Annotated[TestCaseTemplateId, FieldMetadata(alias="templateId")] = pydantic.Field(
+        alias="templateId"
+    )
     name: str
     implementation: TestCaseImplementation
 

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/test_case_with_actual_result_implementation.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/test_case_with_actual_result_implementation.py
@@ -13,10 +13,12 @@ from .non_void_function_definition import NonVoidFunctionDefinition
 
 
 class TestCaseWithActualResultImplementation(UniversalBaseModel):
-    get_actual_result: typing_extensions.Annotated[NonVoidFunctionDefinition, FieldMetadata(alias="getActualResult")]
+    get_actual_result: typing_extensions.Annotated[
+        NonVoidFunctionDefinition, FieldMetadata(alias="getActualResult")
+    ] = pydantic.Field(alias="getActualResult")
     assert_correctness_check: typing_extensions.Annotated[
         AssertCorrectnessCheck, FieldMetadata(alias="assertCorrectnessCheck")
-    ]
+    ] = pydantic.Field(alias="assertCorrectnessCheck")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/void_function_definition_that_takes_actual_result.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/void_function_definition_that_takes_actual_result.py
@@ -19,7 +19,7 @@ class VoidFunctionDefinitionThatTakesActualResult(UniversalBaseModel):
 
     additional_parameters: typing_extensions.Annotated[
         typing.List[Parameter], FieldMetadata(alias="additionalParameters")
-    ]
+    ] = pydantic.Field(alias="additionalParameters")
     code: FunctionImplementationForMultipleLanguages
 
     if IS_PYDANTIC_V2:

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/void_function_signature_that_takes_actual_result.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/void_function_signature_that_takes_actual_result.py
@@ -13,7 +13,9 @@ from .parameter import Parameter
 
 class VoidFunctionSignatureThatTakesActualResult(UniversalBaseModel):
     parameters: typing.List[Parameter]
-    actual_result_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="actualResultType")]
+    actual_result_type: typing_extensions.Annotated["VariableType", FieldMetadata(alias="actualResultType")] = (
+        pydantic.Field(alias="actualResultType")
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/undiscriminated-union-with-response-property/poetry.lock
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/types/variant_a.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/types/variant_a.py
@@ -10,7 +10,7 @@ from ..core.serialization import FieldMetadata
 
 class VariantA(UniversalBaseModel):
     type: typing.Literal["A"] = "A"
-    value_a: typing_extensions.Annotated[str, FieldMetadata(alias="valueA")]
+    value_a: typing_extensions.Annotated[str, FieldMetadata(alias="valueA")] = pydantic.Field(alias="valueA")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/types/variant_b.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/types/variant_b.py
@@ -10,7 +10,7 @@ from ..core.serialization import FieldMetadata
 
 class VariantB(UniversalBaseModel):
     type: typing.Literal["B"] = "B"
-    value_b: typing_extensions.Annotated[int, FieldMetadata(alias="valueB")]
+    value_b: typing_extensions.Annotated[int, FieldMetadata(alias="valueB")] = pydantic.Field(alias="valueB")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/types/variant_c.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/types/variant_c.py
@@ -10,7 +10,7 @@ from ..core.serialization import FieldMetadata
 
 class VariantC(UniversalBaseModel):
     type: typing.Literal["C"] = "C"
-    value_c: typing_extensions.Annotated[bool, FieldMetadata(alias="valueC")]
+    value_c: typing_extensions.Annotated[bool, FieldMetadata(alias="valueC")] = pydantic.Field(alias="valueC")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/undiscriminated-unions/poetry.lock
+++ b/seed/python-sdk/undiscriminated-unions/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/undiscriminated-unions/src/seed/union/types/convert_token.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/union/types/convert_token.py
@@ -10,7 +10,7 @@ from ...core.serialization import FieldMetadata
 
 class ConvertToken(UniversalBaseModel):
     method: str
-    token_id: typing_extensions.Annotated[str, FieldMetadata(alias="tokenId")]
+    token_id: typing_extensions.Annotated[str, FieldMetadata(alias="tokenId")] = pydantic.Field(alias="tokenId")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/undiscriminated-unions/src/seed/union/types/tokenize_card.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/union/types/tokenize_card.py
@@ -10,7 +10,9 @@ from ...core.serialization import FieldMetadata
 
 class TokenizeCard(UniversalBaseModel):
     method: str
-    card_number: typing_extensions.Annotated[str, FieldMetadata(alias="cardNumber")]
+    card_number: typing_extensions.Annotated[str, FieldMetadata(alias="cardNumber")] = pydantic.Field(
+        alias="cardNumber"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/undiscriminated-unions/src/seed/union/types/type_with_optional_union.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/union/types/type_with_optional_union.py
@@ -10,7 +10,9 @@ from .my_union import MyUnion
 
 
 class TypeWithOptionalUnion(UniversalBaseModel):
-    my_union: typing_extensions.Annotated[typing.Optional[MyUnion], FieldMetadata(alias="myUnion")] = None
+    my_union: typing_extensions.Annotated[typing.Optional[MyUnion], FieldMetadata(alias="myUnion")] = pydantic.Field(
+        alias="myUnion", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions-with-local-date/poetry.lock
+++ b/seed/python-sdk/unions-with-local-date/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/unions-with-local-date/src/seed/bigunion/types/big_union.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/bigunion/types/big_union.py
@@ -23,8 +23,12 @@ class Base(UniversalBaseModel):
     """
 
     id: str
-    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="created-at")]
-    archived_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="archived-at")] = None
+    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="created-at")] = pydantic.Field(
+        alias="created-at"
+    )
+    archived_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="archived-at")] = (
+        pydantic.Field(alias="archived-at", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unions-with-local-date/src/seed/types/types/union_with_discriminant.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/types/types/union_with_discriminant.py
@@ -14,7 +14,9 @@ from .foo import Foo
 
 class UnionWithDiscriminant_Foo(UniversalBaseModel):
     foo: Foo
-    type: typing_extensions.Annotated[typing.Literal["foo"], FieldMetadata(alias="_type")] = "foo"
+    type: typing_extensions.Annotated[typing.Literal["foo"], FieldMetadata(alias="_type")] = pydantic.Field(
+        alias="_type", default="foo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2
@@ -27,7 +29,9 @@ class UnionWithDiscriminant_Foo(UniversalBaseModel):
 
 class UnionWithDiscriminant_Bar(UniversalBaseModel):
     bar: Bar
-    type: typing_extensions.Annotated[typing.Literal["bar"], FieldMetadata(alias="_type")] = "bar"
+    type: typing_extensions.Annotated[typing.Literal["bar"], FieldMetadata(alias="_type")] = pydantic.Field(
+        alias="_type", default="bar"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/no-custom-config/poetry.lock
+++ b/seed/python-sdk/unions/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/unions/no-custom-config/src/seed/bigunion/types/big_union.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/bigunion/types/big_union.py
@@ -23,8 +23,12 @@ class Base(UniversalBaseModel):
     """
 
     id: str
-    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="created-at")]
-    archived_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="archived-at")] = None
+    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="created-at")] = pydantic.Field(
+        alias="created-at"
+    )
+    archived_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="archived-at")] = (
+        pydantic.Field(alias="archived-at", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unions/no-custom-config/src/seed/types/types/union_with_discriminant.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/types/types/union_with_discriminant.py
@@ -14,7 +14,9 @@ from .foo import Foo
 
 class UnionWithDiscriminant_Foo(UniversalBaseModel):
     foo: Foo
-    type: typing_extensions.Annotated[typing.Literal["foo"], FieldMetadata(alias="_type")] = "foo"
+    type: typing_extensions.Annotated[typing.Literal["foo"], FieldMetadata(alias="_type")] = pydantic.Field(
+        alias="_type", default="foo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2
@@ -27,7 +29,9 @@ class UnionWithDiscriminant_Foo(UniversalBaseModel):
 
 class UnionWithDiscriminant_Bar(UniversalBaseModel):
     bar: Bar
-    type: typing_extensions.Annotated[typing.Literal["bar"], FieldMetadata(alias="_type")] = "bar"
+    type: typing_extensions.Annotated[typing.Literal["bar"], FieldMetadata(alias="_type")] = pydantic.Field(
+        alias="_type", default="bar"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/union-naming-v1/poetry.lock
+++ b/seed/python-sdk/unions/union-naming-v1/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/bigunion/types/big_union.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/bigunion/types/big_union.py
@@ -23,8 +23,12 @@ class Base(UniversalBaseModel):
     """
 
     id: str
-    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="created-at")]
-    archived_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="archived-at")] = None
+    created_at: typing_extensions.Annotated[dt.datetime, FieldMetadata(alias="created-at")] = pydantic.Field(
+        alias="created-at"
+    )
+    archived_at: typing_extensions.Annotated[typing.Optional[dt.datetime], FieldMetadata(alias="archived-at")] = (
+        pydantic.Field(alias="archived-at", default=None)
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/types/types/union_with_discriminant.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/types/types/union_with_discriminant.py
@@ -14,7 +14,9 @@ from .foo import Foo
 
 class FooUnionWithDiscriminant(UniversalBaseModel):
     foo: Foo
-    type: typing_extensions.Annotated[typing.Literal["foo"], FieldMetadata(alias="_type")] = "foo"
+    type: typing_extensions.Annotated[typing.Literal["foo"], FieldMetadata(alias="_type")] = pydantic.Field(
+        alias="_type", default="foo"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2
@@ -27,7 +29,9 @@ class FooUnionWithDiscriminant(UniversalBaseModel):
 
 class BarUnionWithDiscriminant(UniversalBaseModel):
     bar: Bar
-    type: typing_extensions.Annotated[typing.Literal["bar"], FieldMetadata(alias="_type")] = "bar"
+    type: typing_extensions.Annotated[typing.Literal["bar"], FieldMetadata(alias="_type")] = pydantic.Field(
+        alias="_type", default="bar"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/unions/union-utils/poetry.lock
+++ b/seed/python-sdk/unions/union-utils/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_discriminant.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_discriminant.py
@@ -74,7 +74,9 @@ class UnionWithDiscriminant(UniversalRootModel):
 
 class _UnionWithDiscriminant:
     class Foo(UniversalBaseModel):
-        type: typing_extensions.Annotated[typing.Literal["foo"], FieldMetadata(alias="_type")] = "foo"
+        type: typing_extensions.Annotated[typing.Literal["foo"], FieldMetadata(alias="_type")] = pydantic.Field(
+            alias="_type", default="foo"
+        )
         foo: types_types_foo_Foo
 
         if IS_PYDANTIC_V2:
@@ -86,7 +88,9 @@ class _UnionWithDiscriminant:
                 smart_union = True
 
     class Bar(UniversalBaseModel):
-        type: typing_extensions.Annotated[typing.Literal["bar"], FieldMetadata(alias="_type")] = "bar"
+        type: typing_extensions.Annotated[typing.Literal["bar"], FieldMetadata(alias="_type")] = pydantic.Field(
+            alias="_type", default="bar"
+        )
         bar: types_types_bar_Bar
 
         if IS_PYDANTIC_V2:

--- a/seed/python-sdk/unknown/poetry.lock
+++ b/seed/python-sdk/unknown/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/unknown/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unknown/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/unknown/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unknown/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/unknown/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/unknown/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/url-form-encoded/poetry.lock
+++ b/seed/python-sdk/url-form-encoded/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/url-form-encoded/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/url-form-encoded/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/url-form-encoded/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/validation/no-custom-config/poetry.lock
+++ b/seed/python-sdk/validation/no-custom-config/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/validation/with-defaults/poetry.lock
+++ b/seed/python-sdk/validation/with-defaults/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/variables/poetry.lock
+++ b/seed/python-sdk/variables/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/variables/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/variables/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/variables/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/variables/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/version-no-default/poetry.lock
+++ b/seed/python-sdk/version-no-default/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/version-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/version-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/version-no-default/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/version/poetry.lock
+++ b/seed/python-sdk/version/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/version/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/version/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/version/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/version/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/version/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/version/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket-bearer-auth/poetry.lock
+++ b/seed/python-sdk/websocket-bearer-auth/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/types/receive_event_3.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/types/receive_event_3.py
@@ -9,7 +9,9 @@ from ...core.serialization import FieldMetadata
 
 
 class ReceiveEvent3(UniversalBaseModel):
-    receive_text_3: typing_extensions.Annotated[str, FieldMetadata(alias="receiveText3")]
+    receive_text_3: typing_extensions.Annotated[str, FieldMetadata(alias="receiveText3")] = pydantic.Field(
+        alias="receiveText3"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/types/send_event.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/types/send_event.py
@@ -9,8 +9,8 @@ from ...core.serialization import FieldMetadata
 
 
 class SendEvent(UniversalBaseModel):
-    send_text: typing_extensions.Annotated[str, FieldMetadata(alias="sendText")]
-    send_param: typing_extensions.Annotated[int, FieldMetadata(alias="sendParam")]
+    send_text: typing_extensions.Annotated[str, FieldMetadata(alias="sendText")] = pydantic.Field(alias="sendText")
+    send_param: typing_extensions.Annotated[int, FieldMetadata(alias="sendParam")] = pydantic.Field(alias="sendParam")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/types/send_event_2.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/types/send_event_2.py
@@ -9,8 +9,10 @@ from ...core.serialization import FieldMetadata
 
 
 class SendEvent2(UniversalBaseModel):
-    send_text_2: typing_extensions.Annotated[str, FieldMetadata(alias="sendText2")]
-    send_param_2: typing_extensions.Annotated[bool, FieldMetadata(alias="sendParam2")]
+    send_text_2: typing_extensions.Annotated[str, FieldMetadata(alias="sendText2")] = pydantic.Field(alias="sendText2")
+    send_param_2: typing_extensions.Annotated[bool, FieldMetadata(alias="sendParam2")] = pydantic.Field(
+        alias="sendParam2"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket-inferred-auth/poetry.lock
+++ b/seed/python-sdk/websocket-inferred-auth/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/types/receive_event_3.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/types/receive_event_3.py
@@ -9,7 +9,9 @@ from ...core.serialization import FieldMetadata
 
 
 class ReceiveEvent3(UniversalBaseModel):
-    receive_text_3: typing_extensions.Annotated[str, FieldMetadata(alias="receiveText3")]
+    receive_text_3: typing_extensions.Annotated[str, FieldMetadata(alias="receiveText3")] = pydantic.Field(
+        alias="receiveText3"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/types/send_event.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/types/send_event.py
@@ -9,8 +9,8 @@ from ...core.serialization import FieldMetadata
 
 
 class SendEvent(UniversalBaseModel):
-    send_text: typing_extensions.Annotated[str, FieldMetadata(alias="sendText")]
-    send_param: typing_extensions.Annotated[int, FieldMetadata(alias="sendParam")]
+    send_text: typing_extensions.Annotated[str, FieldMetadata(alias="sendText")] = pydantic.Field(alias="sendText")
+    send_param: typing_extensions.Annotated[int, FieldMetadata(alias="sendParam")] = pydantic.Field(alias="sendParam")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/types/send_event_2.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/types/send_event_2.py
@@ -9,8 +9,10 @@ from ...core.serialization import FieldMetadata
 
 
 class SendEvent2(UniversalBaseModel):
-    send_text_2: typing_extensions.Annotated[str, FieldMetadata(alias="sendText2")]
-    send_param_2: typing_extensions.Annotated[bool, FieldMetadata(alias="sendParam2")]
+    send_text_2: typing_extensions.Annotated[str, FieldMetadata(alias="sendText2")] = pydantic.Field(alias="sendText2")
+    send_param_2: typing_extensions.Annotated[bool, FieldMetadata(alias="sendParam2")] = pydantic.Field(
+        alias="sendParam2"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket/websocket-base/poetry.lock
+++ b/seed/python-sdk/websocket/websocket-base/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket/websocket-base/src/seed/realtime/types/receive_event_3.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/realtime/types/receive_event_3.py
@@ -9,7 +9,9 @@ from ...core.serialization import FieldMetadata
 
 
 class ReceiveEvent3(UniversalBaseModel):
-    receive_text_3: typing_extensions.Annotated[str, FieldMetadata(alias="receiveText3")]
+    receive_text_3: typing_extensions.Annotated[str, FieldMetadata(alias="receiveText3")] = pydantic.Field(
+        alias="receiveText3"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket/websocket-base/src/seed/realtime/types/send_event.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/realtime/types/send_event.py
@@ -9,8 +9,8 @@ from ...core.serialization import FieldMetadata
 
 
 class SendEvent(UniversalBaseModel):
-    send_text: typing_extensions.Annotated[str, FieldMetadata(alias="sendText")]
-    send_param: typing_extensions.Annotated[int, FieldMetadata(alias="sendParam")]
+    send_text: typing_extensions.Annotated[str, FieldMetadata(alias="sendText")] = pydantic.Field(alias="sendText")
+    send_param: typing_extensions.Annotated[int, FieldMetadata(alias="sendParam")] = pydantic.Field(alias="sendParam")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket/websocket-base/src/seed/realtime/types/send_event_2.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/realtime/types/send_event_2.py
@@ -9,8 +9,10 @@ from ...core.serialization import FieldMetadata
 
 
 class SendEvent2(UniversalBaseModel):
-    send_text_2: typing_extensions.Annotated[str, FieldMetadata(alias="sendText2")]
-    send_param_2: typing_extensions.Annotated[bool, FieldMetadata(alias="sendParam2")]
+    send_text_2: typing_extensions.Annotated[str, FieldMetadata(alias="sendText2")] = pydantic.Field(alias="sendText2")
+    send_param_2: typing_extensions.Annotated[bool, FieldMetadata(alias="sendParam2")] = pydantic.Field(
+        alias="sendParam2"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/poetry.lock
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/poetry.lock
@@ -38,13 +38,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
-    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+    {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
+    {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
 
 [[package]]

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/pydantic_utilities.py
@@ -57,6 +57,8 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
+            # Allow population by both the field name and its alias.
+            populate_by_name=True,
         )
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
@@ -70,6 +72,7 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
+            allow_population_by_field_name = True
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/pydantic_utilities.py
@@ -118,9 +118,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(data.keys())
             rewritten: Dict[str, Any] = dict(data)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten
@@ -163,9 +164,10 @@ class UniversalBaseModel(pydantic.BaseModel):
                         "Provide the explicit alias key to disambiguate."
                     )
 
+            original_keys = set(values.keys())
             rewritten: Dict[str, Any] = dict(values)
             for name, alias in name_to_alias.items():
-                if alias != name and name in rewritten and alias not in rewritten:
+                if alias != name and name in original_keys and alias not in rewritten:
                     rewritten[alias] = rewritten.pop(name)
 
             return rewritten

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/pydantic_utilities.py
@@ -2,6 +2,7 @@
 
 # nopycln: file
 import datetime as dt
+import inspect
 from collections import defaultdict
 from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
@@ -37,7 +38,36 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:
-    dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+    # convert_and_respect_annotation_metadata is required for TypedDict aliasing.
+    #
+    # For Pydantic models, whether we should pre-dealias depends on how the model encodes aliasing:
+    # - If the model uses real Pydantic aliases (pydantic.Field(alias=...)), then we must pass wire keys through
+    #   unchanged so Pydantic can validate them.
+    # - If the model encodes aliasing only via FieldMetadata annotations, then we MUST pre-dealias because Pydantic
+    #   will not recognize those aliases during validation.
+    if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+        has_pydantic_aliases = False
+        if IS_PYDANTIC_V2:
+            for field_name, field_info in getattr(type_, "model_fields", {}).items():  # type: ignore[attr-defined]
+                alias = getattr(field_info, "alias", None)
+                if alias is not None and alias != field_name:
+                    has_pydantic_aliases = True
+                    break
+        else:
+            for field in getattr(type_, "__fields__", {}).values():
+                alias = getattr(field, "alias", None)
+                name = getattr(field, "name", None)
+                if alias is not None and name is not None and alias != name:
+                    has_pydantic_aliases = True
+                    break
+
+        dealiased_object = (
+            object_
+            if has_pydantic_aliases
+            else convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
+        )
+    else:
+        dealiased_object = convert_and_respect_annotation_metadata(object_=object_, annotation=type_, direction="read")
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python(dealiased_object)
@@ -57,9 +87,43 @@ class UniversalBaseModel(pydantic.BaseModel):
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(  # type: ignore[typeddict-unknown-key]
             # Allow fields beginning with `model_` to be used in the model
             protected_namespaces=(),
-            # Allow population by both the field name and its alias.
-            populate_by_name=True,
         )
+
+        @pydantic.model_validator(mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def _coerce_field_names_to_aliases(cls, data: Any) -> Any:
+            """
+            Accept Python field names in input by rewriting them to their Pydantic aliases,
+            while avoiding silent collisions when a key could refer to multiple fields.
+            """
+            if not isinstance(data, Mapping):
+                return data
+
+            fields = getattr(cls, "model_fields", {})  # type: ignore[attr-defined]
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field_info in fields.items():
+                alias = getattr(field_info, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            # Detect ambiguous keys: a key that is an alias for one field and a name for another.
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in data and name_to_alias[key] not in data:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(data)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
         @pydantic.model_serializer(mode="plain", when_used="json")  # type: ignore[attr-defined]
         def serialize_model(self) -> Any:  # type: ignore[name-defined]
@@ -72,7 +136,39 @@ class UniversalBaseModel(pydantic.BaseModel):
         class Config:
             smart_union = True
             json_encoders = {dt.datetime: serialize_datetime}
-            allow_population_by_field_name = True
+
+        @pydantic.root_validator(pre=True)
+        def _coerce_field_names_to_aliases(cls, values: Any) -> Any:
+            """
+            Pydantic v1 equivalent of _coerce_field_names_to_aliases.
+            """
+            if not isinstance(values, Mapping):
+                return values
+
+            fields = getattr(cls, "__fields__", {})
+            name_to_alias: Dict[str, str] = {}
+            alias_to_name: Dict[str, str] = {}
+
+            for name, field in fields.items():
+                alias = getattr(field, "alias", None) or name
+                name_to_alias[name] = alias
+                if alias != name:
+                    alias_to_name[alias] = name
+
+            ambiguous_keys = set(alias_to_name.keys()).intersection(set(name_to_alias.keys()))
+            for key in ambiguous_keys:
+                if key in values and name_to_alias[key] not in values:
+                    raise ValueError(
+                        f"Ambiguous input key '{key}': it is both a field name and an alias. "
+                        "Provide the explicit alias key to disambiguate."
+                    )
+
+            rewritten: Dict[str, Any] = dict(values)
+            for name, alias in name_to_alias.items():
+                if alias != name and name in rewritten and alias not in rewritten:
+                    rewritten[alias] = rewritten.pop(name)
+
+            return rewritten
 
     @classmethod
     def model_construct(cls: Type["Model"], _fields_set: Optional[Set[str]] = None, **values: Any) -> "Model":

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/types/receive_event_3.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/types/receive_event_3.py
@@ -9,7 +9,9 @@ from ...core.serialization import FieldMetadata
 
 
 class ReceiveEvent3(UniversalBaseModel):
-    receive_text_3: typing_extensions.Annotated[str, FieldMetadata(alias="receiveText3")]
+    receive_text_3: typing_extensions.Annotated[str, FieldMetadata(alias="receiveText3")] = pydantic.Field(
+        alias="receiveText3"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/types/send_event.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/types/send_event.py
@@ -9,8 +9,8 @@ from ...core.serialization import FieldMetadata
 
 
 class SendEvent(UniversalBaseModel):
-    send_text: typing_extensions.Annotated[str, FieldMetadata(alias="sendText")]
-    send_param: typing_extensions.Annotated[int, FieldMetadata(alias="sendParam")]
+    send_text: typing_extensions.Annotated[str, FieldMetadata(alias="sendText")] = pydantic.Field(alias="sendText")
+    send_param: typing_extensions.Annotated[int, FieldMetadata(alias="sendParam")] = pydantic.Field(alias="sendParam")
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/types/send_event_2.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/types/send_event_2.py
@@ -9,8 +9,10 @@ from ...core.serialization import FieldMetadata
 
 
 class SendEvent2(UniversalBaseModel):
-    send_text_2: typing_extensions.Annotated[str, FieldMetadata(alias="sendText2")]
-    send_param_2: typing_extensions.Annotated[bool, FieldMetadata(alias="sendParam2")]
+    send_text_2: typing_extensions.Annotated[str, FieldMetadata(alias="sendText2")] = pydantic.Field(alias="sendText2")
+    send_param_2: typing_extensions.Annotated[bool, FieldMetadata(alias="sendParam2")] = pydantic.Field(
+        alias="sendParam2"
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2


### PR DESCRIPTION
## Description
Linear ticket: [FER-8077](https://linear.app/buildwithfern/issue/FER-8077/elevenlabs-pydantic-v2-decoding-error-for-nested-field) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

A previous fix, #11011 only helped when callers invoked `model_validate()` directly, but it did not apply to nested validation paths (e.g. when a parent model is validated via `TypeAdapter`), so wire keys like `is_base64_encoded` could still fail with “Field required” inside nested objects. With this PR we will now emit real `pydantic.Field(alias=...)` for aliased fields and update core parsing utilities so nested/union validation works reliably across Pydantic v1 and v2. The fix preserves Python attribute names and adds safe handling for Python-field-name inputs with collision protection.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Aliased fields are now generated as `pydantic.Field(alias="<wire_name>")`, ensuring Pydantic validates wire keys correctly (including nested `TypeAdapter` cases).
- `parse_obj_as` now conditionally pre-dealiases only when needed (TypedDict / FieldMetadata-only paths), avoiding regressions with models that have native Pydantic aliases.
- Added a pre-validation rewrite from python field names to aliases with explicit collision detection
- Removed obsolete override: dropped the Pydantic v2 `model_validate` override in `UncheckedBaseModel` since aliasing is handled natively.
 
## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures wire-key validation works reliably (including nested `TypeAdapter`/unions) by moving to native Pydantic aliases and tightening core parsing.
> 
> - Generate aliased fields with `pydantic.Field(alias="...")`; update codegen to always set alias when a field is aliased
> - Update `parse_obj_as` to only pre-dealias when required (e.g., TypedDict or FieldMetadata-only), preserving native alias handling
> - Add pre-validation rewrite from Python field names to aliases with explicit collision detection in `UniversalBaseModel` (v1/v2)
> - Remove the Pydantic v2 `model_validate` override from `UncheckedBaseModel`
> - Add hardened v1-on-v2 core utilities (checks against `pydantic.v1.BaseModel`) and a regression test
> - Regenerate seed SDKs to reflect new aliasing and utilities; incidental lockfile bumps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a75f340cb488a692a3db75a53106b3c8739ca9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->