### PR TITLE
feat(cli): add .gitignore to fern folder during init

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,7 +2,7 @@
 - version: 3.36.0
   changelogEntry:
     - summary: |
-        The `fern init` command now automatically appends `fern/**/.preview` and `fern/**/.definition` entries to the project's `.gitignore` file.
+        The `fern init` command now automatically creates a `.gitignore` file inside the `fern/` folder with entries to ignore `.preview` and `.definition` directories.
       type: feat
   createdAt: "2026-01-07"
   irVersion: 62

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.36.0
+  changelogEntry:
+    - summary: |
+        The `fern init` command now automatically appends `fern/**/.preview` and `fern/**/.definition` entries to the project's `.gitignore` file.
+      type: feat
+  createdAt: "2026-01-07"
+  irVersion: 62
+
 - version: 3.35.2
   changelogEntry:
     - summary: |

--- a/packages/cli/ete-tests/src/tests/add/__snapshots__/add.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/add/__snapshots__/add.test.ts.snap
@@ -5,6 +5,13 @@ exports[`fern add > fern add <generator> --group sdk 1`] = `
   {
     "contents": [
       {
+        "contents": "**/.preview
+**/.definition
+",
+        "name": ".gitignore",
+        "type": "file",
+      },
+      {
         "contents": [
           {
             "contents": "name: api

--- a/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
@@ -5,6 +5,13 @@ exports[`fern init > init docs 1`] = `
   {
     "contents": [
       {
+        "contents": "**/.preview
+**/.definition
+",
+        "name": ".gitignore",
+        "type": "file",
+      },
+      {
         "contents": [
           {
             "contents": "name: api
@@ -187,6 +194,13 @@ exports[`fern init > init openapi 1`] = `
   {
     "contents": [
       {
+        "contents": "**/.preview
+**/.definition
+",
+        "name": ".gitignore",
+        "type": "file",
+      },
+      {
         "contents": "{
     "organization": "fern",
     "version": "0.0.0"
@@ -339,6 +353,13 @@ components:
 
 exports[`fern init > no existing fern directory 1`] = `
 [
+  {
+    "contents": "**/.preview
+**/.definition
+",
+    "name": ".gitignore",
+    "type": "file",
+  },
   {
     "contents": [
       {

--- a/packages/cli/init/src/createFernDirectoryAndOrganization.ts
+++ b/packages/cli/init/src/createFernDirectoryAndOrganization.ts
@@ -13,9 +13,7 @@ import chalk from "chalk";
 import { mkdir, writeFile } from "fs/promises";
 import { kebabCase } from "lodash-es";
 
-const GITIGNORE_CONTENT = `**/.preview
-**/.definition
-`;
+const GITIGNORE_CONTENT = "**/.preview\n**/.definition\n";
 
 export async function createFernDirectoryAndWorkspace({
     organization,


### PR DESCRIPTION
## Description

Refs: Requested by @jsklan

The `fern init` command now automatically creates a `.gitignore` file inside the `fern/` folder with entries to ignore `.preview` and `.definition` directories.

## Changes Made

- Added `writeGitignore` function in `createFernDirectoryAndOrganization.ts` that creates `fern/.gitignore` with patterns:
  - `**/.preview`
  - `**/.definition`
- Updated CLI versions.yml with new version 3.36.0
- Updated snapshot tests to include the new `.gitignore` file

## Human Review Checklist

- [ ] Verify the `.gitignore` is created inside the `fern/` folder (not at project root) - this is intentional to avoid modifying user's existing root `.gitignore`
- [ ] Confirm the gitignore only triggers on NEW fern directory creation (not when fern directory already exists) - see line 64 in `createFernDirectoryAndOrganization.ts`

## Testing

- [x] Snapshot tests updated for `init` and `add` commands
- [ ] Manual testing completed

---

Link to Devin run: https://app.devin.ai/sessions/7fab1bce042f4932a8214f665a923074