### PR TITLE
feat(python): add `wire_tests.exclusions` custom config to skip selected wire tests

### DIFF
--- a/generators/python-v2/sdk/src/SdkCustomConfig.ts
+++ b/generators/python-v2/sdk/src/SdkCustomConfig.ts
@@ -38,13 +38,22 @@ const ClientConfigSchema = z.object({
     exported_class_name: z.string().optional()
 });
 
+/**
+ * Schema for wire test configuration options.
+ */
+const WireTestsConfigSchema = z.object({
+    enabled: z.boolean().optional(),
+    exclusions: z.array(z.string()).optional()
+});
+
 export const SdkCustomConfigSchema = z.object({
+    /** @deprecated Use `wire_tests.enabled` instead */
     enable_wire_tests: z.boolean().optional(),
     package_path: relativePathSchema.optional(),
     client: ClientConfigSchema.optional(),
     client_class_name: z.string().optional(),
     inline_request_params: z.boolean().optional(),
-    wire_test_exclusions: z.array(z.string()).optional()
+    wire_tests: WireTestsConfigSchema.optional()
 });
 
 export type SdkCustomConfigSchema = z.infer<typeof SdkCustomConfigSchema>;

--- a/generators/python-v2/sdk/src/SdkCustomConfig.ts
+++ b/generators/python-v2/sdk/src/SdkCustomConfig.ts
@@ -43,7 +43,8 @@ export const SdkCustomConfigSchema = z.object({
     package_path: relativePathSchema.optional(),
     client: ClientConfigSchema.optional(),
     client_class_name: z.string().optional(),
-    inline_request_params: z.boolean().optional()
+    inline_request_params: z.boolean().optional(),
+    wire_test_exclusions: z.array(z.string()).optional()
 });
 
 export type SdkCustomConfigSchema = z.infer<typeof SdkCustomConfigSchema>;

--- a/generators/python-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/python-v2/sdk/src/SdkGeneratorCli.ts
@@ -49,7 +49,8 @@ export class SdkGeneratorCli extends AbstractPythonGeneratorCli<SdkCustomConfigS
     }
 
     private async generateWireTestFiles(context: SdkGeneratorContext): Promise<void> {
-        if (!context.customConfig.enable_wire_tests) {
+        const wireTestsEnabled = context.customConfig.wire_tests?.enabled ?? context.customConfig.enable_wire_tests;
+        if (!wireTestsEnabled) {
             return;
         }
 

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -236,6 +236,9 @@ export class WireTestGenerator {
         );
 
         const pythonFile = this.buildTestFile(serviceName, endpointTestCases);
+        if (pythonFile === null) {
+            return null;
+        }
 
         return new WriteablePythonFile({
             filename: `test_${serviceName}`,
@@ -257,7 +260,7 @@ export class WireTestGenerator {
             exampleIndex: number;
             isErrorResponse: boolean;
         }>
-    ): python.PythonFile {
+    ): python.PythonFile | null {
         const statements: python.AstNode[] = [];
 
         // Add raw imports that the AST doesn't support (simple "import X" statements)
@@ -269,6 +272,7 @@ export class WireTestGenerator {
         statements.push(this.createImportRegistration());
 
         // Add test functions for each endpoint
+        let testFunctionCount = 0;
         for (const { endpoint, example, service, exampleIndex, isErrorResponse } of testCases) {
             const testFunction = this.generateEndpointTestFunction(
                 serviceName,
@@ -280,7 +284,12 @@ export class WireTestGenerator {
             );
             if (testFunction) {
                 statements.push(testFunction);
+                testFunctionCount++;
             }
+        }
+
+        if (testFunctionCount === 0) {
+            return null;
         }
 
         const pathSegments = `tests/wire/test_${serviceName}`.split("/");

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -346,7 +346,7 @@ export class WireTestGenerator {
                 servicePath.length > 0
                     ? `${servicePath}.${endpoint.name.snakeCase.safeName}`
                     : endpoint.name.snakeCase.safeName;
-            const excluded = this.context.customConfig.wire_test_exclusions ?? [];
+            const excluded = this.context.customConfig.wire_tests?.exclusions ?? [];
             if (
                 excluded.includes(selector) ||
                 excluded.some((pattern) => pattern.endsWith(".*") && selector.startsWith(pattern.slice(0, -2) + "."))

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -4,9 +4,9 @@
 - version: 4.50.0
   changelogEntry:
     - summary: |
-        Add `wire_test_exclusions` custom config option to exclude selected endpoints/services from wire test generation using definition-level selectors.
+        Add `wire_tests` config group with `enabled` and `exclusions` options. The `exclusions` option allows excluding specific endpoints/services from wire test generation using definition-level selectors. The existing `enable_wire_tests` option is now deprecated in favor of `wire_tests.enabled`.
       type: feat
-  createdAt: "2026-01-24"
+  createdAt: "2026-01-25"
   irVersion: 62
 
 - version: 4.49.0

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.50.0
+  changelogEntry:
+    - summary: |
+        Add `wire_test_exclusions` custom config option to exclude selected endpoints/services from wire test generation using definition-level selectors.
+      type: feat
+  createdAt: "2026-01-24"
+  irVersion: 62
+
 - version: 4.49.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -94,8 +94,13 @@ class AbstractGenerator(ABC):
             recursion_limit = generator_config.custom_config.get("recursion_limit")
 
         enable_wire_tests = False
-        if generator_config.custom_config is not None and "enable_wire_tests" in generator_config.custom_config:
-            enable_wire_tests = generator_config.custom_config.get("enable_wire_tests")
+        if generator_config.custom_config is not None:
+            # Check wire_tests.enabled first (preferred), fall back to enable_wire_tests (deprecated)
+            wire_tests_config = generator_config.custom_config.get("wire_tests")
+            if wire_tests_config is not None and isinstance(wire_tests_config, dict):
+                enable_wire_tests = wire_tests_config.get("enabled", False)
+            elif "enable_wire_tests" in generator_config.custom_config:
+                enable_wire_tests = generator_config.custom_config.get("enable_wire_tests")
 
         package_path = None
         if generator_config.custom_config is not None and "package_path" in generator_config.custom_config:

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -97,8 +97,12 @@ class AbstractGenerator(ABC):
         if generator_config.custom_config is not None:
             # Check wire_tests.enabled first (preferred), fall back to enable_wire_tests (deprecated)
             wire_tests_config = generator_config.custom_config.get("wire_tests")
+            wire_tests_enabled = None
             if wire_tests_config is not None and isinstance(wire_tests_config, dict):
-                enable_wire_tests = wire_tests_config.get("enabled", False)
+                wire_tests_enabled = wire_tests_config.get("enabled")
+            # Use wire_tests.enabled if explicitly set, otherwise fall back to enable_wire_tests
+            if wire_tests_enabled is not None:
+                enable_wire_tests = wire_tests_enabled
             elif "enable_wire_tests" in generator_config.custom_config:
                 enable_wire_tests = generator_config.custom_config.get("enable_wire_tests")
 

--- a/generators/python/src/fern_python/generators/sdk/custom_config.py
+++ b/generators/python/src/fern_python/generators/sdk/custom_config.py
@@ -43,6 +43,18 @@ class CustomReadmeSection(pydantic.BaseModel):
     content: str
 
 
+class WireTestsConfig(pydantic.BaseModel):
+    """Configuration for wire test generation."""
+
+    enabled: bool = False
+    # Exclude specific endpoints/services from wire tests using definition-level
+    # identifiers in the form "<service_path>.<endpoint_name>" or "<service_path>.*".
+    exclusions: Optional[List[str]] = None
+
+    class Config:
+        extra = pydantic.Extra.forbid
+
+
 class SDKCustomConfig(pydantic.BaseModel):
     extra_dependencies: Dict[str, Union[str, DependencyCustomConfig]] = {}
     extra_dev_dependencies: Dict[str, Union[str, BaseDependencyCustomConfig]] = {}
@@ -71,9 +83,8 @@ class SDKCustomConfig(pydantic.BaseModel):
     # parameters in function signatures where possible.
     inline_request_params: bool = True
 
-    # Wire-test generation only: exclude specific endpoints/services from wire tests using
-    # definition-level identifiers in the form "<service_path>.<endpoint_name>" or "<service_path>.*".
-    wire_test_exclusions: Optional[List[str]] = None
+    # Wire test configuration
+    wire_tests: Optional[WireTestsConfig] = None
 
     # If true, treats path parameters as named parameters in endpoint functions
     inline_path_params: bool = False
@@ -127,6 +138,7 @@ class SDKCustomConfig(pydantic.BaseModel):
     # the recursion limit is at least this value.
     recursion_limit: Optional[int] = pydantic.Field(None, gt=1000)
 
+    # deprecated, use wire_tests.enabled instead
     enable_wire_tests: bool = False
 
     custom_pager_name: Optional[str] = None

--- a/generators/python/src/fern_python/generators/sdk/custom_config.py
+++ b/generators/python/src/fern_python/generators/sdk/custom_config.py
@@ -71,6 +71,10 @@ class SDKCustomConfig(pydantic.BaseModel):
     # parameters in function signatures where possible.
     inline_request_params: bool = True
 
+    # Wire-test generation only: exclude specific endpoints/services from wire tests using
+    # definition-level identifiers in the form "<service_path>.<endpoint_name>" or "<service_path>.*".
+    wire_test_exclusions: Optional[List[str]] = None
+
     # If true, treats path parameters as named parameters in endpoint functions
     inline_path_params: bool = False
 


### PR DESCRIPTION
## Description
Linear ticket: [FER-8179](https://linear.app/buildwithfern/issue/FER-8179/allow-wire-test-exclusions-for-specified-services-or-endpoints) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
This PR adds a new `wire_tests` config group to the Python generator with `enabled` and `exclusions` options. The `exclusions` option prevents generating wire tests for specific endpoints or entire services using definition-level selectors (e.g. `service.subservice.endpoint` or `service.subservice.*`), so customers don't need to reference IR endpoint IDs. This is needed for endpoints implemented with custom logic that cannot be meaningfully exercised by WireMock. The existing `enable_wire_tests` option is now deprecated in favor of `wire_tests.enabled`.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
`New config group: `wire_tests` with `enabled: bool` and `exclusions: string[]` options
`Definition-level selectors: support exact endpoint selectors (`service.subservice.endpoint`) and service-wide selectors (`service.subservice.*`)
`Wire test generation behavior: matched endpoints are omitted from generated `tests/wire/test_*.py` files
`Deprecation: `enable_wire_tests` is deprecated in favor of `wire_tests.enabled` (with backward-compatible fallback)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable wire test group and improves generation robustness.
> 
> - **Config**: New `wire_tests` group with `enabled` and `exclusions` (definition-level selectors like `service.subservice.endpoint` or `service.subservice.*`); `enable_wire_tests` marked deprecated but still honored as fallback
> - **Generation**: `WireTestGenerator` filters out excluded endpoints/services and returns `null` when no test functions remain; `buildTestFile` now null-safe to prevent empty files
> - **CLI/runtime**: Both TS (`SdkGeneratorCli`) and Python (`abstract_generator.py`, `custom_config.py`) read `wire_tests.enabled` first, then fallback
> - **Changelog**: Version bump to `4.50.0` documenting the new config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfd32a7b17bf06b2814c245e5ebac2c991cc5217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->