### PR TITLE
feat(docs): add light-mode-code setting to docs.yml

### DIFF
--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -710,6 +710,12 @@ types:
           If set to true, the code blocks will be displayed in dark mode, regardless of the selected theme.
 
           @default: false
+      light-mode-code:
+        type: optional<boolean>
+        docs: |
+          If set to true, the code blocks will be displayed in light mode, regardless of the selected theme.
+
+          @default: false
       default-search-filters:
         type: optional<boolean>
         docs: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.36.0
+  changelogEntry:
+    - summary: |
+        Add `light-mode-code` setting to docs.yml. When set to true, code blocks will be displayed in light mode regardless of the selected theme. This is the inverse of the existing `dark-mode-code` setting.
+      type: feat
+  createdAt: "2026-01-06"
+  irVersion: 62
+
 - version: 3.35.1
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -408,6 +408,7 @@ function convertSettingsConfig(
 
     return {
         darkModeCode: settings.darkModeCode ?? false,
+        lightModeCode: settings.lightModeCode ?? false,
         defaultSearchFilters: settings.defaultSearchFilters ?? false,
         language: settings.language ?? "en",
         disableSearch: settings.disableSearch ?? false,

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/DocsSettingsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/DocsSettingsConfig.ts
@@ -24,6 +24,12 @@ export interface DocsSettingsConfig {
      */
     darkModeCode?: boolean;
     /**
+     * If set to true, the code blocks will be displayed in light mode, regardless of the selected theme.
+     *
+     * @default: false
+     */
+    lightModeCode?: boolean;
+    /**
      * By default (`false`), search will display results for pages across all products and versions.
      * If set to true, search will display results for pages within the current product and version.
      *

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/DocsSettingsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/DocsSettingsConfig.ts
@@ -15,6 +15,7 @@ export const DocsSettingsConfig: core.serialization.ObjectSchema<
     searchText: core.serialization.property("search-text", core.serialization.string().optional()),
     disableSearch: core.serialization.property("disable-search", core.serialization.boolean().optional()),
     darkModeCode: core.serialization.property("dark-mode-code", core.serialization.boolean().optional()),
+    lightModeCode: core.serialization.property("light-mode-code", core.serialization.boolean().optional()),
     defaultSearchFilters: core.serialization.property(
         "default-search-filters",
         core.serialization.boolean().optional(),
@@ -39,6 +40,7 @@ export declare namespace DocsSettingsConfig {
         "search-text"?: string | null;
         "disable-search"?: boolean | null;
         "dark-mode-code"?: boolean | null;
+        "light-mode-code"?: boolean | null;
         "default-search-filters"?: boolean | null;
         "http-snippets"?: HttpSnippetsConfig.Raw | null;
         "hide-404-page"?: boolean | null;


### PR DESCRIPTION
## Description

Refs: Companion PR to https://github.com/fern-api/fern-platform/pull/6225

Adds a new `light-mode-code` setting to docs.yml that forces code blocks to display in light mode regardless of the selected theme. This is the inverse of the existing `dark-mode-code` setting.

## Changes Made

- Added `light-mode-code` property to `DocsSettingsConfig` in the docs.yml API definition
- Added `lightModeCode` to the TypeScript API type with JSDoc documentation
- Added serialization support mapping `light-mode-code` (YAML) to `lightModeCode` (TypeScript)
- Updated `parseDocsConfiguration` to include the new setting with default value `false`
- Added changelog entry for version 3.36.0

## Usage

```yaml
# docs.yml
settings:
  light-mode-code: true  # Forces light code blocks even in dark mode
```

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing completed (requires fern-platform PR to be merged first)

## Human Review Checklist

- [ ] Verify the new setting follows the same pattern as `dark-mode-code`
- [ ] Verify serialization correctly maps kebab-case to camelCase
- [ ] Coordinate merge timing with fern-platform PR #6225

---
Link to Devin run: https://app.devin.ai/sessions/c0ff290bf09844f79c4ff090e370dd59
Requested by: @jon-fern