### PR TITLE
fix(python): use endpoint ID for wire test snippet generation

### DIFF
--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGeneratorContext.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGeneratorContext.ts
@@ -336,6 +336,18 @@ export abstract class AbstractDynamicSnippetsGeneratorContext {
         return endpoints;
     }
 
+    public resolveEndpointById(endpointId: FernIr.dynamic.EndpointId): FernIr.dynamic.Endpoint | undefined {
+        return this._ir.endpoints[endpointId];
+    }
+
+    public resolveEndpointByIdOrThrow(endpointId: FernIr.dynamic.EndpointId): FernIr.dynamic.Endpoint {
+        const endpoint = this.resolveEndpointById(endpointId);
+        if (endpoint == null) {
+            throw new Error(`Failed to find endpoint with ID "${endpointId}"`);
+        }
+        return endpoint;
+    }
+
     public needsRequestParameter({
         request,
         inlinePathParameters,

--- a/generators/python-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
@@ -64,6 +64,24 @@ export class DynamicSnippetsGenerator extends AbstractDynamicSnippetsGenerator<
         );
     }
 
+    /**
+     * Generates just the method call AST without the client instantiation, using the endpoint ID directly.
+     * This is useful for wire tests where the client is created separately with test-specific configuration,
+     * and when there are multiple endpoints with the same HTTP method and path pattern across different namespaces.
+     */
+    public generateMethodCallSnippetAstById({
+        endpointId,
+        request
+    }: {
+        endpointId: FernIr.dynamic.EndpointId;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+    }): python.AstNode {
+        const endpoint = this.context.resolveEndpointByIdOrThrow(endpointId);
+        const context = this.context.clone() as DynamicSnippetsGeneratorContext;
+        const snippetGenerator = this.createSnippetGenerator(context);
+        return snippetGenerator.generateMethodCallSnippetAst({ endpoint, request });
+    }
+
     protected createSnippetGenerator(context: DynamicSnippetsGeneratorContext): EndpointSnippetGenerator {
         return new EndpointSnippetGenerator({ context });
     }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -448,7 +448,12 @@ export class WireTestGenerator {
             };
 
             // Generate just the method call AST using DynamicSnippetsGenerator
-            return this.snippetGenerator.generateMethodCallSnippetAst(snippetRequest);
+            // Use the endpoint ID directly to avoid path collision issues when multiple
+            // namespaces have endpoints with the same HTTP method and path pattern
+            return this.snippetGenerator.generateMethodCallSnippetAstById({
+                endpointId: endpoint.id,
+                request: snippetRequest
+            });
         } catch (error) {
             // Fallback: log error and generate a placeholder
             this.context.logger.error(

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.46.10
+  changelogEntry:
+    - summary: |
+        Fix wire test generation to use endpoint ID for lookup instead of path matching.
+        This fixes a bug where wire tests would call the wrong client methods when multiple
+        namespaces have endpoints with the same HTTP method and path pattern (e.g., POST /v2/Services).
+      type: fix
+  createdAt: "2026-01-08"
+  irVersion: 62
+
 - version: 4.46.9
   changelogEntry:
     - summary: |


### PR DESCRIPTION
Add resolveEndpointById and resolveEndpointByIdOrThrow methods to AbstractDynamicSnippetsGeneratorContext to look up endpoints by ID directly.

Add generateMethodCallSnippetAstById method to DynamicSnippetsGenerator that uses the endpoint ID instead of path matching.

Update WireTestGenerator.generateApiCallAst to use the new method, fixing the bug where wire tests would call the wrong client methods when multiple namespaces have endpoints with the same HTTP method and path pattern.