### PR TITLE
fix(typescript): fix duplicate keys in passthrough serialization

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.43.6
+  changelogEntry:
+    - summary: |
+        Fix duplicate keys in serialized objects when using `.passthrough()` with property name transformations.
+        Previously, the passthrough function would spread both the raw input (with original keys like `version_number`)
+        and the transformed output (with camelCase keys like `versionNumber`), resulting in objects with duplicate
+        data under different key names. Now the function correctly returns only the transformed output, which already
+        includes passthrough properties via the `unrecognizedObjectKeys: "passthrough"` option.
+      type: fix
+  createdAt: "2026-01-07"
+  irVersion: 63
+
 - version: 3.43.5
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/schemas/builders/object/object.ts
+++ b/generators/typescript/utils/core-utilities/src/core/schemas/builders/object/object.ts
@@ -275,30 +275,16 @@ export function getObjectUtils<Raw, Parsed>(schema: BaseObjectSchema<Raw, Parsed
                     _getParsedProperties: () => schema._getParsedProperties(),
                     _getRawProperties: () => schema._getRawProperties(),
                     parse: (raw, opts) => {
-                        const transformed = schema.parse(raw, { ...opts, unrecognizedObjectKeys: "passthrough" });
-                        if (!transformed.ok) {
-                            return transformed;
-                        }
-                        return {
-                            ok: true,
-                            value: {
-                                ...(raw as any),
-                                ...transformed.value,
-                            },
-                        };
+                        return schema.parse(raw, {
+                            ...opts,
+                            unrecognizedObjectKeys: "passthrough",
+                        }) as MaybeValid<Parsed & { [key: string]: unknown }>;
                     },
                     json: (parsed, opts) => {
-                        const transformed = schema.json(parsed, { ...opts, unrecognizedObjectKeys: "passthrough" });
-                        if (!transformed.ok) {
-                            return transformed;
-                        }
-                        return {
-                            ok: true,
-                            value: {
-                                ...(parsed as any),
-                                ...transformed.value,
-                            },
-                        };
+                        return schema.json(parsed, {
+                            ...opts,
+                            unrecognizedObjectKeys: "passthrough",
+                        }) as MaybeValid<Raw & { [key: string]: unknown }>;
                     },
                     getType: () => SchemaType.OBJECT,
                 };


### PR DESCRIPTION
## Description

Fixes duplicate keys appearing in serialized objects when using `.passthrough()` with property name transformations (e.g., snake_case to camelCase).

Link to Devin run: https://app.devin.ai/sessions/72bacfab144f456cb67261cfed08fc49
Requested by: @jsklan

## Changes Made

- Simplified the `passthrough()` function in the object schema builder to directly return the result of `schema.parse()`/`schema.json()` with `unrecognizedObjectKeys: "passthrough"` option
- Removed the redundant spreading of both raw input and transformed output that caused duplicate keys

### The Bug

Previously, the `passthrough()` function would:
```typescript
return {
    ok: true,
    value: {
        ...(raw as any),           // Spreads original keys (e.g., version_number)
        ...transformed.value,       // Spreads transformed keys (e.g., versionNumber)
    },
};
```

This resulted in objects containing both `version_number` and `versionNumber` with the same data.

### The Fix

The `validateAndTransformObject` function already handles passthrough of unrecognized keys when `unrecognizedObjectKeys: "passthrough"` is set (see lines 209-210 in the same file). The fix simply returns the transformed result directly, avoiding the duplicate key issue.

## Testing

- [x] Verified fix against customer reproduction case (822 tests passing)
- [x] Lint checks pass
- [ ] No seed test fixture added (serialization layer only generates with property name transformations which couldn't be triggered in a minimal fixture)

## Human Review Checklist

- [ ] Verify the type assertions (`as MaybeValid<...>`) are safe given that `unrecognizedObjectKeys: "passthrough"` ensures extra properties are included
- [ ] Confirm `validateAndTransformObject` properly handles passthrough at lines 200-212
- [ ] Consider if any existing code could have relied on the buggy behavior (unlikely but worth considering)