### PR TITLE
fix(typescript): fix generator containers not exiting after completing work

### DIFF
--- a/generators/base/src/AbstractGeneratorCli.ts
+++ b/generators/base/src/AbstractGeneratorCli.ts
@@ -61,6 +61,9 @@ export abstract class AbstractGeneratorCli<
             await generatorNotificationService.sendUpdate(
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(FernGeneratorExec.ExitStatusUpdate.successful({}))
             );
+
+            // Stop the notification service to allow the process to exit
+            generatorNotificationService.stop();
         } catch (e) {
             await generatorNotificationService.sendUpdate(
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(
@@ -69,6 +72,9 @@ export abstract class AbstractGeneratorCli<
                     })
                 )
             );
+
+            // Stop the notification service to allow the process to exit
+            generatorNotificationService.stop();
             throw e;
         }
     }

--- a/generators/browser-compatible-base/src/AbstractGeneratorNotificationService.ts
+++ b/generators/browser-compatible-base/src/AbstractGeneratorNotificationService.ts
@@ -3,4 +3,5 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 export abstract class AbstractGeneratorNotificationService {
     public abstract bufferUpdate(update: FernGeneratorExec.GeneratorUpdate): void;
     public abstract sendUpdate(update: FernGeneratorExec.GeneratorUpdate): Promise<void>;
+    public abstract stop(): void;
 }

--- a/generators/browser-compatible-base/src/GeneratorNotificationService.ts
+++ b/generators/browser-compatible-base/src/GeneratorNotificationService.ts
@@ -17,6 +17,7 @@ export class GeneratorNotificationService implements AbstractGeneratorNotificati
     private client: FernGeneratorExecClient | undefined;
     private taskId: FernGeneratorExec.TaskId | undefined;
     private buffer: FernGeneratorExec.GeneratorUpdate[] = [];
+    private flushIntervalId: ReturnType<typeof setInterval> | undefined;
 
     constructor(environment: FernGeneratorExec.GeneratorEnvironment) {
         if (environment.type === "remote") {
@@ -27,7 +28,7 @@ export class GeneratorNotificationService implements AbstractGeneratorNotificati
             this.taskId = environment.id;
             // Every 2 seconds we flush the buffer
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            setInterval(async () => {
+            this.flushIntervalId = setInterval(async () => {
                 if (this.buffer.length > 0) {
                     await this.flush();
                 }
@@ -52,6 +53,13 @@ export class GeneratorNotificationService implements AbstractGeneratorNotificati
 
         this.buffer.push(update);
         await this.flush();
+    }
+
+    public stop(): void {
+        if (this.flushIntervalId != null) {
+            clearInterval(this.flushIntervalId);
+            this.flushIntervalId = undefined;
+        }
     }
 
     private async flush(): Promise<void> {

--- a/generators/browser-compatible-base/src/NopGeneratorNotificationService.ts
+++ b/generators/browser-compatible-base/src/NopGeneratorNotificationService.ts
@@ -12,4 +12,9 @@ export class NopGeneratorNotificationService extends AbstractGeneratorNotificati
         // no-op
         return Promise.resolve();
     }
+
+    public stop(): void {
+        // no-op
+        return;
+    }
 }

--- a/generators/typescript/express/versions.yml
+++ b/generators/typescript/express/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
+    - summary: |
+        Fix generator containers not exiting after completing their work. The `GeneratorNotificationService`
+        now properly clears its flush interval when stopped, allowing the Node.js process to exit naturally.
+      type: fix
+  irVersion: 61
+  createdAt: "2026-01-12"
+  version: 0.18.9
+
+- changelogEntry:
     - summary: Bump generator CLI version to publish new Docker image.
       type: chore
   irVersion: 61

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.43.8
+  changelogEntry:
+    - summary: |
+        Fix generator containers not exiting after completing their work. The `GeneratorNotificationService`
+        now properly clears its flush interval when stopped, allowing the Node.js process to exit naturally.
+      type: fix
+  createdAt: "2026-01-12"
+  irVersion: 63
+
 - version: 3.43.7
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -235,10 +235,10 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
             );
             // biome-ignore lint/suspicious/noConsole: allow console
             console.log("Sent success event to coordinator");
+
+            // Stop the notification service to allow the process to exit
+            generatorNotificationService.stop();
         } catch (e) {
-            // This call tears down generator service
-            // TODO: if using in conjunction with MCP server generator, MCP server generator to tear down the service?
-            // SEE: go-v2
             await generatorNotificationService.sendUpdate(
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(
                     FernGeneratorExec.ExitStatusUpdate.error({
@@ -248,6 +248,9 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
             );
             // biome-ignore lint/suspicious/noConsole: allow console
             console.log("Sent error event to coordinator");
+
+            // Stop the notification service to allow the process to exit
+            generatorNotificationService.stop();
             throw e;
         }
     }


### PR DESCRIPTION
## Description

Fixes generator ECS tasks (launched by Fiddle) never exiting after completing their work. The last log message from generators was "Sent success event to coordinator" but the ECS task would continue running indefinitely.

**Link to Devin run**: https://app.devin.ai/sessions/9e202ad68c25409c95d9e0b220eb6abd
**Requested by**: @tjb9dc

## Root Cause

The `GeneratorNotificationService` constructor sets up a `setInterval` that runs every 2 seconds to flush buffered updates. This interval was never cleared, which keeps the Node.js event loop active and prevents the process from naturally terminating even after all generation work is complete.

## Changes Made

- Added `stop()` method to `AbstractGeneratorNotificationService` interface
- Implemented `stop()` in `GeneratorNotificationService` to clear the flush interval that was keeping the Node.js event loop active
- Implemented `stop()` in `NopGeneratorNotificationService` as a no-op
- Called `stop()` after sending exit status (both success and error paths) in:
  - `generators/base/src/AbstractGeneratorCli.ts`
  - `generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts`
- Updated `versions.yml` for TypeScript SDK (3.43.8) and Express (0.18.9) generators
- [ ] Updated README.md generator (not applicable)

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [x] All CI checks pass
- [ ] Manual testing in ECS environment (requires deployment)

## Review Checklist

- [ ] Verify `stop()` is called in both success and error paths
- [ ] Confirm the interval cleanup logic is correct (`clearInterval` + setting to `undefined`)
- [ ] Note: This affects all TypeScript-based generators using `GeneratorNotificationService`