### PR TITLE
feat(cli): add placeholder page for python-docs in fern docs dev

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.0
+  changelogEntry:
+    - summary: |
+        Add placeholder page for python-docs in `fern docs dev`. When running local development, a helpful placeholder page is shown explaining that Python library documentation requires `fern generate --docs` or `fern generate --docs --preview` to generate.
+      type: feat
+  createdAt: "2026-01-14"
+  irVersion: 63
+
 - version: 3.41.1
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -1373,9 +1373,9 @@ export class DocsDefinitionResolver {
 title: ${title}
 ---
 
-<Note>
-This is a placeholder page. Python library documentation is automatically generated when you run \`fern generate --docs\` or \`fern generate --docs --preview\`.
-</Note>
+<Warning>
+Python library documentation is not yet supported with \`fern docs dev\`. This feature will be added in a future release. To view the generated documentation, run \`fern generate --docs --preview\`.
+</Warning>
 
 ## About Python Library Docs
 
@@ -1406,10 +1406,6 @@ The generated documentation will replace this placeholder page with complete API
 - Class and function references
 - Type annotations and signatures
 - Docstring content
-
-## Local Development
-
-During local development with \`fern docs dev\`, this placeholder is shown because the Python documentation generation requires server-side processing that is only available during the full docs generation process.
 `;
 
         this.parsedDocsConfig.pages[RelativeFilePath.of(syntheticPageId)] = placeholderMarkdown;

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -1373,10 +1373,8 @@ export class DocsDefinitionResolver {
 title: ${title}
 ---
 
-# ${title}
-
 <Note>
-This is a placeholder page. Python library documentation is automatically generated when you run \`fern generate --docs\`.
+This is a placeholder page. Python library documentation is automatically generated when you run \`fern generate --docs\` or \`fern generate --docs --preview\`.
 </Note>
 
 ## About Python Library Docs
@@ -1394,6 +1392,12 @@ To generate the full Python library documentation, run:
 
 \`\`\`bash
 fern generate --docs
+\`\`\`
+
+Or to preview without publishing:
+
+\`\`\`bash
+fern generate --docs --preview
 \`\`\`
 
 The generated documentation will replace this placeholder page with complete API reference content including:


### PR DESCRIPTION
When running `fern docs dev`, Python library documentation cannot be generated since it requires server-side processing via FDR. This change adds a helpful placeholder page that:

- Explains why Python docs are not available in dev mode
- Shows the GitHub URL being used for the library
- Provides instructions on how to generate the full docs
- Lists what content will be generated

The placeholder page is visible in dev mode but is marked as noindex to prevent search engine indexing. In production mode, FDR replaces this placeholder with the actual generated documentation.


## Testing
Tested locally: 
<img width="1728" height="1117" alt="Screenshot 2026-01-14 at 11 01 48 AM" src="https://github.com/user-attachments/assets/9f8aaeba-3b92-4332-a0a3-8e87dbedbbc4" />

