### PR TITLE
chore(internal): add ACH to special tokens to preserve capitalization

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.30.4
+  changelogEntry:
+    - summary: |
+        Add ACH to special tokens list to preserve capitalization in docs sidebar navigation.
+      type: chore
+  createdAt: "2025-12-22"
+  irVersion: 62
+
 - version: 3.30.3
   changelogEntry:
     - summary: |

--- a/packages/commons/core-utils/src/titleCase.ts
+++ b/packages/commons/core-utils/src/titleCase.ts
@@ -158,6 +158,7 @@ export const SPECIAL_TOKENS = [
     "MV",
 
     // finance
+    "ACH",
     "USD",
     "EUR",
     "GBP",


### PR DESCRIPTION
## Description

Fixes an issue where "ACH" (Automated Clearing House) was being converted to "Ach" in the docs sidebar navigation when used as an OpenAPI tag name.

Link to Devin run: https://app.devin.ai/sessions/09b76b20a087431c9d785df349cbc43e
Requested by: danny@buildwithfern.com (@dannysheridan)

## Changes Made

- Added "ACH" to the `SPECIAL_TOKENS` array in the finance section to preserve its capitalization when the `titleCase` function is applied
- Added version entry 3.30.4 to `versions.yml` with changelog entry

## Human Review Checklist

- [ ] Verify "ACH" is a legitimate acronym that should preserve capitalization (it's a standard banking/payments term for Automated Clearing House)
- [ ] Verify version bump from 3.30.3 to 3.30.4 is correct
- [ ] Note: A corresponding PR was merged in fern-platform repo (PR #6122) for the same fix

## Testing

- [x] Lint checks passed (`pnpm run check`)
- [x] Pre-commit hooks passed