### PR TITLE
feat(docs): add Excel file support to allowed file types

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.36.1
+  changelogEntry:
+    - summary: |
+        Add Excel file support (.xlsx and .xls) to the allowed file types for documentation uploads. This enables users to host Excel files using the `<Download />` component.
+      type: feat
+  createdAt: "2026-01-08"
+  irVersion: 62
+
 - version: 3.36.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,7 +2,7 @@
 - version: 3.36.1
   changelogEntry:
     - summary: |
-        Add Excel file support (.xlsx and .xls) to the allowed file types for documentation uploads. This enables users to host Excel files using the `<Download />` component.
+        Add Excel file support (.xlsx) to the allowed file types for documentation uploads. This enables users to host Excel files using the `<Download />` component.
       type: feat
   createdAt: "2026-01-08"
   irVersion: 62

--- a/packages/cli/yaml/docs-validator/src/rules/valid-file-types/valid-file-types.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-file-types/valid-file-types.ts
@@ -28,7 +28,6 @@ const ALLOWED_FILE_TYPES = new Set<MimeType>([
     "application/xml",
     // spreadsheet files
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
-    "application/vnd.ms-excel", // .xls
     // font files
     "font/woff",
     "font/woff2",

--- a/packages/cli/yaml/docs-validator/src/rules/valid-file-types/valid-file-types.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-file-types/valid-file-types.ts
@@ -28,6 +28,7 @@ const ALLOWED_FILE_TYPES = new Set<MimeType>([
     "application/xml",
     // spreadsheet files
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+    "application/x-cfb", // .xls (and other legacy Microsoft Office formats)
     // font files
     "font/woff",
     "font/woff2",

--- a/packages/cli/yaml/docs-validator/src/rules/valid-file-types/valid-file-types.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-file-types/valid-file-types.ts
@@ -26,6 +26,9 @@ const ALLOWED_FILE_TYPES = new Set<MimeType>([
     // document files
     "application/pdf",
     "application/xml",
+    // spreadsheet files
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+    "application/vnd.ms-excel", // .xls
     // font files
     "font/woff",
     "font/woff2",


### PR DESCRIPTION
## Description

Refs: User request via Slack

Adds Excel file support (.xlsx and .xls) to the allowed file types for documentation uploads. This enables users to host Excel files using the `<Download />` component.

**Link to Devin run:** https://app.devin.ai/sessions/b5dbc55cdf854ad8a71c2941b2132b47
**Requested by:** Colton Berry (@coltondotio)

## Changes Made

- Added excel related MIME types to allow excel files to be uploaded / hosted in docs
- Added changelog entry for version 3.36.1

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing - the change is a simple allowlist addition

## Human Review Checklist

- [ ] Verify the MIME types are correct for Excel files
- [ ] Consider if other spreadsheet formats should be supported (e.g., .ods, .csv)