### PR TITLE
chore(internal): remove `.cursorindexignore`

### DIFF
--- a/.cursorindexignore
+++ b/.cursorindexignore
@@ -1,4 +1,0 @@
-node_modules
-.pnpm
-.turbo
-.nx


### PR DESCRIPTION
We already have `.cursorindexingignore`