### PR TITLE
fix(cli): accept UUID-format hashes in preview URL validation

### DIFF
--- a/packages/cli/cli/src/commands/docs-preview/deleteDocsPreview.ts
+++ b/packages/cli/cli/src/commands/docs-preview/deleteDocsPreview.ts
@@ -7,9 +7,10 @@ import { CliContext } from "../../cli-context/CliContext";
 
 /**
  * Preview URLs follow the pattern: {org}-preview-{hash}.docs.buildwithfern.com
+ * The hash can be a short alphanumeric string or a UUID with hyphens.
  * This regex validates that the hostname contains "-preview-" and ends with ".docs.buildwithfern.com"
  */
-const PREVIEW_URL_PATTERN = /^[a-z0-9-]+-preview-[a-z0-9]+\.docs\.buildwithfern\.com$/i;
+const PREVIEW_URL_PATTERN = /^[a-z0-9-]+-preview-[a-z0-9-]+\.docs\.buildwithfern\.com$/i;
 
 function isPreviewUrl(url: string): boolean {
     // Normalize the URL to extract just the hostname

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.37.4
+  changelogEntry:
+    - summary: |
+        Fix `fern docs preview delete` to accept preview URLs with UUID-format hashes (e.g., `org-preview-9b2b47f0-c44b-4338-b579-46872f33404a.docs.buildwithfern.com`). Previously, the command only accepted short alphanumeric hashes and rejected UUIDs containing hyphens.
+      type: fix
+  createdAt: "2026-01-10"
+  irVersion: 62
+
 - version: 3.37.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes `fern docs preview delete` command rejecting valid preview URLs that use UUID-format hashes.

**Reported issue:** The command was rejecting URLs like `audiences-api-preview-9b2b47f0-c44b-4338-b579-46872f33404a.docs.buildwithfern.com` with the error "Invalid preview URL" because the regex pattern didn't allow hyphens in the hash portion.

## Changes Made

- Updated the `PREVIEW_URL_PATTERN` regex to allow hyphens in the hash portion (`[a-z0-9]+` → `[a-z0-9-]+`)
- Added clarifying comment that the hash can be a short alphanumeric string or a UUID with hyphens

## Testing

- [x] Manual testing: Verified the regex now matches both short hashes (`abc123`) and UUIDs (`9b2b47f0-c44b-4338-b579-46872f33404a`)
- [ ] Unit tests added/updated (no existing tests for this function)

## Human Review Checklist

- [ ] Verify the regex change doesn't introduce false positives for non-preview URLs
- [ ] Consider if unit tests should be added for the `isPreviewUrl` function

---

Requested by: @tjb9dc
Link to Devin run: https://app.devin.ai/sessions/752acef8724f4638b2855ae73f4a1b19