### PR TITLE
feat(ruby): add support for `additional_query_parameters` in request options

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/http/base_request.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/http/base_request.Template.rb
@@ -22,10 +22,16 @@ module <%= gem_namespace %>
           @request_options = request_options
         end
 
+        # @return [Hash] The query parameters merged with additional query parameters from request options.
+        def encode_query
+          additional_query = @request_options&.dig(:additional_query_parameters) || @request_options&.dig("additional_query_parameters") || {}
+          @query.merge(additional_query)
+        end
+
         # Child classes should implement:
         # - encode_headers: Returns the encoded HTTP request headers.
         # - encode_body: Returns the encoded HTTP request body.
       end
     end
   end
-end 
+end  

--- a/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
@@ -47,17 +47,19 @@ module <%= gem_namespace %>
         # @param request [<%= gem_namespace %>::Internal::Http::BaseRequest] The HTTP request.
         # @return [URI::Generic] The URL.
         def build_url(request)
+          encoded_query = request.encode_query
+
           # If the path is already an absolute URL, use it directly
           if request.path.start_with?("http://", "https://")
             url = request.path
-            url = "#{url}?#{encode_query(request.query)}" if request.query&.any?
+            url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
             return URI.parse(url)
           end
 
           path = request.path.start_with?("/") ? request.path[1..] : request.path
           base = request.base_url || @base_url
           url = "#{base.chomp("/")}/#{path}"
-          url = "#{url}?#{encode_query(request.query)}" if request.query&.any?
+          url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
           URI.parse(url)
         end
 
@@ -113,4 +115,4 @@ module <%= gem_namespace %>
       end
     end
   end
-end                                
+end                                                                

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc79
+  changelogEntry:
+    - summary: |
+        Add support for additional_query_parameters in request options. Users can now pass
+        additional query parameters via request_options[:additional_query_parameters] which
+        will be merged with the endpoint's query parameters when making HTTP requests.
+      type: feat
+  createdAt: "2026-01-14"
+  irVersion: 61
+
 - version: 1.0.0-rc78
   changelogEntry:
     - summary: Update Dockerfile to use the latest generator-cli with improve reference.md generation.

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/http/base_request.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/http/base_request.rb
@@ -22,6 +22,12 @@ module Seed
           @request_options = request_options
         end
 
+        # @return [Hash] The query parameters merged with additional query parameters from request options.
+        def encode_query
+          additional_query = @request_options&.dig(:additional_query_parameters) || @request_options&.dig("additional_query_parameters") || {}
+          @query.merge(additional_query)
+        end
+
         # Child classes should implement:
         # - encode_headers: Returns the encoded HTTP request headers.
         # - encode_body: Returns the encoded HTTP request body.

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/http/raw_client.rb
@@ -47,17 +47,19 @@ module Seed
         # @param request [Seed::Internal::Http::BaseRequest] The HTTP request.
         # @return [URI::Generic] The URL.
         def build_url(request)
+          encoded_query = request.encode_query
+
           # If the path is already an absolute URL, use it directly
           if request.path.start_with?("http://", "https://")
             url = request.path
-            url = "#{url}?#{encode_query(request.query)}" if request.query&.any?
+            url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
             return URI.parse(url)
           end
 
           path = request.path.start_with?("/") ? request.path[1..] : request.path
           base = request.base_url || @base_url
           url = "#{base.chomp("/")}/#{path}"
-          url = "#{url}?#{encode_query(request.query)}" if request.query&.any?
+          url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
           URI.parse(url)
         end
 

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/http/base_request.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/http/base_request.rb
@@ -22,6 +22,12 @@ module Seed
           @request_options = request_options
         end
 
+        # @return [Hash] The query parameters merged with additional query parameters from request options.
+        def encode_query
+          additional_query = @request_options&.dig(:additional_query_parameters) || @request_options&.dig("additional_query_parameters") || {}
+          @query.merge(additional_query)
+        end
+
         # Child classes should implement:
         # - encode_headers: Returns the encoded HTTP request headers.
         # - encode_body: Returns the encoded HTTP request body.

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/http/raw_client.rb
@@ -47,17 +47,19 @@ module Seed
         # @param request [Seed::Internal::Http::BaseRequest] The HTTP request.
         # @return [URI::Generic] The URL.
         def build_url(request)
+          encoded_query = request.encode_query
+
           # If the path is already an absolute URL, use it directly
           if request.path.start_with?("http://", "https://")
             url = request.path
-            url = "#{url}?#{encode_query(request.query)}" if request.query&.any?
+            url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
             return URI.parse(url)
           end
 
           path = request.path.start_with?("/") ? request.path[1..] : request.path
           base = request.base_url || @base_url
           url = "#{base.chomp("/")}/#{path}"
-          url = "#{url}?#{encode_query(request.query)}" if request.query&.any?
+          url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
           URI.parse(url)
         end
 


### PR DESCRIPTION
## Description

Refs: Requested by @iamnamananand996

Implements the `additional_query_parameters` request option for the Ruby v2 SDK generator. This feature was already documented in the generated SDK but not actually implemented.

[Link to Devin run](https://app.devin.ai/sessions/5861c4ab1db74421bae32daef6f4e2bb)

## Changes Made

- Added `encode_query` method to `BaseRequest` class that merges `additional_query_parameters` from request options with the endpoint's query parameters
- Updated `RawClient.build_url` to use the new `encode_query` method instead of directly accessing `request.query`
- Added changelog entry for version 1.0.0-rc79
- Regenerated seed tests for `imdb` and `query-parameters` fixtures

This follows the same pattern as the existing `additional_headers` implementation in `encode_headers`.

## Testing

- [x] Lint checks passed (`pnpm run check`)
- [x] Seed tests regenerated and passing (`imdb`, `query-parameters` fixtures)
- [ ] Unit tests added/updated (no new tests added - relies on existing patterns)

## Human Review Checklist

- [x] Verify the `encode_query` method correctly handles both symbol (`:additional_query_parameters`) and string (`"additional_query_parameters"`) keys - **Uses same pattern as `additional_headers`**
- [x] Confirm the merge order is correct (additional params should override base params if there are conflicts) - **`Hash#merge` gives precedence to argument hash**
- [ ] Consider if wire tests should be added to verify the feature works end-to-end - **Not added; follows existing patterns**