### PR TITLE
fix(python): enable wire tests by default

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.46.7
+  changelogEntry:
+    - summary: Enable wire tests by default. The `enable_wire_tests` config option now defaults to `true`.
+      type: fix
+  createdAt: "2026-01-05"
+  irVersion: 62
+
 - version: 4.46.7-rc0
   changelogEntry:
     - summary: Skip installation of generator-cli in Python SDK generator as it is already installed in the base image.

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -93,7 +93,7 @@ class AbstractGenerator(ABC):
         if generator_config.custom_config is not None and "recursion_limit" in generator_config.custom_config:
             recursion_limit = generator_config.custom_config.get("recursion_limit")
 
-        enable_wire_tests = False
+        enable_wire_tests = True
         if generator_config.custom_config is not None and "enable_wire_tests" in generator_config.custom_config:
             enable_wire_tests = generator_config.custom_config.get("enable_wire_tests")
 

--- a/generators/python/src/fern_python/generators/sdk/custom_config.py
+++ b/generators/python/src/fern_python/generators/sdk/custom_config.py
@@ -123,7 +123,7 @@ class SDKCustomConfig(pydantic.BaseModel):
     # the recursion limit is at least this value.
     recursion_limit: Optional[int] = pydantic.Field(None, gt=1000)
 
-    enable_wire_tests: bool = False
+    enable_wire_tests: bool = True
 
     custom_pager_name: Optional[str] = None
 


### PR DESCRIPTION
## Description

Fixes the Python SDK generator to include wire tests by default, which is the expected behavior.

**Link to Devin run:** https://app.devin.ai/sessions/6314c359a20d4fcbbb3ba27cce073dc2
**Requested by:** judah@buildwithfern.com (@jsklan)

## Changes Made

- Changed the default value of `enable_wire_tests` from `False` to `True` in `custom_config.py`
- Changed the default value of `enable_wire_tests` from `False` to `True` in `abstract_generator.py`
- Added version 4.46.7 changelog entry documenting this fix

## Human Review Checklist

- [ ] Verify this is the intended default behavior (wire tests enabled by default)
- [ ] Consider if users who relied on wire tests being disabled need to be notified of this change
- [ ] Verify version bump from 4.46.7-rc0 to 4.46.7 is appropriate

## Testing

- [x] Pre-commit hooks passed
- [ ] CI tests will validate the change