### PR TITLE
feat(postman): disable optional query parameters by default in Postman collections

### DIFF
--- a/generators/postman/fern/definition/collection.yml
+++ b/generators/postman/fern/definition/collection.yml
@@ -57,6 +57,7 @@ types:
       key: string
       value: string
       description: optional<string>
+      disabled: optional<boolean>
 
   PostmanRequest:
     properties:

--- a/generators/postman/src/request/GeneratedExampleRequest.ts
+++ b/generators/postman/src/request/GeneratedExampleRequest.ts
@@ -31,13 +31,20 @@ export class GeneratedExampleRequest extends AbstractGeneratedRequest {
             if (queryParameterDeclaration == null) {
                 throw new Error(`Cannot find query parameter ${exampleQueryParameter.name.wireValue}`);
             }
+
+            // Optional parameters should be disabled by default in Postman UI
+            const isOptional =
+                queryParameterDeclaration.valueType.type === "container" &&
+                queryParameterDeclaration.valueType.container.type === "optional";
+
             return {
                 key: exampleQueryParameter.name.wireValue,
                 description: queryParameterDeclaration.docs ?? undefined,
                 value:
                     typeof exampleQueryParameter.value.jsonExample !== "string"
                         ? JSON.stringify(exampleQueryParameter.value.jsonExample)
-                        : exampleQueryParameter.value.jsonExample
+                        : exampleQueryParameter.value.jsonExample,
+                disabled: isOptional ? true : undefined
             };
         });
     }

--- a/generators/postman/src/writePostmanCollection.ts
+++ b/generators/postman/src/writePostmanCollection.ts
@@ -63,7 +63,9 @@ export async function writePostmanCollection(pathToConfig: string): Promise<void
                     ir.apiDisplayName ??
                     startCase(ir.apiName.originalName)
             });
-            const rawCollectionDefinition = PostmanParsing.PostmanCollectionSchema.jsonOrThrow(_collectionDefinition);
+            const rawCollectionDefinition = PostmanParsing.PostmanCollectionSchema.jsonOrThrow(_collectionDefinition, {
+                unrecognizedObjectKeys: "passthrough"
+            });
             // biome-ignore lint/suspicious/noConsole: allow console
             console.log("Converted ir to postman collection");
 

--- a/generators/postman/versions.yml
+++ b/generators/postman/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
 
-- version: 0.4.4
+- version: 0.5.0
   changelogEntry:
     - type: feat
       summary: |

--- a/generators/postman/versions.yml
+++ b/generators/postman/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
 
+- version: 0.4.4
+  changelogEntry:
+    - type: feat
+      summary: |
+        Optional query parameters are now disabled by default in Postman collections.
+        This means they appear unchecked in the Postman UI, preventing users from
+        accidentally sending optional parameters they don't intend to use.
+  createdAt: "2026-01-07"
+  irVersion: 53
+
 - version: 0.4.3
   changelogEntry:
     - type: chore

--- a/seed/postman/client-side-params/collection.json
+++ b/seed/postman/client-side-params/collection.json
@@ -75,12 +75,14 @@
                 {
                   "key": "fields",
                   "description": "Comma-separated list of fields to include",
-                  "value": "fields"
+                  "value": "fields",
+                  "disabled": true
                 },
                 {
                   "key": "search",
                   "description": "Search query",
-                  "value": "search"
+                  "value": "search",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -141,12 +143,14 @@
                     {
                       "key": "fields",
                       "description": "Comma-separated list of fields to include",
-                      "value": "fields"
+                      "value": "fields",
+                      "disabled": true
                     },
                     {
                       "key": "search",
                       "description": "Search query",
-                      "value": "search"
+                      "value": "search",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -390,42 +394,50 @@
                 {
                   "key": "page",
                   "description": "Page index of the results to return. First page is 0.",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "per_page",
                   "description": "Number of results per page.",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "include_totals",
                   "description": "Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).",
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 },
                 {
                   "key": "sort",
                   "description": "Field to sort by. Use field:order where order is 1 for ascending and -1 for descending.",
-                  "value": "sort"
+                  "value": "sort",
+                  "disabled": true
                 },
                 {
                   "key": "connection",
                   "description": "Connection filter",
-                  "value": "connection"
+                  "value": "connection",
+                  "disabled": true
                 },
                 {
                   "key": "q",
                   "description": "Query string following Lucene query string syntax",
-                  "value": "q"
+                  "value": "q",
+                  "disabled": true
                 },
                 {
                   "key": "search_engine",
                   "description": "Search engine version (v1, v2, or v3)",
-                  "value": "search_engine"
+                  "value": "search_engine",
+                  "disabled": true
                 },
                 {
                   "key": "fields",
                   "description": "Comma-separated list of fields to include or exclude",
-                  "value": "fields"
+                  "value": "fields",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -461,42 +473,50 @@
                     {
                       "key": "page",
                       "description": "Page index of the results to return. First page is 0.",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "per_page",
                       "description": "Number of results per page.",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "include_totals",
                       "description": "Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).",
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     },
                     {
                       "key": "sort",
                       "description": "Field to sort by. Use field:order where order is 1 for ascending and -1 for descending.",
-                      "value": "sort"
+                      "value": "sort",
+                      "disabled": true
                     },
                     {
                       "key": "connection",
                       "description": "Connection filter",
-                      "value": "connection"
+                      "value": "connection",
+                      "disabled": true
                     },
                     {
                       "key": "q",
                       "description": "Query string following Lucene query string syntax",
-                      "value": "q"
+                      "value": "q",
+                      "disabled": true
                     },
                     {
                       "key": "search_engine",
                       "description": "Search engine version (v1, v2, or v3)",
-                      "value": "search_engine"
+                      "value": "search_engine",
+                      "disabled": true
                     },
                     {
                       "key": "fields",
                       "description": "Comma-separated list of fields to include or exclude",
-                      "value": "fields"
+                      "value": "fields",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -537,12 +557,14 @@
                 {
                   "key": "fields",
                   "description": "Comma-separated list of fields to include or exclude",
-                  "value": "fields"
+                  "value": "fields",
+                  "disabled": true
                 },
                 {
                   "key": "include_fields",
                   "description": "true to include the fields specified, false to exclude them",
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 }
               ],
               "variable": [
@@ -585,12 +607,14 @@
                     {
                       "key": "fields",
                       "description": "Comma-separated list of fields to include or exclude",
-                      "value": "fields"
+                      "value": "fields",
+                      "disabled": true
                     },
                     {
                       "key": "include_fields",
                       "description": "true to include the fields specified, false to exclude them",
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     }
                   ],
                   "variable": [
@@ -888,17 +912,20 @@
                 {
                   "key": "strategy",
                   "description": "Filter by strategy type (e.g., auth0, google-oauth2, samlp)",
-                  "value": "strategy"
+                  "value": "strategy",
+                  "disabled": true
                 },
                 {
                   "key": "name",
                   "description": "Filter by connection name",
-                  "value": "name"
+                  "value": "name",
+                  "disabled": true
                 },
                 {
                   "key": "fields",
                   "description": "Comma-separated list of fields to include",
-                  "value": "fields"
+                  "value": "fields",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -934,17 +961,20 @@
                     {
                       "key": "strategy",
                       "description": "Filter by strategy type (e.g., auth0, google-oauth2, samlp)",
-                      "value": "strategy"
+                      "value": "strategy",
+                      "disabled": true
                     },
                     {
                       "key": "name",
                       "description": "Filter by connection name",
-                      "value": "name"
+                      "value": "name",
+                      "disabled": true
                     },
                     {
                       "key": "fields",
                       "description": "Comma-separated list of fields to include",
-                      "value": "fields"
+                      "value": "fields",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -985,7 +1015,8 @@
                 {
                   "key": "fields",
                   "description": "Comma-separated list of fields to include",
-                  "value": "fields"
+                  "value": "fields",
+                  "disabled": true
                 }
               ],
               "variable": [
@@ -1028,7 +1059,8 @@
                     {
                       "key": "fields",
                       "description": "Comma-separated list of fields to include",
-                      "value": "fields"
+                      "value": "fields",
+                      "disabled": true
                     }
                   ],
                   "variable": [
@@ -1074,42 +1106,50 @@
                 {
                   "key": "fields",
                   "description": "Comma-separated list of fields to include",
-                  "value": "fields"
+                  "value": "fields",
+                  "disabled": true
                 },
                 {
                   "key": "include_fields",
                   "description": "Whether specified fields are included or excluded",
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 },
                 {
                   "key": "page",
                   "description": "Page number (zero-based)",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "per_page",
                   "description": "Number of results per page",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "include_totals",
                   "description": "Include total count in response",
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 },
                 {
                   "key": "is_global",
                   "description": "Filter by global clients",
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 },
                 {
                   "key": "is_first_party",
                   "description": "Filter by first party clients",
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 },
                 {
                   "key": "app_type",
                   "description": "Filter by application type (spa, native, regular_web, non_interactive)",
-                  "value": "[\"app_type\",\"app_type\"]"
+                  "value": "[\"app_type\",\"app_type\"]",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -1145,42 +1185,50 @@
                     {
                       "key": "fields",
                       "description": "Comma-separated list of fields to include",
-                      "value": "fields"
+                      "value": "fields",
+                      "disabled": true
                     },
                     {
                       "key": "include_fields",
                       "description": "Whether specified fields are included or excluded",
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     },
                     {
                       "key": "page",
                       "description": "Page number (zero-based)",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "per_page",
                       "description": "Number of results per page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "include_totals",
                       "description": "Include total count in response",
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     },
                     {
                       "key": "is_global",
                       "description": "Filter by global clients",
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     },
                     {
                       "key": "is_first_party",
                       "description": "Filter by first party clients",
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     },
                     {
                       "key": "app_type",
                       "description": "Filter by application type (spa, native, regular_web, non_interactive)",
-                      "value": "[\"app_type\",\"app_type\"]"
+                      "value": "[\"app_type\",\"app_type\"]",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1221,12 +1269,14 @@
                 {
                   "key": "fields",
                   "description": "Comma-separated list of fields to include",
-                  "value": "fields"
+                  "value": "fields",
+                  "disabled": true
                 },
                 {
                   "key": "include_fields",
                   "description": "Whether specified fields are included or excluded",
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 }
               ],
               "variable": [
@@ -1269,12 +1319,14 @@
                     {
                       "key": "fields",
                       "description": "Comma-separated list of fields to include",
-                      "value": "fields"
+                      "value": "fields",
+                      "disabled": true
                     },
                     {
                       "key": "include_fields",
                       "description": "Whether specified fields are included or excluded",
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     }
                   ],
                   "variable": [

--- a/seed/postman/enum/collection.json
+++ b/seed/postman/enum/collection.json
@@ -511,7 +511,8 @@
                     {
                       "key": "maybeOperand",
                       "description": null,
-                      "value": ">"
+                      "value": ">",
+                      "disabled": true
                     },
                     {
                       "key": "operandOrColor",
@@ -521,7 +522,8 @@
                     {
                       "key": "maybeOperandOrColor",
                       "description": null,
-                      "value": "red"
+                      "value": "red",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -565,7 +567,8 @@
                 {
                   "key": "maybeOperand",
                   "description": null,
-                  "value": ">"
+                  "value": ">",
+                  "disabled": true
                 },
                 {
                   "key": "operandOrColor",
@@ -575,7 +578,8 @@
                 {
                   "key": "maybeOperandOrColor",
                   "description": null,
-                  "value": "red"
+                  "value": "red",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -615,7 +619,8 @@
                     {
                       "key": "maybeOperand",
                       "description": null,
-                      "value": ">"
+                      "value": ">",
+                      "disabled": true
                     },
                     {
                       "key": "operandOrColor",
@@ -625,7 +630,8 @@
                     {
                       "key": "maybeOperandOrColor",
                       "description": null,
-                      "value": "red"
+                      "value": "red",
+                      "disabled": true
                     }
                   ],
                   "variable": []

--- a/seed/postman/examples/collection.json
+++ b/seed/postman/examples/collection.json
@@ -868,12 +868,14 @@
                 {
                   "key": "shallow",
                   "description": null,
-                  "value": "false"
+                  "value": "false",
+                  "disabled": true
                 },
                 {
                   "key": "tag",
                   "description": null,
-                  "value": "development"
+                  "value": "development",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -914,12 +916,14 @@
                     {
                       "key": "shallow",
                       "description": null,
-                      "value": "false"
+                      "value": "false",
+                      "disabled": true
                     },
                     {
                       "key": "tag",
                       "description": null,
-                      "value": "development"
+                      "value": "development",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -963,12 +967,14 @@
                     {
                       "key": "shallow",
                       "description": null,
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     },
                     {
                       "key": "tag",
                       "description": null,
-                      "value": "tag"
+                      "value": "tag",
+                      "disabled": true
                     }
                   ],
                   "variable": []

--- a/seed/postman/literal/collection.json
+++ b/seed/postman/literal/collection.json
@@ -448,7 +448,8 @@
                 {
                   "key": "optional_prompt",
                   "description": null,
-                  "value": "You are a helpful assistant"
+                  "value": "You are a helpful assistant",
+                  "disabled": true
                 },
                 {
                   "key": "alias_prompt",
@@ -458,7 +459,8 @@
                 {
                   "key": "alias_optional_prompt",
                   "description": null,
-                  "value": "You are a helpful assistant"
+                  "value": "You are a helpful assistant",
+                  "disabled": true
                 },
                 {
                   "key": "stream",
@@ -468,7 +470,8 @@
                 {
                   "key": "optional_stream",
                   "description": null,
-                  "value": "false"
+                  "value": "false",
+                  "disabled": true
                 },
                 {
                   "key": "alias_stream",
@@ -478,7 +481,8 @@
                 {
                   "key": "alias_optional_stream",
                   "description": null,
-                  "value": "false"
+                  "value": "false",
+                  "disabled": true
                 },
                 {
                   "key": "query",
@@ -523,7 +527,8 @@
                     {
                       "key": "optional_prompt",
                       "description": null,
-                      "value": "You are a helpful assistant"
+                      "value": "You are a helpful assistant",
+                      "disabled": true
                     },
                     {
                       "key": "alias_prompt",
@@ -533,7 +538,8 @@
                     {
                       "key": "alias_optional_prompt",
                       "description": null,
-                      "value": "You are a helpful assistant"
+                      "value": "You are a helpful assistant",
+                      "disabled": true
                     },
                     {
                       "key": "stream",
@@ -543,7 +549,8 @@
                     {
                       "key": "optional_stream",
                       "description": null,
-                      "value": "false"
+                      "value": "false",
+                      "disabled": true
                     },
                     {
                       "key": "alias_stream",
@@ -553,7 +560,8 @@
                     {
                       "key": "alias_optional_stream",
                       "description": null,
-                      "value": "false"
+                      "value": "false",
+                      "disabled": true
                     },
                     {
                       "key": "query",
@@ -601,7 +609,8 @@
                     {
                       "key": "optional_prompt",
                       "description": null,
-                      "value": "You are a helpful assistant"
+                      "value": "You are a helpful assistant",
+                      "disabled": true
                     },
                     {
                       "key": "alias_prompt",
@@ -611,7 +620,8 @@
                     {
                       "key": "alias_optional_prompt",
                       "description": null,
-                      "value": "You are a helpful assistant"
+                      "value": "You are a helpful assistant",
+                      "disabled": true
                     },
                     {
                       "key": "query",
@@ -626,7 +636,8 @@
                     {
                       "key": "optional_stream",
                       "description": null,
-                      "value": "false"
+                      "value": "false",
+                      "disabled": true
                     },
                     {
                       "key": "alias_stream",
@@ -636,7 +647,8 @@
                     {
                       "key": "alias_optional_stream",
                       "description": null,
-                      "value": "false"
+                      "value": "false",
+                      "disabled": true
                     }
                   ],
                   "variable": []

--- a/seed/postman/mixed-file-directory/collection.json
+++ b/seed/postman/mixed-file-directory/collection.json
@@ -211,7 +211,8 @@
                     {
                       "key": "limit",
                       "description": "The maximum number of results to return.",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -247,7 +248,8 @@
                         {
                           "key": "limit",
                           "description": "The maximum number of results to return.",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -288,7 +290,8 @@
                 {
                   "key": "limit",
                   "description": "The maximum number of results to return.",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -323,7 +326,8 @@
                     {
                       "key": "limit",
                       "description": "The maximum number of results to return.",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": []

--- a/seed/postman/nullable-optional/collection.json
+++ b/seed/postman/nullable-optional/collection.json
@@ -288,22 +288,26 @@
                 {
                   "key": "limit",
                   "description": null,
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "offset",
                   "description": null,
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "includeDeleted",
                   "description": null,
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 },
                 {
                   "key": "sortBy",
                   "description": null,
-                  "value": "sortBy"
+                  "value": "sortBy",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -339,22 +343,26 @@
                     {
                       "key": "limit",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "offset",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "includeDeleted",
                       "description": null,
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     },
                     {
                       "key": "sortBy",
                       "description": null,
-                      "value": "sortBy"
+                      "value": "sortBy",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -400,17 +408,20 @@
                 {
                   "key": "department",
                   "description": null,
-                  "value": "department"
+                  "value": "department",
+                  "disabled": true
                 },
                 {
                   "key": "role",
                   "description": null,
-                  "value": "role"
+                  "value": "role",
+                  "disabled": true
                 },
                 {
                   "key": "isActive",
                   "description": null,
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -452,17 +463,20 @@
                     {
                       "key": "department",
                       "description": null,
-                      "value": "department"
+                      "value": "department",
+                      "disabled": true
                     },
                     {
                       "key": "role",
                       "description": null,
-                      "value": "role"
+                      "value": "role",
+                      "disabled": true
                     },
                     {
                       "key": "isActive",
                       "description": null,
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -843,17 +857,20 @@
                 {
                   "key": "role",
                   "description": null,
-                  "value": "ADMIN"
+                  "value": "ADMIN",
+                  "disabled": true
                 },
                 {
                   "key": "status",
                   "description": null,
-                  "value": "active"
+                  "value": "active",
+                  "disabled": true
                 },
                 {
                   "key": "secondaryRole",
                   "description": null,
-                  "value": "ADMIN"
+                  "value": "ADMIN",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -890,17 +907,20 @@
                     {
                       "key": "role",
                       "description": null,
-                      "value": "ADMIN"
+                      "value": "ADMIN",
+                      "disabled": true
                     },
                     {
                       "key": "status",
                       "description": null,
-                      "value": "active"
+                      "value": "active",
+                      "disabled": true
                     },
                     {
                       "key": "secondaryRole",
                       "description": null,
-                      "value": "ADMIN"
+                      "value": "ADMIN",
+                      "disabled": true
                     }
                   ],
                   "variable": []

--- a/seed/postman/nullable-request-body/collection.json
+++ b/seed/postman/nullable-request-body/collection.json
@@ -127,12 +127,14 @@
                     {
                       "key": "query_param_object",
                       "description": null,
-                      "value": "{\"id\":\"id\",\"name\":\"name\"}"
+                      "value": "{\"id\":\"id\",\"name\":\"name\"}",
+                      "disabled": true
                     },
                     {
                       "key": "query_param_integer",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": [
@@ -185,12 +187,14 @@
                     {
                       "key": "query_param_object",
                       "description": null,
-                      "value": "{\"id\":\"id\",\"name\":\"name\"}"
+                      "value": "{\"id\":\"id\",\"name\":\"name\"}",
+                      "disabled": true
                     },
                     {
                       "key": "query_param_integer",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": [

--- a/seed/postman/nullable/collection.json
+++ b/seed/postman/nullable/collection.json
@@ -35,27 +35,32 @@
                 {
                   "key": "usernames",
                   "description": null,
-                  "value": "usernames"
+                  "value": "usernames",
+                  "disabled": true
                 },
                 {
                   "key": "avatar",
                   "description": null,
-                  "value": "avatar"
+                  "value": "avatar",
+                  "disabled": true
                 },
                 {
                   "key": "activated",
                   "description": null,
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 },
                 {
                   "key": "tags",
                   "description": null,
-                  "value": "tags"
+                  "value": "tags",
+                  "disabled": true
                 },
                 {
                   "key": "extra",
                   "description": null,
-                  "value": "true"
+                  "value": "true",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -90,27 +95,32 @@
                     {
                       "key": "usernames",
                       "description": null,
-                      "value": "usernames"
+                      "value": "usernames",
+                      "disabled": true
                     },
                     {
                       "key": "avatar",
                       "description": null,
-                      "value": "avatar"
+                      "value": "avatar",
+                      "disabled": true
                     },
                     {
                       "key": "activated",
                       "description": null,
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     },
                     {
                       "key": "tags",
                       "description": null,
-                      "value": "tags"
+                      "value": "tags",
+                      "disabled": true
                     },
                     {
                       "key": "extra",
                       "description": null,
-                      "value": "true"
+                      "value": "true",
+                      "disabled": true
                     }
                   ],
                   "variable": []

--- a/seed/postman/pagination-custom/collection.json
+++ b/seed/postman/pagination-custom/collection.json
@@ -49,7 +49,8 @@
                 {
                   "key": "starting_after",
                   "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                  "value": "starting_after"
+                  "value": "starting_after",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -84,7 +85,8 @@
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []

--- a/seed/postman/pagination/collection.json
+++ b/seed/postman/pagination/collection.json
@@ -155,22 +155,26 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "per_page",
                       "description": "Defaults to per page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     },
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -205,22 +209,26 @@
                         {
                           "key": "page",
                           "description": "Defaults to first page",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         },
                         {
                           "key": "per_page",
                           "description": "Defaults to per page",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         },
                         {
                           "key": "order",
                           "description": null,
-                          "value": "asc"
+                          "value": "asc",
+                          "disabled": true
                         },
                         {
                           "key": "starting_after",
                           "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                          "value": "starting_after"
+                          "value": "starting_after",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -259,7 +267,8 @@
                     {
                       "key": "cursor",
                       "description": null,
-                      "value": "cursor"
+                      "value": "cursor",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -294,7 +303,8 @@
                         {
                           "key": "cursor",
                           "description": null,
-                          "value": "cursor"
+                          "value": "cursor",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -411,22 +421,26 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "per_page",
                       "description": "Defaults to per page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     },
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -461,22 +475,26 @@
                         {
                           "key": "page",
                           "description": "Defaults to first page",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         },
                         {
                           "key": "per_page",
                           "description": "Defaults to per page",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         },
                         {
                           "key": "order",
                           "description": null,
-                          "value": "asc"
+                          "value": "asc",
+                          "disabled": true
                         },
                         {
                           "key": "starting_after",
                           "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                          "value": "starting_after"
+                          "value": "starting_after",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -515,22 +533,26 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1.1"
+                      "value": "1.1",
+                      "disabled": true
                     },
                     {
                       "key": "per_page",
                       "description": "Defaults to per page",
-                      "value": "1.1"
+                      "value": "1.1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     },
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -565,22 +587,26 @@
                         {
                           "key": "page",
                           "description": "Defaults to first page",
-                          "value": "1.1"
+                          "value": "1.1",
+                          "disabled": true
                         },
                         {
                           "key": "per_page",
                           "description": "Defaults to per page",
-                          "value": "1.1"
+                          "value": "1.1",
+                          "disabled": true
                         },
                         {
                           "key": "order",
                           "description": null,
-                          "value": "asc"
+                          "value": "asc",
+                          "disabled": true
                         },
                         {
                           "key": "starting_after",
                           "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                          "value": "starting_after"
+                          "value": "starting_after",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -697,17 +723,20 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "limit",
                       "description": "The maximum number of elements to return.\nThis is also used as the step size in this\npaginated endpoint.",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -742,17 +771,20 @@
                         {
                           "key": "page",
                           "description": "Defaults to first page",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         },
                         {
                           "key": "limit",
                           "description": "The maximum number of elements to return.\nThis is also used as the step size in this\npaginated endpoint.",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         },
                         {
                           "key": "order",
                           "description": null,
-                          "value": "asc"
+                          "value": "asc",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -791,17 +823,20 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "limit",
                       "description": "The maximum number of elements to return.\nThis is also used as the step size in this\npaginated endpoint.",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -836,17 +871,20 @@
                         {
                           "key": "page",
                           "description": "Defaults to first page",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         },
                         {
                           "key": "limit",
                           "description": "The maximum number of elements to return.\nThis is also used as the step size in this\npaginated endpoint.",
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         },
                         {
                           "key": "order",
                           "description": null,
-                          "value": "asc"
+                          "value": "asc",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -885,7 +923,8 @@
                     {
                       "key": "cursor",
                       "description": null,
-                      "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+                      "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -920,7 +959,8 @@
                         {
                           "key": "cursor",
                           "description": null,
-                          "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+                          "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -959,7 +999,8 @@
                     {
                       "key": "cursor",
                       "description": null,
-                      "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+                      "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -994,7 +1035,8 @@
                         {
                           "key": "cursor",
                           "description": null,
-                          "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+                          "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -1033,7 +1075,8 @@
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1068,7 +1111,8 @@
                         {
                           "key": "starting_after",
                           "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                          "value": "starting_after"
+                          "value": "starting_after",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -1107,7 +1151,8 @@
                     {
                       "key": "offset",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1142,7 +1187,8 @@
                         {
                           "key": "offset",
                           "description": null,
-                          "value": "1"
+                          "value": "1",
+                          "disabled": true
                         }
                       ],
                       "variable": []
@@ -1190,22 +1236,26 @@
                 {
                   "key": "page",
                   "description": "Defaults to first page",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "per_page",
                   "description": "Defaults to per page",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "order",
                   "description": null,
-                  "value": "asc"
+                  "value": "asc",
+                  "disabled": true
                 },
                 {
                   "key": "starting_after",
                   "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                  "value": "starting_after"
+                  "value": "starting_after",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -1240,22 +1290,26 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "per_page",
                       "description": "Defaults to per page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     },
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1294,7 +1348,8 @@
                 {
                   "key": "cursor",
                   "description": null,
-                  "value": "cursor"
+                  "value": "cursor",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -1329,7 +1384,8 @@
                     {
                       "key": "cursor",
                       "description": null,
-                      "value": "cursor"
+                      "value": "cursor",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1446,22 +1502,26 @@
                 {
                   "key": "page",
                   "description": "Defaults to first page",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "per_page",
                   "description": "Defaults to per page",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "order",
                   "description": null,
-                  "value": "asc"
+                  "value": "asc",
+                  "disabled": true
                 },
                 {
                   "key": "starting_after",
                   "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                  "value": "starting_after"
+                  "value": "starting_after",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -1496,22 +1556,26 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "per_page",
                       "description": "Defaults to per page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     },
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1550,22 +1614,26 @@
                 {
                   "key": "page",
                   "description": "Defaults to first page",
-                  "value": "1.1"
+                  "value": "1.1",
+                  "disabled": true
                 },
                 {
                   "key": "per_page",
                   "description": "Defaults to per page",
-                  "value": "1.1"
+                  "value": "1.1",
+                  "disabled": true
                 },
                 {
                   "key": "order",
                   "description": null,
-                  "value": "asc"
+                  "value": "asc",
+                  "disabled": true
                 },
                 {
                   "key": "starting_after",
                   "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                  "value": "starting_after"
+                  "value": "starting_after",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -1600,22 +1668,26 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1.1"
+                      "value": "1.1",
+                      "disabled": true
                     },
                     {
                       "key": "per_page",
                       "description": "Defaults to per page",
-                      "value": "1.1"
+                      "value": "1.1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     },
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1732,17 +1804,20 @@
                 {
                   "key": "page",
                   "description": "Defaults to first page",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "limit",
                   "description": "The maximum number of elements to return.\nThis is also used as the step size in this\npaginated endpoint.",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "order",
                   "description": null,
-                  "value": "asc"
+                  "value": "asc",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -1777,17 +1852,20 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "limit",
                       "description": "The maximum number of elements to return.\nThis is also used as the step size in this\npaginated endpoint.",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1826,17 +1904,20 @@
                 {
                   "key": "page",
                   "description": "Defaults to first page",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "limit",
                   "description": "The maximum number of elements to return.\nThis is also used as the step size in this\npaginated endpoint.",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "order",
                   "description": null,
-                  "value": "asc"
+                  "value": "asc",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -1871,17 +1952,20 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "limit",
                       "description": "The maximum number of elements to return.\nThis is also used as the step size in this\npaginated endpoint.",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "order",
                       "description": null,
-                      "value": "asc"
+                      "value": "asc",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1920,7 +2004,8 @@
                 {
                   "key": "cursor",
                   "description": null,
-                  "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+                  "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -1955,7 +2040,8 @@
                     {
                       "key": "cursor",
                       "description": null,
-                      "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+                      "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -1994,7 +2080,8 @@
                 {
                   "key": "cursor",
                   "description": null,
-                  "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+                  "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -2029,7 +2116,8 @@
                     {
                       "key": "cursor",
                       "description": null,
-                      "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
+                      "value": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -2068,7 +2156,8 @@
                 {
                   "key": "starting_after",
                   "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                  "value": "starting_after"
+                  "value": "starting_after",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -2103,7 +2192,8 @@
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -2142,7 +2232,8 @@
                 {
                   "key": "starting_after",
                   "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                  "value": "starting_after"
+                  "value": "starting_after",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -2177,7 +2268,8 @@
                     {
                       "key": "starting_after",
                       "description": "The cursor used for pagination in order to fetch\nthe next page of results.",
-                      "value": "starting_after"
+                      "value": "starting_after",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -2216,7 +2308,8 @@
                 {
                   "key": "offset",
                   "description": null,
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -2251,7 +2344,8 @@
                     {
                       "key": "offset",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -2291,7 +2385,8 @@
                 {
                   "key": "page",
                   "description": "Defaults to first page",
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -2327,7 +2422,8 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -2366,7 +2462,8 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": []
@@ -2405,7 +2502,8 @@
                     {
                       "key": "page",
                       "description": "Defaults to first page",
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": []

--- a/seed/postman/path-parameters/collection.json
+++ b/seed/postman/path-parameters/collection.json
@@ -228,7 +228,8 @@
                 {
                   "key": "limit",
                   "description": null,
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 }
               ],
               "variable": [
@@ -277,7 +278,8 @@
                     {
                       "key": "limit",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": [
@@ -621,7 +623,8 @@
                 {
                   "key": "limit",
                   "description": null,
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 }
               ],
               "variable": [
@@ -670,7 +673,8 @@
                     {
                       "key": "limit",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     }
                   ],
                   "variable": [

--- a/seed/postman/query-parameters-openapi-as-objects/collection.json
+++ b/seed/postman/query-parameters-openapi-as-objects/collection.json
@@ -61,47 +61,56 @@
             {
               "key": "userList",
               "description": null,
-              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+              "disabled": true
             },
             {
               "key": "optionalDeadline",
               "description": null,
-              "value": "2024-01-15T09:30:00Z"
+              "value": "2024-01-15T09:30:00Z",
+              "disabled": true
             },
             {
               "key": "keyValue",
               "description": null,
-              "value": "{\"keyValue\":\"keyValue\"}"
+              "value": "{\"keyValue\":\"keyValue\"}",
+              "disabled": true
             },
             {
               "key": "optionalString",
               "description": null,
-              "value": "optionalString"
+              "value": "optionalString",
+              "disabled": true
             },
             {
               "key": "nestedUser",
               "description": null,
-              "value": "{\"name\":\"name\",\"user\":{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}}"
+              "value": "{\"name\":\"name\",\"user\":{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}}",
+              "disabled": true
             },
             {
               "key": "optionalUser",
               "description": null,
-              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+              "disabled": true
             },
             {
               "key": "excludeUser",
               "description": null,
-              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+              "disabled": true
             },
             {
               "key": "filter",
               "description": null,
-              "value": "filter"
+              "value": "filter",
+              "disabled": true
             },
             {
               "key": "neighbor",
               "description": null,
-              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+              "disabled": true
             },
             {
               "key": "neighborRequired",
@@ -172,47 +181,56 @@
                 {
                   "key": "userList",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "optionalDeadline",
                   "description": null,
-                  "value": "2024-01-15T09:30:00Z"
+                  "value": "2024-01-15T09:30:00Z",
+                  "disabled": true
                 },
                 {
                   "key": "keyValue",
                   "description": null,
-                  "value": "{\"keyValue\":\"keyValue\"}"
+                  "value": "{\"keyValue\":\"keyValue\"}",
+                  "disabled": true
                 },
                 {
                   "key": "optionalString",
                   "description": null,
-                  "value": "optionalString"
+                  "value": "optionalString",
+                  "disabled": true
                 },
                 {
                   "key": "nestedUser",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"user\":{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}}"
+                  "value": "{\"name\":\"name\",\"user\":{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}}",
+                  "disabled": true
                 },
                 {
                   "key": "optionalUser",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "excludeUser",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "filter",
                   "description": null,
-                  "value": "filter"
+                  "value": "filter",
+                  "disabled": true
                 },
                 {
                   "key": "neighbor",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "neighborRequired",

--- a/seed/postman/query-parameters-openapi/collection.json
+++ b/seed/postman/query-parameters-openapi/collection.json
@@ -61,47 +61,56 @@
             {
               "key": "userList",
               "description": null,
-              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+              "disabled": true
             },
             {
               "key": "optionalDeadline",
               "description": null,
-              "value": "2024-01-15T09:30:00Z"
+              "value": "2024-01-15T09:30:00Z",
+              "disabled": true
             },
             {
               "key": "keyValue",
               "description": null,
-              "value": "{\"keyValue\":\"keyValue\"}"
+              "value": "{\"keyValue\":\"keyValue\"}",
+              "disabled": true
             },
             {
               "key": "optionalString",
               "description": null,
-              "value": "optionalString"
+              "value": "optionalString",
+              "disabled": true
             },
             {
               "key": "nestedUser",
               "description": null,
-              "value": "{\"name\":\"name\",\"user\":{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}}"
+              "value": "{\"name\":\"name\",\"user\":{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}}",
+              "disabled": true
             },
             {
               "key": "optionalUser",
               "description": null,
-              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+              "disabled": true
             },
             {
               "key": "excludeUser",
               "description": null,
-              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+              "disabled": true
             },
             {
               "key": "filter",
               "description": null,
-              "value": "filter"
+              "value": "filter",
+              "disabled": true
             },
             {
               "key": "neighbor",
               "description": null,
-              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+              "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+              "disabled": true
             },
             {
               "key": "neighborRequired",
@@ -172,47 +181,56 @@
                 {
                   "key": "userList",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "optionalDeadline",
                   "description": null,
-                  "value": "2024-01-15T09:30:00Z"
+                  "value": "2024-01-15T09:30:00Z",
+                  "disabled": true
                 },
                 {
                   "key": "keyValue",
                   "description": null,
-                  "value": "{\"keyValue\":\"keyValue\"}"
+                  "value": "{\"keyValue\":\"keyValue\"}",
+                  "disabled": true
                 },
                 {
                   "key": "optionalString",
                   "description": null,
-                  "value": "optionalString"
+                  "value": "optionalString",
+                  "disabled": true
                 },
                 {
                   "key": "nestedUser",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"user\":{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}}"
+                  "value": "{\"name\":\"name\",\"user\":{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}}",
+                  "disabled": true
                 },
                 {
                   "key": "optionalUser",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "excludeUser",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "filter",
                   "description": null,
-                  "value": "filter"
+                  "value": "filter",
+                  "disabled": true
                 },
                 {
                   "key": "neighbor",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "neighborRequired",

--- a/seed/postman/query-parameters/collection.json
+++ b/seed/postman/query-parameters/collection.json
@@ -70,7 +70,8 @@
                 {
                   "key": "optionalDeadline",
                   "description": null,
-                  "value": "2024-01-15T09:30:00Z"
+                  "value": "2024-01-15T09:30:00Z",
+                  "disabled": true
                 },
                 {
                   "key": "keyValue",
@@ -80,7 +81,8 @@
                 {
                   "key": "optionalString",
                   "description": null,
-                  "value": "optionalString"
+                  "value": "optionalString",
+                  "disabled": true
                 },
                 {
                   "key": "nestedUser",
@@ -90,7 +92,8 @@
                 {
                   "key": "optionalUser",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "excludeUser",
@@ -170,7 +173,8 @@
                     {
                       "key": "optionalDeadline",
                       "description": null,
-                      "value": "2024-01-15T09:30:00Z"
+                      "value": "2024-01-15T09:30:00Z",
+                      "disabled": true
                     },
                     {
                       "key": "keyValue",
@@ -180,7 +184,8 @@
                     {
                       "key": "optionalString",
                       "description": null,
-                      "value": "optionalString"
+                      "value": "optionalString",
+                      "disabled": true
                     },
                     {
                       "key": "nestedUser",
@@ -190,7 +195,8 @@
                     {
                       "key": "optionalUser",
                       "description": null,
-                      "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                      "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                      "disabled": true
                     },
                     {
                       "key": "excludeUser",

--- a/seed/postman/request-parameters/collection.json
+++ b/seed/postman/request-parameters/collection.json
@@ -375,7 +375,8 @@
                 {
                   "key": "optionalDeadline",
                   "description": null,
-                  "value": "2024-01-15T09:30:00Z"
+                  "value": "2024-01-15T09:30:00Z",
+                  "disabled": true
                 },
                 {
                   "key": "keyValue",
@@ -385,7 +386,8 @@
                 {
                   "key": "optionalString",
                   "description": null,
-                  "value": "optionalString"
+                  "value": "optionalString",
+                  "disabled": true
                 },
                 {
                   "key": "nestedUser",
@@ -395,7 +397,8 @@
                 {
                   "key": "optionalUser",
                   "description": null,
-                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                  "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                  "disabled": true
                 },
                 {
                   "key": "excludeUser",
@@ -485,7 +488,8 @@
                     {
                       "key": "optionalDeadline",
                       "description": null,
-                      "value": "2024-01-15T09:30:00Z"
+                      "value": "2024-01-15T09:30:00Z",
+                      "disabled": true
                     },
                     {
                       "key": "keyValue",
@@ -495,7 +499,8 @@
                     {
                       "key": "optionalString",
                       "description": null,
-                      "value": "optionalString"
+                      "value": "optionalString",
+                      "disabled": true
                     },
                     {
                       "key": "nestedUser",
@@ -505,7 +510,8 @@
                     {
                       "key": "optionalUser",
                       "description": null,
-                      "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}"
+                      "value": "{\"name\":\"name\",\"tags\":[\"tags\",\"tags\"]}",
+                      "disabled": true
                     },
                     {
                       "key": "excludeUser",

--- a/seed/postman/required-nullable/collection.json
+++ b/seed/postman/required-nullable/collection.json
@@ -35,7 +35,8 @@
             {
               "key": "required_nullable_baz",
               "description": "A required baz",
-              "value": "required_nullable_baz"
+              "value": "required_nullable_baz",
+              "disabled": true
             }
           ],
           "variable": []
@@ -75,7 +76,8 @@
                 {
                   "key": "required_nullable_baz",
                   "description": "A required baz",
-                  "value": "required_nullable_baz"
+                  "value": "required_nullable_baz",
+                  "disabled": true
                 }
               ],
               "variable": []
@@ -113,12 +115,14 @@
                 {
                   "key": "optional_baz",
                   "description": "An optional baz",
-                  "value": "optional_baz"
+                  "value": "optional_baz",
+                  "disabled": true
                 },
                 {
                   "key": "optional_nullable_baz",
                   "description": "An optional baz",
-                  "value": "optional_nullable_baz"
+                  "value": "optional_nullable_baz",
+                  "disabled": true
                 },
                 {
                   "key": "required_baz",
@@ -128,7 +132,8 @@
                 {
                   "key": "required_nullable_baz",
                   "description": "A required baz",
-                  "value": "required_nullable_baz"
+                  "value": "required_nullable_baz",
+                  "disabled": true
                 }
               ],
               "variable": []

--- a/seed/postman/trace/collection.json
+++ b/seed/postman/trace/collection.json
@@ -1764,7 +1764,8 @@
                 {
                   "key": "optionalDatetime",
                   "description": null,
-                  "value": "2024-01-15T09:30:00Z"
+                  "value": "2024-01-15T09:30:00Z",
+                  "disabled": true
                 }
               ],
               "variable": [
@@ -1821,7 +1822,8 @@
                     {
                       "key": "optionalDatetime",
                       "description": null,
-                      "value": "2024-01-15T09:30:00Z"
+                      "value": "2024-01-15T09:30:00Z",
+                      "disabled": true
                     }
                   ],
                   "variable": [
@@ -1877,7 +1879,8 @@
                 {
                   "key": "limit",
                   "description": null,
-                  "value": "1"
+                  "value": "1",
+                  "disabled": true
                 },
                 {
                   "key": "otherField",
@@ -1892,7 +1895,8 @@
                 {
                   "key": "optionalMultipleField",
                   "description": null,
-                  "value": "optionalMultipleField"
+                  "value": "optionalMultipleField",
+                  "disabled": true
                 },
                 {
                   "key": "multipleField",
@@ -1941,7 +1945,8 @@
                     {
                       "key": "limit",
                       "description": null,
-                      "value": "1"
+                      "value": "1",
+                      "disabled": true
                     },
                     {
                       "key": "otherField",
@@ -1956,7 +1961,8 @@
                     {
                       "key": "optionalMultipleField",
                       "description": null,
-                      "value": "optionalMultipleField"
+                      "value": "optionalMultipleField",
+                      "disabled": true
                     },
                     {
                       "key": "multipleField",


### PR DESCRIPTION
## Description

Optional query parameters in generated Postman collections now appear unchecked by default in the Postman UI. This prevents users from accidentally sending optional parameters they don't intend to use.

Link to Devin run: https://app.devin.ai/sessions/856aff1fcdf64cdf81e4df76bd67dd60
Requested by: @jsklan

## Changes Made

- Added `disabled: optional<boolean>` field to the `PostmanUrlVariable` type definition in `collection.yml`
- Updated `getQueryParams()` in `GeneratedExampleRequest.ts` to set `disabled: true` for optional query parameters
- Added `unrecognizedObjectKeys: "passthrough"` option to serialization in `writePostmanCollection.ts` (required because the Postman SDK doesn't yet have the `disabled` field in its schema)
- Bumped postman generator version to 0.5.0
- Updated seed test outputs (17 collection.json files)

## Implementation Notes

1. **Optionality Detection**: The task description suggested using `availability?.required`, but this field doesn't exist in the IR types. Instead, I used the standard pattern from other generators: `valueType.type === "container" && valueType.container.type === "optional"`.

2. **Serialization Workaround**: The `@fern-fern/postman-sdk` package doesn't have the `disabled` field defined in its `PostmanUrlVariable` type. To preserve the field during serialization, I added `unrecognizedObjectKeys: "passthrough"` to the `jsonOrThrow` call. This allows the new field to pass through until the SDK is regenerated.

## Human Review Checklist

- [ ] Verify the approach of checking `valueType` for optionality is the correct pattern
- [ ] Confirm this behavior is desired for all HTTP methods (GET, POST, PATCH, etc.)
- [ ] Review the `passthrough` workaround - is this acceptable until the SDK is updated?
- [ ] Verify version bump to 0.5.0 is appropriate for this feature change

## Testing

- [x] Seed tests run successfully (103/103 passed)
- [x] Verified `disabled: true` appears in generated collection.json files for optional parameters
- [x] Unit tests added/updated
- [x] Manually imported seed output collection into postman to see difference

### Before:

<img width="869" height="800" alt="image" src="https://github.com/user-attachments/assets/3d388ca3-4c74-40dd-aa32-c7eb77f1b8cf" />

### After:

<img width="858" height="811" alt="image" src="https://github.com/user-attachments/assets/bbb9b00b-aef8-494e-b3ab-3b8af2dc06ee" />