### PR TITLE
fix(typescript, ci): standardize GitHub repo URL format and simplify local vs remote parity workflow

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -22,10 +22,6 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: "buildwithfern"
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   test-remote-local-parity:
     runs-on: ubuntu-latest
@@ -50,56 +46,3 @@ jobs:
 
       - name: Run Seed Test Remote-Local (GitHub Output Mode)
         run: pnpm seed test-remote-local --output-mode github
-
-      # - name: Run Seed Test Remote-Local (Local Output Mode)
-      # run: pnpm seed test-remote-local --output-mode local
-
-      - name: Check for Changes
-        id: check-changes
-        run: |
-          if [[ -n $(git status --porcelain) ]]; then
-            echo "has-changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "has-changes=false" >> $GITHUB_OUTPUT
-          fi
-
-      # - name: Create Pull Request
-      #   if: steps.check-changes.outputs.has-changes == 'true'
-      #   id: cpr
-      #   uses: peter-evans/create-pull-request@v5
-      #   with:
-      #     token: ${{ secrets.ACTIONS_PAT }}
-      #     commit-message: "chore(seed): update remote-local parity test outputs"
-      #     title: "chore(seed): update remote-local parity test outputs"
-      #     branch: seed-remote-local-parity-updates
-      #     body: |
-      #       Auto-generated PR from seed-remote-local-parity workflow.
-
-      #       This PR contains updates from running:
-      #       - `pnpm seed test-remote-local --output-mode github`
-      #       - `pnpm seed test-remote-local --output-mode local`
-
-      #       Triggered by: ${{ github.event_name }}
-      #       Branch: ${{ github.ref_name }}
-      #       Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      #     delete-branch: true
-      #     add-paths: |
-      #       seed-remote-local/**
-      #     labels: |
-      #       seed
-      #       automated-pr
-
-      # - name: Log PR Creation
-      #   if: steps.cpr.outputs.pull-request-operation == 'created'
-      #   run: |
-      #     echo "PR Created: ${{ steps.cpr.outputs.pull-request-url }}"
-
-      # - name: Log PR Update
-      #   if: steps.cpr.outputs.pull-request-operation == 'updated'
-      #   run: |
-      #     echo "PR Updated: ${{ steps.cpr.outputs.pull-request-url }}"
-
-      # - name: Log No Changes
-      #   if: steps.check-changes.outputs.has-changes == 'false'
-      #   run: |
-      #     echo "No changes detected - skipping PR creation"

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -6,6 +6,12 @@ on:
   #   - cron: "0 13 * * *"
   # Runs when triggered manually
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test (defaults to main)"
+        required: false
+        default: "main"
+        type: string
 
 # Cancel previous workflows when another is triggered
 concurrency:
@@ -28,7 +34,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ inputs.branch || 'main' }}
 
       - name: Install
         uses: ./.github/actions/install

--- a/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
+++ b/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
@@ -81,7 +81,9 @@ export function getRepoUrlFromUrl(repoUrl: string | undefined): string | undefin
         return undefined;
     }
     if (repoUrl.startsWith("https://github.com/")) {
-        return `github:${removeGitSuffix(repoUrl).replace("https://github.com/", "")}`;
+        // Maybe temporary. Simplifying output so local generation matches remote generation.
+        // return `github:${removeGitSuffix(repoUrl).replace("https://github.com/", "")}`;
+        return `git+${repoUrl}`;
     }
     if (repoUrl.startsWith("ssh://github.com/")) {
         return `github:${removeGitSuffix(repoUrl).replace("ssh://github.com/", "")}`;

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.43.5
+  changelogEntry:
+    - summary: |
+        Fix GitHub repository URL format in package.json to use `git+https://` format,
+        ensuring local generation output matches remote generation.
+      type: fix
+  createdAt: "2026-01-07"
+  irVersion: 63
+
 - version: 3.43.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Updates the TypeScript generator to use `git+https://` format for GitHub repository URLs in generated package.json files, ensuring local generation output matches remote generation.

Also cleans up the remote vs local generation parity test workflow by removing unused steps and adding a configurable branch input for manual runs.

## Changes Made
- **TypeScript generator**: Changed `getRepoUrlFromUrl` to output `git+https://` format instead of `github:` shorthand for GitHub URLs
- **CI workflow**: Added `branch` input for manual workflow runs, removed unused git-based change detection (the command already fails on diff)

## Testing
- [x] Manual testing completed
- [x] Verified local and remote generation now produce matching output