### PR TITLE
fix(ruby): fix inconsistent module naming for orgs with digits

### DIFF
--- a/generators/ruby-v2/base/src/asIs/test/test_helper.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/test/test_helper.Template.rb
@@ -1,1 +1,1 @@
-require_relative '../lib/<%= sdkName %>'
+require_relative '../lib/<%= rootFolderName %>'

--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -90,7 +90,6 @@ export abstract class AbstractRubyGeneratorContext<
 
     public getRootModuleName(): string {
         // Use upperFirst on the organization name directly to avoid snakeCase
-        // inserting underscores before digits (e.g., "auth0" -> "Auth0" not "Auth_0")
         return upperFirst(this.customConfig.module ?? this.config.organization);
     }
 

--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -6,7 +6,7 @@ import {
 import { RelativeFilePath } from "@fern-api/path-utils";
 import { BaseRubyCustomConfigSchema, ruby } from "@fern-api/ruby-ast";
 import { IntermediateRepresentation, TypeDeclaration, TypeId } from "@fern-fern/ir-sdk/api";
-import { capitalize, snakeCase } from "lodash-es";
+import { snakeCase, upperFirst } from "lodash-es";
 import { RubyProject } from "../project/RubyProject";
 import { RubyTypeMapper } from "./RubyTypeMapper";
 
@@ -89,7 +89,9 @@ export abstract class AbstractRubyGeneratorContext<
     }
 
     public getRootModuleName(): string {
-        return capitalize(this.getRootFolderName());
+        // Use upperFirst on the organization name directly to avoid snakeCase
+        // inserting underscores before digits (e.g., "auth0" -> "Auth0" not "Auth_0")
+        return upperFirst(this.customConfig.module ?? this.config.organization);
     }
 
     public getRootModule(): ruby.Module_ {

--- a/generators/ruby-v2/base/src/project/RubyProject.ts
+++ b/generators/ruby-v2/base/src/project/RubyProject.ts
@@ -138,6 +138,7 @@ export class RubyProject extends AbstractProject<AbstractRubyGeneratorContext<Ba
                 await this.createAsIsFile({
                     filename,
                     gemNamespace: this.rubyContext.getRootModuleName(),
+                    rootFolderName: this.rubyContext.getRootFolderName(),
                     customPagerClassName: this.rubyContext.customConfig.customPagerName
                 })
             );
@@ -147,10 +148,12 @@ export class RubyProject extends AbstractProject<AbstractRubyGeneratorContext<Ba
     private async createAsIsFile({
         filename,
         gemNamespace,
+        rootFolderName,
         customPagerClassName
     }: {
         filename: string;
         gemNamespace: string;
+        rootFolderName: string;
         customPagerClassName?: string;
     }): Promise<File> {
         const contents = (await readFile(getAsIsFilepath(filename))).toString();
@@ -161,6 +164,7 @@ export class RubyProject extends AbstractProject<AbstractRubyGeneratorContext<Ba
                 contents,
                 variables: getTemplateVariables({
                     gemNamespace,
+                    rootFolderName,
                     customPagerClassName
                 })
             })
@@ -211,14 +215,19 @@ function replaceTemplate({ contents, variables }: { contents: string; variables:
 
 function getTemplateVariables({
     gemNamespace,
+    rootFolderName,
     customPagerClassName
 }: {
     gemNamespace: string;
+    rootFolderName: string;
     customPagerClassName?: string;
 }): Record<string, unknown> {
     return {
         gem_namespace: gemNamespace,
+        // sdkName is used for SDK branding (e.g., X-Fern-SDK-Name header)
         sdkName: gemNamespace.toLowerCase(),
+        // rootFolderName is used for require paths (matches actual file/folder names)
+        rootFolderName,
         custom_pager_class_name: customPagerClassName ?? "CustomPager"
     };
 }

--- a/generators/ruby-v2/base/src/project/RubyProject.ts
+++ b/generators/ruby-v2/base/src/project/RubyProject.ts
@@ -137,7 +137,7 @@ export class RubyProject extends AbstractProject<AbstractRubyGeneratorContext<Ba
             this.coreFiles.push(
                 await this.createAsIsFile({
                     filename,
-                    gemNamespace: firstCharUpperCase(this.context.config.organization || "fern"),
+                    gemNamespace: this.rubyContext.getRootModuleName(),
                     customPagerClassName: this.rubyContext.customConfig.customPagerName
                 })
             );
@@ -203,10 +203,6 @@ export class RubyProject extends AbstractProject<AbstractRubyGeneratorContext<Ba
     private filePathFromRubyFile(file: File): AbsoluteFilePath {
         return join(this.absolutePathToOutputDirectory, file.directory, RelativeFilePath.of(file.filename));
     }
-}
-
-function firstCharUpperCase(st: string): string {
-    return st.length < 1 ? st : st.charAt(0).toUpperCase() + st.substring(1);
 }
 
 function replaceTemplate({ contents, variables }: { contents: string; variables: Record<string, unknown> }): string {

--- a/generators/ruby-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -46,7 +46,9 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
     }
 
     public getRootModuleName(): string {
-        return upperFirst(this.customConfig?.clientModuleName ?? this.config.organization);
+        // Use module config first, then clientModuleName, then organization
+        // This aligns with AbstractRubyGeneratorContext.getRootModuleName()
+        return upperFirst(this.customConfig?.module ?? this.customConfig?.clientModuleName ?? this.config.organization);
     }
 
     public isSingleEnvironmentID(

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -9,6 +9,8 @@
         Previously, internal types used `module Auth0` while public types used `module Auth_0` due to
         lodash's snakeCase inserting underscores before digits. Now all code paths use upperFirst
         directly on the organization name, producing consistent module names like `Auth0`.
+        Also fixes test_helper.rb require path to use the correct folder name (e.g., `auth_0`)
+        instead of the module name (e.g., `auth0`), preventing LoadError when running tests.
   irVersion: 61
 
 - version: 1.0.0-rc74

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc75
+  createdAt: "2026-01-06"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fix inconsistent module naming for organization names containing digits (e.g., "auth0").
+        Previously, internal types used `module Auth0` while public types used `module Auth_0` due to
+        lodash's snakeCase inserting underscores before digits. Now all code paths use upperFirst
+        directly on the organization name, producing consistent module names like `Auth0`.
+  irVersion: 61
+
 - version: 1.0.0-rc74
   createdAt: "2025-12-19"
   changelogEntry:


### PR DESCRIPTION
## Description

Refs: Reported via internal investigation of auth0-fern-config SDK generation issues

Fixes inconsistent module naming in the Ruby v2 generator where organization names containing digits (e.g., "auth0") produced different module names in different code paths. Internal types used `module Auth0` while public types used `module Auth_0`, causing `LoadError` and `NameError` at runtime.

**Root cause:** lodash's `snakeCase('auth0')` inserts an underscore before digits, producing `auth_0`. Then `capitalize()` produces `Auth_0`. Meanwhile, `firstCharUpperCase()` in as-is files produced `Auth0`.

**Link to Devin run:** https://app.devin.ai/sessions/3d112cd502b04c18bc02bf2511fad7d2
**Requested by:** @iamnamananand996

## Changes Made

- Changed `getRootModuleName()` in `AbstractRubyGeneratorContext` to use `upperFirst(organization)` directly instead of `capitalize(snakeCase(organization))`
- Updated `createAsIsFiles()` in `RubyProject` to use `context.getRootModuleName()` instead of a separate `firstCharUpperCase()` implementation
- Removed unused `firstCharUpperCase()` function
- Aligned `DynamicSnippetsGeneratorContext.getRootModuleName()` to check `module` config first for consistency
- Added `rootFolderName` template variable for require paths (separate from `sdkName` used for SDK branding headers)
- Fixed `test_helper.Template.rb` to use `rootFolderName` instead of `sdkName` for require path, preventing `LoadError` when running tests
- Added changelog entry in `versions.yml` for version 1.0.0-rc75
- [x] Updated README.md generator (if applicable) - N/A

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed - Lint checks pass (`pnpm run check`)
- [x] All ruby-sdk-v2 seed tests pass

## Human Review Checklist

- [ ] **Breaking change consideration**: This changes module naming from `Auth_0` to `Auth0` for orgs with digits. Existing generated SDKs may have different module names after regeneration.
- [ ] **File vs module naming**: Files use `getRootFolderName()` (snakeCase → `auth_0.rb`) while modules use `getRootModuleName()` (upperFirst → `Auth0`). The `rootFolderName` template variable is used for require paths, `sdkName` for SDK branding headers. Verify this separation is correct.
- [ ] **DynamicSnippetsGeneratorContext priority**: Added `module` config check before `clientModuleName` - confirm this priority order is correct.