### PR TITLE
chore(internal): update vitest configuration imports to use new centralized config module

### DIFF
--- a/generators/base/vitest.config.ts
+++ b/generators/base/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/browser-compatible-base/vitest.config.ts
+++ b/generators/browser-compatible-base/vitest.config.ts
@@ -1,18 +1,12 @@
-import { defineConfig } from "vitest/config";
+import { defaultConfig, defineConfig, mergeConfig } from "@fern-api/configs/vitest/base.mjs";
 
-export default defineConfig({
-    test: {
-        globals: true,
-        include: ["**/*.{test,spec}.ts"],
-        server: {
-            deps: {
-                fallbackCJS: true
+export default mergeConfig(
+    defaultConfig,
+    defineConfig({
+        test: {
+            env: {
+                FERN_STACK_TRACK: "1"
             }
-        },
-        maxConcurrency: 10,
-        passWithNoTests: true,
-        env: {
-            FERN_STACK_TRACK: "1"
         }
-    }
-});
+    })
+);

--- a/generators/csharp/codegen/vitest.config.ts
+++ b/generators/csharp/codegen/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/csharp/dynamic-snippets/vitest.config.ts
+++ b/generators/csharp/dynamic-snippets/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/csharp/formatter/vitest.config.ts
+++ b/generators/csharp/formatter/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/go-v2/ast/vitest.config.ts
+++ b/generators/go-v2/ast/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/go-v2/dynamic-snippets/vitest.config.ts
+++ b/generators/go-v2/dynamic-snippets/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/go-v2/formatter/vitest.config.ts
+++ b/generators/go-v2/formatter/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/java-v2/ast/vitest.config.ts
+++ b/generators/java-v2/ast/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/java-v2/dynamic-snippets/vitest.config.ts
+++ b/generators/java-v2/dynamic-snippets/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/php/codegen/vitest.config.ts
+++ b/generators/php/codegen/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/php/dynamic-snippets/vitest.config.ts
+++ b/generators/php/dynamic-snippets/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/python-v2/ast/vitest.config.ts
+++ b/generators/python-v2/ast/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/python-v2/base/vitest.config.ts
+++ b/generators/python-v2/base/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/python-v2/dynamic-snippets/vitest.config.ts
+++ b/generators/python-v2/dynamic-snippets/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/python-v2/formatter/vitest.config.ts
+++ b/generators/python-v2/formatter/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/ruby-v2/ast/vitest.config.ts
+++ b/generators/ruby-v2/ast/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/ruby-v2/dynamic-snippets/vitest.config.ts
+++ b/generators/ruby-v2/dynamic-snippets/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/rust/base/vitest.config.ts
+++ b/generators/rust/base/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/rust/codegen/vitest.config.ts
+++ b/generators/rust/codegen/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/rust/dynamic-snippets/vitest.config.ts
+++ b/generators/rust/dynamic-snippets/vitest.config.ts
@@ -1,10 +1,9 @@
-import { defineConfig } from "vitest/config";
+import { mergeConfig, defaultConfig, defineConfig } from "@fern-api/configs/vitest/base.mjs";
 
-export default defineConfig({
+export default mergeConfig(defaultConfig, defineConfig({
     test: {
-        globals: true,
         env: {
             NODE_ENV: "test"
         }
     }
-});
+}));

--- a/generators/rust/model/vitest.config.ts
+++ b/generators/rust/model/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/rust/sdk/vitest.config.ts
+++ b/generators/rust/sdk/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/swift/base/vitest.config.ts
+++ b/generators/swift/base/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/swift/codegen/vitest.config.ts
+++ b/generators/swift/codegen/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/swift/dynamic-snippets/vitest.config.ts
+++ b/generators/swift/dynamic-snippets/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/swift/model/vitest.config.ts
+++ b/generators/swift/model/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/swift/sdk/vitest.config.ts
+++ b/generators/swift/sdk/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript-v2/ast/vitest.config.ts
+++ b/generators/typescript-v2/ast/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript-v2/dynamic-snippets/vitest.config.ts
+++ b/generators/typescript-v2/dynamic-snippets/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript-v2/formatter/vitest.config.ts
+++ b/generators/typescript-v2/formatter/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript/express/cli/vitest.config.ts
+++ b/generators/typescript/express/cli/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript/sdk/cli/vitest.config.ts
+++ b/generators/typescript/sdk/cli/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript/sdk/generator/vitest.config.ts
+++ b/generators/typescript/sdk/generator/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/generators/typescript/utils/commons/vitest.config.ts
+++ b/generators/typescript/utils/commons/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/ai/vitest.config.ts
+++ b/packages/cli/ai/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/commons/vitest.config.ts
+++ b/packages/cli/api-importers/commons/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/conjure/conjure-sdk/vitest.config.ts
+++ b/packages/cli/api-importers/conjure/conjure-sdk/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/conjure/conjure-to-fern-tests/vitest.config.ts
+++ b/packages/cli/api-importers/conjure/conjure-to-fern-tests/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/conjure/conjure-to-fern/vitest.config.ts
+++ b/packages/cli/api-importers/conjure/conjure-to-fern/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/openapi-pruner/vitest.config.ts
+++ b/packages/cli/api-importers/openapi-pruner/vitest.config.ts
@@ -1,7 +1,1 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-    test: {
-        globals: true
-    }
-});
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/openapi-to-ir/vitest.config.ts
+++ b/packages/cli/api-importers/openapi-to-ir/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/vitest.config.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/vitest.config.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/vitest.config.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/v3-importer-commons/vitest.config.ts
+++ b/packages/cli/api-importers/v3-importer-commons/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/api-importers/v3-importer-tests/vitest.config.ts
+++ b/packages/cli/api-importers/v3-importer-tests/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/auth/vitest.config.ts
+++ b/packages/cli/auth/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/cli-logger/vitest.config.ts
+++ b/packages/cli/cli-logger/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/cli-migrations/vitest.config.ts
+++ b/packages/cli/cli-migrations/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/cli-source-resolver/vitest.config.ts
+++ b/packages/cli/cli-source-resolver/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/cli/vitest.config.ts
+++ b/packages/cli/cli/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/configuration-loader/vitest.config.ts
+++ b/packages/cli/configuration-loader/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/configuration/vitest.config.ts
+++ b/packages/cli/configuration/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/docs-importers/commons/vitest.config.ts
+++ b/packages/cli/docs-importers/commons/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/docs-importers/mintlify/vitest.config.ts
+++ b/packages/cli/docs-importers/mintlify/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/docs-importers/readme/vitest.config.ts
+++ b/packages/cli/docs-importers/readme/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/docs-markdown-utils/vitest.config.ts
+++ b/packages/cli/docs-markdown-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/docs-preview/vitest.config.ts
+++ b/packages/cli/docs-preview/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/docs-resolver/vitest.config.ts
+++ b/packages/cli/docs-resolver/vitest.config.ts
@@ -1,16 +1,14 @@
-import { defineConfig } from "vitest/config";
+import { defaultConfig, defineConfig, mergeConfig } from "@fern-api/configs/vitest/base.mjs";
 
-export default defineConfig({
-    test: {
-        globals: true,
-        include: ["**/*.{test,spec}.ts"],
-        server: {
-            deps: {
-                fallbackCJS: true,
-                inline: ["@fern-api/ui-core-utils"]
+export default mergeConfig(
+    defaultConfig,
+    defineConfig({
+        test: {
+            server: {
+                deps: {
+                    inline: ["@fern-api/ui-core-utils"]
+                }
             }
-        },
-        maxConcurrency: 10,
-        passWithNoTests: true
-    }
-});
+        }
+    })
+);

--- a/packages/cli/ete-tests/vitest.config.ts
+++ b/packages/cli/ete-tests/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/fern-definition/formatter/vitest.config.ts
+++ b/packages/cli/fern-definition/formatter/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/fern-definition/ir-to-jsonschema/vitest.config.ts
+++ b/packages/cli/fern-definition/ir-to-jsonschema/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/fern-definition/schema/vitest.config.ts
+++ b/packages/cli/fern-definition/schema/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/fern-definition/validator/vitest.config.ts
+++ b/packages/cli/fern-definition/validator/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/generation/ir-generator-tests/vitest.config.ts
+++ b/packages/cli/generation/ir-generator-tests/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/generation/ir-generator/vitest.config.ts
+++ b/packages/cli/generation/ir-generator/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/generation/ir-migrations/vitest.config.ts
+++ b/packages/cli/generation/ir-migrations/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/generation/local-generation/docker-utils/vitest.config.ts
+++ b/packages/cli/generation/local-generation/docker-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/generation/local-generation/local-workspace-runner/vitest.config.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/generation/protoc-gen-fern/vitest.config.ts
+++ b/packages/cli/generation/protoc-gen-fern/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/vitest.config.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/generation/source-resolver/vitest.config.ts
+++ b/packages/cli/generation/source-resolver/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/init/vitest.config.ts
+++ b/packages/cli/init/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/logger/vitest.config.ts
+++ b/packages/cli/logger/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/mock/vitest.config.ts
+++ b/packages/cli/mock/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/register/vitest.config.ts
+++ b/packages/cli/register/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/semver-utils/vitest.config.ts
+++ b/packages/cli/semver-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/workspace/browser-compatible-fern-workspace/vitest.config.ts
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/workspace/commons/vitest.config.ts
+++ b/packages/cli/workspace/commons/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/workspace/lazy-fern-workspace/vitest.config.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/workspace/loader/vitest.config.ts
+++ b/packages/cli/workspace/loader/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/workspace/oss-validator/vitest.config.ts
+++ b/packages/cli/workspace/oss-validator/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/yaml/docs-validator/vitest.config.ts
+++ b/packages/cli/yaml/docs-validator/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/yaml/generators-validator/vitest.config.ts
+++ b/packages/cli/yaml/generators-validator/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/casings-generator/vitest.config.ts
+++ b/packages/commons/casings-generator/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/core-utils/vitest.config.ts
+++ b/packages/commons/core-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/fs-utils/vitest.config.ts
+++ b/packages/commons/fs-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/github/vitest.config.ts
+++ b/packages/commons/github/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/ir-utils/vitest.config.ts
+++ b/packages/commons/ir-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/loadable/vitest.config.ts
+++ b/packages/commons/loadable/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/logging-execa/vitest.config.ts
+++ b/packages/commons/logging-execa/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/mock-utils/vitest.config.ts
+++ b/packages/commons/mock-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/path-utils/vitest.config.ts
+++ b/packages/commons/path-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/commons/test-utils/vitest.config.ts
+++ b/packages/commons/test-utils/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./*": "./*"
+  },
   "devDependencies": {
     "esbuild-plugin-polyfill-node": "^0.3.0",
     "tsup": "^8.5.0",

--- a/packages/configs/vitest/base.d.mts
+++ b/packages/configs/vitest/base.d.mts
@@ -1,0 +1,4 @@
+export { defineConfig, mergeConfig, type TestUserConfig } from "vitest/config";
+export const defaultConfig: TestUserConfig;
+declare const config: TestUserConfig;
+export default config;

--- a/packages/configs/vitest/base.mjs
+++ b/packages/configs/vitest/base.mjs
@@ -1,6 +1,8 @@
 import { defineConfig } from "vitest/config";
 
-export default defineConfig({
+export { defineConfig, mergeConfig } from "vitest/config";
+
+export const defaultConfig = {
     test: {
         globals: true,
         include: ["**/*.{test,spec}.ts"],
@@ -13,4 +15,6 @@ export default defineConfig({
         maxConcurrency: 10,
         passWithNoTests: true
     }
-});
+};
+
+export default defineConfig(defaultConfig);

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/generator-cli/vitest.config.ts
+++ b/packages/generator-cli/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/ir-sdk/vitest.config.ts
+++ b/packages/ir-sdk/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/scripts/vitest.config.ts
+++ b/packages/scripts/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/seed/vitest.config.ts
+++ b/packages/seed/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/snippets/core/vitest.config.ts
+++ b/packages/snippets/core/vitest.config.ts
@@ -1,1 +1,1 @@
-export { default } from "../../../shared/vitest.config";
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/turbo.json
+++ b/turbo.json
@@ -42,7 +42,6 @@
       "outputs": [],
       "inputs": [
         "$TURBO_ROOT$/packages/configs/**",
-        "$TURBO_ROOT$/shared/vitest.config.ts",
         "$TURBO_ROOT$/test-definitions-openapi/**",
         "$TURBO_ROOT$/test-definitions/**",
         "$TURBO_ROOT$/tsconfig.eslint.json",
@@ -58,7 +57,6 @@
       "outputs": [],
       "inputs": [
         "$TURBO_ROOT$/packages/configs/**",
-        "$TURBO_ROOT$/shared/vitest.config.ts",
         "$TURBO_ROOT$/test-definitions-openapi/**",
         "$TURBO_ROOT$/test-definitions/**",
         "$TURBO_ROOT$/tsconfig.eslint.json",
@@ -74,7 +72,6 @@
       "outputs": [],
       "inputs": [
         "$TURBO_ROOT$/packages/configs/**",
-        "$TURBO_ROOT$/shared/vitest.config.ts",
         "$TURBO_ROOT$/test-definitions-openapi/**",
         "$TURBO_ROOT$/test-definitions/**",
         "$TURBO_ROOT$/tsconfig.eslint.json",


### PR DESCRIPTION
- Replaced all instances of importing from "../../../shared/vitest.config" with imports from "@fern-api/configs/vitest/base.mjs" across various packages and generators.
- Updated dynamic snippets and base configurations to utilize the new mergeConfig and defaultConfig from the centralized module.
- Removed references to the old shared configuration file in turbo.json.
