### PR TITLE
fix(java-v2): Fix README/reference.md generation on enterprise networks

### DIFF
--- a/generators/java-v2/sdk/src/JavaGeneratorAgent.ts
+++ b/generators/java-v2/sdk/src/JavaGeneratorAgent.ts
@@ -22,7 +22,7 @@ export class JavaGeneratorAgent extends AbstractGeneratorAgent<SdkGeneratorConte
         readmeConfigBuilder: ReadmeConfigBuilder;
         ir: IntermediateRepresentation;
     }) {
-        super({ logger, config, selfHosted: ir.selfHosted });
+        super({ logger, config, selfHosted: ir.selfHosted, skipInstall: true });
         this.readmeConfigBuilder = readmeConfigBuilder;
         this.publishConfig = ir.publishConfig;
     }

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -87,7 +87,7 @@ RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github
 
 RUN test -f /bin/java-v2 || echo "java-v2 CLI not found or not executable"
 
-RUN npm install -f -g @fern-api/generator-cli@0.2.0
+RUN npm install -f -g @fern-api/generator-cli@0.5.0
 
 # Patch @octokit/request to fix CVE-2025-25290 (ReDoS vulnerability)
 # Use npm pack + tar to replace the package without running npm install (which fails due to workspace: protocol)


### PR DESCRIPTION
## Summary

Fixes README.md and reference.md generation failures on enterprise networks that use SSL inspection/interception.

### Problem

On enterprise networks with SSL inspection, the Java V2 generator fails to generate README.md and reference.md files with these errors:

```
[Java V2 STDERR] Failed to generate README.md, this is OK.
[Java V2 STDERR] Failed to generate reference.md, this is OK.
```

The root cause is:
1. The `GeneratorAgentClient` attempts to run `npm install -f -g @fern-api/generator-cli` at runtime
2. This fails with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` on networks with SSL inspection
3. The fallback to the pre-installed CLI fails because the Docker image had an outdated version (0.2.0)

### Solution

1. **Update generator-cli version**: Bump from `0.2.0` to `0.5.0` in the Dockerfile
2. **Skip runtime npm install**: Add `skipInstall: true` to `JavaGeneratorAgent` so it uses the pre-installed CLI directly without attempting network access

## Changes

| File | Change |
|------|--------|
| `generators/java/sdk/Dockerfile` | Updated `@fern-api/generator-cli` from `0.2.0` → `0.5.0` |
| `generators/java-v2/sdk/src/JavaGeneratorAgent.ts` | Added `skipInstall: true` to skip runtime npm install |

## Verification Steps

### For reviewers
1. Confirm the `skipInstall: true` flag prevents the runtime npm install in `GeneratorAgentClient.getOrInstall()`
2. Verify the Dockerfile installs `@fern-api/generator-cli@0.5.0`

### For QA (enterprise network testing)
1. Build the Docker image: `docker build -f generators/java/sdk/Dockerfile -t fernapi/fern-java-sdk:test .`
2. Run SDK generation on an enterprise network with SSL inspection
3. Verify README.md and reference.md are generated without errors
4. Verify no `npm install` network calls are attempted at runtime

### For local testing
1. Run Java SDK seed tests to ensure no regression
2. Verify the generated README.md and reference.md content is correct