### PR TITLE
fix(python): wrap streaming endpoint calls in wire tests to consume lazy iterators

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.46.7-rc3
+  changelogEntry:
+    - summary: |
+        Fix wire test generation for streaming endpoints. Streaming methods return lazy iterators
+        (Iterator[bytes] or AsyncIterator[bytes]) that don't execute the HTTP request until iterated.
+        Wire tests now wrap streaming endpoint calls in 'for _ in ...: pass' loops to ensure the
+        HTTP request is actually made. This applies to streaming, streamParameter, and fileDownload
+        response types.
+      type: fix
+  createdAt: "2026-01-07"
+  irVersion: 62
+
 - version: 4.46.7-rc2
   changelogEntry:
     - summary: Fixed Python SDK generation to use native Pydantic field aliases and improved core parsing so wire-key and nested/union validation works correctly across Pydantic v1/v2.

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -393,6 +393,5 @@ allowedFailures:
   - response-property
   - streaming-parameter
   - server-sent-event-examples:with-wire-tests # TODO: update wiretests geranation then remove it
-  - server-sent-events:with-wire-tests # TODO: update wiretests geranation then remove it
   - trace
   - websocket

--- a/seed/python-sdk/server-sent-events/with-wire-tests/tests/wire/test_completions.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/tests/wire/test_completions.py
@@ -5,5 +5,6 @@ def test_completions_stream() -> None:
     """Test stream endpoint with WireMock"""
     test_id = "completions.stream.0"
     client = get_client(test_id)
-    client.completions.stream(query="query")
+    for _ in client.completions.stream(query="query"):
+        pass
     verify_request_count(test_id, "POST", "/stream", None, 1)


### PR DESCRIPTION
## Description

Refs: Customer issue with wire test failures for streaming endpoints

Fixes wire test generation for streaming endpoints. Streaming methods return lazy iterators (`Iterator[bytes]` or `AsyncIterator[bytes]`) that don't execute the HTTP request until iterated. This caused wire tests to fail because the HTTP request was never actually made.

**Link to Devin run**: https://app.devin.ai/sessions/5f1edc330e4c40df91ec572fbe81fc37
**Requested by**: @jsklan

## Changes Made

- Added `isStreamingEndpoint()` helper method to detect endpoints with streaming responses
- Wire tests now wrap streaming endpoint calls in `for _ in ...: pass` loops to consume the iterator
- Applies to three response body types: `streaming`, `streamParameter`, and `fileDownload`
- Removed `server-sent-events:with-wire-tests` from `allowedFailures` since it now passes
- Added changelog entry for version 4.46.7-rc3

**Before (buggy):**
```python
client.completions.stream(query="query")
verify_request_count(...)  # Fails - HTTP request never made
```

**After (fixed):**
```python
for _ in client.completions.stream(query="query"):
    pass
verify_request_count(...)  # Passes - iterator consumed, HTTP request made
```

## Testing

- [x] Ran `pnpm seed:local test --generator python-sdk --fixture server-sent-events` - passes
- [x] Ran `pnpm seed:local test --generator python-sdk --fixture file-download` - passes
- [x] Verified fix against customer's fern folder with TTS streaming endpoints
- [x] Ran `pnpm check:fix` - no issues

## Review Checklist

- [ ] Verify the three response types (`streaming`, `streamParameter`, `fileDownload`) are correct for detecting streaming endpoints
- [ ] Check that `apiCallAst.toString()` handles edge cases correctly (complex nested calls, etc.)