### PR TITLE
chore(internal): remove cache build artifacts step from remote-local parity workflow

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
+      - name: Compile
+        run: pnpm compile
+
+      - name: Build Fern CLI
+        run: pnpm fern:build
+
       - name: Build Seed CLI
         run: pnpm seed:build
 

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -20,40 +20,7 @@ env:
   TURBO_TEAM: "buildwithfern"
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch || 'main' }}
-
-      - name: Install
-        uses: ./.github/actions/install
-
-      - name: Compile
-        run: pnpm compile
-
-      - name: Build Fern CLI
-        run: pnpm fern:build
-
-      - name: Build Seed CLI
-        run: pnpm seed:build
-
-      - name: Cache Build Artifacts
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            packages/cli/cli/dist
-            packages/seed/dist
-            node_modules
-            packages/**/node_modules
-            packages/**/dist
-          key: build-${{ github.run_id }}
-
   test-remote-local-parity:
-    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -73,16 +40,8 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
-      - name: Restore Build Artifacts
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            packages/cli/cli/dist
-            packages/seed/dist
-            node_modules
-            packages/**/node_modules
-            packages/**/dist
-          key: build-${{ github.run_id }}
+      - name: Build Seed CLI
+        run: pnpm seed:build
 
       - name: Run Seed Test Remote-Local (${{ matrix.generator }})
         run: pnpm seed test-remote-local --generator ${{ matrix.generator }} --output-mode github


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Removes the separate `setup` job and GitHub Actions cache from the remote-local parity workflow. Each matrix job now builds directly using `pnpm seed:build`, which leverages Vercel + Turbo remote caching for fast compilation.

## Changes Made
- Removed the `setup` job that was building and caching artifacts
- Removed the `needs: setup` dependency from the matrix jobs
- Removed GitHub Actions cache save/restore steps
- Added `pnpm seed:build` step directly in each matrix job

## Testing
- [ ] Manual testing completed (workflow needs to be triggered manually to verify)

## Human Review Checklist
- [ ] Verify that `pnpm seed:build` includes all necessary compilation steps (the original setup job ran `pnpm compile`, `pnpm fern:build`, and `pnpm seed:build` - confirm Turbo handles these dependencies)
- [ ] Consider triggering the workflow manually to verify it works correctly with Turbo remote caching

---
Requested by: @jsklan
Link to Devin run: https://app.devin.ai/sessions/af44c227ea1048a4836b7839bb7eaf30