### PR TITLE
fix(java, python): Fix README/reference.md generation on enterprise networks

### DIFF
--- a/generators/java-v2/sdk/src/JavaGeneratorAgent.ts
+++ b/generators/java-v2/sdk/src/JavaGeneratorAgent.ts
@@ -22,7 +22,7 @@ export class JavaGeneratorAgent extends AbstractGeneratorAgent<SdkGeneratorConte
         readmeConfigBuilder: ReadmeConfigBuilder;
         ir: IntermediateRepresentation;
     }) {
-        super({ logger, config, selfHosted: ir.selfHosted });
+        super({ logger, config, selfHosted: ir.selfHosted, skipInstall: true });
         this.readmeConfigBuilder = readmeConfigBuilder;
         this.publishConfig = ir.publishConfig;
     }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.27.5-rc0
+  changelogEntry:
+    - summary: Skip installation of generator-cli in Java V2 generator as it is already installed in the base image.
+      type: chore
+  createdAt: "2025-12-23"
+  irVersion: 61
+
 - version: 3.27.4
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.46.7-rc0
+  changelogEntry:
+    - summary: Skip installation of generator-cli in Python SDK generator as it is already installed in the base image.
+      type: chore
+  createdAt: "2025-12-23"
+  irVersion: 62
+
 - version: 4.46.6
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/sdk_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/sdk_generator.py
@@ -292,6 +292,7 @@ class SdkGenerator(AbstractGenerator):
             generator_exec_wrapper=generator_exec_wrapper,
             context=context,
             endpoint_metadata=endpoint_metadata_collector,
+            skip_install=True,
         )
 
         snippets = snippet_registry.snippets()


### PR DESCRIPTION
## Summary

Fixes README.md and reference.md generation failures/slowness on enterprise networks that use SSL inspection/interception.

### Problem

On enterprise networks with SSL inspection, generators fail or hang when trying to generate README.md and reference.md files:

**Java V2:**
```
[Java V2 STDERR] Failed to generate README.md, this is OK.
[Java V2 STDERR] Failed to generate reference.md, this is OK.
```

**Python:**
- Hangs for a long time before eventually generating

The root cause is:
1. Both generators attempt to run `npm install -f -g @fern-api/generator-cli` at runtime
2. This fails/times out with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` on networks with SSL inspection
3. The `generator-cli` is already pre-installed in the Docker images, so this network call is unnecessary

### Solution

1. **Skip runtime npm install**: Use the pre-installed CLI directly
   - **Java V2**: Add `skipInstall: true` to `JavaGeneratorAgent`
   - **Python**: Add `skip_install=True` to `GeneratorCli` instantiation

2. **Add robust debug logging**: Help diagnose any remaining issues with detailed logs throughout the generation chain

## Changes

| File | Change |
|------|--------|
| `generators/java-v2/sdk/src/JavaGeneratorAgent.ts` | Added `skipInstall: true` |
| `generators/java-v2/sdk/src/SdkGeneratorCli.ts` | Added detailed error logging for README/reference generation |
| `generators/base/src/AbstractGeneratorAgent.ts` | Added debug logging for config building and CLI calls |
| `generators/base/src/GeneratorAgentClient.ts` | Added debug logging for CLI commands and results |
| `generators/python/src/fern_python/generators/sdk/sdk_generator.py` | Added `skip_install=True` |
| `generators/python/sdk/versions.yml` | Added RC version 4.46.7-rc0 |

## Debug Logging Added

The new logging will show:
- `AbstractGeneratorAgent.generateReadme: Building README config...`
- `AbstractGeneratorAgent.readFeatureConfig: Reading feature configuration...`
- `AbstractGeneratorAgent.getFeaturesConfig: Trying path: /assets/features.yml`
- `GeneratorAgentClient.generateReadme: Running command: generator-cli generate readme --config /tmp/xxx`
- `GeneratorAgentClient.generateReadme: Command failed: <error message>`

## Verification Steps

### For reviewers
1. Confirm the `skipInstall` flags prevent runtime npm install
2. Verify both Docker images have `generator-cli` pre-installed
3. Review debug logging for completeness

### For QA (enterprise network testing)
1. Build the Docker images
2. Run SDK generation on an enterprise network with SSL inspection
3. Check debug logs for any errors in the generation chain
4. Verify README.md and reference.md are generated without errors or delays

### For local testing
1. Run Java SDK and Python SDK seed tests to ensure no regression
2. Verify the generated README.md and reference.md content is correct