### PR TITLE
fix(cli): skip AsyncAPI JSON files in no-non-component-refs validation rule

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.2
+  changelogEntry:
+    - summary: |
+        Fix `fern check` to properly skip AsyncAPI JSON files in the `no-non-component-refs` validation rule. The rule now detects AsyncAPI specs in both YAML format (`asyncapi:`) and JSON format (`"asyncapi"`) to avoid false positive validation errors about non-component references.
+      type: fix
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.42.1
   changelogEntry:
     - summary: |

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
@@ -38,7 +38,9 @@ export const NoNonComponentRefsRule: Rule = {
                                     }
 
                                     // Skip AsyncAPI files - they have different reference patterns than OpenAPI
-                                    const isAsyncAPI = contents.includes("asyncapi:");
+                                    // Check for both YAML format (asyncapi:) and JSON format ("asyncapi")
+                                    const isAsyncAPI =
+                                        contents.includes("asyncapi:") || contents.includes('"asyncapi"');
                                     if (isAsyncAPI) {
                                         continue; // Skip AsyncAPI files
                                     }


### PR DESCRIPTION
## Description

Fixes false positive validation errors when running `fern check` on projects with AsyncAPI specs in JSON format.

**Link to Devin run:** https://app.devin.ai/sessions/5c145092b34f4184a8cd0e60745a2622
**Requested by:** @fern-support

## Changes Made

- Updated the `no-non-component-refs` validation rule to detect AsyncAPI specs in both YAML format (`asyncapi:`) and JSON format (`"asyncapi"`)
- Previously, only YAML-formatted AsyncAPI files were being skipped, causing JSON-formatted AsyncAPI files to be incorrectly validated as OpenAPI specs and generating 18 false positive errors about non-component references
- Added version 3.42.2 changelog entry

## Testing

- [x] Manual testing completed - verified with [smallest-ai-fern-config](https://github.com/fern-demo/smallest-ai-fern-config) project which has AsyncAPI JSON files
- Before fix: 18 validation errors about non-component refs
- After fix: 0 validation errors
- [ ] Unit tests added/updated

## Human Review Checklist

- [ ] Verify the string matching approach (`contents.includes('"asyncapi"')`) won't cause false positives in edge cases
- [ ] Consider if unit tests should be added for AsyncAPI JSON detection