### PR TITLE
fix(typescript): fix null check for nullable query parameters and passthrough serialization

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/GeneratedQueryParams.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/GeneratedQueryParams.ts
@@ -371,8 +371,8 @@ export class GeneratedQueryParams {
                 ts.factory.createIfStatement(
                     ts.factory.createBinaryExpression(
                         referenceToQueryParameterProperty,
-                        ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsEqualsToken),
-                        ts.factory.createIdentifier("undefined")
+                        ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsToken),
+                        ts.factory.createNull()
                     ),
                     ts.factory.createBlock(statements)
                 )

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -6,6 +6,12 @@
         the generated code now correctly checks for both `null` and `undefined` using `!= null` instead of only checking
         `!== undefined`. This prevents TypeScript errors when calling methods like `.toISOString()` on nullable Date parameters.
       type: fix
+    - summary: |
+        Fix passthrough serialization to only preserve truly unknown keys. Previously, the passthrough() function would
+        spread both raw and transformed objects, causing duplicate keys with different casing (e.g., both `version_number`
+        and `versionNumber` would appear in the parsed result). The fix now filters out known raw keys before spreading,
+        ensuring only genuinely unknown keys are preserved in the passthrough result.
+      type: fix
   createdAt: "2026-01-05"
   irVersion: 63
 

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.43.2
+  changelogEntry:
+    - summary: |
+        Fix null check for nullable query parameters. When a query parameter type is nullable (e.g., `Date | null | undefined`),
+        the generated code now correctly checks for both `null` and `undefined` using `!= null` instead of only checking
+        `!== undefined`. This prevents TypeScript errors when calling methods like `.toISOString()` on nullable Date parameters.
+      type: fix
+  createdAt: "2026-01-05"
+  irVersion: 63
+
 - version: 3.43.1
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/schemas/builders/object/object.ts
+++ b/generators/typescript/utils/core-utilities/src/core/schemas/builders/object/object.ts
@@ -279,12 +279,14 @@ export function getObjectUtils<Raw, Parsed>(schema: BaseObjectSchema<Raw, Parsed
                         if (!transformed.ok) {
                             return transformed;
                         }
+                        const rawKeys = new Set(schema._getRawProperties().map(String));
+                        const unknownKeys = keys(raw as object).filter((key) => !rawKeys.has(key as string));
                         return {
                             ok: true,
                             value: {
-                                ...(raw as any),
+                                ...filterObject(raw as object, unknownKeys),
                                 ...transformed.value,
-                            },
+                            } as Parsed & { [key: string]: unknown },
                         };
                     },
                     json: (parsed, opts) => {
@@ -292,12 +294,14 @@ export function getObjectUtils<Raw, Parsed>(schema: BaseObjectSchema<Raw, Parsed
                         if (!transformed.ok) {
                             return transformed;
                         }
+                        const parsedKeys = new Set(schema._getParsedProperties().map(String));
+                        const unknownKeys = keys(parsed as object).filter((key) => !parsedKeys.has(key as string));
                         return {
                             ok: true,
                             value: {
-                                ...(parsed as any),
+                                ...filterObject(parsed as object, unknownKeys),
                                 ...transformed.value,
-                            },
+                            } as Raw & { [key: string]: unknown },
                         };
                     },
                     getType: () => SchemaType.OBJECT,


### PR DESCRIPTION
## Description

Fixes two issues in the TypeScript SDK generator:
1. TypeScript compilation errors when nullable query parameters (e.g., `Date | null | undefined`) are used in generated SDKs
2. Wire test failures where passthrough serialization was preserving both snake_case and camelCase keys (e.g., both `version_number` and `versionNumber` appearing in parsed results)

Link to Devin run: https://app.devin.ai/sessions/e8498bbef06245228a6e1502b58d2f36
Requested by: judah@buildwithfern.com (@jsklan)

## Changes Made

### Fix 1: Nullable Query Parameter Null Check
- Fixed the null check in `GeneratedQueryParams.withQueryParameter()` to use `!= null` instead of `!== undefined` for nullable query parameters
- This ensures both `null` and `undefined` values are properly handled before calling methods like `.toISOString()` on Date parameters

**Before (generated code):**
```typescript
if (fromDate !== undefined) {
    _queryParams.from_date = fromDate.toISOString(); // Error: fromDate could be null
}
```

**After (generated code):**
```typescript
if (fromDate != null) {
    _queryParams.from_date = fromDate.toISOString(); // Safe: null and undefined are both excluded
}
```

### Fix 2: Passthrough Serialization
- Fixed the `passthrough()` function in core-utilities to only preserve truly unknown keys
- Previously, spreading both raw and transformed objects caused duplicate keys with different casing
- Now filters out known raw/parsed keys before spreading, ensuring only genuinely unknown keys are preserved

## Testing

- [x] Verified fix by regenerating SDK from test fixture and confirming TypeScript build passes
- [x] All 822 tests pass (including wire tests that were previously failing)
- [x] Lint checks pass
- [ ] Unit tests added/updated

## Human Review Checklist

- [ ] Verify nullable query parameter fix is correct for all nullable types (not just Date)
- [ ] Confirm passthrough fix doesn't break other serialization scenarios that rely on passthrough behavior
- [ ] Verify the type assertions (`as Parsed & { [key: string]: unknown }`) are safe and don't mask type errors
- [ ] Consider whether a seed test fixture should be added to prevent regressions