### PR TITLE
fix(python): make wire tests compatible with clients that don’t accept `headers=`

### DIFF
--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGeneratorContext.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGeneratorContext.ts
@@ -43,6 +43,9 @@ export abstract class AbstractDynamicSnippetsGeneratorContext {
     }): TypeInstance[] {
         const instances: TypeInstance[] = [];
         for (const [key, value] of Object.entries(values)) {
+            if (value === undefined) {
+                continue;
+            }
             this.errors.scope(key);
             try {
                 const parameter = parameters.find((param) => param.name.wireValue === key);
@@ -115,6 +118,9 @@ export abstract class AbstractDynamicSnippetsGeneratorContext {
     }): TypeInstance[] {
         const instances: TypeInstance[] = [];
         for (const [key, value] of Object.entries(values)) {
+            if (value === undefined) {
+                continue;
+            }
             this.errors.scope(key);
             try {
                 const parameter = parameters.find((param) => param.name.wireValue === key);

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.46.11
+  changelogEntry:
+    - summary: |
+        Wire test generator now skips undefined example values and injects `X-Test-Id` in a constructor-compatible way via `headers` or `httpx_client`.
+      type: fix
+  createdAt: "2026-01-09"
+  irVersion: 62
+
 - version: 4.46.10
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: [FER-8169](https://linear.app/buildwithfern/issue/FER-8169/elevenlabs-wire-test-generation-and-startup-errors) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Updates the Python wire test generator to be constructor-signature aware for header injection. We now generate wire tests that inject `X-Test-Id` via `headers=` when supported, otherwise via a preconfigured `httpx_client`.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Update generated `tests/wire/conftest.py:get_client()` to inject `X-Test-Id` via headers when present, otherwise via `httpx_client`.
- Skip undefined example values during dynamic snippet parameter association to avoid generating invalid Python expressions in wire tests (e.g. emitting `kwarg=` with no value).

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
