### PR TITLE
chore(ci): Add automatic retry strategy for remote-local parity tests

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -99,7 +99,12 @@ jobs:
         run: pnpm seed:build
 
       - name: Run Seed Test Remote-Local (${{ matrix.generator }})
-        run: pnpm seed test-remote-local --generator ${{ matrix.generator }} --output-mode github
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 5
+          retry_wait_seconds: 120
+          command: pnpm seed test-remote-local --generator ${{ matrix.generator }} --output-mode github
         env:
           FERN_TOKEN: ${{ secrets.FERN_FERN_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TEST_REMOTE_LOCAL_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/actions/runs/20853139957/job/59912816674

Adds automatic retry logic to the remote-local generation parity tests to handle intermittent failures caused by remote server issues.

## Changes Made

- Wrapped the "Run Seed Test Remote-Local" step with `nick-fields/retry@v3` action
- Configured retry strategy:
  - Up to 5 attempts total
  - 2 minute (120 second) delay between retries
  - 30 minute timeout per attempt

## Testing

- [ ] Manual testing completed (workflow changes can only be tested when run on GitHub Actions)

## Human Review Checklist

- [ ] Verify interpretation: User requested "5 retries" - implemented as `max_attempts: 5` (5 total attempts). If user meant 5 retries after initial failure, this should be changed to `max_attempts: 6`
- [ ] Confirm `nick-fields/retry@v3` is an acceptable third-party action for this repo

---

Link to Devin run: https://app.devin.ai/sessions/35dedc768be44a3987eae6f9bb1f4c09
Requested by: @jsklan