### PR TITLE
feat(cli): add line number reporting to YAML validation errors

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.31.0
+  changelogEntry:
+    - summary: |
+        Add line number reporting to YAML validation errors for docs.yml, product.yml, and version.yml files. Error messages now include the line number where the error occurred, making it easier to locate and fix configuration issues without requiring a YAML schema.
+      type: feat
+  createdAt: "2025-12-22"
+  irVersion: 62
+
 - version: 3.30.4
   changelogEntry:
     - summary: |

--- a/packages/cli/workspace/loader/package.json
+++ b/packages/cli/workspace/loader/package.json
@@ -43,6 +43,7 @@
     "@fern-api/task-context": "workspace:*",
     "chalk": "^5.3.0",
     "js-yaml": "^4.1.1",
+    "js-yaml-source-map": "^0.2.2",
     "zod": "^3.22.3"
   },
   "devDependencies": {

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -56,6 +56,7 @@
     "file-type": "^19.0.0",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.1",
+    "js-yaml-source-map": "^0.2.2",
     "mdast-util-to-hast": "^13.2.0",
     "next-mdx-remote": "^5.0.0",
     "openapi-types": "^12.0.0",

--- a/packages/cli/yaml/docs-validator/src/docsAst/DocsConfigFileAstVisitor.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/DocsConfigFileAstVisitor.ts
@@ -1,4 +1,5 @@
 import { docsYml } from "@fern-api/configuration-loader";
+import { type YamlSourceMap } from "@fern-api/core-utils";
 import { NodePath } from "@fern-api/fern-definition-schema";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
@@ -16,8 +17,8 @@ export interface DocsConfigFileAstNodeTypes {
         willBeUploaded?: boolean;
     };
     markdownPage: { title: string; content: string; absoluteFilepath: AbsoluteFilePath };
-    versionFile: { path: string; content: unknown };
-    productFile: { path: string; content: unknown };
+    versionFile: { path: string; content: unknown; absoluteFilepath: AbsoluteFilePath; sourceMap: YamlSourceMap };
+    productFile: { path: string; content: unknown; absoluteFilepath: AbsoluteFilePath; sourceMap: YamlSourceMap };
     apiSection: {
         config: docsYml.RawSchemas.ApiReferenceConfiguration;
         workspace: AbstractAPIWorkspace<unknown>;

--- a/packages/cli/yaml/docs-validator/src/docsAst/validateProductConfig.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/validateProductConfig.ts
@@ -1,5 +1,5 @@
 import { docsYml } from "@fern-api/configuration-loader";
-import { sanitizeNullValues, validateAgainstJsonSchema } from "@fern-api/core-utils";
+import { sanitizeNullValues, validateAgainstJsonSchema, type YamlSourceMap } from "@fern-api/core-utils";
 
 import * as DocsYmlJsonSchema from "./products-yml.schema.json";
 
@@ -15,9 +15,20 @@ interface ProductFileFailureParseResult {
     message: string;
 }
 
-export async function validateProductConfigFileSchema({ value }: { value: unknown }): Promise<ProductParseResult> {
+export async function validateProductConfigFileSchema({
+    value,
+    filePath,
+    sourceMap
+}: {
+    value: unknown;
+    filePath?: string;
+    sourceMap?: YamlSourceMap;
+}): Promise<ProductParseResult> {
     // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
-    const result = validateAgainstJsonSchema(value, DocsYmlJsonSchema as any);
+    const result = validateAgainstJsonSchema(value, DocsYmlJsonSchema as any, {
+        filePath,
+        sourceMap
+    });
     if (result.success) {
         // Sanitize null/undefined values before parsing
         const removedPaths: string[][] = [];
@@ -29,9 +40,8 @@ export async function validateProductConfigFileSchema({ value }: { value: unknow
         };
     }
 
-    const path = result.error?.instancePath ? ` at ${result?.error.instancePath}` : "";
     return {
         type: "failure",
-        message: `${result.error?.message ?? "Failed to parse because JSON schema validation failed"}${path}`
+        message: result.error?.message ?? "Failed to parse because JSON schema validation failed"
     };
 }

--- a/packages/cli/yaml/docs-validator/src/rules/validate-product-file/validate-product-file.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/validate-product-file/validate-product-file.ts
@@ -5,8 +5,12 @@ export const ValidateProductFileRule: Rule = {
     name: "validate-product-file",
     create: () => {
         return {
-            productFile: async ({ path, content }) => {
-                const parseResult = await validateProductConfigFileSchema({ value: content });
+            productFile: async ({ content, absoluteFilepath, sourceMap }) => {
+                const parseResult = await validateProductConfigFileSchema({
+                    value: content,
+                    filePath: absoluteFilepath,
+                    sourceMap
+                });
                 if (parseResult.type === "success") {
                     return [];
                 }

--- a/packages/cli/yaml/docs-validator/src/rules/validate-version-file/validate-version-file.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/validate-version-file/validate-version-file.ts
@@ -5,8 +5,12 @@ export const ValidateVersionFileRule: Rule = {
     name: "validate-version-file",
     create: () => {
         return {
-            versionFile: async ({ path, content }) => {
-                const parseResult = await validateVersionConfigFileSchema({ value: content });
+            versionFile: async ({ content, absoluteFilepath, sourceMap }) => {
+                const parseResult = await validateVersionConfigFileSchema({
+                    value: content,
+                    filePath: absoluteFilepath,
+                    sourceMap
+                });
                 if (parseResult.type === "success") {
                     return [];
                 }

--- a/packages/commons/core-utils/src/index.ts
+++ b/packages/commons/core-utils/src/index.ts
@@ -43,6 +43,10 @@ export { type SetRequired } from "./setRequired";
 export { stripLeadingSlash } from "./stripLeadingSlash";
 export { titleCase } from "./titleCase";
 export type { ContainerRunner, Digit, Letter, LowercaseLetter, UppercaseLetter } from "./types";
-export { validateAgainstJsonSchema } from "./validateAgainstJsonSchema";
+export {
+    type SourceLocation,
+    validateAgainstJsonSchema,
+    type YamlSourceMap
+} from "./validateAgainstJsonSchema";
 export { visitDiscriminatedUnion } from "./visitDiscriminatedUnion";
 export type { WithoutQuestionMarks } from "./withoutQuestionMarks";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7134,6 +7134,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      js-yaml-source-map:
+        specifier: ^0.2.2
+        version: 0.2.2(js-yaml@4.1.1)
       zod:
         specifier: ^3.22.3
         version: 3.25.76
@@ -7271,6 +7274,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      js-yaml-source-map:
+        specifier: ^0.2.2
+        version: 0.2.2(js-yaml@4.1.1)
       mdast-util-to-hast:
         specifier: ^13.2.0
         version: 13.2.1
@@ -7682,7 +7688,7 @@ importers:
         version: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -24361,7 +24367,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -24379,6 +24385,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       babel-jest: 30.2.0(@babel/core@7.28.5)
+      esbuild: 0.25.12
       jest-util: 30.2.0
 
   ts-morph@27.0.2:


### PR DESCRIPTION
## Description
Refs: Slack thread from @Ryan-Amirthan about difficulty locating YAML configuration errors

Adds line number reporting to YAML validation errors for docs.yml, product.yml, and version.yml files. Error messages now use a clean `file:line:` format that is clickable in VS Code, JetBrains, and other modern terminals.

**Before:**
```
[error] Invalid object at path $.navigation[1].variants[0].layout[2].contents[1]: does not match any allowed schema (has properties: page)
Did you mean to add 'path'? at /navigation/1/variants/0/layout/2/contents/1
```

**After:**
```
/path/to/docs.yml:42: Invalid object at path $.navigation[1].variants[0].layout[2].contents[1]: does not match any allowed schema (has properties: page)
Did you mean to add 'path'?
```

The `file:line:` format at the start of the message enables click-to-navigate in supported terminals.

## Changes Made
- Added `YamlSourceMap` interface and helper functions to `validateAgainstJsonSchema.ts` for line number lookup
- Updated `formatErrorMessageWithFilePath` to use `file:line:` prefix format (removed redundant JSON path suffix)
- Modified `loadDocsWorkspace.ts` to create a source map when parsing YAML and pass it to validation
- Updated `validateProductConfig.ts` and `validateVersionConfig.ts` to accept optional source map parameter
- Updated `DocsConfigFileAstNodeTypes` interface to include `absoluteFilepath` and `sourceMap` for version/product files
- Added `js-yaml-source-map` dependency to workspace-loader and docs-validator packages
- Added version 3.31.0 entry to CLI versions.yml

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed (lint checks pass)

## Human Review Checklist
- [ ] Verify the `file:line:` prefix format is clear and clickable in VS Code terminal
- [ ] Check that the interface changes to `DocsConfigFileAstNodeTypes` (adding required `absoluteFilepath` and `sourceMap` fields) don't break existing code
- [ ] Verify source map lookup handles edge cases (JSON Pointer escaping with ~0 and ~1, missing properties falling back gracefully)
- [ ] Confirm error messages are still informative when line number cannot be resolved

---
**Link to Devin run:** https://app.devin.ai/sessions/7dac2f5c0b3e4c9aab5279a854f15db8
**Requested by:** @Ryan-Amirthan (ryanstep@buildwithfern.com)