### PR TITLE
fix(java): Install fast-content-type-parse dependency for @octokit/request CVE patch

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -91,11 +91,17 @@ RUN npm install -f -g @fern-api/generator-cli@0.2.0
 
 # Patch @octokit/request to fix CVE-2025-25290 (ReDoS vulnerability)
 # Use npm pack + tar to replace the package without running npm install (which fails due to workspace: protocol)
+# Also install fast-content-type-parse which is a new dependency in @octokit/request@10.0.7
 RUN cd /usr/local/lib/node_modules/@fern-api/generator-cli/node_modules/@octokit && \
     rm -rf request && \
     npm pack @octokit/request@10.0.7 && \
     tar -xzf octokit-request-10.0.7.tgz && \
     mv package request && \
-    rm octokit-request-10.0.7.tgz
+    rm octokit-request-10.0.7.tgz && \
+    cd /usr/local/lib/node_modules/@fern-api/generator-cli/node_modules && \
+    npm pack fast-content-type-parse@2.0.1 && \
+    tar -xzf fast-content-type-parse-2.0.1.tgz && \
+    mv package fast-content-type-parse && \
+    rm fast-content-type-parse-2.0.1.tgz
 
 ENTRYPOINT ["sh", "/init.sh"]

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.27.5-rc2
+  changelogEntry:
+    - summary: Install fast-content-type-parse dependency required by @octokit/request@10.0.7 CVE patch.
+      type: fix
+  createdAt: "2025-12-23"
+  irVersion: 61
+
 - version: 3.27.5-rc1
   changelogEntry:
     - summary: Add debug logging to generator agent methods to help diagnose issues with README and reference generation.

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - version: 3.27.5-rc3
   changelogEntry:
-    - summary: [Retry Publish] Install fast-content-type-parse dependency required by @octokit/request@10.0.7 CVE patch.
+    - summary: Retry Publishing of rc2
       type: fix
   createdAt: "2025-12-24"
   irVersion: 61

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.27.5-rc3
+  changelogEntry:
+    - summary: [Retry Publish] Install fast-content-type-parse dependency required by @octokit/request@10.0.7 CVE patch.
+      type: fix
+  createdAt: "2025-12-24"
+  irVersion: 61
 
 - version: 3.27.5-rc2
   changelogEntry:


### PR DESCRIPTION
## Summary

The `@octokit/request@10.0.7` CVE patch (for CVE-2025-25290 ReDoS vulnerability) introduced a new dependency on `fast-content-type-parse` that was not being installed. This caused the `generator-cli` to fail with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'fast-content-type-parse' imported from /usr/local/lib/node_modules/@fern-api/generator-cli/node_modules/@octokit/request/dist-bundle/index.js
```

This resulted in README.md and reference.md generation failing silently for enterprise clients running the Java SDK generator.

## Changes

- Install `fast-content-type-parse@2.0.1` as part of the `@octokit/request` CVE patch in the Dockerfile
- Add RC version entry for the fix

## Verification

Tested locally by:
1. Building the Docker image with the fix
2. Running `fern-local generate --local --log-level debug` against a Fern project
3. Confirmed README.md and reference.md generation succeeds with logs showing:
   - `GeneratorAgentClient.generateReadme: Command succeeded, stdout length: 11259, stderr: (empty)`
   - `Successfully generated README.md`
   - `Successfully generated reference.md`

## Related Context

This fixes an issue reported by enterprise clients on networks that block npm registry access, where the `skipInstall` fix was applied but README/reference generation still failed due to the missing dependency.