### PR TITLE
fix(cli): handle read-only files when overwriting .preview folder

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.37.1
+  changelogEntry:
+    - summary: |
+        Fix `fern generate --preview` failing with permission errors when the `.preview` folder already exists. The CLI now properly handles read-only files (like `.git/objects`) by making them writable before deletion.
+      type: fix
+  createdAt: "2026-01-09"
+  irVersion: 62
+
 - version: 3.37.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes `fern generate --preview` failing with `EACCES: permission denied` errors when the `.preview` folder already exists from a previous run.

**Link to Devin run**: https://app.devin.ai/sessions/0807c2beab2146e980ed354374695cb8
**Requested by**: @jsklan

## Problem

When running `fern generate --preview` multiple times, the CLI would fail with:
```
EACCES: permission denied, open '.../.preview/fern-typescript-sdk/.git/objects/...'
```

This happens because:
1. The generated SDK zip may include a `.git` directory
2. Git creates `.git/objects` files with read-only permissions
3. Node.js `rm()` fails to delete read-only files on some systems
4. The subsequent `decompress` fails when trying to write to existing files

## Changes Made

- Added `forceRemoveDirectory()` helper that makes files writable before deletion
- Added `makeWritableRecursive()` helper to recursively chmod files to 0o755
- Updated `downloadZipForTask()` to use the new force removal
- Updated `downloadFilesWithFernIgnoreInTempRepo()` for consistency
- Added changelog entry for version 3.37.2

## Testing

- [x] Manual testing: Verified lint checks pass (`pnpm run check`)
- [ ] Unit tests added/updated (no new tests - the fix is in file system operations that are difficult to unit test without mocking)

## Human Review Checklist

- [ ] Verify the recursive chmod approach handles edge cases safely (symlinks, special files)
- [ ] Confirm error suppression in `makeWritableRecursive` is appropriate (errors are ignored since files may be deleted/inaccessible mid-operation)
- [ ] Check that chmod to 0o755 is the appropriate permission level for this use case
- [ ] Note: This fix hasn't been tested on the actual failing scenario (macOS with .git/objects files) - only lint checks verified