### PR TITLE
feat(ci): add push and workflow_run triggers to remote-local parity tests

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -1,6 +1,11 @@
 name: Test Remote vs Local Generation Parity
 
 on:
+  # Runs on every commit to main
+  push:
+    branches:
+      - main
+
   # Runs when triggered manually
   workflow_dispatch:
     inputs:
@@ -9,6 +14,18 @@ on:
         required: false
         default: "main"
         type: string
+
+  # Runs when a generator is published successfully
+  workflow_run:
+    workflows:
+      - "Publish TypeScript SDK Generator"
+      - "Publish Go SDK Generator"
+      - "Publish Java SDK Generator"
+      - "Publish Python SDK Generator"
+    types:
+      - completed
+    branches:
+      - main
 
 # Cancel previous workflows when another is triggered
 concurrency:
@@ -20,17 +37,49 @@ env:
   TURBO_TEAM: "buildwithfern"
 
 jobs:
+  # Determine which generator to test based on the triggering workflow
+  determine-generator:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    outputs:
+      generators: ${{ steps.set-generators.outputs.generators }}
+    steps:
+      - name: Set generators to test
+        id: set-generators
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Map workflow name to generator
+            case "${{ github.event.workflow_run.name }}" in
+              "Publish TypeScript SDK Generator")
+                echo 'generators=["ts-sdk"]' >> $GITHUB_OUTPUT
+                ;;
+              "Publish Go SDK Generator")
+                echo 'generators=["go-sdk"]' >> $GITHUB_OUTPUT
+                ;;
+              "Publish Java SDK Generator")
+                echo 'generators=["java-sdk"]' >> $GITHUB_OUTPUT
+                ;;
+              "Publish Python SDK Generator")
+                echo 'generators=["python-sdk"]' >> $GITHUB_OUTPUT
+                ;;
+              *)
+                echo "Unknown workflow: ${{ github.event.workflow_run.name }}"
+                exit 1
+                ;;
+            esac
+          else
+            # For push and workflow_dispatch, test all generators
+            echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
+          fi
+
   test-remote-local-parity:
+    needs: determine-generator
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        generator:
-          - ts-sdk
-          - java-sdk
-          - go-sdk
-          - python-sdk
+        generator: ${{ fromJson(needs.determine-generator.outputs.generators) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Refs: Requested by @jsklan

Link to Devin run: https://app.devin.ai/sessions/1e197ac274ca4facb6fa94109629d4c5

Updates the `test-remote-vs-local-generation-parity` workflow to run automatically instead of only on manual dispatch.

## Changes Made

- Added `push` trigger on main branch - runs all 4 generators (ts-sdk, java-sdk, go-sdk, python-sdk)
- Added `workflow_run` trigger that listens for successful completion of the 4 publish workflows:
  - Publish TypeScript SDK Generator
  - Publish Go SDK Generator
  - Publish Java SDK Generator
  - Publish Python SDK Generator
- When triggered by a publish workflow, only the specific generator that was published is tested
- Added a `determine-generator` job that maps the triggering workflow to the appropriate generator(s)

## Human Review Checklist

- [ ] Verify the workflow names in the `workflow_run` trigger match exactly with the actual publish workflow `name` fields
- [ ] Confirm the `if` condition (`github.event.workflow_run.conclusion == 'success'`) properly filters out failed publish runs
- [ ] The `workflow_run` trigger uses `branches: main` which should only trigger for publishes from main

## Testing

- [ ] Manual testing not possible for workflow changes - will need to verify after merge by:
  1. Pushing to main and confirming all 4 generators run
  2. Publishing a generator and confirming only that generator's test runs