### PR TITLE
feat(ruby): add RETRIES, ADDITIONAL_HEADERS, and ADDITIONAL_QUERY_PARAMETERS README sections

### DIFF
--- a/generators/ruby-v2/sdk/features.yml
+++ b/generators/ruby-v2/sdk/features.yml
@@ -13,7 +13,31 @@ features:
     description: |
       Failed API calls will raise errors that can be rescued from granularly.
 
+  - id: RETRIES
+    advanced: true
+    description: |
+      The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+      retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+      A request is deemed retryable when any of the following HTTP status codes is returned:
+
+      - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+      - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+      Use the `max_retries` option to configure this behavior.
+
   - id: TIMEOUTS
     advanced: true
     description: |
       The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
+
+  - id: ADDITIONAL_HEADERS
+    advanced: true
+    description: |
+      If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+  - id: ADDITIONAL_QUERY_PARAMETERS
+    advanced: true
+    description: |
+      If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.

--- a/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -66,7 +66,10 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             }
         > = {
             [FernGeneratorCli.StructuredFeatureId.Errors]: { renderer: this.renderErrorsSnippet.bind(this) },
+            [FernGeneratorCli.StructuredFeatureId.Retries]: { renderer: this.renderRetriesSnippet.bind(this) },
             [FernGeneratorCli.StructuredFeatureId.Timeouts]: { renderer: this.renderTimeoutsSnippet.bind(this) },
+            ADDITIONAL_HEADERS: { renderer: this.renderAdditionalHeadersSnippet.bind(this) },
+            ADDITIONAL_QUERY_PARAMETERS: { renderer: this.renderAdditionalQueryParametersSnippet.bind(this) },
             ...(this.isPaginationEnabled
                 ? {
                       [FernGeneratorCli.StructuredFeatureId.Pagination]: {
@@ -230,6 +233,44 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             response = ${this.getMethodCall(endpoint)}(
                 ...,
                 timeout: 30  # 30 second timeout
+            )
+        `);
+    }
+
+    private renderRetriesSnippet(endpoint: EndpointWithFilepath): string {
+        return this.writeCode(dedent`require "${this.rootPackageName}"
+
+            ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} = ${this.rootPackageClientName}::Client.new(
+                base_url: ${this.getEnvironmentURLExample()},
+                max_retries: 3  # Configure max retries (default is 2)
+            )
+        `);
+    }
+
+    private renderAdditionalHeadersSnippet(endpoint: EndpointWithFilepath): string {
+        return this.writeCode(dedent`require "${this.rootPackageName}"
+
+            response = ${this.getMethodCall(endpoint)}(
+                ...,
+                request_options: {
+                    additional_headers: {
+                        "X-Custom-Header" => "custom-value"
+                    }
+                }
+            )
+        `);
+    }
+
+    private renderAdditionalQueryParametersSnippet(endpoint: EndpointWithFilepath): string {
+        return this.writeCode(dedent`require "${this.rootPackageName}"
+
+            response = ${this.getMethodCall(endpoint)}(
+                ...,
+                request_options: {
+                    additional_query_parameters: {
+                        "custom_param" => "custom-value"
+                    }
+                }
             )
         `);
     }

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc77
+  createdAt: "2026-01-13"
+  changelogEntry:
+    - type: feat
+      summary: |
+        Add RETRIES, ADDITIONAL_HEADERS, and ADDITIONAL_QUERY_PARAMETERS sections to generated README.md.
+        These sections document how to configure automatic retries, add custom headers, and add custom
+        query parameters to API requests. The features were previously removed because they had Go-specific
+        descriptions; they are now restored with Ruby-specific documentation and code snippets.
+  irVersion: 61
+
 - version: 1.0.0-rc76
   createdAt: "2026-01-06"
   changelogEntry:

--- a/seed/ruby-sdk-v2/accept-header/README.md
+++ b/seed/ruby-sdk-v2/accept-header/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.endpoint(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.endpoint(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.endpoint(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/alias-extends/README.md
+++ b/seed/ruby-sdk-v2/alias-extends/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.extended_inline_request_body(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.extended_inline_request_body(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.extended_inline_request_body(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/alias/README.md
+++ b/seed/ruby-sdk-v2/alias/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.get(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.get(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.get(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/api-wide-base-path/README.md
+++ b/seed/ruby-sdk-v2/api-wide-base-path/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -75,6 +78,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -85,6 +110,40 @@ require "seed"
 response = client.service.post(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.post(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.post(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/README.md
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.get_with_bearer_token(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_with_bearer_token(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_with_bearer_token(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/bytes-download/README.md
+++ b/seed/ruby-sdk-v2/bytes-download/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.simple(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.simple(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.simple(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/bytes-upload/README.md
+++ b/seed/ruby-sdk-v2/bytes-upload/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.upload(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.upload(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.upload(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/content-type/README.md
+++ b/seed/ruby-sdk-v2/content-type/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.service.patch(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.patch(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.patch(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/examples/no-custom-config/README.md
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -79,6 +82,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -89,6 +114,40 @@ require "seed"
 response = client.echo(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.echo(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.echo(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/examples/readme-config/README.md
+++ b/seed/ruby-sdk-v2/examples/readme-config/README.md
@@ -17,7 +17,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Documentation
@@ -246,6 +249,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -265,6 +290,40 @@ require "seed"
 response = client.service.create_movie(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.create_big_entity(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.create_big_entity(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/examples/require-paths/README.md
+++ b/seed/ruby-sdk-v2/examples/require-paths/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -79,6 +82,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -89,6 +114,40 @@ require "seed"
 response = client.echo(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.echo(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.echo(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/examples/wire-tests/README.md
+++ b/seed/ruby-sdk-v2/examples/wire-tests/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -79,6 +82,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -89,6 +114,40 @@ require "seed"
 response = client.echo(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.echo(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.echo(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/README.md
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.endpoints.container.get_and_return_list_of_primitives(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.endpoints.container.get_and_return_list_of_primitives(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.endpoints.container.get_and_return_list_of_primitives(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/extends/README.md
+++ b/seed/ruby-sdk-v2/extends/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -75,6 +78,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -85,6 +110,40 @@ require "seed"
 response = client.extended_inline_request_body(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.extended_inline_request_body(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.extended_inline_request_body(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/file-download/README.md
+++ b/seed/ruby-sdk-v2/file-download/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.simple(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.simple(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.simple(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/file-upload-openapi/README.md
+++ b/seed/ruby-sdk-v2/file-upload-openapi/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.file_upload_example.upload_file(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.file_upload_example.upload_file(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.file_upload_example.upload_file(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/file-upload/README.md
+++ b/seed/ruby-sdk-v2/file-upload/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.just_file(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.just_file(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.just_file(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/README.md
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.get_with_bearer_token(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_with_bearer_token(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_with_bearer_token(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/header-auth/README.md
+++ b/seed/ruby-sdk-v2/header-auth/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.get_with_bearer_token(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_with_bearer_token(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_with_bearer_token(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/http-head/README.md
+++ b/seed/ruby-sdk-v2/http-head/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.user.head(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.user.head(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.user.head(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/idempotency-headers/README.md
+++ b/seed/ruby-sdk-v2/idempotency-headers/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.payment.create(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.payment.create(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.payment.create(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/imdb/README.md
+++ b/seed/ruby-sdk-v2/imdb/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.imdb.create_movie(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.imdb.create_movie(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.imdb.create_movie(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/license/README.md
+++ b/seed/ruby-sdk-v2/license/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.get(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.get(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.get(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/mixed-case/README.md
+++ b/seed/ruby-sdk-v2/mixed-case/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.get_resource(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_resource(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_resource(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/multiple-request-bodies/README.md
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -79,6 +82,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -89,6 +114,40 @@ require "seed"
 response = client.upload_json_document(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.upload_json_document(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.upload_json_document(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/no-environment/README.md
+++ b/seed/ruby-sdk-v2/no-environment/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.dummy.get_dummy(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.get_dummy(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.get_dummy(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/no-retries/README.md
+++ b/seed/ruby-sdk-v2/no-retries/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.retries.get_users(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.retries.get_users(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.retries.get_users(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/nullable-allof-extends/README.md
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -79,6 +82,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -89,6 +114,40 @@ require "seed"
 response = client.create_test(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.create_test(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.create_test(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/nullable-optional/README.md
+++ b/seed/ruby-sdk-v2/nullable-optional/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -84,6 +87,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -94,6 +119,40 @@ require "seed"
 response = client.nullable_optional.create_user(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.nullable_optional.create_user(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.nullable_optional.create_user(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/nullable-request-body/README.md
+++ b/seed/ruby-sdk-v2/nullable-request-body/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.test_group.test_method_name(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.test_group.test_method_name(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.test_group.test_method_name(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/nullable/README.md
+++ b/seed/ruby-sdk-v2/nullable/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -85,6 +88,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -95,6 +120,40 @@ require "seed"
 response = client.nullable.create_user(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.nullable.create_user(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.nullable.create_user(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/optional/README.md
+++ b/seed/ruby-sdk-v2/optional/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.optional.send_optional_body(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.optional.send_optional_body(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.optional.send_optional_body(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/plain-text/README.md
+++ b/seed/ruby-sdk-v2/plain-text/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.get_text(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_text(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get_text(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/property-access/README.md
+++ b/seed/ruby-sdk-v2/property-access/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -82,6 +85,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -92,6 +117,40 @@ require "seed"
 response = client.create_user(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.create_user(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.create_user(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/README.md
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -105,6 +108,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -115,6 +140,40 @@ require "seed"
 response = client.search(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.search(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.search(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/query-parameters-openapi/README.md
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -105,6 +108,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -115,6 +140,40 @@ require "seed"
 response = client.search(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.search(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.search(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/query-parameters/README.md
+++ b/seed/ruby-sdk-v2/query-parameters/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -104,6 +107,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -114,6 +139,40 @@ require "seed"
 response = client.user.get_username(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.user.get_username(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.user.get_username(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/request-parameters/README.md
+++ b/seed/ruby-sdk-v2/request-parameters/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -76,6 +79,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -86,6 +111,40 @@ require "seed"
 response = client.user.create_username(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.user.create_username(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.user.create_username(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/required-nullable/README.md
+++ b/seed/ruby-sdk-v2/required-nullable/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.get_foo(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.get_foo(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.get_foo(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/reserved-keywords/README.md
+++ b/seed/ruby-sdk-v2/reserved-keywords/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.package.test(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.package.test(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.package.test(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/README.md
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.get(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.get(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/server-sent-event-examples/README.md
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.completions.stream(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.completions.stream(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.completions.stream(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/server-sent-events/README.md
+++ b/seed/ruby-sdk-v2/server-sent-events/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.completions.stream(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.completions.stream(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.completions.stream(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/simple-api/README.md
+++ b/seed/ruby-sdk-v2/simple-api/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -79,6 +82,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -89,6 +114,40 @@ require "seed"
 response = client.user.get(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.user.get(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.user.get(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/simple-fhir/README.md
+++ b/seed/ruby-sdk-v2/simple-fhir/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.get_account(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.get_account(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.get_account(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/single-url-environment-default/README.md
+++ b/seed/ruby-sdk-v2/single-url-environment-default/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -79,6 +82,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -89,6 +114,40 @@ require "seed"
 response = client.dummy.get_dummy(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.get_dummy(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.get_dummy(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/README.md
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -79,6 +82,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -89,6 +114,40 @@ require "seed"
 response = client.dummy.get_dummy(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.get_dummy(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.get_dummy(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/streaming-parameter/README.md
+++ b/seed/ruby-sdk-v2/streaming-parameter/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.dummy.generate(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.generate(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.generate(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/streaming/README.md
+++ b/seed/ruby-sdk-v2/streaming/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.dummy.generate_stream(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.generate_stream(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.dummy.generate_stream(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/README.md
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.get_union(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.get_union(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.get_union(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/undiscriminated-unions/README.md
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.union.get(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.union.get(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.union.get(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/unknown/README.md
+++ b/seed/ruby-sdk-v2/unknown/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.unknown.post(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.unknown.post(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.unknown.post(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/url-form-encoded/README.md
+++ b/seed/ruby-sdk-v2/url-form-encoded/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -74,6 +77,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -84,6 +109,40 @@ require "seed"
 response = client.submit_form_data(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.submit_form_data(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.submit_form_data(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/validation/README.md
+++ b/seed/ruby-sdk-v2/validation/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -76,6 +79,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -86,6 +111,40 @@ require "seed"
 response = client.create(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.create(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.create(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/variables/README.md
+++ b/seed/ruby-sdk-v2/variables/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.service.post(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.service.post(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.service.post(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/version-no-default/README.md
+++ b/seed/ruby-sdk-v2/version-no-default/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.user.get_user(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.user.get_user(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.user.get_user(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 

--- a/seed/ruby-sdk-v2/version/README.md
+++ b/seed/ruby-sdk-v2/version/README.md
@@ -11,7 +11,10 @@ The Seed Ruby library provides convenient access to the Seed APIs from Ruby.
 - [Environments](#environments)
 - [Errors](#errors)
 - [Advanced](#advanced)
+  - [Retries](#retries)
   - [Timeouts](#timeouts)
+  - [Additional Headers](#additional-headers)
+  - [Additional Query Parameters](#additional-query-parameters)
 - [Contributing](#contributing)
 
 ## Reference
@@ -71,6 +74,28 @@ end
 
 ## Advanced
 
+### Retries
+
+The SDK is instrumented with automatic retries. A request will be retried as long as the request is deemed
+retryable and the number of retry attempts has not grown larger than the configured retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` option to configure this behavior.
+
+```ruby
+require "seed"
+
+client = Seed::Client.new(
+    base_url: "https://example.com",
+    max_retries: 3  # Configure max retries (default is 2)
+)
+```
+
 ### Timeouts
 
 The SDK defaults to a 60 second timeout. Use the `timeout` option to configure this behavior.
@@ -81,6 +106,40 @@ require "seed"
 response = client.user.get_user(
     ...,
     timeout: 30  # 30 second timeout
+)
+```
+
+### Additional Headers
+
+If you would like to send additional headers as part of the request, use the `additional_headers` request option.
+
+```ruby
+require "seed"
+
+response = client.user.get_user(
+    ...,
+    request_options: {
+        additional_headers: {
+            "X-Custom-Header" => "custom-value"
+        }
+    }
+)
+```
+
+### Additional Query Parameters
+
+If you would like to send additional query parameters as part of the request, use the `additional_query_parameters` request option.
+
+```ruby
+require "seed"
+
+response = client.user.get_user(
+    ...,
+    request_options: {
+        additional_query_parameters: {
+            "custom_param" => "custom-value"
+        }
+    }
 )
 ```
 


### PR DESCRIPTION
## Description
closes: [FER-6428](https://linear.app/buildwithfern/issue/FER-6428/ruby-cleanup-ruby-v2-readme)

Refs: Analysis task from SDK Generator Features Matrix comparison

Adds three new documentation sections to the Ruby SDK's generated README.md that were previously removed because they had Go-specific descriptions. These sections are now restored with Ruby-specific documentation and code snippets.

## Changes Made

- Added `RETRIES` feature section documenting automatic retry behavior with `max_retries` option
- Added `ADDITIONAL_HEADERS` feature section documenting how to pass custom headers via `request_options`
- Added `ADDITIONAL_QUERY_PARAMETERS` feature section documenting how to pass custom query params via `request_options`
- Wired up corresponding snippet renderers in `ReadmeSnippetBuilder.ts`
- [x] Updated README.md generator
- [x] Updated `versions.yml` with changelog entry (1.0.0-rc77)

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [x] Seed tests pass - 57 README files updated across all ruby-sdk-v2 fixtures

## Human Review Checklist

- [ ] Verify the string feature IDs (`ADDITIONAL_HEADERS`, `ADDITIONAL_QUERY_PARAMETERS`) work correctly with the README generation system (they're not in the StructuredFeatureId enum but FeatureId accepts strings)
- [ ] Confirm the Ruby code snippets in the renderers are syntactically correct and idiomatic (note: uses `...` as placeholder for other arguments)

---

Link to Devin run: https://app.devin.ai/sessions/c2d3411e56e642a39c7c0241161775bd
Requested by: @iamnamananand996