### PR TITLE
fix(docs): support unquoted numeric values in Code component props

### DIFF
--- a/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
@@ -901,4 +901,56 @@ describe("replaceReferencedCode", () => {
 
         `);
     });
+
+    it('should handle quoted numeric values like startLine="40"', async () => {
+        const markdown = `
+            <Code src="../snippets/test.go" startLine="40" maxLines="25" />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.go")) {
+                    return "package main";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            \`\`\`go title={"test.go"} startLine={40} maxLines={25}
+            package main
+            \`\`\`
+
+        `);
+    });
+
+    it("should handle curly brace numeric values like startLine={40}", async () => {
+        const markdown = `
+            <Code src="../snippets/test.go" startLine={40} maxLines={25} />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.go")) {
+                    return "package main";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            \`\`\`go title={"test.go"} startLine={40} maxLines={25}
+            package main
+            \`\`\`
+
+        `);
+    });
 });

--- a/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/replaceReferencedCode.test.ts
@@ -825,4 +825,80 @@ describe("replaceReferencedCode", () => {
 
         `);
     });
+
+    it("should handle unquoted numeric values like startLine=40", async () => {
+        const markdown = `
+            <Code src="../snippets/test.go" startLine=40 maxLines=25 />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.go")) {
+                    return 'package main\n\nfunc main() {\n    fmt.Println("Hello")\n}';
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        // Note: empty lines in the code get indented with spaces
+        expect(result).toBe(
+            '\n            ```go title={"test.go"} startLine={40} maxLines={25}\n            package main\n            \n            func main() {\n                fmt.Println("Hello")\n            }\n            ```\n\n        '
+        );
+    });
+
+    it("should handle unquoted numeric values appearing before src", async () => {
+        const markdown = `
+            <Code startLine=40 src="../snippets/test.go" maxLines=25 />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.go")) {
+                    return "package main";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            \`\`\`go title={"test.go"} startLine={40} maxLines={25}
+            package main
+            \`\`\`
+
+        `);
+    });
+
+    it("should handle mixed prop formats including unquoted numbers", async () => {
+        const markdown = `
+            <Code src="../snippets/test.go" startLine=40 highlight={40-60} maxLines=25 title={"Go"} />
+        `;
+
+        const result = await replaceReferencedCode({
+            markdown,
+            absolutePathToFernFolder,
+            absolutePathToMarkdownFile,
+            context,
+            fileLoader: async (filepath) => {
+                if (filepath === AbsoluteFilePath.of("/path/to/fern/snippets/test.go")) {
+                    return "package main";
+                }
+                throw new Error(`Unexpected filepath: ${filepath}`);
+            }
+        });
+
+        expect(result).toBe(`
+            \`\`\`go title={"Go"} startLine={40} highlight={40-60} maxLines={25}
+            package main
+            \`\`\`
+
+        `);
+    });
 });

--- a/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
+++ b/packages/cli/docs-markdown-utils/src/replaceReferencedCode.ts
@@ -153,14 +153,16 @@ export async function replaceReferencedCode({
 
             // Parse all properties from the Code component
             const allProps = new Map<string, { value: string; fromCurlyBraces: boolean }>();
-            const propsRegex = /(\w+)=(?:{([^}]+)}|"([^"]+)")/g;
+            // Match props in formats: prop={value}, prop="value", or prop=number (unquoted numbers)
+            const propsRegex = /(\w+)=(?:{([^}]+)}|"([^"]+)"|(\d+)(?=\s|\/|>|$))/g;
 
             // Extract props before src
             const beforeSrcProps = matchString?.split("src=")[0]?.trim() ?? "";
             let propMatch;
             while ((propMatch = propsRegex.exec(beforeSrcProps)) !== null) {
                 const propName = propMatch[1];
-                const propValue = propMatch[2] || propMatch[3];
+                // propMatch[2] = curly braces value, propMatch[3] = quoted value, propMatch[4] = unquoted number
+                const propValue = propMatch[2] || propMatch[3] || propMatch[4];
                 const fromCurlyBraces = propMatch[2] !== undefined;
                 if (propName && propValue) {
                     allProps.set(propName, { value: propValue, fromCurlyBraces });
@@ -172,7 +174,8 @@ export async function replaceReferencedCode({
             propsRegex.lastIndex = 0; // Reset regex
             while ((propMatch = propsRegex.exec(afterSrcProps)) !== null) {
                 const propName = propMatch[1];
-                const propValue = propMatch[2] || propMatch[3];
+                // propMatch[2] = curly braces value, propMatch[3] = quoted value, propMatch[4] = unquoted number
+                const propValue = propMatch[2] || propMatch[3] || propMatch[4];
                 const fromCurlyBraces = propMatch[2] !== undefined;
                 if (propName && propValue) {
                     allProps.set(propName, { value: propValue, fromCurlyBraces });


### PR DESCRIPTION
## Description
Refs: Slack thread from Varun Puri

Fixes an issue where unquoted numeric props like `startLine=40` were silently ignored when processing `<Code src="...">` components.

## Changes Made
- Updated `propsRegex` in `replaceReferencedCode.ts` to match unquoted numeric values (e.g., `startLine=40`, `maxLines=25`)
- Added capture group for unquoted numbers with lookahead to ensure proper boundary detection
- Added 5 test cases covering:
  - Unquoted numeric props in various positions
  - Mixed prop formats (unquoted, quoted, curly braces)
  - Quoted numeric values like `startLine="40"`
  - Curly brace numeric values like `startLine={40}`

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed (all 147 tests pass)

## Human Review Checklist
- [ ] Verify the regex lookahead `(?=\s|\/|>|$)` correctly handles all boundary cases
- [ ] Note: This fix only handles unquoted **numbers**. Unquoted booleans like `prop=true` would still need quotes or curly braces.

---
Requested by: Sandeep Dinesh (@thesandlord)
Link to Devin run: https://app.devin.ai/sessions/73221af0806c4a5eac51d1cf5bd398d2