### PR TITLE
fix(internal): fix test-remote-local Docker Hub version fetching and parallelize CI

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         generator:
-          # - ts-sdk  # temporarily disabled
+          - ts-sdk
           - java-sdk
           - go-sdk
           - python-sdk

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -23,9 +23,9 @@ env:
   TURBO_TEAM: "buildwithfern"
 
 jobs:
-  test-remote-local-parity:
+  setup:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -44,8 +44,51 @@ jobs:
       - name: Build Seed CLI
         run: pnpm seed:build
 
-      - name: Run Seed Test Remote-Local (GitHub Output Mode)
-        run: pnpm seed test-remote-local --output-mode github
+      - name: Cache Build Artifacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            packages/cli/cli/dist
+            packages/seed/dist
+            node_modules
+            packages/**/node_modules
+            packages/**/dist
+          key: build-${{ github.run_id }}
+
+  test-remote-local-parity:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        generator:
+          # - ts-sdk  # temporarily disabled
+          - java-sdk
+          - go-sdk
+          - python-sdk
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || 'main' }}
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - name: Restore Build Artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            packages/cli/cli/dist
+            packages/seed/dist
+            node_modules
+            packages/**/node_modules
+            packages/**/dist
+          key: build-${{ github.run_id }}
+
+      - name: Run Seed Test Remote-Local (${{ matrix.generator }})
+        run: pnpm seed test-remote-local --generator ${{ matrix.generator }} --output-mode github
         env:
           FERN_TOKEN: ${{ secrets.FERN_FERN_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TEST_REMOTE_LOCAL_GITHUB_TOKEN }}

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -1,9 +1,6 @@
 name: Test Remote vs Local Generation Parity
 
 on:
-  # Runs every morning at 8:00 AM Eastern Time (1:00 PM UTC)
-  # schedule:
-  #   - cron: "0 13 * * *"
   # Runs when triggered manually
   workflow_dispatch:
     inputs:

--- a/packages/seed/src/commands/test-remote-local/constants.ts
+++ b/packages/seed/src/commands/test-remote-local/constants.ts
@@ -103,7 +103,7 @@ export const GITHUB_TOKEN_ENV_VAR_REFERENCE = "${GITHUB_TOKEN}";
 // Docker Hub
 export const DOCKER_HUB_API_BASE_URL = "https://hub.docker.com/v2";
 export const DOCKER_HUB_TAGS_PAGE_SIZE = 100;
-export const DOCKER_HUB_TAGS_ORDERING = "-last_updated";
+export const DOCKER_HUB_TAGS_ORDERING = "last_updated";
 
 // GitHub
 export const GITHUB_BASE_URL = "https://github.com";


### PR DESCRIPTION
## Description
Fixes the test-remote-local workflow which was fetching outdated generator versions from Docker Hub due to incorrect API ordering, and parallelizes the CI workflow for faster execution.

## Changes Made
- **Docker Hub ordering fix**: Changed `DOCKER_HUB_TAGS_ORDERING` from `-last_updated` to `last_updated` to fetch newest tags first, fixing version detection (was returning 3.42.4 instead of 3.43.5)
- **CI parallelization**: Split workflow into setup job + matrix strategy to run generator tests in parallel
- **Diff exclusions**: Added generator-specific exclusions (pnpm-lock.yaml for ts-sdk, .fern folder for all) to reduce false positive diffs

## Testing
- [x] Verified Docker Hub API returns correct ordering with `last_updated` parameter
- [x] Manual testing of version fetching logic