### PR TITLE
fix(go): gracefully handle go fmt failures during generation

### DIFF
--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -84,10 +84,17 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
         await Promise.all(files.map(async (file) => await file.write(AbsoluteFilePath.of(outputDir))));
         const isModule = this.getModuleConfig({ config: this.context.config }) != null;
         if (files.length > 0 && isModule) {
-            await loggingExeca(this.context.logger, "go", ["fmt", "./..."], {
-                doNotPipeOutput: true,
-                cwd: this.absolutePathToOutputDirectory
-            });
+            try {
+                await loggingExeca(this.context.logger, "go", ["fmt", "./..."], {
+                    doNotPipeOutput: true,
+                    cwd: this.absolutePathToOutputDirectory
+                });
+            } catch (error) {
+                this.context.logger.warn(
+                    `Failed to format Go files with 'go fmt': ${error instanceof Error ? error.message : String(error)}. ` +
+                        "The generated files have been written but may not be properly formatted."
+                );
+            }
         }
         return this.absolutePathToOutputDirectory;
     }

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.22.5
+  changelogEntry:
+    - summary: |
+        Gracefully handle `go fmt` failures during generation. When formatting fails, the generator
+        now logs a warning and continues to output the generated files instead of failing the entire
+        generation. This allows developers to debug generated output even when formatting issues occur.
+      type: fix
+  createdAt: "2026-01-12"
+  irVersion: 60
+
 - version: 1.22.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Discussion in #sdk-dev about Go SDK generation failures when `go fmt` encounters issues

When generating Go SDKs, if `go fmt` fails (e.g., due to `.fernignore` issues or other compilation problems), the entire generation would fail, preventing developers from seeing the generated output for debugging purposes.

This PR changes the behavior to gracefully handle `go fmt` failures by logging a warning and continuing to output the generated files.

**Link to Devin run**: https://app.devin.ai/sessions/cbb28720e3c14b2da2e8dc88d8caffdd
**Requested by**: @jsklan

## Changes Made

- Wrapped the `go fmt` execution in a try-catch block in `GoProject.ts`
- When `go fmt` fails, logs a warning message instead of throwing an error
- Files are still written to disk even if formatting fails
- Added changelog entry for version 1.22.5

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Unit tests added/updated (no new tests - behavior change is straightforward)
- [ ] Manual testing completed (not tested with actual failing `go fmt` scenario)

## Human Review Checklist

- [ ] Verify the warning message is clear and actionable
- [ ] Consider if this behavior should be configurable (current implementation always continues on failure)
- [ ] Note: Users who want strict compilation guarantees should add `go build ./...` as a CI step in their SDK repo