### PR TITLE
fix(cli): rename java-model generator to fern-java-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Fern's model generators will output schemas or types defined in your OpenAPI spe
 | Generator ID                  | Latest Version                                                                                   | Entrypoint                                                                    |
 | ----------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
 | `fernapi/fern-pydantic-model` | ![Pydantic Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-pydantic-model) | [cli.py](./generators/python/src/fern_python/generators/sdk/cli.py)           |
-| `fernapi/java-model`          | ![Java Model Generator Version](https://img.shields.io/docker/v/fernapi/java-model)              | [Cli.java](./generators/java/sdk/src/main/java/com/fern/java/client/Cli.java) |
+| `fernapi/fern-java-model`     | ![Java Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-java-model)         | [Cli.java](./generators/java/sdk/src/main/java/com/fern/java/client/Cli.java) |
 | `fernapi/fern-ruby-model`     | ![Ruby Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-ruby-model)         | [cli.ts](./generators/ruby/model/src/cli.ts)                                  |
 | `fernapi/fern-go-model`       | ![Go Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-go-model)             | [main.go](./generators/go/cmd/fern-go-model/main.go)                          |
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.1
+  changelogEntry:
+    - summary: |
+        Rename java-model generator to fern-java-model.
+      type: fix
+  createdAt: "2026-01-14"
+  irVersion: 63
+
 - version: 3.42.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/GeneratorName.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/GeneratorName.ts
@@ -5,7 +5,7 @@ export const GeneratorName = {
     TYPESCRIPT_BROWSER_SDK: "fernapi/fern-typescript-browser-sdk",
     TYPESCRIPT_EXPRESS: "fernapi/fern-typescript-express",
     JAVA: "fernapi/fern-java",
-    JAVA_MODEL: "fernapi/java-model",
+    JAVA_MODEL: "fernapi/fern-java-model",
     JAVA_SDK: "fernapi/fern-java-sdk",
     JAVA_SPRING: "fernapi/fern-java-spring",
     PYTHON_FASTAPI: "fernapi/fern-fastapi-server",

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
@@ -73,7 +73,7 @@ function getGeneratorMetadataFromName(generatorName: string, context?: TaskConte
         // Java
         case "fern-java-sdk":
             return "java-sdk";
-        case "java-model":
+        case "fern-java-model":
             return "java-model";
         case "fern-java-spring":
             return "java-spring";

--- a/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
@@ -38,7 +38,7 @@ groups:
           noOptionalProperties: true
   java:
     generators:
-      - name: fernapi/java-model
+      - name: fernapi/fern-java-model
         version: 1.8.5
         output:
           location: maven


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

The java-model generator was the only generator missing the `fern-` prefix in it name. Docker images for versions 1.1.0+ are only published to `fernapi/fern-java-model`, but the CLI was configured to use `fernapi/java-model`, causing IR SDK releases to fail.

- Update GeneratorName.ts to use fernapi/fern-java-model
- Update ir-types-latest/generators.yml to use the correct name
- Update README.md generator table

Existing customer configs using `fernapi/java-model` will continue to work via the backend alias configuration.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
