### PR TITLE
chore(ci): bump fetch depth on prod publish

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 20
 
       - name: Install
         uses: ./.github/actions/install


### PR DESCRIPTION
The prod job in the CLI publish workflow was silently skipping releases due to insufficient git history.
The workflow used fetch-depth: 2, creating a shallow clone with only 2 commits. The version comparison script runs:

> `previous_commit=$(git log -n 2 --pretty=format:"%h" -- packages/cli/cli/versions.yml | tail -n 1)`

With a shallow clone, if only one commit in that limited history touched versions.yml, then previous_commit equals current_commit. Both point to the same file contents, so the diff finds nothing new to publish:

> `Preview of the previous file (da6591a10)- version: 3.41.0Preview of the current file (da6591a10)- version: 3.41.0[Publish]: No new version to publish. Skipping.`

This bump fetch depth to the past 20 commits, a reasonable number based on our CLI release history:

> The data shows very frequent CLI releases. The maximum gap in the last 50 releases is only 17 commits (Gap 23). Most gaps are 1-7 commits.
> Summary:
> - Max gap seen: 17 commits
> - Average gap: ~3-4 commits
> - This repo releases the CLI with almost every feature PR
