### PR TITLE
feat(openapi): add x-fern-parameter-name support for websocket query parameters

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/parseAsyncAPIV2.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/parseAsyncAPIV2.ts
@@ -183,7 +183,10 @@ export function parseAsyncAPIV2({
                                 context.namespace
                             ),
                             description: resolvedSchema.description,
-                            parameterNameOverride: undefined,
+                            parameterNameOverride: getExtension<string>(
+                                resolvedSchema,
+                                FernOpenAPIExtension.PARAMETER_NAME
+                            ),
                             availability: convertAvailability(resolvedSchema),
                             source,
                             explode: undefined
@@ -206,7 +209,7 @@ export function parseAsyncAPIV2({
                             context.namespace
                         ),
                         description: schema.description,
-                        parameterNameOverride: undefined,
+                        parameterNameOverride: getExtension<string>(schema, FernOpenAPIExtension.PARAMETER_NAME),
                         availability: convertAvailability(schema),
                         source,
                         explode: undefined

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -263,7 +263,7 @@ export function parseAsyncAPIV3({
                 const parameterObject = {
                     name: parameterKey,
                     description: resolvedParameter.description,
-                    parameterNameOverride: undefined,
+                    parameterNameOverride: getExtension<string>(resolvedParameter, FernOpenAPIExtension.PARAMETER_NAME),
                     schema: parameterSchema,
                     variableReference: undefined,
                     availability: convertAvailability(parameter),

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/asyncapi-websocket-parameter-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/asyncapi-websocket-parameter-name.json
@@ -1,0 +1,184 @@
+{
+  "servers": [],
+  "websocketServers": [
+    {
+      "name": "API",
+      "url": "wss://api.example.com/v1/ws"
+    }
+  ],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [],
+  "webhooks": [],
+  "channels": {
+    "/chat": {
+      "audiences": [],
+      "handshake": {
+        "headers": [],
+        "queryParameters": [
+          {
+            "name": "session_settings",
+            "schema": {
+              "generatedName": "WebsocketSessionSettings",
+              "description": "The session settings for the connection.",
+              "value": {
+                "description": "The session settings for the connection.",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "WebsocketSessionSettings",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "description": "The session settings for the connection.",
+            "parameterNameOverride": "connect_session_settings",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            }
+          },
+          {
+            "name": "api_key",
+            "schema": {
+              "description": "The API key for authentication.",
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "WebsocketApiKey",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "description": "The API key for authentication.",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            }
+          },
+          {
+            "name": "model_version",
+            "schema": {
+              "generatedName": "WebsocketModelVersion",
+              "description": "The model version to use.",
+              "value": {
+                "description": "The model version to use.",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "WebsocketModelVersion",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "description": "The model version to use.",
+            "parameterNameOverride": "version",
+            "source": {
+              "file": "../asyncapi.yml",
+              "type": "openapi"
+            }
+          }
+        ],
+        "pathParameters": []
+      },
+      "groupName": [
+        "/chat"
+      ],
+      "messages": [],
+      "servers": [
+        {
+          "name": "API",
+          "url": "wss://api.example.com/v1/ws"
+        }
+      ],
+      "path": "/chat",
+      "examples": [
+        {
+          "queryParameters": [],
+          "headers": [],
+          "messages": []
+        }
+      ],
+      "source": {
+        "file": "../asyncapi.yml",
+        "type": "openapi"
+      }
+    }
+  },
+  "groupedSchemas": {
+    "rootSchemas": {
+      "SendPayload": {
+        "properties": [
+          {
+            "key": "text",
+            "schema": {
+              "generatedName": "SendPayloadText",
+              "schema": {
+                "type": "string"
+              },
+              "description": "The text to send",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": [],
+            "conflict": {},
+            "generatedName": "sendPayloadText"
+          }
+        ],
+        "generatedName": "SendPayload",
+        "allOf": [],
+        "allOfPropertyConflicts": [],
+        "groupName": [],
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../asyncapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ReceivePayload": {
+        "properties": [
+          {
+            "key": "response",
+            "schema": {
+              "generatedName": "ReceivePayloadResponse",
+              "schema": {
+                "type": "string"
+              },
+              "description": "The response text",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": [],
+            "conflict": {},
+            "generatedName": "receivePayloadResponse"
+          }
+        ],
+        "generatedName": "ReceivePayload",
+        "allOf": [],
+        "allOfPropertyConflicts": [],
+        "groupName": [],
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../asyncapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-websocket-parameter-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-websocket-parameter-name.json
@@ -1,0 +1,130 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "ReceivePayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "response": {
+                "docs": "The response text",
+                "type": "string",
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+          "SendPayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "text": {
+                "docs": "The text to send",
+                "type": "string",
+              },
+            },
+            "source": {
+              "openapi": "../asyncapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  SendPayload:
+    properties:
+      text:
+        type: string
+        docs: The text to send
+    source:
+      openapi: ../asyncapi.yml
+  ReceivePayload:
+    properties:
+      response:
+        type: string
+        docs: The response text
+    source:
+      openapi: ../asyncapi.yml
+",
+    },
+    "chat.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "channel": {
+          "auth": false,
+          "examples": [
+            {
+              "messages": [],
+            },
+          ],
+          "messages": {},
+          "path": "/chat",
+          "query-parameters": {
+            "api_key": {
+              "docs": "The API key for authentication.",
+              "type": "string",
+            },
+            "model_version": {
+              "docs": "The model version to use.",
+              "name": "version",
+              "type": "optional<string>",
+            },
+            "session_settings": {
+              "docs": "The session settings for the connection.",
+              "name": "connect_session_settings",
+              "type": "optional<string>",
+            },
+          },
+          "url": "API",
+        },
+      },
+      "rawContents": "channel:
+  path: /chat
+  url: API
+  auth: false
+  query-parameters:
+    session_settings:
+      type: optional<string>
+      docs: The session settings for the connection.
+      name: connect_session_settings
+    api_key:
+      type: string
+      docs: The API key for authentication.
+    model_version:
+      type: optional<string>
+      docs: The model version to use.
+      name: version
+  messages: {}
+  examples:
+    - messages: []
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "API",
+      "default-url": "Base",
+      "environments": {
+        "API": "wss://api.example.com/v1/ws",
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": "Base",
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+environments:
+  API: wss://api.example.com/v1/ws
+default-environment: API
+default-url: Base
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-websocket-parameter-name/asyncapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-websocket-parameter-name/asyncapi.yml
@@ -1,0 +1,76 @@
+asyncapi: 2.6.0
+defaultContentType: application/json
+id: http://example.com/websocket-parameter-name
+
+info:
+  title: WebSocket Parameter Name Test
+  description: Test for x-fern-parameter-name extension on websocket query parameters
+  version: 1.0.0
+
+servers:
+  API:
+    url: wss://api.example.com/v1/ws
+    protocol: wss
+    description: Example WebSocket API
+
+channels:
+  /chat:
+    bindings:
+      ws:
+        query:
+          type: object
+          properties:
+            session_settings:
+              description: The session settings for the connection.
+              type: string
+              x-fern-parameter-name: connect_session_settings
+            api_key:
+              description: The API key for authentication.
+              type: string
+            model_version:
+              description: The model version to use.
+              type: string
+              x-fern-parameter-name: version
+          required:
+            - api_key
+    publish:
+      description: Send messages to the WebSocket
+      operationId: sendMessage
+      message:
+        $ref: "#/components/messages/SendMessage"
+    subscribe:
+      description: Receive messages from the WebSocket
+      operationId: receiveMessage
+      message:
+        $ref: "#/components/messages/ReceiveMessage"
+
+components:
+  messages:
+    SendMessage:
+      messageId: sendMessage
+      summary: Send a message
+      payload:
+        $ref: "#/components/schemas/SendPayload"
+    ReceiveMessage:
+      messageId: receiveMessage
+      summary: Receive a message
+      payload:
+        $ref: "#/components/schemas/ReceivePayload"
+
+  schemas:
+    SendPayload:
+      type: object
+      required:
+        - text
+      properties:
+        text:
+          description: The text to send
+          type: string
+    ReceivePayload:
+      type: object
+      required:
+        - response
+      properties:
+        response:
+          description: The response text
+          type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-websocket-parameter-name/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-websocket-parameter-name/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-websocket-parameter-name/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-websocket-parameter-name/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - asyncapi: ../asyncapi.yml


### PR DESCRIPTION
## Description

Refs: Slack thread from @aditya-arolkar-swe

Link to Devin run: https://app.devin.ai/sessions/2143d4e4bc654af4b7ca3d0aee402c1c

This PR adds support for the `x-fern-parameter-name` extension on websocket query parameters in AsyncAPI specs. Previously, this extension was only supported for HTTP endpoint parameters, and websocket query parameters always had `parameterNameOverride` set to `undefined`.

This enables users to rename websocket query parameters in generated SDKs to avoid naming conflicts (e.g., when a query parameter and an event type would generate the same property name).

## Changes Made

- Updated `parseAsyncAPIV2.ts` to extract `x-fern-parameter-name` extension for websocket query parameters (both reference and non-reference schemas)
- Updated `parseAsyncAPIV3.ts` to extract `x-fern-parameter-name` extension for websocket channel parameters
- Added test fixture `asyncapi-websocket-parameter-name` to validate the feature

## Testing

- [x] Unit tests added (new test fixture with snapshots)
- [x] Lint checks pass

## Human Review Checklist

- [ ] Verify the extension extraction logic matches how it's done for HTTP parameters in `convertParameters.ts`
- [ ] Confirm both AsyncAPI v2 code paths (reference objects at line 186-189 and non-reference at line 212) are correctly updated
- [ ] Check that the generated Fern definition correctly uses `name:` field for overridden parameters (visible in snapshot at `chat.yml`)