### PR TITLE
fix: Add debug logging and fix missing fast-content-type-parse dependency

### DIFF
--- a/generators/base/src/AbstractGeneratorAgent.ts
+++ b/generators/base/src/AbstractGeneratorAgent.ts
@@ -124,9 +124,7 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             const errorStack = error instanceof Error ? error.stack : undefined;
-            this.logger.debug(
-                `AbstractGeneratorAgent.generateReadme: FAILED to build README config: ${errorMessage}`
-            );
+            this.logger.debug(`AbstractGeneratorAgent.generateReadme: FAILED to build README config: ${errorMessage}`);
             if (errorStack) {
                 this.logger.debug(`AbstractGeneratorAgent.generateReadme: Stack trace: ${errorStack}`);
             }

--- a/generators/base/src/GeneratorAgentClient.ts
+++ b/generators/base/src/GeneratorAgentClient.ts
@@ -21,24 +21,68 @@ export class GeneratorAgentClient {
 
     public async generateReadme<ReadmeConfig>({ readmeConfig }: { readmeConfig: ReadmeConfig }): Promise<string> {
         this.logger.debug("GeneratorAgentClient.generateReadme: Writing config to temp file...");
-        const readmeConfigFilepath = await this.writeConfig({
-            config: readmeConfig
-        });
-        this.logger.debug(`GeneratorAgentClient.generateReadme: Config written to ${readmeConfigFilepath}`);
+
+        let readmeConfigFilepath: AbsoluteFilePath;
+        try {
+            readmeConfigFilepath = await this.writeConfig({
+                config: readmeConfig
+            });
+            this.logger.debug(`GeneratorAgentClient.generateReadme: Config written to ${readmeConfigFilepath}`);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReadme: FAILED to write config to temp file: ${errorMessage}`
+            );
+            throw error;
+        }
 
         const args = ["generate", "readme", "--config", readmeConfigFilepath];
         this.logger.debug(`GeneratorAgentClient.generateReadme: Running command: generator-cli ${args.join(" ")}`);
 
-        const cli = await this.getOrInstall({ doNotPipeOutput: true });
+        let cli: LoggingExecutable;
+        try {
+            cli = await this.getOrInstall({ doNotPipeOutput: true });
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReadme: FAILED to get/install generator-cli: ${errorMessage}`
+            );
+            throw error;
+        }
+
+        // Verify CLI is accessible by checking version
+        try {
+            const versionResult = await cli(["--version"]);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReadme: Using generator-cli version: ${versionResult.stdout.trim()}`
+            );
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReadme: FAILED to get generator-cli version (CLI may not be installed): ${errorMessage}`
+            );
+            throw new Error(`generator-cli is not accessible: ${errorMessage}`);
+        }
+
         try {
             const content = await cli(args);
             this.logger.debug(
                 `GeneratorAgentClient.generateReadme: Command succeeded, stdout length: ${content.stdout.length}, stderr: ${content.stderr || "(empty)"}`
             );
             return content.stdout;
-        } catch (error) {
+        } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            this.logger.debug(`GeneratorAgentClient.generateReadme: Command failed: ${errorMessage}`);
+            // Try to extract more details from the error
+            const execaError = error as { exitCode?: number; stderr?: string; stdout?: string; command?: string };
+            const exitCode = execaError.exitCode ?? "unknown";
+            const stderr = execaError.stderr ?? "(no stderr)";
+            const stdout = execaError.stdout ?? "(no stdout)";
+            this.logger.debug(
+                `GeneratorAgentClient.generateReadme: Command FAILED with exit code ${exitCode}`
+            );
+            this.logger.debug(`GeneratorAgentClient.generateReadme: stderr: ${stderr}`);
+            this.logger.debug(`GeneratorAgentClient.generateReadme: stdout: ${stdout}`);
+            this.logger.debug(`GeneratorAgentClient.generateReadme: error message: ${errorMessage}`);
             throw error;
         }
     }
@@ -67,31 +111,105 @@ export class GeneratorAgentClient {
         referenceConfig: ReferenceConfig;
     }): Promise<string> {
         this.logger.debug("GeneratorAgentClient.generateReference: Writing config to temp file...");
-        const referenceConfigFilepath = await this.writeConfig({
-            config: referenceConfig
-        });
-        this.logger.debug(`GeneratorAgentClient.generateReference: Config written to ${referenceConfigFilepath}`);
+
+        let referenceConfigFilepath: AbsoluteFilePath;
+        try {
+            referenceConfigFilepath = await this.writeConfig({
+                config: referenceConfig
+            });
+            this.logger.debug(`GeneratorAgentClient.generateReference: Config written to ${referenceConfigFilepath}`);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReference: FAILED to write config to temp file: ${errorMessage}`
+            );
+            throw error;
+        }
 
         const args = ["generate-reference", "--config", referenceConfigFilepath];
         this.logger.debug(`GeneratorAgentClient.generateReference: Running command: generator-cli ${args.join(" ")}`);
 
-        const cli = await this.getOrInstall({ doNotPipeOutput: true });
+        let cli: LoggingExecutable;
+        try {
+            cli = await this.getOrInstall({ doNotPipeOutput: true });
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReference: FAILED to get/install generator-cli: ${errorMessage}`
+            );
+            throw error;
+        }
+
+        // Verify CLI is accessible by checking version
+        try {
+            const versionResult = await cli(["--version"]);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReference: Using generator-cli version: ${versionResult.stdout.trim()}`
+            );
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReference: FAILED to get generator-cli version (CLI may not be installed): ${errorMessage}`
+            );
+            throw new Error(`generator-cli is not accessible: ${errorMessage}`);
+        }
+
         try {
             const content = await cli(args);
             this.logger.debug(
                 `GeneratorAgentClient.generateReference: Command succeeded, stdout length: ${content.stdout.length}, stderr: ${content.stderr || "(empty)"}`
             );
             return content.stdout;
-        } catch (error) {
+        } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            this.logger.debug(`GeneratorAgentClient.generateReference: Command failed: ${errorMessage}`);
+            // Try to extract more details from the error
+            const execaError = error as { exitCode?: number; stderr?: string; stdout?: string; command?: string };
+            const exitCode = execaError.exitCode ?? "unknown";
+            const stderr = execaError.stderr ?? "(no stderr)";
+            const stdout = execaError.stdout ?? "(no stdout)";
+            this.logger.debug(
+                `GeneratorAgentClient.generateReference: Command FAILED with exit code ${exitCode}`
+            );
+            this.logger.debug(`GeneratorAgentClient.generateReference: stderr: ${stderr}`);
+            this.logger.debug(`GeneratorAgentClient.generateReference: stdout: ${stdout}`);
+            this.logger.debug(`GeneratorAgentClient.generateReference: error message: ${errorMessage}`);
             throw error;
         }
     }
 
     public async writeConfig<T>({ config }: { config: T }): Promise<AbsoluteFilePath> {
-        const file = await tmp.file();
-        await writeFile(file.path, JSON.stringify(config));
+        // Create temp file
+        let file: tmp.FileResult;
+        try {
+            file = await tmp.file();
+            this.logger.debug(`GeneratorAgentClient.writeConfig: Created temp file at ${file.path}`);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(`GeneratorAgentClient.writeConfig: FAILED to create temp file: ${errorMessage}`);
+            throw error;
+        }
+
+        // Serialize config to JSON
+        let configJson: string;
+        try {
+            configJson = JSON.stringify(config);
+            this.logger.debug(`GeneratorAgentClient.writeConfig: Serialized config to JSON (${configJson.length} bytes)`);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(`GeneratorAgentClient.writeConfig: FAILED to serialize config to JSON: ${errorMessage}`);
+            throw error;
+        }
+
+        // Write to file
+        try {
+            await writeFile(file.path, configJson);
+            this.logger.debug(`GeneratorAgentClient.writeConfig: Wrote config to ${file.path}`);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(`GeneratorAgentClient.writeConfig: FAILED to write to file: ${errorMessage}`);
+            throw error;
+        }
+
         return AbsoluteFilePath.of(file.path);
     }
 

--- a/generators/base/src/GeneratorAgentClient.ts
+++ b/generators/base/src/GeneratorAgentClient.ts
@@ -20,13 +20,27 @@ export class GeneratorAgentClient {
     }
 
     public async generateReadme<ReadmeConfig>({ readmeConfig }: { readmeConfig: ReadmeConfig }): Promise<string> {
+        this.logger.debug("GeneratorAgentClient.generateReadme: Writing config to temp file...");
         const readmeConfigFilepath = await this.writeConfig({
             config: readmeConfig
         });
+        this.logger.debug(`GeneratorAgentClient.generateReadme: Config written to ${readmeConfigFilepath}`);
+
         const args = ["generate", "readme", "--config", readmeConfigFilepath];
+        this.logger.debug(`GeneratorAgentClient.generateReadme: Running command: generator-cli ${args.join(" ")}`);
+
         const cli = await this.getOrInstall({ doNotPipeOutput: true });
-        const content = await cli(args);
-        return content.stdout;
+        try {
+            const content = await cli(args);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReadme: Command succeeded, stdout length: ${content.stdout.length}, stderr: ${content.stderr || "(empty)"}`
+            );
+            return content.stdout;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(`GeneratorAgentClient.generateReadme: Command failed: ${errorMessage}`);
+            throw error;
+        }
     }
 
     public async pushToGitHub<GitHubConfig>({
@@ -52,13 +66,27 @@ export class GeneratorAgentClient {
     }: {
         referenceConfig: ReferenceConfig;
     }): Promise<string> {
+        this.logger.debug("GeneratorAgentClient.generateReference: Writing config to temp file...");
         const referenceConfigFilepath = await this.writeConfig({
             config: referenceConfig
         });
+        this.logger.debug(`GeneratorAgentClient.generateReference: Config written to ${referenceConfigFilepath}`);
+
         const args = ["generate-reference", "--config", referenceConfigFilepath];
+        this.logger.debug(`GeneratorAgentClient.generateReference: Running command: generator-cli ${args.join(" ")}`);
+
         const cli = await this.getOrInstall({ doNotPipeOutput: true });
-        const content = await cli(args);
-        return content.stdout;
+        try {
+            const content = await cli(args);
+            this.logger.debug(
+                `GeneratorAgentClient.generateReference: Command succeeded, stdout length: ${content.stdout.length}, stderr: ${content.stderr || "(empty)"}`
+            );
+            return content.stdout;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.debug(`GeneratorAgentClient.generateReference: Command failed: ${errorMessage}`);
+            throw error;
+        }
     }
 
     public async writeConfig<T>({ config }: { config: T }): Promise<AbsoluteFilePath> {
@@ -69,12 +97,14 @@ export class GeneratorAgentClient {
 
     private async getOrInstall(options: createLoggingExecutable.Options = {}): Promise<LoggingExecutable> {
         if (this.skipInstall) {
+            this.logger.debug("GeneratorAgentClient.getOrInstall: skipInstall=true, using pre-installed generator-cli");
             return createLoggingExecutable("generator-cli", {
                 cwd: process.cwd(),
                 logger: this.logger,
                 ...options
             });
         }
+        this.logger.debug("GeneratorAgentClient.getOrInstall: skipInstall=false, running install...");
         return this.install(options);
     }
 

--- a/generators/base/src/GeneratorAgentClient.ts
+++ b/generators/base/src/GeneratorAgentClient.ts
@@ -77,9 +77,7 @@ export class GeneratorAgentClient {
             const exitCode = execaError.exitCode ?? "unknown";
             const stderr = execaError.stderr ?? "(no stderr)";
             const stdout = execaError.stdout ?? "(no stdout)";
-            this.logger.debug(
-                `GeneratorAgentClient.generateReadme: Command FAILED with exit code ${exitCode}`
-            );
+            this.logger.debug(`GeneratorAgentClient.generateReadme: Command FAILED with exit code ${exitCode}`);
             this.logger.debug(`GeneratorAgentClient.generateReadme: stderr: ${stderr}`);
             this.logger.debug(`GeneratorAgentClient.generateReadme: stdout: ${stdout}`);
             this.logger.debug(`GeneratorAgentClient.generateReadme: error message: ${errorMessage}`);
@@ -167,9 +165,7 @@ export class GeneratorAgentClient {
             const exitCode = execaError.exitCode ?? "unknown";
             const stderr = execaError.stderr ?? "(no stderr)";
             const stdout = execaError.stdout ?? "(no stdout)";
-            this.logger.debug(
-                `GeneratorAgentClient.generateReference: Command FAILED with exit code ${exitCode}`
-            );
+            this.logger.debug(`GeneratorAgentClient.generateReference: Command FAILED with exit code ${exitCode}`);
             this.logger.debug(`GeneratorAgentClient.generateReference: stderr: ${stderr}`);
             this.logger.debug(`GeneratorAgentClient.generateReference: stdout: ${stdout}`);
             this.logger.debug(`GeneratorAgentClient.generateReference: error message: ${errorMessage}`);
@@ -193,7 +189,9 @@ export class GeneratorAgentClient {
         let configJson: string;
         try {
             configJson = JSON.stringify(config);
-            this.logger.debug(`GeneratorAgentClient.writeConfig: Serialized config to JSON (${configJson.length} bytes)`);
+            this.logger.debug(
+                `GeneratorAgentClient.writeConfig: Serialized config to JSON (${configJson.length} bytes)`
+            );
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             this.logger.debug(`GeneratorAgentClient.writeConfig: FAILED to serialize config to JSON: ${errorMessage}`);

--- a/generators/java-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/java-v2/sdk/src/SdkGeneratorCli.ts
@@ -59,18 +59,32 @@ export class SdkGeneratorCLI extends AbstractJavaGeneratorCli<SdkCustomConfigSch
             }
 
             try {
+                context.logger.debug("Starting README.md generation...");
                 await this.generateReadme({
                     context,
                     endpointSnippets
                 });
+                context.logger.debug("Successfully generated README.md");
             } catch (e) {
-                context.logger.warn("Failed to generate README.md, this is OK.");
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                context.logger.warn(`Failed to generate README.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`README.md generation error stack: ${errorStack}`);
+                }
             }
 
             try {
+                context.logger.debug("Starting reference.md generation...");
                 await this.generateReference({ context });
+                context.logger.debug("Successfully generated reference.md");
             } catch (e) {
-                context.logger.warn("Failed to generate reference.md, this is OK.");
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                const errorStack = e instanceof Error ? e.stack : undefined;
+                context.logger.warn(`Failed to generate reference.md: ${errorMessage}`);
+                if (errorStack) {
+                    context.logger.debug(`reference.md generation error stack: ${errorStack}`);
+                }
             }
 
             try {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.27.5-rc1
+  changelogEntry:
+    - summary: Add debug logging to generator agent methods to help diagnose issues with README and reference generation.
+      type: chore
+  createdAt: "2025-12-23"
+  irVersion: 61
+
 - version: 3.27.5-rc0
   changelogEntry:
     - summary: Skip installation of generator-cli in Java V2 generator as it is already installed in the base image.


### PR DESCRIPTION
## Summary

This PR:
1. Adds comprehensive debug logging for README/reference.md generation
2. **Fixes a critical bug** where `generator-cli` fails due to missing `fast-content-type-parse` dependency

### Critical Bug Fix

The `@octokit/request` patch in the Dockerfile was missing a required dependency:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'fast-content-type-parse' 
imported from /usr/local/lib/node_modules/@fern-api/generator-cli/node_modules/@octokit/request/dist-bundle/index.js
```

This caused `generator-cli --version` to fail, which in turn caused README.md and reference.md generation to fail.

**Fix**: Added `fast-content-type-parse@2.0.1` to the Dockerfile patch.

## Changes

| File | Change |
|------|--------|
| `generators/java/sdk/Dockerfile` | Added `fast-content-type-parse` dependency for @octokit/request patch |
| `generators/java-v2/sdk/src/SdkGeneratorCli.ts` | Added debug logging |
| `generators/base/src/AbstractGeneratorAgent.ts` | Added comprehensive logging |
| `generators/base/src/GeneratorAgentClient.ts` | Added comprehensive logging |

## Verification Steps

1. Build the Docker image
2. Run SDK generation on enterprise network
3. Verify `generator-cli --version` works
4. Verify README.md and reference.md are generated successfully