### PR TITLE
feat(cli): match production output for local generation

### DIFF
--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/LocalFileSystemOutputLocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/LocalFileSystemOutputLocationSchema.ts
@@ -5,4 +5,5 @@
 export interface LocalFileSystemOutputLocationSchema {
     path: string;
     "generate-full-project"?: boolean;
+    "preserve-unmanaged-files"?: boolean;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/LocalFileSystemOutputLocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/LocalFileSystemOutputLocationSchema.ts
@@ -4,4 +4,5 @@
 
 export interface LocalFileSystemOutputLocationSchema {
     path: string;
+    "generate-full-project"?: boolean;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/LocalFileSystemOutputLocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/LocalFileSystemOutputLocationSchema.ts
@@ -12,11 +12,13 @@ export const LocalFileSystemOutputLocationSchema: core.serialization.ObjectSchem
 > = core.serialization.object({
     path: core.serialization.string(),
     "generate-full-project": core.serialization.boolean().optional(),
+    "preserve-unmanaged-files": core.serialization.boolean().optional(),
 });
 
 export declare namespace LocalFileSystemOutputLocationSchema {
     export interface Raw {
         path: string;
         "generate-full-project"?: boolean | null;
+        "preserve-unmanaged-files"?: boolean | null;
     }
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/LocalFileSystemOutputLocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/LocalFileSystemOutputLocationSchema.ts
@@ -11,10 +11,12 @@ export const LocalFileSystemOutputLocationSchema: core.serialization.ObjectSchem
     GeneratorsYml.LocalFileSystemOutputLocationSchema
 > = core.serialization.object({
     path: core.serialization.string(),
+    "generate-full-project": core.serialization.boolean().optional(),
 });
 
 export declare namespace LocalFileSystemOutputLocationSchema {
     export interface Raw {
         path: string;
+        "generate-full-project"?: boolean | null;
     }
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -224,7 +224,11 @@ export async function writeFilesToDiskAndRunGenerator({
         absolutePathToTmpSnippetTemplatesJSON,
         version,
         ai,
-        isWhitelabel: ir.readmeConfig?.whiteLabel ?? false
+        isWhitelabel: ir.readmeConfig?.whiteLabel ?? false,
+        preserveUnmanagedFiles:
+            (generatorInvocation.raw?.output?.location === "local-file-system" &&
+                generatorInvocation.raw.output["preserve-unmanaged-files"]) ??
+            false
     });
     const generatedFilesResult = await taskHandler.copyGeneratedFiles();
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -461,6 +461,12 @@ function getPublishConfig({
     packageName?: string;
     context: TaskContext;
 }): FernIr.PublishingConfig | undefined {
+    const generateFullProject =
+        (generatorInvocation.raw?.output?.location === "local-file-system" &&
+            generatorInvocation.raw.output["generate-full-project"]) ??
+        org?.selfHostedSdKs ??
+        false;
+
     if (generatorInvocation.raw?.github != null && isGithubSelfhosted(generatorInvocation.raw.github)) {
         const [owner, repo] = generatorInvocation.raw.github.uri.split("/");
         if (owner == null || repo == null) {
@@ -553,7 +559,7 @@ function getPublishConfig({
         }
 
         return FernIr.PublishingConfig.filesystem({
-            generateFullProject: org?.selfHostedSdKs ?? false,
+            generateFullProject,
             publishTarget
         });
     }
@@ -561,7 +567,7 @@ function getPublishConfig({
     return generatorInvocation.outputMode._visit({
         downloadFiles: () => {
             return FernIr.PublishingConfig.filesystem({
-                generateFullProject: org?.selfHostedSdKs ?? false,
+                generateFullProject,
                 publishTarget: undefined
             });
         },


### PR DESCRIPTION
## Description
Linear ticket: [FER-8184](https://linear.app/buildwithfern/issue/FER-8184/fix-mismatch-between-local-and-remote-generation-structures)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
This PR makes `local-file-system` generation capable of producing the same “full project” SDK layout as production (e.g. `pyproject.toml`, `src/<package>` etc.), via a new `generate-full-project` output option. It also adds `preserve-unmanaged-files` to avoid destructive wipes during local generation while still pruning stale generated files inside generator-managed roots.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Add `generate-full-project` for `local-file-system` outputs
  - Plumbed from generators.yml → IR publish config so generators can scaffold a full project locally.
  - Files: `packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts`, `packages/cli/configuration/.../LocalFileSystemOutputLocationSchema.ts` (api + serialization)
- Add `preserve-unmanaged-files` for `local-file-system` outputs
  - Local generation overlays output without deleting non-managed files, respects .fernignore, and prunes stale generated files by diffing against the current tmp output (no manifest).
  - Files: `packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts`, `packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts`, plus the same schema files

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
