### PR TITLE
chore(internal): allow Claude to push to claude/* branches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,11 @@
       "Bash(git pull:*)",
       "Bash(git checkout:*)",
       "Bash(git branch:*)",
-      "Bash(git merge:*)"
+      "Bash(git merge:*)",
+      "Bash(git push*origin claude/:*)"
+    ],
+    "ask": [
+      "Bash(git push:*)"
     ],
     "deny": [
       "Read(**/.env)",
@@ -33,8 +37,7 @@
       "Edit(**/generated)",
       "Edit(./packages/ir-sdk/src)",
       "Edit(./packages/ir-sdk/src/sdk)",
-      "Edit(./generators/go/internal/fern/ir)",
-      "Bash(git push:*)"
+      "Edit(./generators/go/internal/fern/ir)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Description
Updates Claude Code permission settings to allow git push operations to `claude/*` branches while still requiring confirmation for other push operations.

## Changes Made
- **Allow claude/ branch pushes**: Added `Bash(git push*origin claude/:*)` to allow list for auto-approved pushes to Claude's auto-created branches
- **Ask for other pushes**: Added `ask` block with `Bash(git push:*)` to prompt for confirmation on non-claude branch pushes
- **Removed blanket deny**: Moved git push from deny to ask for better developer experience

## Testing
- [x] Verified settings.json syntax is valid
- [x] Confirmed permission precedence: allow > ask means claude/ branches auto-approve while others prompt