### PR TITLE
feat(cli): add dynamic-ir-only upload step for SDK

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -633,6 +633,12 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     type: "string",
                     description:
                         "Path to a custom .fernignore file to use instead of the one on the main branch (remote generation only)"
+                })
+                .option("dynamic-ir-only", {
+                    boolean: true,
+                    description:
+                        "Only upload dynamic IR for specified version, skip SDK generation (remote generation only)",
+                    default: false
                 }),
         async (argv) => {
             if (argv.api != null && argv.docs != null) {
@@ -647,6 +653,21 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
             if (argv.fernignore != null && (argv.local || argv.runner != null)) {
                 return cliContext.failWithoutThrowing(
                     "The --fernignore flag is not supported with local generation (--local or --runner). It can only be used with remote generation."
+                );
+            }
+            if (argv["dynamic-ir-only"] && (argv.local || argv.runner != null)) {
+                return cliContext.failWithoutThrowing(
+                    "The --dynamic-ir-only flag is not supported with local generation (--local or --runner). It can only be used with remote generation."
+                );
+            }
+            if (argv["dynamic-ir-only"] && argv.version == null) {
+                return cliContext.failWithoutThrowing(
+                    "The --dynamic-ir-only flag requires a version to be specified with --version."
+                );
+            }
+            if (argv["dynamic-ir-only"] && argv.docs != null) {
+                return cliContext.failWithoutThrowing(
+                    "The --dynamic-ir-only flag can only be used for API generation, not docs generation."
                 );
             }
             if (argv.api != null) {
@@ -667,7 +688,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     runner: argv.runner as ContainerRunner,
                     inspect: false,
                     lfsOverride: argv.lfsOverride,
-                    fernignorePath: argv.fernignore
+                    fernignorePath: argv.fernignore,
+                    dynamicIrOnly: argv["dynamic-ir-only"]
                 });
             }
             if (argv.docs != null) {
@@ -714,7 +736,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 runner: argv.runner as ContainerRunner,
                 inspect: false,
                 lfsOverride: argv.lfsOverride,
-                fernignorePath: argv.fernignore
+                fernignorePath: argv.fernignore,
+                dynamicIrOnly: argv["dynamic-ir-only"]
             });
         }
     );

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -33,7 +33,8 @@ export async function generateWorkspace({
     runner,
     inspect,
     lfsOverride,
-    fernignorePath
+    fernignorePath,
+    dynamicIrOnly
 }: {
     organization: string;
     workspace: AbstractAPIWorkspace<unknown>;
@@ -51,6 +52,7 @@ export async function generateWorkspace({
     inspect: boolean;
     lfsOverride: string | undefined;
     fernignorePath: string | undefined;
+    dynamicIrOnly: boolean;
 }): Promise<void> {
     if (workspace.generatorsConfiguration == null) {
         context.logger.warn("This workspaces has no generators.yml");
@@ -137,7 +139,8 @@ export async function generateWorkspace({
                     whitelabel: workspace.generatorsConfiguration?.whitelabel,
                     absolutePathToPreview,
                     mode,
-                    fernignorePath
+                    fernignorePath,
+                    dynamicIrOnly
                 });
             }
         })

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -30,7 +30,8 @@ export async function generateAPIWorkspaces({
     runner,
     inspect,
     lfsOverride,
-    fernignorePath
+    fernignorePath,
+    dynamicIrOnly
 }: {
     project: Project;
     cliContext: CliContext;
@@ -46,6 +47,7 @@ export async function generateAPIWorkspaces({
     inspect: boolean;
     lfsOverride: string | undefined;
     fernignorePath: string | undefined;
+    dynamicIrOnly: boolean;
 }): Promise<void> {
     let token: FernToken | undefined = undefined;
 
@@ -134,7 +136,8 @@ export async function generateAPIWorkspaces({
                     runner,
                     inspect,
                     lfsOverride,
-                    fernignorePath
+                    fernignorePath,
+                    dynamicIrOnly
                 });
             });
         })

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.31.0
+  changelogEntry:
+    - summary: |
+        Add a `--dynamic-ir-only` flag to SDK generation to enable access to dynamic snippets from SDKs without regenerating the entire SDK.
+      type: fix
+  createdAt: "2025-12-23"
+  irVersion: 62
+
 - version: 3.30.6
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -28,7 +28,8 @@ export async function runRemoteGenerationForAPIWorkspace({
     whitelabel,
     absolutePathToPreview,
     mode,
-    fernignorePath
+    fernignorePath,
+    dynamicIrOnly
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -42,6 +43,7 @@ export async function runRemoteGenerationForAPIWorkspace({
     absolutePathToPreview: AbsoluteFilePath | undefined;
     mode: "pull-request" | undefined;
     fernignorePath: string | undefined;
+    dynamicIrOnly: boolean;
 }): Promise<RemoteGenerationForAPIWorkspaceResponse | null> {
     if (generatorGroup.generators.length === 0) {
         context.logger.warn("No generators specified.");
@@ -98,7 +100,8 @@ export async function runRemoteGenerationForAPIWorkspace({
                     readme: generatorInvocation.readme,
                     irVersionOverride: generatorInvocation.irVersionOverride,
                     absolutePathToPreview,
-                    fernignorePath
+                    fernignorePath,
+                    dynamicIrOnly
                 });
                 if (remoteTaskHandlerResponse != null && remoteTaskHandlerResponse.createdSnippets) {
                     snippetsProducedBy.push(generatorInvocation);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -488,9 +488,7 @@ async function uploadDynamicIRForSdkGeneration({
     });
 
     if (uploadResponse.ok) {
-        context.logger.debug(
-            `Uploaded dynamic IR for ${language}:${packageName} (${version})`
-        );
+        context.logger.debug(`Uploaded dynamic IR for ${language}:${packageName} (${version})`);
     } else {
         context.logger.warn(`Failed to upload dynamic IR for ${language}: ${uploadResponse.status}`);
     }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -224,6 +224,9 @@ export async function runRemoteGenerationForGenerator({
                 dynamicGeneratorConfig,
                 context: interactiveTaskContext
             });
+            interactiveTaskContext.logger.debug(
+                `Uploaded dynamic IR for ${generatorInvocation.language}:${packageName}`
+            );
         } catch (error) {
             interactiveTaskContext.logger.warn(
                 `Failed to upload dynamic IR for SDK generation: ${error instanceof Error ? error.message : String(error)}`


### PR DESCRIPTION
- fixes an issue so the dynamic IR can be generated even if an explicit version isn't set (it grabs the version computed from the SDK tag)
- adds a flag to just upload the dynamic IR (so people can access this without needing to re-publish their SDK)
