### PR TITLE
feat(cli): add generateFullProject property to LocalFileSystemOutputLocationSchema

### DIFF
--- a/fern/apis/generators-yml/definition/group.yml
+++ b/fern/apis/generators-yml/definition/group.yml
@@ -187,6 +187,9 @@ types:
   LocalFileSystemOutputLocationSchema:
     properties:
       path: string
+      generateFullProject:
+        type: optional<boolean>
+        docs: If true, generates the complete project including package.json, pyproject.toml, etc. Requires paid plan.
 
   NugetOutputLocationSchema:
     properties:

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -3191,6 +3191,16 @@
             },
             "path": {
               "type": "string"
+            },
+            "generateFullProject": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -577,6 +577,10 @@ async function convertGenerator({
         publishMetadata: getPublishMetadata({ generatorInvocation: generator }),
         readme,
         settings: generator.api?.settings ?? undefined,
+        generateFullProject:
+            generator.output?.location === "local-file-system"
+                ? (generator.output.generateFullProject ?? false)
+                : false,
         apiOverride:
             generator.api?.specs != null || generator.api?.auth != null || generator.api?.["auth-schemes"] != null
                 ? {

--- a/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
@@ -159,6 +159,11 @@ export interface GeneratorInvocation {
     readme: ReadmeSchema | undefined;
     settings: ApiDefinitionSettingsSchema | undefined;
     /**
+     * If true, generates the complete project including package.json, pyproject.toml, etc.
+     * Defaults to false when not specified.
+     */
+    generateFullProject: boolean;
+    /**
      * Override the API configuration for this generator.
      * When provided, these values take precedence over the top-level api configuration.
      */

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/LocalFileSystemOutputLocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/LocalFileSystemOutputLocationSchema.ts
@@ -4,4 +4,6 @@
 
 export interface LocalFileSystemOutputLocationSchema {
     path: string;
+    /** If true, generates the complete project including package.json, pyproject.toml, etc. Requires paid plan. */
+    generateFullProject?: boolean;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/LocalFileSystemOutputLocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/LocalFileSystemOutputLocationSchema.ts
@@ -11,10 +11,12 @@ export const LocalFileSystemOutputLocationSchema: core.serialization.ObjectSchem
     GeneratorsYml.LocalFileSystemOutputLocationSchema
 > = core.serialization.object({
     path: core.serialization.string(),
+    generateFullProject: core.serialization.boolean().optional(),
 });
 
 export declare namespace LocalFileSystemOutputLocationSchema {
     export interface Raw {
         path: string;
+        generateFullProject?: boolean | null;
     }
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -553,7 +553,7 @@ function getPublishConfig({
         }
 
         return FernIr.PublishingConfig.filesystem({
-            generateFullProject: org?.selfHostedSdKs ?? false,
+            generateFullProject: generatorInvocation.generateFullProject || (org?.selfHostedSdKs ?? false),
             publishTarget
         });
     }
@@ -561,7 +561,7 @@ function getPublishConfig({
     return generatorInvocation.outputMode._visit({
         downloadFiles: () => {
             return FernIr.PublishingConfig.filesystem({
-                generateFullProject: org?.selfHostedSdKs ?? false,
+                generateFullProject: generatorInvocation.generateFullProject || (org?.selfHostedSdKs ?? false),
                 publishTarget: undefined
             });
         },

--- a/packages/seed/src/utils/getGeneratorInvocation.ts
+++ b/packages/seed/src/utils/getGeneratorInvocation.ts
@@ -66,6 +66,7 @@ export async function getGeneratorInvocation({
                 : undefined,
         readme,
         settings: undefined,
+        generateFullProject: false,
         raw
     };
 }


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-8155](https://linear.app/buildwithfern/issue/FER-8155/add-generatefullproject-property-to), Closes [FER-8154](https://linear.app/buildwithfern/issue/FER-8154/update-configuration-loading-to-handle-generatefullproject-property)

Adds a new optional boolean property `generateFullProject` to the `LocalFileSystemOutputLocationSchema` type in the generators.yml schema and implements the configuration loading to handle this property. This is part of the larger effort to support local full-project SDK generation without GitHub files.

## Changes Made
- Added `generateFullProject` optional boolean property to `LocalFileSystemOutputLocationSchema` in `fern/apis/generators-yml/definition/group.yml`
- Property defaults to `false` when not specified (implicit for optional booleans)
- Added documentation explaining the property's purpose
- Regenerated schema types via `pnpm update:generators`:
  - Updated `generators-yml.schema.json` with the new property
  - Updated TypeScript API type in `packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/`
  - Updated serialization type in `packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/`
- Added `generateFullProject` to `GeneratorInvocation` interface in `GeneratorsConfiguration.ts`
- Updated `convertGenerator` to read `generateFullProject` from the raw schema when output location is `local-file-system`
- Updated `getPublishConfig` to use `generateFullProject` from generator invocation (OR'd with org's `selfHostedSdKs` flag)
- Added `generateFullProject: false` to seed's `getGeneratorInvocation.ts` to satisfy the updated interface

## Testing
- [x] Lint checks passed (`pnpm run check`)
- [x] Generated files regenerated via `pnpm update:generators`
- [x] TypeScript compilation passed (`pnpm compile --filter @fern-api/seed-cli`)
- [ ] Manual testing of local generation with `generateFullProject: true`

## Human Review Checklist
- [ ] Verify property name matches the existing IR type in `packages/ir-sdk/fern/apis/ir-types-latest/definition/publish.yml`
- [ ] Confirm the OR logic is correct: `generatorInvocation.generateFullProject || (org?.selfHostedSdKs ?? false)` - this means either the config flag OR the org flag enables full project generation
- [ ] Verify the property flows correctly: generators.yml → convertGenerator → GeneratorInvocation → getPublishConfig → IR

---

[Link to Devin run](https://app.devin.ai/sessions/5aa8559de6014938a35afe7a89d89ccb)
Requested by: @jsklan