### PR TITLE
fix(openapi): handle discriminator mapping without oneOf in both conversion paths

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -1123,6 +1123,36 @@ export function convertSchemaObject(
             });
         }
 
+        // handle discriminator.mapping without oneOf/anyOf
+        // Some OpenAPI specs define discriminated unions using discriminator.mapping
+        // without explicit oneOf/anyOf. The convertDiscriminatedOneOf function will
+        // use the discriminator.mapping to build the union subtypes.
+        if (
+            schema.discriminator?.mapping != null &&
+            Object.keys(schema.discriminator.mapping).length > 0 &&
+            schema.oneOf == null &&
+            schema.anyOf == null
+        ) {
+            return convertDiscriminatedOneOf({
+                nameOverride,
+                generatedName,
+                title,
+                breadcrumbs,
+                description,
+                availability,
+                discriminator: schema.discriminator,
+                properties: schema.properties ?? {},
+                required: schema.required,
+                wrapAsOptional,
+                wrapAsNullable,
+                context,
+                namespace,
+                groupName,
+                encoding,
+                source
+            });
+        }
+
         // handle objects
         if (schema.allOf != null || schema.properties != null) {
             const filteredAllOfs: (OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject)[] = [];

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/discriminator-base-class.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/discriminator-base-class.json
@@ -1,0 +1,316 @@
+{
+  "title": "Discriminator Base Class Test",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "createForm",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "CreateFormRequest",
+      "request": {
+        "schema": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "createFormRequestFormFields",
+              "key": "form_fields",
+              "schema": {
+                "generatedName": "CreateFormRequestFormFields",
+                "description": "Array of form fields with different types",
+                "value": {
+                  "description": "Array of form fields with different types",
+                  "value": {
+                    "generatedName": "CreateFormRequestFormFieldsItem",
+                    "schema": "FormFieldBase",
+                    "source": {
+                      "file": "../openapi.yml",
+                      "type": "openapi"
+                    },
+                    "type": "reference"
+                  },
+                  "generatedName": "CreateFormRequestFormFields",
+                  "groupName": [],
+                  "type": "array"
+                },
+                "groupName": [],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "CreateFormRequest",
+          "groupName": [],
+          "additionalProperties": false,
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/form",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {},
+            "type": "object"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "FormFieldBase": {
+        "value": {
+          "commonProperties": [
+            {
+              "key": "name",
+              "schema": {
+                "description": "Display name for the field",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "FormFieldBaseName",
+                "groupName": [],
+                "type": "primitive"
+              }
+            },
+            {
+              "key": "x",
+              "schema": {
+                "description": "X coordinate",
+                "schema": {
+                  "type": "int"
+                },
+                "generatedName": "FormFieldBaseX",
+                "groupName": [],
+                "type": "primitive"
+              }
+            },
+            {
+              "key": "y",
+              "schema": {
+                "description": "Y coordinate",
+                "schema": {
+                  "type": "int"
+                },
+                "generatedName": "FormFieldBaseY",
+                "groupName": [],
+                "type": "primitive"
+              }
+            }
+          ],
+          "description": "Base form field with discriminator",
+          "discriminantProperty": "type",
+          "generatedName": "FormFieldBase",
+          "schemas": {
+            "text": {
+              "generatedName": "ComponentsSchemasFormFieldText",
+              "schema": "FormFieldText",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            },
+            "checkbox": {
+              "generatedName": "ComponentsSchemasFormFieldCheckbox",
+              "schema": "FormFieldCheckbox",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            },
+            "signature": {
+              "generatedName": "ComponentsSchemasFormFieldSignature",
+              "schema": "FormFieldSignature",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            }
+          },
+          "groupName": [],
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "discriminated"
+        },
+        "type": "oneOf"
+      },
+      "FormFieldText": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "formFieldTextPlaceholder",
+            "key": "placeholder",
+            "schema": {
+              "generatedName": "FormFieldTextPlaceholder",
+              "description": "Placeholder text",
+              "value": {
+                "description": "Placeholder text",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "FormFieldTextPlaceholder",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "formFieldTextMaxLength",
+            "key": "maxLength",
+            "schema": {
+              "generatedName": "FormFieldTextMaxLength",
+              "description": "Maximum length",
+              "value": {
+                "description": "Maximum length",
+                "schema": {
+                  "type": "int"
+                },
+                "generatedName": "FormFieldTextMaxLength",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "description": "Text input field",
+        "generatedName": "FormFieldText",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "FormFieldCheckbox": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "formFieldCheckboxChecked",
+            "key": "checked",
+            "schema": {
+              "generatedName": "FormFieldCheckboxChecked",
+              "description": "Default checked state",
+              "value": {
+                "description": "Default checked state",
+                "schema": {
+                  "type": "boolean"
+                },
+                "generatedName": "FormFieldCheckboxChecked",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "description": "Checkbox field",
+        "generatedName": "FormFieldCheckbox",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "FormFieldSignature": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "formFieldSignatureRequired",
+            "key": "required",
+            "schema": {
+              "generatedName": "FormFieldSignatureRequired",
+              "description": "Whether signature is required",
+              "value": {
+                "description": "Whether signature is required",
+                "schema": {
+                  "type": "boolean"
+                },
+                "generatedName": "FormFieldSignatureRequired",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "description": "Signature field",
+        "generatedName": "FormFieldSignature",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/discriminator-base-class.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/discriminator-base-class.json
@@ -1,0 +1,208 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createForm": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {},
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/form",
+              "request": {
+                "body": {
+                  "properties": {
+                    "form_fields": {
+                      "docs": "Array of form fields with different types",
+                      "type": "optional<list<FormFieldBase>>",
+                    },
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "CreateFormRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "FormFieldBase": {
+            "availability": undefined,
+            "base-properties": {
+              "name": {
+                "docs": "Display name for the field",
+                "type": "string",
+              },
+              "x": {
+                "docs": "X coordinate",
+                "type": "integer",
+              },
+              "y": {
+                "docs": "Y coordinate",
+                "type": "integer",
+              },
+            },
+            "discriminant": "type",
+            "docs": "Base form field with discriminator",
+            "encoding": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+            "union": {
+              "checkbox": "FormFieldCheckbox",
+              "signature": "FormFieldSignature",
+              "text": "FormFieldText",
+            },
+          },
+          "FormFieldCheckbox": {
+            "docs": "Checkbox field",
+            "inline": undefined,
+            "properties": {
+              "checked": {
+                "docs": "Default checked state",
+                "type": "optional<boolean>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "FormFieldSignature": {
+            "docs": "Signature field",
+            "inline": undefined,
+            "properties": {
+              "required": {
+                "docs": "Whether signature is required",
+                "type": "optional<boolean>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "FormFieldText": {
+            "docs": "Text input field",
+            "inline": undefined,
+            "properties": {
+              "maxLength": {
+                "docs": "Maximum length",
+                "type": "optional<integer>",
+              },
+              "placeholder": {
+                "docs": "Placeholder text",
+                "type": "optional<string>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    createForm:
+      path: /form
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      request:
+        name: CreateFormRequest
+        body:
+          properties:
+            form_fields:
+              type: optional<list<FormFieldBase>>
+              docs: Array of form fields with different types
+        content-type: application/json
+      examples:
+        - request: {}
+  source:
+    openapi: ../openapi.yml
+types:
+  FormFieldBase:
+    discriminant: type
+    base-properties:
+      name:
+        type: string
+        docs: Display name for the field
+      x:
+        type: integer
+        docs: X coordinate
+      'y':
+        type: integer
+        docs: Y coordinate
+    docs: Base form field with discriminator
+    union:
+      text: FormFieldText
+      checkbox: FormFieldCheckbox
+      signature: FormFieldSignature
+    source:
+      openapi: ../openapi.yml
+  FormFieldText:
+    docs: Text input field
+    properties:
+      placeholder:
+        type: optional<string>
+        docs: Placeholder text
+      maxLength:
+        type: optional<integer>
+        docs: Maximum length
+    source:
+      openapi: ../openapi.yml
+  FormFieldCheckbox:
+    docs: Checkbox field
+    properties:
+      checked:
+        type: optional<boolean>
+        docs: Default checked state
+    source:
+      openapi: ../openapi.yml
+  FormFieldSignature:
+    docs: Signature field
+    properties:
+      required:
+        type: optional<boolean>
+        docs: Whether signature is required
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Discriminator Base Class Test",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Discriminator Base Class Test
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/discriminator-base-class/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/discriminator-base-class/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/discriminator-base-class/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/discriminator-base-class/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/discriminator-base-class/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/discriminator-base-class/openapi.yml
@@ -1,0 +1,103 @@
+openapi: 3.0.0
+info:
+  title: Discriminator Base Class Test
+  version: 1.0.0
+
+paths:
+  /form:
+    post:
+      operationId: createForm
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                form_fields:
+                  description: Array of form fields with different types
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/FormFieldBase'
+      responses:
+        "200":
+          description: Success
+
+components:
+  schemas:
+    FormFieldBase:
+      description: Base form field with discriminator
+      required:
+        - type
+        - name
+        - x
+        - y
+      properties:
+        type:
+          type: string
+        name:
+          description: Display name for the field
+          type: string
+        x:
+          description: X coordinate
+          type: integer
+        y:
+          description: Y coordinate
+          type: integer
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          text: '#/components/schemas/FormFieldText'
+          checkbox: '#/components/schemas/FormFieldCheckbox'
+          signature: '#/components/schemas/FormFieldSignature'
+
+    FormFieldText:
+      description: Text input field
+      allOf:
+        - $ref: '#/components/schemas/FormFieldBase'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              description: A text input field
+              type: string
+              default: text
+            placeholder:
+              description: Placeholder text
+              type: string
+            maxLength:
+              description: Maximum length
+              type: integer
+
+    FormFieldCheckbox:
+      description: Checkbox field
+      allOf:
+        - $ref: '#/components/schemas/FormFieldBase'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              description: A checkbox field
+              type: string
+              default: checkbox
+            checked:
+              description: Default checked state
+              type: boolean
+
+    FormFieldSignature:
+      description: Signature field
+      allOf:
+        - $ref: '#/components/schemas/FormFieldBase'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              description: A signature field
+              type: string
+              default: signature
+            required:
+              description: Whether signature is required
+              type: boolean

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.33.0
+  changelogEntry:
+    - summary: |
+        Fix handling of OpenAPI schemas that use `discriminator.mapping` without explicit `oneOf`/`anyOf`. These schemas are now correctly converted as discriminated unions instead of plain objects. This pattern is used by APIs like Dropbox Sign where a base schema defines a discriminator with mapping to variant schemas.
+      type: fix
+  createdAt: "2026-01-06"
+  irVersion: 62
+
 - version: 3.32.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Refs: Slack thread from Sandeep Dinesh

Link to Devin run: https://app.devin.ai/sessions/eddb3e06655c47ec89a88b5bced08a4e
Requested by: Sandeep Dinesh (@thesandlord)

Fixes handling of OpenAPI schemas that have `discriminator.mapping` but no explicit `oneOf`/`anyOf`. This pattern is used by some APIs (like Dropbox Sign) where a base schema defines a discriminator with mapping to variant schemas, but doesn't list them in a `oneOf`.

Previously, such schemas were incorrectly converted as plain objects. Now they are properly converted as discriminated unions.

## Changes Made
- Added `tryConvertDiscriminatorMappingSchema()` method in `SchemaConverter.ts` (for `--from-openapi` direct path) that:
  - Detects schemas with `discriminator.mapping` but no `oneOf`/`anyOf`
  - Synthesizes a `oneOf` from the mapping values
  - Delegates to `OneOfSchemaConverter` for proper discriminated union conversion
- Added handling in `convertSchemas.ts` (for OpenAPI→Fern conversion path) that:
  - Detects the same `discriminator.mapping` pattern
  - Calls `convertDiscriminatedOneOf` which uses the mapping internally to build union subtypes
- Added test fixture `discriminator-base-class` demonstrating this pattern
- Bumped CLI version to 3.33.0

## Updates since last revision
- Rebased on latest main
- Removed smoke test API changes (per user request)
- Added version bump to 3.33.0 in `versions.yml`

## Testing
- [x] Unit tests added/updated (new test fixture with snapshots)
- [x] Manual testing completed (lint checks pass)
- [x] Verified fix works on Dropbox Sign docs preview (discriminated union now renders with "Hide 10 variants" UI)

## Human Review Checklist
- [ ] Verify the fix handles edge cases where `discriminator.mapping` exists but the schema should remain an object
- [ ] Confirm both code paths (SchemaConverter.ts and convertSchemas.ts) produce consistent results
- [ ] Note: The openapi-ir-parser path calls `convertDiscriminatedOneOf` directly without synthesizing oneOf first - verify this is correct since `convertDiscriminatedOneOf` uses `discriminator.mapping` internally (line 51-74 of convertDiscriminatedOneOf.ts)