### PR TITLE
chore(rust): support complex dependency specs and configurable API key header

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -230,7 +230,7 @@ impl HttpClient {
             .or(self.config.api_key.as_ref());
 
         if let Some(key) = api_key {
-            headers.insert("api_key", key.parse().map_err(|_| ApiError::InvalidHeader)?);
+            headers.insert("{{API_KEY_HEADER}}", key.parse().map_err(|_| ApiError::InvalidHeader)?);
         }
 
         // Apply bearer token (request options override config)

--- a/generators/rust/base/src/project/RustProject.ts
+++ b/generators/rust/base/src/project/RustProject.ts
@@ -127,6 +127,9 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
             content = content.replace(/\{\{UUID_EXPORTS\}\}/g, "");
         }
 
+        // Replace API key header name from IR auth schemes
+        content = content.replace(/\{\{API_KEY_HEADER\}\}/g, this.context.getApiKeyHeaderName());
+
         return content;
     }
 

--- a/generators/rust/codegen/src/custom-config/BaseRustConfigSchema.ts
+++ b/generators/rust/codegen/src/custom-config/BaseRustConfigSchema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { CustomReadmeSectionSchema } from "./CustomReadmeSectionSchema";
+import { DependencyValueSchema } from "./RustDependencySpecSchema";
 
 export const BaseRustCustomConfigSchema = z.object({
     // =========================================================================
@@ -10,8 +11,8 @@ export const BaseRustCustomConfigSchema = z.object({
     clientClassName: z.string().optional(),
     environmentEnumName: z.string().optional(),
     customReadmeSections: z.array(CustomReadmeSectionSchema).optional(),
-    extraDependencies: z.record(z.string()).optional(),
-    extraDevDependencies: z.record(z.string()).optional(),
+    extraDependencies: z.record(DependencyValueSchema).optional(),
+    extraDevDependencies: z.record(DependencyValueSchema).optional(),
 
     // =========================================================================
     // Package Metadata (for crates.io publishing)

--- a/generators/rust/codegen/src/custom-config/RustDependencySpecSchema.ts
+++ b/generators/rust/codegen/src/custom-config/RustDependencySpecSchema.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+// Schema for Rust dependency specification (matches RustDependencySpec interface)
+export const RustDependencySpecSchema = z.object({
+    version: z.string(),
+    features: z.array(z.string()).optional(),
+    optional: z.boolean().optional(),
+    defaultFeatures: z.boolean().optional(),
+    package: z.string().optional(),
+    path: z.string().optional(),
+    git: z.string().optional(),
+    branch: z.string().optional(),
+    rev: z.string().optional(),
+    registry: z.string().optional()
+});
+
+// Dependency value can be either a version string or a full spec object
+export const DependencyValueSchema = z.union([z.string(), RustDependencySpecSchema]);
+
+export type RustDependencySpec = z.infer<typeof RustDependencySpecSchema>;
+export type DependencyValue = z.infer<typeof DependencyValueSchema>;

--- a/generators/rust/codegen/src/custom-config/index.ts
+++ b/generators/rust/codegen/src/custom-config/index.ts
@@ -1,2 +1,4 @@
 export { BaseRustCustomConfigSchema } from "./BaseRustConfigSchema";
 export { CustomReadmeSectionSchema } from "./CustomReadmeSectionSchema";
+export { RustDependencySpecSchema, DependencyValueSchema } from "./RustDependencySpecSchema";
+export type { RustDependencySpec, DependencyValue } from "./RustDependencySpecSchema";

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -230,7 +230,7 @@ impl HttpClient {
             .or(self.config.api_key.as_ref());
 
         if let Some(key) = api_key {
-            headers.insert("api_key", key.parse().map_err(|_| ApiError::InvalidHeader)?);
+            headers.insert("{{API_KEY_HEADER}}", key.parse().map_err(|_| ApiError::InvalidHeader)?);
         }
 
         // Apply bearer token (request options override config)

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.14.1
+  changelogEntry:
+    - summary: |
+        Support complex dependency specs in extraDependencies and extraDevDependencies config. Dependencies can now be specified as either version strings or full RustDependencySpec objects with features, optional, git, path, and other Cargo.toml options. Also made API key header name configurable via IR auth schemes.
+      type: feat
+  createdAt: "2026-01-08"
+  irVersion: 62
+
 - version: 0.14.0
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - summary: |
         Support complex dependency specs in extraDependencies and extraDevDependencies config. Dependencies can now be specified as either version strings or full RustDependencySpec objects with features, optional, git, path, and other Cargo.toml options. Also made API key header name configurable via IR auth schemes.
-      type: feat
+      type: chore
   createdAt: "2026-01-08"
   irVersion: 62
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -3,7 +3,7 @@
   changelogEntry:
     - summary: |
         Add Excel file support (.xlsx) to the allowed file types for documentation uploads. This enables users to host Excel files using the `<Download />` component.
-      type: feat
+      type: chore
   createdAt: "2026-01-08"
   irVersion: 62
 


### PR DESCRIPTION
## Description

Extended `extraDependencies` and `extraDevDependencies` to accept either version strings or full `RustDependencySpec` objects. Added schema validation for `RustDependencySpec` and updated code to handle both formats. Also made the API key header name configurable via IR auth schemes.

## Changes Made

- Extended `extraDependencies` and `extraDevDependencies` config to accept either simple version strings (e.g., `"1.0.0"`) or full `RustDependencySpec` objects with `features`, `optional`, `git`, `path`, `branch`, `rev`, `registry`, etc.
- Added `RustDependencySpecSchema.ts` with zod validation for the dependency specification
- Added `getApiKeyHeaderName()` method that reads the header name from IR auth schemes, defaulting to `"api_key"`
- Updated `http_client.rs` template to use `{{API_KEY_HEADER}}` placeholder instead of hardcoded `"api_key"`
- Updated test snapshot to match template change
- Added changelog entry for v0.14.1 (chore)
- Fixed CLI changelog entry type for v3.36.1 from `feat` to `chore` (pre-existing CI issue)
- [ ] Updated README.md generator (if applicable)

## Testing

- [x] Unit tests added/updated (snapshot updated)
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify the type casting in `getApiKeyHeaderName()` is safe for all IR auth scheme variants
- [ ] Confirm `{{API_KEY_HEADER}}` placeholder replacement works correctly in generated code
- [ ] Check that existing dependency handling still works with simple version strings

---

Link to Devin run: https://app.devin.ai/sessions/93397dab17814ae9aa62510b4aeb87cb
Requested by: naman.anand@buildwithfern.com (@iamnamananand996)