### PR TITLE
chore(internal): upgrade CLI to IR v63

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.37.6
+  changelogEntry:
+    - summary: |
+        Bump IR version to 63.
+      type: chore
+  createdAt: "2026-01-12"
+  irVersion: 63
+
 - version: 3.37.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Just adds a new version to `versions.yml` with `irVersion: 63`. Allows `fern generator upgrade` to upgrade to IR v63 SDK generator versions.

## Changes Made
Purely a changelog change.

## Testing
Tested that this does indeed fix `fern generator upgrade`.
- [X] Unit tests added/updated
- [X] Manual testing completed
