### PR TITLE
chore(java): correct java-model generator name for IR SDK release

### DIFF
--- a/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
@@ -38,7 +38,7 @@ groups:
           noOptionalProperties: true
   java:
     generators:
-      - name: fernapi/java-model
+      - name: fernapi/fern-java-model
         version: 1.8.5
         output:
           location: maven


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

The IR SDK release workflow has been failing since November 2025 because the generator name was `fernapi/java-model` but Docker images for versions 1.1.0+ are published under `fernapi/fern-java-model`

Updated the generator name to match the actual Docker Hub image name.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
