### PR TITLE
fix(cli): broken link checker incorrectly flags links to paths with external redirects

### DIFF
--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -29,4 +29,15 @@ describe("fern docs broken-links", () => {
         // in query parameters (e.g., ?source=docs.example.com) should NOT be flagged
         expect(stripAnsi(stdout)).toContain("All checks passed");
     }, 20_000);
+
+    it("links to paths with external redirects should not be flagged as broken", async () => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("external-redirect")),
+            reject: false
+        });
+        // This fixture tests that links to internal paths (e.g., /ui) that have
+        // redirects configured to external URLs (e.g., https://auth-platform.example.com)
+        // should NOT be flagged as broken links
+        expect(stripAnsi(stdout)).toContain("All checks passed");
+    }, 20_000);
 });

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/external-redirect/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/external-redirect/fern/docs.yml
@@ -1,0 +1,18 @@
+instances:
+  - url: developer.example.com
+
+navigation:
+  - page: Test
+    path: test.md
+
+redirects:
+  - source: /ui
+    destination: https://auth-platform.example.com
+    permanent: false
+  - source: /ui/:path*
+    destination: https://auth-platform.example.com/:path*
+    permanent: false
+  - source: /console
+    destination: https://console.example.com/dashboard
+    permanent: true
+

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/external-redirect/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/external-redirect/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "test-org",
+  "version": "0.0.0"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/external-redirect/fern/test.md
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/external-redirect/fern/test.md
@@ -1,0 +1,16 @@
+# Test External Redirect Links
+
+This fixture tests that links to internal paths that redirect to external URLs
+are NOT incorrectly flagged as broken links.
+
+## Links that redirect to external URLs (should NOT be flagged)
+
+1. Link to /ui which redirects externally: [Developer Console](/ui)
+2. Link to /ui subpath which redirects externally: [Applications](/ui/applications)
+3. Link to /console which redirects externally: [Console](/console)
+4. Full URL to same domain with redirect: [Full URL](https://developer.example.com/ui)
+
+## Regular external link (should NOT be flagged)
+
+1. External link: [Google](https://google.com)
+

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
@@ -62,6 +62,13 @@ export async function checkIfPathnameExists({
             redirectedPath = nextRedirectPath;
         }
 
+        // If the redirect destination is an external URL, consider it valid
+        // This handles cases where internal paths redirect to external services
+        // (e.g., /ui -> https://auth-platform.example.com)
+        if (isExternalUrl(redirectedPath)) {
+            return true;
+        }
+
         if (markdown && pageSlugs.has(removeLeadingSlash(redirectedPath))) {
             return true;
         }
@@ -104,6 +111,10 @@ export async function checkIfPathnameExists({
     for (const slug of slugs) {
         const url = new URL(`/${slug}`, wrapWithHttps(baseUrl.domain));
         const targetSlug = withRedirects(new URL(pathname, url).pathname, baseUrl, redirects);
+        // If the redirect destination is an external URL, consider it valid
+        if (isExternalUrl(targetSlug)) {
+            continue;
+        }
         if (!pageSlugs.has(removeLeadingSlash(targetSlug))) {
             brokenSlugs.push(slug);
         }
@@ -130,4 +141,13 @@ function withoutAnchors(slug: string): string {
         return slug;
     }
     return slug.substring(0, hashIndex);
+}
+
+/**
+ * Checks if a path is an external URL (starts with http:// or https://).
+ * This is used to identify when a redirect destination points to an external service,
+ * which should be considered valid without checking if it exists in the docs navigation.
+ */
+function isExternalUrl(path: string): boolean {
+    return path.startsWith("http://") || path.startsWith("https://");
 }


### PR DESCRIPTION
## Description

The broken link checker incorrectly flags links to internal paths that have redirects configured to external URLs. For example, when a docs site has:

```
redirects:
  - source: "/ui"
    destination: https://auth-platform.example.com 
```
Links to `/ui` are flagged as broken because the checker resolves the redirect to an external URL, then fails to find it in the docs navigation (since external URLs aren't internal pages).

The fix adds a check after redirect resolution: if the destination is an external URL (`http://` or `https://`), the link is considered valid immediately.

## Changes Made

- Added `isExternalUrl()` helper function to detect external URLs
- After resolving redirects, check if destination is external and return `true` (valid) immediately
- Applied fix to both absolute path checking and relative path slug loop

**Files:**
- `packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts`

## Testing

- [x] Unit tests added/updated
  - New test fixture: `packages/cli/ete-tests/src/tests/broken-links/fixtures/external-redirect/`
  - New test case: "links to paths with external redirects should not be flagged as broken"

- [ ] Manual testing completed