### PR TITLE
feat(java): add backward-compatible builder() method for OAuth client credentials

### DIFF
--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -195,7 +195,8 @@ This SDK supports two authentication methods:
 If you already have a valid access token, you can use it directly:
 
 \`\`\`java
-${clientClassName} client = ${clientClassName}.withToken("your-access-token")
+${clientClassName} client = ${clientClassName}.builder()
+    .token("your-access-token")
     .url("https://api.example.com")
     .build();
 \`\`\`
@@ -205,7 +206,8 @@ ${clientClassName} client = ${clientClassName}.withToken("your-access-token")
 The SDK can automatically handle token acquisition and refresh:
 
 \`\`\`java
-${clientClassName} client = ${clientClassName}.withCredentials("client-id", "client-secret")
+${clientClassName} client = ${clientClassName}.builder()
+    .credentials("client-id", "client-secret")
     .url("https://api.example.com")
     .build();
 \`\`\``;

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -283,6 +283,7 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
             // For staged builder, add static factory methods that delegate to builder class
             ClassName tokenAuthClassName = builderName.nestedClass("_TokenAuth");
             ClassName credentialsAuthClassName = builderName.nestedClass("_CredentialsAuth");
+            ClassName builderStageClassName = builderName.nestedClass("_Builder");
 
             result.getClientImpl()
                     .addMethod(MethodSpec.methodBuilder("withToken")
@@ -306,6 +307,15 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                             .addParameter(String.class, "clientSecret")
                             .returns(credentialsAuthClassName)
                             .addStatement("return $T.withCredentials(clientId, clientSecret)", builderName)
+                            .build());
+
+            result.getClientImpl()
+                    .addMethod(MethodSpec.methodBuilder("builder")
+                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                            .addJavadoc("Creates a new client builder.\n")
+                            .addJavadoc("@return A builder for configuring and creating the client")
+                            .returns(builderStageClassName)
+                            .addStatement("return $T.builder()", builderName)
                             .build());
         } else {
             result.getClientImpl()
@@ -1463,6 +1473,55 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                         .addStatement("return new _CredentialsAuth(clientId, clientSecret)");
 
                 clientBuilder.addMethod(withCredentialsMethod.build());
+
+                // Add builder() factory method to base builder
+                ClassName builderStageClassName = builderName.nestedClass("_Builder");
+                clientBuilder.addMethod(MethodSpec.methodBuilder("builder")
+                        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                        .addJavadoc("Creates a new client builder.\n")
+                        .addJavadoc("Use this method to start building a client with the classic builder pattern.\n")
+                        .addJavadoc("\n")
+                        .addJavadoc("@return A builder for configuring authentication and creating the client")
+                        .returns(builderStageClassName)
+                        .addStatement("return new _Builder()")
+                        .build());
+
+                // Create _Builder nested class with token() and credentials() methods
+                TypeSpec.Builder builderStageBuilder = TypeSpec.classBuilder("_Builder")
+                        .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
+
+                // Add token() method that returns _TokenAuth
+                builderStageBuilder.addMethod(MethodSpec.methodBuilder("token")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addJavadoc("Configure the client to use a pre-generated access token for authentication.\n")
+                        .addJavadoc("Use this when you already have a valid access token and want to bypass\n")
+                        .addJavadoc("the OAuth client credentials flow.\n")
+                        .addJavadoc("\n")
+                        .addJavadoc(
+                                "@param $L The access token to use for Authorization header\n",
+                                tokenOverridePropertyName)
+                        .addJavadoc("@return A builder configured for token authentication")
+                        .addParameter(String.class, tokenOverridePropertyName)
+                        .returns(tokenAuthClassName)
+                        .addStatement("return new _TokenAuth($L)", tokenOverridePropertyName)
+                        .build());
+
+                // Add credentials() method that returns _CredentialsAuth
+                builderStageBuilder.addMethod(MethodSpec.methodBuilder("credentials")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addJavadoc("Configure the client to use OAuth client credentials for authentication.\n")
+                        .addJavadoc("The builder will automatically handle token acquisition and refresh.\n")
+                        .addJavadoc("\n")
+                        .addJavadoc("@param clientId The OAuth client ID\n")
+                        .addJavadoc("@param clientSecret The OAuth client secret\n")
+                        .addJavadoc("@return A builder configured for OAuth client credentials authentication")
+                        .addParameter(String.class, "clientId")
+                        .addParameter(String.class, "clientSecret")
+                        .returns(credentialsAuthClassName)
+                        .addStatement("return new _CredentialsAuth(clientId, clientSecret)")
+                        .build());
+
+                clientBuilder.addType(builderStageBuilder.build());
 
                 // Make configureAuthMethod empty for base class (subclasses override)
                 if (configureAuthMethod != null) {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.28.3
+  changelogEntry:
+    - summary: |
+        Add backward-compatible `builder()` method for OAuth client credentials authentication.
+        This restores support for the classic builder pattern `Client.builder().token("...")` and
+        `Client.builder().credentials("...", "...")` alongside the existing `withToken()` and
+        `withCredentials()` shortcuts. This prevents breaking changes for customers who upgraded.
+      type: feat
+  createdAt: "2026-01-14"
+  irVersion: 63
+
 - version: 3.28.2
   changelogEntry:
     - summary: Update Dockerfile to use the latest generator-cli with improve reference.md generation.

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.28.3
+- version: 3.29.0
   changelogEntry:
     - summary: |
         Add backward-compatible `builder()` method for OAuth client credentials authentication.

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/README.md
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/README.md
@@ -84,7 +84,8 @@ This SDK supports two authentication methods:
 If you already have a valid access token, you can use it directly:
 
 ```java
-SeedOauthClientCredentialsClient client = SeedOauthClientCredentialsClient.withToken("your-access-token")
+SeedOauthClientCredentialsClient client = SeedOauthClientCredentialsClient.builder()
+    .token("your-access-token")
     .url("https://api.example.com")
     .build();
 ```
@@ -94,7 +95,8 @@ SeedOauthClientCredentialsClient client = SeedOauthClientCredentialsClient.withT
 The SDK can automatically handle token acquisition and refresh:
 
 ```java
-SeedOauthClientCredentialsClient client = SeedOauthClientCredentialsClient.withCredentials("client-id", "client-secret")
+SeedOauthClientCredentialsClient client = SeedOauthClientCredentialsClient.builder()
+    .credentials("client-id", "client-secret")
     .url("https://api.example.com")
     .build();
 ```

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClient.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClient.java
@@ -65,4 +65,12 @@ public class AsyncSeedOauthClientCredentialsClient {
             String clientId, String clientSecret) {
         return AsyncSeedOauthClientCredentialsClientBuilder.withCredentials(clientId, clientSecret);
     }
+
+    /**
+     * Creates a new client builder.
+     * @return A builder for configuring and creating the client
+     */
+    public static AsyncSeedOauthClientCredentialsClientBuilder._Builder builder() {
+        return AsyncSeedOauthClientCredentialsClientBuilder.builder();
+    }
 }

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClientBuilder.java
@@ -47,6 +47,16 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
         return new _CredentialsAuth(clientId, clientSecret);
     }
 
+    /**
+     * Creates a new client builder.
+     * Use this method to start building a client with the classic builder pattern.
+     *
+     * @return A builder for configuring authentication and creating the client
+     */
+    public static _Builder builder() {
+        return new _Builder();
+    }
+
     public AsyncSeedOauthClientCredentialsClientBuilder url(String url) {
         this.environment = Environment.custom(url);
         return this;
@@ -248,6 +258,32 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
                     .addHeader("Authorization", oAuthTokenSupplier)
                     .build();
             return new AsyncSeedOauthClientCredentialsClient(finalOptions);
+        }
+    }
+
+    public static final class _Builder {
+        /**
+         * Configure the client to use a pre-generated access token for authentication.
+         * Use this when you already have a valid access token and want to bypass
+         * the OAuth client credentials flow.
+         *
+         * @param token The access token to use for Authorization header
+         * @return A builder configured for token authentication
+         */
+        public _TokenAuth token(String token) {
+            return new _TokenAuth(token);
+        }
+
+        /**
+         * Configure the client to use OAuth client credentials for authentication.
+         * The builder will automatically handle token acquisition and refresh.
+         *
+         * @param clientId The OAuth client ID
+         * @param clientSecret The OAuth client secret
+         * @return A builder configured for OAuth client credentials authentication
+         */
+        public _CredentialsAuth credentials(String clientId, String clientSecret) {
+            return new _CredentialsAuth(clientId, clientSecret);
         }
     }
 }

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClient.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClient.java
@@ -65,4 +65,12 @@ public class SeedOauthClientCredentialsClient {
             String clientId, String clientSecret) {
         return SeedOauthClientCredentialsClientBuilder.withCredentials(clientId, clientSecret);
     }
+
+    /**
+     * Creates a new client builder.
+     * @return A builder for configuring and creating the client
+     */
+    public static SeedOauthClientCredentialsClientBuilder._Builder builder() {
+        return SeedOauthClientCredentialsClientBuilder.builder();
+    }
 }

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClientBuilder.java
@@ -47,6 +47,16 @@ public class SeedOauthClientCredentialsClientBuilder {
         return new _CredentialsAuth(clientId, clientSecret);
     }
 
+    /**
+     * Creates a new client builder.
+     * Use this method to start building a client with the classic builder pattern.
+     *
+     * @return A builder for configuring authentication and creating the client
+     */
+    public static _Builder builder() {
+        return new _Builder();
+    }
+
     public SeedOauthClientCredentialsClientBuilder url(String url) {
         this.environment = Environment.custom(url);
         return this;
@@ -248,6 +258,32 @@ public class SeedOauthClientCredentialsClientBuilder {
                     .addHeader("Authorization", oAuthTokenSupplier)
                     .build();
             return new SeedOauthClientCredentialsClient(finalOptions);
+        }
+    }
+
+    public static final class _Builder {
+        /**
+         * Configure the client to use a pre-generated access token for authentication.
+         * Use this when you already have a valid access token and want to bypass
+         * the OAuth client credentials flow.
+         *
+         * @param token The access token to use for Authorization header
+         * @return A builder configured for token authentication
+         */
+        public _TokenAuth token(String token) {
+            return new _TokenAuth(token);
+        }
+
+        /**
+         * Configure the client to use OAuth client credentials for authentication.
+         * The builder will automatically handle token acquisition and refresh.
+         *
+         * @param clientId The OAuth client ID
+         * @param clientSecret The OAuth client secret
+         * @return A builder configured for OAuth client credentials authentication
+         */
+        public _CredentialsAuth credentials(String clientId, String clientSecret) {
+            return new _CredentialsAuth(clientId, clientSecret);
         }
     }
 }


### PR DESCRIPTION
## Description

Refs: Slack thread from @tstanmay13

This PR restores backward compatibility for the Java SDK OAuth client builder pattern. A recent change switched from `Client.builder().token("...")` to `Client.withToken("...")`, which broke existing customers who upgraded. This adds support for the classic builder pattern while keeping the new shortcuts.

Link to Devin run: https://app.devin.ai/sessions/0242ece003fd4dd8877c0c87e13df85e
Requested by: @tstanmay13

## Changes Made

- Added `builder()` static method on OAuth client classes that returns a new `_Builder` stage class
- Created `_Builder` nested class with `token()` and `credentials()` methods that delegate to `_TokenAuth` and `_CredentialsAuth` respectively
- [x] Updated README.md generator to show the classic `builder().token()` pattern in authentication documentation
- Added changelog entry for version 3.29.0

Both patterns now work:
```java
// Classic pattern (restored)
Client.builder().token("...").build()
Client.builder().credentials("...", "...").build()

// Shortcut pattern (still available)
Client.withToken("...").build()
Client.withCredentials("...", "...").build()
```

## Testing

- [x] Ran `pnpm seed test --generator java-sdk --fixture oauth-client-credentials` - passed
- [x] Lint checks passed (`pnpm run check`)

## Updates Since Last Revision

- Fixed version number from 3.28.3 to 3.29.0 (semver requires minor version bump for `feat` type changes)

## Human Review Checklist

- [ ] Verify the `_Builder` class is correctly accessible as a public static nested class
- [ ] Confirm both sync and async client builders have the new `builder()` method
- [ ] Check that existing `withToken()` and `withCredentials()` shortcuts are preserved
- [ ] Verify version 3.29.0 is appropriate for this feature addition