### PR TITLE
fix(ruby): fix wire tests and pagination field names for paginated endpoints

### DIFF
--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -108,7 +108,8 @@ export class HttpEndpointGenerator {
             switch (endpoint.pagination.type) {
                 case "custom": {
                     const customPagerClassName = this.context.customConfig.customPagerName ?? "CustomPager";
-                    const itemField = endpoint.pagination.results.property.name.wireValue;
+                    // Use snakeCase.safeName for Ruby method calls
+                    const itemField = endpoint.pagination.results.property.name.name.snakeCase.safeName;
                     requestStatements = [
                         ...requestStatements,
                         ruby.invokeMethod({
@@ -144,14 +145,21 @@ export class HttpEndpointGenerator {
                             keywordArguments: [
                                 ruby.keywordArgument({
                                     name: "cursor_field",
-                                    value: ruby.codeblock(`:${endpoint.pagination.next.property.name.wireValue}`)
+                                    // Use snakeCase.safeName for Ruby method calls (e.g., "next" -> "next_")
+                                    value: ruby.codeblock(
+                                        `:${endpoint.pagination.next.property.name.name.snakeCase.safeName}`
+                                    )
                                 }),
                                 ruby.keywordArgument({
                                     name: "item_field",
-                                    value: ruby.codeblock(`:${endpoint.pagination.results.property.name.wireValue}`)
+                                    // Use snakeCase.safeName for Ruby method calls
+                                    value: ruby.codeblock(
+                                        `:${endpoint.pagination.results.property.name.name.snakeCase.safeName}`
+                                    )
                                 }),
                                 ruby.keywordArgument({
                                     name: "initial_cursor",
+                                    // Keep wireValue for query params (sent over HTTP)
                                     value: ruby.codeblock(
                                         `${QUERY_PARAMETER_BAG_NAME}[:${endpoint.pagination.page.property.name.wireValue}]`
                                     )
@@ -161,6 +169,7 @@ export class HttpEndpointGenerator {
                                 ["next_cursor"],
                                 [
                                     ruby.codeblock(
+                                        // Keep wireValue for query params (sent over HTTP)
                                         `${QUERY_PARAMETER_BAG_NAME}[:${endpoint.pagination.page.property.name.wireValue}] = next_cursor`
                                     ),
                                     ...requestStatements
@@ -181,18 +190,25 @@ export class HttpEndpointGenerator {
                             keywordArguments: [
                                 ruby.keywordArgument({
                                     name: "initial_page",
+                                    // Keep wireValue for query params (sent over HTTP)
                                     value: ruby.codeblock(
                                         `${QUERY_PARAMETER_BAG_NAME}[:${endpoint.pagination.page.property.name.wireValue}]`
                                     )
                                 }),
                                 ruby.keywordArgument({
                                     name: "item_field",
-                                    value: ruby.codeblock(`:${endpoint.pagination.results.property.name.wireValue}`)
+                                    // Use snakeCase.safeName for Ruby method calls
+                                    value: ruby.codeblock(
+                                        `:${endpoint.pagination.results.property.name.name.snakeCase.safeName}`
+                                    )
                                 }),
                                 ruby.keywordArgument({
                                     name: "has_next_field",
+                                    // Use snakeCase.safeName for Ruby method calls
                                     value: endpoint.pagination.hasNextPage
-                                        ? ruby.codeblock(`:${endpoint.pagination.hasNextPage.property.name.wireValue}`)
+                                        ? ruby.codeblock(
+                                              `:${endpoint.pagination.hasNextPage.property.name.name.snakeCase.safeName}`
+                                          )
                                         : ruby.nilValue()
                                 }),
                                 ruby.keywordArgument({
@@ -204,6 +220,7 @@ export class HttpEndpointGenerator {
                                 ["next_page"],
                                 [
                                     ruby.codeblock(
+                                        // Keep wireValue for query params (sent over HTTP)
                                         `${QUERY_PARAMETER_BAG_NAME}[:${endpoint.pagination.page.property.name.wireValue}] = next_page`
                                     ),
                                     ...requestStatements

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -9,6 +9,13 @@
         Cursor and offset pagination endpoints return lazy iterators that don't make HTTP requests
         until iterated. Wire tests now call `.pages.next_page` on the returned iterator to trigger
         the first HTTP request, ensuring WireMock receives the expected request for verification.
+    - type: fix
+      summary: |
+        Fix pagination field names to use Ruby-safe method names instead of wire values.
+        Fields like `cursor_field`, `item_field`, and `has_next_field` are used to call Ruby
+        methods on response objects via `send()`. Previously these used `wireValue` which doesn't
+        account for Ruby reserved word escaping (e.g., "next" -> "next_"). Now uses
+        `snakeCase.safeName` which matches the actual Ruby accessor names.
   irVersion: 61
 
 - version: 1.0.0-rc75

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc76
+  createdAt: "2026-01-06"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fix wire tests for paginated endpoints not triggering HTTP requests.
+        Cursor and offset pagination endpoints return lazy iterators that don't make HTTP requests
+        until iterated. Wire tests now call `.pages.next_page` on the returned iterator to trigger
+        the first HTTP request, ensuring WireMock receives the expected request for verification.
+  irVersion: 61
+
 - version: 1.0.0-rc75
   createdAt: "2026-01-06"
   changelogEntry:


### PR DESCRIPTION
## Description

Refs: Follow-up to #11419 (module naming fix)

This PR contains two related fixes for Ruby SDK pagination:

1. **Wire test fix**: Fixes wire tests for paginated endpoints that were failing with "Expected 1 requests, found 0". The Ruby SDK's cursor and offset pagination endpoints return lazy iterators (`CursorItemIterator`, `OffsetItemIterator`) that don't make HTTP requests until iterated. The wire tests were calling the SDK method but not iterating, so WireMock never received any requests.

2. **Pagination field name fix**: Fixes `NoMethodError: undefined method 'next'` errors for cursor pagination endpoints. Fields like `cursor_field`, `item_field`, and `has_next_field` are used to call Ruby methods on response objects via `send()`. Previously these used `wireValue` which doesn't account for Ruby reserved word escaping (e.g., "next" → "next_"). Now uses `snakeCase.safeName` which matches the actual Ruby accessor names.

**Link to Devin run:** https://app.devin.ai/sessions/3d112cd502b04c18bc02bf2511fad7d2
**Requested by:** @iamnamananand996

## Changes Made

- Modified `WireTestGenerator.generateEndpointTestMethod()` to detect lazy pagination endpoints (cursor or offset type)
- For lazy paginated endpoints, wrap the snippet in a `begin...end` block and call `.pages.next_page` to trigger the first HTTP request
- Modified `HttpEndpointGenerator` to use `snakeCase.safeName` instead of `wireValue` for pagination field names used as Ruby method calls:
  - `cursor_field` (cursor pagination)
  - `item_field` (cursor, offset, and custom pagination)
  - `has_next_field` (offset pagination)
- Query parameter keys remain as `wireValue` since they're sent over HTTP
- Added changelog entries in `versions.yml` for version 1.0.0-rc76
- [ ] Updated README.md generator (if applicable) - N/A

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed - Lint checks pass (`pnpm run check`)

## Human Review Checklist

- [ ] **Lazy vs eager pagination assumption**: Verify that cursor/offset pagination returns lazy iterators while custom pagination (`CustomPager`) is eager (makes request in constructor). This determines which endpoints need the `.pages.next_page` trigger.
- [ ] **Iterator API**: Confirm that both `CursorItemIterator` and `OffsetItemIterator` expose a `.pages` method that returns a page iterator with `next_page`. Based on code review, both do.
- [ ] **Generated Ruby syntax**: The fix wraps multi-line snippets in `begin...end` blocks. Verify this produces valid Ruby for all snippet patterns.
- [ ] **Field name path**: Verify that `.property.name.name.snakeCase.safeName` is the correct path to access the Ruby-safe method name. The double `.name` looks unusual - confirm this matches the IR structure.
- [ ] **wireValue vs safeName distinction**: Query params use `wireValue` (sent over HTTP), field accessors use `snakeCase.safeName` (Ruby method calls). Verify this distinction is correct for all cases.