### PR TITLE
feat(python): use bytes type for binary WebSocket payloads

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -3,7 +3,8 @@
 
 - version: 4.46.7-rc3
   changelogEntry:
-    - summary: WebSocket methods now use `bytes` type for binary payloads (format: binary) instead of `str`.
+    - summary: |
+        WebSocket methods now use `bytes` type for binary payloads (format: binary) instead of `str`.
       type: feat
   createdAt: "2026-01-07"
   irVersion: 62

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.46.7-rc3
+  changelogEntry:
+    - summary: WebSocket methods now use `bytes` type for binary payloads (format: binary) instead of `str`.
+      type: feat
+  createdAt: "2026-01-07"
+  irVersion: 62
+
 - version: 4.46.7-rc2
   changelogEntry:
     - summary: Fixed Python SDK generation to use native Pydantic field aliases and improved core parsing so wire-key and nested/union validation works correctly across Pydantic v1/v2.

--- a/generators/python/src/fern_python/generators/context/type_reference_to_type_hint_converter.py
+++ b/generators/python/src/fern_python/generators/context/type_reference_to_type_hint_converter.py
@@ -212,6 +212,8 @@ class TypeReferenceToTypeHintConverter:
         )
 
     def _get_type_hint_for_primitive(self, primitive: ir_types.PrimitiveType) -> AST.TypeHint:
+        if self._is_binary_string(primitive):
+            return AST.TypeHint.bytes()
         to_return = primitive.v_1.visit(
             integer=AST.TypeHint.int_,
             double=AST.TypeHint.float_,
@@ -228,6 +230,18 @@ class TypeReferenceToTypeHintConverter:
             float_=AST.TypeHint.float_,
         )
         return to_return
+
+    def _is_binary_string(self, primitive: ir_types.PrimitiveType) -> bool:
+        if primitive.v_1 != ir_types.PrimitiveTypeV1.STRING:
+            return False
+        if primitive.v_2 is None:
+            return False
+        v2_union = primitive.v_2.get_as_union()
+        if v2_union.type != "string":
+            return False
+        if v2_union.validation is None:
+            return False
+        return v2_union.validation.format == "binary"
 
     def _unbox_type_reference(self, type_reference: ir_types.TypeReference) -> ir_types.TypeReference:
         return type_reference.visit(


### PR DESCRIPTION
## Description

Refs: User request from @patrickthornton

When AsyncAPI messages are marked with `contentType: application/octet-stream` and `payload: { type: string, format: binary }`, the Python SDK now generates `bytes` type hints instead of `str` for WebSocket message parameters.

## Changes Made

- Added `_is_binary_string()` helper method to detect primitives with `format: "binary"` validation
- Modified `_get_type_hint_for_primitive()` to return `AST.TypeHint.bytes()` for binary string primitives
- Added version entry 4.46.7-rc3 to versions.yml

## Testing

- [ ] Unit tests added/updated (Note: Could not add a Fern definition test fixture because `bytes` is not supported as a WebSocket message body type in Fern definitions - the binary format is set when AsyncAPI is converted to Fern IR)
- [x] Manual code review completed

## Human Review Checklist

- [ ] Verify the `_is_binary_string` logic correctly accesses the `PrimitiveType.v_2` union structure and validation format
- [ ] **Important**: This change applies to ALL primitive type hints, not just WebSocket messages. Confirm this is the desired behavior and won't affect HTTP endpoints with binary payloads (which may have separate handling)
- [ ] Verify the IR correctly preserves `format: "binary"` from AsyncAPI definitions

---

Link to Devin run: https://app.devin.ai/sessions/24b9fb2e623047f584bb06e66893c15b