### PR TITLE
fix(cli): support air-gapped environments for protobuf OpenAPI generation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.38.1
+  changelogEntry:
+    - summary: |
+        Fix protobuf OpenAPI generation to support air-gapped environments. The CLI now checks for a pre-cached `buf.lock` file in the proto directory before calling `buf dep update`. This enables self-hosted deployments with `from-openapi: true` proto specs to work in air-gapped environments by pre-caching dependencies.
+      type: fix
+  createdAt: "2026-01-13"
+  irVersion: 63
+
 - version: 3.38.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs fern-api/fern-platform#6341

Fixes protobuf OpenAPI generation (`from-openapi: true`) to support air-gapped environments by checking for a pre-cached `buf.lock` file before calling `buf dep update`.

**Link to Devin run:** https://app.devin.ai/sessions/b12b1c780dd24ca9bcb7118646dfa729
**Requested by:** Sandeep Dinesh (@thesandlord)

## Changes Made

- Modified `ProtobufOpenAPIGenerator.ts` to check if `buf.lock` already exists in the proto directory before calling `buf dep update`
- If `buf.lock` exists (e.g., pre-cached for air-gapped deployments), skip the network call and use cached dependencies
- Added `access` import from `fs/promises` for file existence check
- Added version 3.38.1 changelog entry

This mirrors the existing air-gapped support in `ProtobufIRGenerator.ts` (lines 248-265), which already has this fix for non-OpenAPI protobuf generation.

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed

**Note:** This fix is needed for the self-hosted tests in fern-platform#6341 to pass. The tests use a gRPC spec with `from-openapi: true` and external buf dependencies (`buf.build/googleapis/googleapis`). Without this fix, `buf dep update` fails at runtime in air-gapped environments even when `buf.lock` is pre-cached.

## Human Review Checklist

- [ ] Verify logic matches the existing implementation in `ProtobufIRGenerator.ts`
- [ ] Confirm that the `cleanupBufLock` flag behavior is correct when using pre-existing buf.lock (we don't set it since we didn't create the file)