### PR TITLE
fix(typescript): Use full URL format for GitHub repository URL in package.json

### DIFF
--- a/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
+++ b/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
@@ -80,13 +80,40 @@ export function getRepoUrlFromUrl(repoUrl: string | undefined): string | undefin
     if (repoUrl == null) {
         return undefined;
     }
-    // Use full URL format for consistency between local and remote generation.
-    // npm pkg fix will normalize these URLs consistently when using the full format.
+    // GitHub URLs use full git+https:// format for consistency between local and remote generation
+    if (repoUrl.startsWith("https://github.com/")) {
+        const cleanUrl = removeGitSuffix(repoUrl);
+        return `git+${cleanUrl}.git`;
+    }
+    if (repoUrl.startsWith("ssh://github.com/")) {
+        const cleanUrl = removeGitSuffix(repoUrl).replace("ssh://", "https://");
+        return `git+${cleanUrl}.git`;
+    }
+    // Bitbucket and GitLab use shorthand format
+    if (repoUrl.startsWith("https://bitbucket.org/")) {
+        return `bitbucket:${removeGitSuffix(repoUrl).replace("https://bitbucket.org/", "")}`;
+    }
+    if (repoUrl.startsWith("ssh://bitbucket.org/")) {
+        return `bitbucket:${removeGitSuffix(repoUrl).replace("ssh://bitbucket.org/", "")}`;
+    }
+    if (repoUrl.startsWith("https://gitlab.com/")) {
+        return `gitlab:${removeGitSuffix(repoUrl).replace("https://gitlab.com/", "")}`;
+    }
+    if (repoUrl.startsWith("ssh://gitlab.com/")) {
+        return `gitlab:${removeGitSuffix(repoUrl).replace("ssh://gitlab.com/", "")}`;
+    }
     if (!repoUrl.startsWith("git+")) {
         repoUrl = `git+${repoUrl}`;
     }
     if (!repoUrl.endsWith(".git")) {
         repoUrl = `${repoUrl}.git`;
+    }
+    return repoUrl;
+}
+
+function removeGitSuffix(repoUrl: string): string {
+    if (repoUrl.endsWith(".git")) {
+        return repoUrl.slice(0, -4);
     }
     return repoUrl;
 }

--- a/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
+++ b/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
@@ -80,36 +80,13 @@ export function getRepoUrlFromUrl(repoUrl: string | undefined): string | undefin
     if (repoUrl == null) {
         return undefined;
     }
-    if (repoUrl.startsWith("https://github.com/")) {
-        return `github:${removeGitSuffix(repoUrl).replace("https://github.com/", "")}`;
-    }
-    if (repoUrl.startsWith("ssh://github.com/")) {
-        return `github:${removeGitSuffix(repoUrl).replace("ssh://github.com/", "")}`;
-    }
-    if (repoUrl.startsWith("https://bitbucket.org/")) {
-        return `bitbucket:${removeGitSuffix(repoUrl).replace("https://bitbucket.org/", "")}`;
-    }
-    if (repoUrl.startsWith("ssh://bitbucket.org/")) {
-        return `bitbucket:${removeGitSuffix(repoUrl).replace("ssh://bitbucket.org/", "")}`;
-    }
-    if (repoUrl.startsWith("https://gitlab.com/")) {
-        return `gitlab:${removeGitSuffix(repoUrl).replace("https://gitlab.com/", "")}`;
-    }
-    if (repoUrl.startsWith("ssh://gitlab.com/")) {
-        return `gitlab:${removeGitSuffix(repoUrl).replace("ssh://gitlab.com/", "")}`;
-    }
+    // Use full URL format for consistency between local and remote generation.
+    // npm pkg fix will normalize these URLs consistently when using the full format.
     if (!repoUrl.startsWith("git+")) {
         repoUrl = `git+${repoUrl}`;
     }
     if (!repoUrl.endsWith(".git")) {
         repoUrl = `${repoUrl}.git`;
-    }
-    return repoUrl;
-}
-
-function removeGitSuffix(repoUrl: string): string {
-    if (repoUrl.endsWith(".git")) {
-        return repoUrl.slice(0, -4);
     }
     return repoUrl;
 }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.43.5
+  changelogEntry:
+    - summary: |
+        Fix repository URL format in package.json to use full URL format (git+https://...) instead of shorthand
+        format (github:...) for consistency between local and remote generation. This ensures `npm pkg fix`
+        normalizes the URL consistently across all generation environments.
+      type: fix
+  createdAt: "2026-01-07"
+  irVersion: 63
+
 - version: 3.43.4
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -2,9 +2,9 @@
 - version: 3.43.5
   changelogEntry:
     - summary: |
-        Fix repository URL format in package.json to use full URL format (git+https://...) instead of shorthand
-        format (github:...) for consistency between local and remote generation. This ensures `npm pkg fix`
-        normalizes the URL consistently across all generation environments.
+        Fix GitHub repository URL format in package.json to use full URL format (git+https://github.com/...)
+        instead of shorthand format (github:...) for consistency between local and remote generation.
+        Bitbucket and GitLab URLs continue to use their respective shorthand formats.
       type: fix
   createdAt: "2026-01-07"
   irVersion: 63


### PR DESCRIPTION
## Description

Refs: https://app.devin.ai/sessions/425fb90c1a984c8bbf253cac10eb279b
Requested by: @jsklan

Fixes the `pnpm seed:local test-remote-local --generator ts-sdk` test failure caused by inconsistent repository URL formats between local and remote generation.

## Changes Made

- Updated `getRepoUrlFromUrl` function to use full URL format (`git+https://github.com/...`) for GitHub URLs only
- Preserved shorthand format (`bitbucket:...`, `gitlab:...`) for Bitbucket and GitLab URLs
- Added version 3.43.5 to versions.yml with changelog entry

## Root Cause

The test compares local generation (Docker) with remote generation (Fiddle). The issue was:
- Local generation: `https://github.com/fern-api/empty` → `github:fern-api/empty` → after `npm pkg fix` → `git+github:fern-api/empty.git`
- Remote generation: `https://github.com/fern-api/empty` → after `npm pkg fix` → `git+https://github.com/fern-api/empty.git`

By using the full URL format for GitHub URLs, `npm pkg fix` will normalize URLs the same way in both environments.

## Testing

- [ ] Manual testing completed - **Requires @jsklan to verify by running `pnpm seed:local test-remote-local --generator ts-sdk`** (I don't have access to the necessary secrets)
- [x] Lint checks pass (`pnpm run check`)

## Human Review Checklist

- [ ] Verify this fix resolves the test failure by running `pnpm seed:local test-remote-local --generator ts-sdk`
- [ ] Confirm that preserving shorthand format for Bitbucket/GitLab is the intended behavior