### PR TITLE
chore(java): optimize IR parsing and parallelize code generation

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -48,6 +48,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -344,7 +345,7 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         }
     }
 
-    private final List<GeneratedFile> generatedFiles = new ArrayList<>();
+    private final List<GeneratedFile> generatedFiles = Collections.synchronizedList(new ArrayList<>());
 
     private Path outputDirectory = null;
 

--- a/generators/java/sdk/src/main/java/com/fern/java/client/Cli.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/Cli.java
@@ -432,9 +432,9 @@ public final class Cli extends AbstractGeneratorCli<JavaSdkCustomConfig, JavaSdk
 
         generatedInferredAuthTokenSupplier.ifPresent(this::addGeneratedFile);
 
-        // subpackage clients and their WebSocket channels
+        // subpackage clients and their WebSocket channels - parallelized for performance
         log(generatorExecClient, "Generating API client classes");
-        ir.getSubpackages().values().forEach(subpackage -> {
+        ir.getSubpackages().values().parallelStream().forEach(subpackage -> {
             // Generate subpackage clients if there are endpoints or WebSocket channels
             if (subpackage.getHasEndpointsInTree() || subpackage.getWebsocket().isPresent()) {
                 AbstractSubpackageClientGenerator syncServiceClientGenerator = new SyncSubpackageClientGenerator(

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -6,7 +6,7 @@
         JSON tree in memory. This reduces memory usage significantly for large API specifications.
         Also adds JVM tuning flags (-Xms4g, G1GC configuration) for improved garbage collection
         performance during local seed testing.
-      type: feat
+      type: chore
   createdAt: "2026-01-14"
   irVersion: 63
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -7,6 +7,12 @@
         Also adds JVM tuning flags (-Xms4g, G1GC configuration) for improved garbage collection
         performance during local seed testing.
       type: chore
+    - summary: |
+        Parallelize code generation for improved performance on multi-core machines. Type generation,
+        interface generation, and subpackage client generation now run in parallel using Java parallel
+        streams. This can significantly reduce generation time for large API specifications with many
+        types and endpoints.
+      type: chore
   createdAt: "2026-01-14"
   irVersion: 63
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.28.3
+  changelogEntry:
+    - summary: |
+        Optimize IR parsing performance by using streaming JSON parsing instead of building the full
+        JSON tree in memory. This reduces memory usage significantly for large API specifications.
+        Also adds JVM tuning flags (-Xms4g, G1GC configuration) for improved garbage collection
+        performance during local seed testing.
+      type: feat
+  createdAt: "2026-01-14"
+  irVersion: 63
+
 - version: 3.28.2
   changelogEntry:
     - summary: Update Dockerfile to use the latest generator-cli with improve reference.md generation.

--- a/seed/java-sdk/seed.yml
+++ b/seed/java-sdk/seed.yml
@@ -43,7 +43,7 @@ test:
       - chmod +x install-gradle.sh && ./install-gradle.sh
       - cd sdk && tar -xvf build/distributions/sdk.tar -C .
       - pnpm turbo run compile --filter @fern-api/java-sdk && pnpm turbo run dist:cli --filter @fern-api/java-sdk
-    runCommand: cd sdk/sdk && java -cp sdk.jar:lib/* com.fern.java.client.Cli {CONFIG_PATH}
+    runCommand: cd sdk/sdk && java -Xms4g -XX:G1HeapRegionSize=16m -XX:MaxGCPauseMillis=100 -XX:InitiatingHeapOccupancyPercent=35 -cp sdk.jar:lib/* com.fern.java.client.Cli {CONFIG_PATH}
     env:
       # Path to Node.js executable (uses system node)
       NODE_PATH: node


### PR DESCRIPTION
## Description

Refs: JFR profile analysis for Java generator performance

Optimizes the Java generator's IR parsing to reduce memory usage and improve GC performance, and parallelizes code generation for improved performance on multi-core machines when processing large API specifications.

**Link to Devin run**: https://app.devin.ai/sessions/1a0c74a7bfa84d09aa0e17f58d9618c8
**Requested by**: @tjb9dc

## Changes Made

### Streaming IR Parsing
- Replaced tree-based JSON parsing (`readTree()` + `treeToValue()`) with Jackson streaming API in `AbstractGeneratorCli.getIr()`
- The streaming approach transforms `{"integer": overflow_value}` to `{"long": value}` on-the-fly during parsing
- Uses `BigInteger` to safely handle numeric values that may exceed long range (e.g., `9223372036854776000`)

### JVM Tuning
- Added JVM tuning flags to seed.yml for local testing: `-Xms4g -XX:G1HeapRegionSize=16m -XX:MaxGCPauseMillis=100 -XX:InitiatingHeapOccupancyPercent=35`

### Parallel Code Generation
- Made `generatedFiles` list thread-safe using `Collections.synchronizedList()`
- Parallelized type generation in `TypesGenerator.generateFiles()` using parallel streams
- Parallelized interface generation in `TypesGenerator.getGeneratedInterfaces()` using parallel streams
- Parallelized subpackage client generation in `Cli.java` using parallel streams

### Version
- Bumped version to 3.28.3

## Updates Since Last Revision

- Added parallelization of code generation (types, interfaces, subpackage clients) for improved performance on multi-core machines
- Made `generatedFiles` list thread-safe to support parallel generation

## Human Review Checklist

- [ ] **Integer overflow handling**: The streaming approach only converts `{"integer": overflow_value}` fields. The old `IntegerOverflowProcessor` also handled overflow values in arbitrary fields and array elements. Please verify this behavioral change is acceptable.
- [ ] **Memory optimization**: The implementation still buffers the transformed JSON in a `ByteArrayOutputStream` before parsing. This reduces object overhead vs tree model but isn't true end-to-end streaming.
- [ ] **JVM flags scope**: The JVM flags only apply to local seed testing (`seed.yml`), not production Docker runs.
- [ ] **Parallel generation thread safety**: Verify that `Collections.synchronizedList()` is sufficient for thread-safe file collection. No other shared mutable state should be accessed during parallel generation.
- [ ] **Non-deterministic output order**: Parallel streams don't guarantee order. Verify that generated file order doesn't affect the final output.

## Testing

- [ ] Unit tests added/updated
- [x] Lint checks passed (`pnpm run check`, `./gradlew compileJava`)
- [ ] Manual testing with large API spec (user to test with `pnpm seed:local run --generator java-sdk --path ~/Projects/twilio-core-fern-config/fern/apis/core`)
- [ ] Performance comparison with JFR profiling before/after parallelization