### PR TITLE
chore(java): fix java model IR

### DIFF
--- a/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
@@ -39,11 +39,11 @@ groups:
   java:
     generators:
       - name: fernapi/java-model
-        version: 0.9.28
+        version: 1.8.5
         output:
           location: maven
           url: maven.buildwithfern.com
-          coordinate: com.fern.fern:irV60
+          coordinate: com.fern.fern:irV63
         config:
           wrapped-aliases: true
           enable-forward-compatible-enums: true


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

The IR SDK release workflow has been failing for Java since November 2025
because the generator version was set to 0.9.28, which doesn't exist.
Updated to version 1.8.5 (current valid version) and corrected the Maven
coordinate to irV63 to match the current IR version.


## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- 
- 
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
