### PR TITLE
fix(java): support all builder methods in _Builder class for OAuth client credentials

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -1486,12 +1486,117 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                         .addStatement("return new _Builder()")
                         .build());
 
-                // Create _Builder nested class with token() and credentials() methods
+                // Create _Builder nested class with all builder methods plus token() and credentials()
                 TypeSpec.Builder builderStageBuilder = TypeSpec.classBuilder("_Builder")
                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
 
-                // Add token() method that returns _TokenAuth
-                builderStageBuilder.addMethod(MethodSpec.methodBuilder("token")
+                // Add fields to store configuration values
+                builderStageBuilder.addField(FieldSpec.builder(
+                                generatedEnvironmentsClass.getClassName(), "environment")
+                        .addModifiers(Modifier.PRIVATE)
+                        .build());
+
+                builderStageBuilder.addField(FieldSpec.builder(
+                                ParameterizedTypeName.get(ClassName.get(Optional.class), ClassName.get(Integer.class)),
+                                "timeout")
+                        .addModifiers(Modifier.PRIVATE)
+                        .initializer("$T.empty()", Optional.class)
+                        .build());
+
+                builderStageBuilder.addField(FieldSpec.builder(
+                                ParameterizedTypeName.get(ClassName.get(Optional.class), ClassName.get(Integer.class)),
+                                "maxRetries")
+                        .addModifiers(Modifier.PRIVATE)
+                        .initializer("$T.empty()", Optional.class)
+                        .build());
+
+                builderStageBuilder.addField(FieldSpec.builder(OkHttpClient.class, "httpClient")
+                        .addModifiers(Modifier.PRIVATE)
+                        .build());
+
+                builderStageBuilder.addField(FieldSpec.builder(
+                                ParameterizedTypeName.get(
+                                        ClassName.get(Map.class),
+                                        ClassName.get(String.class),
+                                        ClassName.get(String.class)),
+                                "headers")
+                        .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                        .initializer("new $T<>()", HashMap.class)
+                        .build());
+
+                // Add environment() method if environments are present
+                if (generatedEnvironmentsClass.optionsPresent()) {
+                    builderStageBuilder.addMethod(MethodSpec.methodBuilder("environment")
+                            .addModifiers(Modifier.PUBLIC)
+                            .addParameter(generatedEnvironmentsClass.getClassName(), "environment")
+                            .returns(builderStageClassName)
+                            .addStatement("this.environment = environment")
+                            .addStatement("return this")
+                            .build());
+                }
+
+                // Add url() method if single URL environment
+                if (generatedEnvironmentsClass.info() instanceof SingleUrlEnvironmentClass) {
+                    SingleUrlEnvironmentClass singleUrlEnvClass =
+                            ((SingleUrlEnvironmentClass) generatedEnvironmentsClass.info());
+                    builderStageBuilder.addMethod(MethodSpec.methodBuilder("url")
+                            .addModifiers(Modifier.PUBLIC)
+                            .addParameter(String.class, "url")
+                            .returns(builderStageClassName)
+                            .addStatement(
+                                    "this.environment = $T.$N(url)",
+                                    generatedEnvironmentsClass.getClassName(),
+                                    singleUrlEnvClass.getCustomMethod())
+                            .addStatement("return this")
+                            .build());
+                }
+
+                // Add timeout() method
+                builderStageBuilder.addMethod(MethodSpec.methodBuilder("timeout")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addJavadoc("Sets the timeout (in seconds) for the client. Defaults to 60 seconds.")
+                        .addParameter(int.class, "timeout")
+                        .returns(builderStageClassName)
+                        .addStatement("this.timeout = $T.of(timeout)", Optional.class)
+                        .addStatement("return this")
+                        .build());
+
+                // Add maxRetries() method
+                builderStageBuilder.addMethod(MethodSpec.methodBuilder("maxRetries")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addJavadoc("Sets the maximum number of retries for the client. Defaults to 2 retries.")
+                        .addParameter(int.class, "maxRetries")
+                        .returns(builderStageClassName)
+                        .addStatement("this.maxRetries = $T.of(maxRetries)", Optional.class)
+                        .addStatement("return this")
+                        .build());
+
+                // Add httpClient() method
+                builderStageBuilder.addMethod(MethodSpec.methodBuilder("httpClient")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addJavadoc("Sets the underlying OkHttp client")
+                        .addParameter(OkHttpClient.class, "httpClient")
+                        .returns(builderStageClassName)
+                        .addStatement("this.httpClient = httpClient")
+                        .addStatement("return this")
+                        .build());
+
+                // Add addHeader() method
+                builderStageBuilder.addMethod(MethodSpec.methodBuilder("addHeader")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addJavadoc("Add a custom header to be sent with all requests.\n")
+                        .addJavadoc("@param name The header name\n")
+                        .addJavadoc("@param value The header value\n")
+                        .addJavadoc("@return This builder for method chaining")
+                        .addParameter(String.class, "name")
+                        .addParameter(String.class, "value")
+                        .returns(builderStageClassName)
+                        .addStatement("this.headers.put(name, value)")
+                        .addStatement("return this")
+                        .build());
+
+                // Add token() method that returns _TokenAuth with configuration copied using setter methods
+                MethodSpec.Builder tokenMethodBuilder = MethodSpec.methodBuilder("token")
                         .addModifiers(Modifier.PUBLIC)
                         .addJavadoc("Configure the client to use a pre-generated access token for authentication.\n")
                         .addJavadoc("Use this when you already have a valid access token and want to bypass\n")
@@ -1503,11 +1608,27 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                         .addJavadoc("@return A builder configured for token authentication")
                         .addParameter(String.class, tokenOverridePropertyName)
                         .returns(tokenAuthClassName)
-                        .addStatement("return new _TokenAuth($L)", tokenOverridePropertyName)
-                        .build());
+                        .addStatement("_TokenAuth auth = new _TokenAuth($L)", tokenOverridePropertyName)
+                        .beginControlFlow("if (this.environment != null)")
+                        .addStatement("auth.environment = this.environment")
+                        .endControlFlow()
+                        .beginControlFlow("if (this.timeout.isPresent())")
+                        .addStatement("auth.timeout(this.timeout.get())")
+                        .endControlFlow()
+                        .beginControlFlow("if (this.maxRetries.isPresent())")
+                        .addStatement("auth.maxRetries(this.maxRetries.get())")
+                        .endControlFlow()
+                        .beginControlFlow("if (this.httpClient != null)")
+                        .addStatement("auth.httpClient(this.httpClient)")
+                        .endControlFlow()
+                        .beginControlFlow("for ($T.Entry<String, String> header : this.headers.entrySet())", Map.class)
+                        .addStatement("auth.addHeader(header.getKey(), header.getValue())")
+                        .endControlFlow()
+                        .addStatement("return auth");
+                builderStageBuilder.addMethod(tokenMethodBuilder.build());
 
-                // Add credentials() method that returns _CredentialsAuth
-                builderStageBuilder.addMethod(MethodSpec.methodBuilder("credentials")
+                // Add credentials() method that returns _CredentialsAuth with configuration copied using setter methods
+                MethodSpec.Builder credentialsMethodBuilder = MethodSpec.methodBuilder("credentials")
                         .addModifiers(Modifier.PUBLIC)
                         .addJavadoc("Configure the client to use OAuth client credentials for authentication.\n")
                         .addJavadoc("The builder will automatically handle token acquisition and refresh.\n")
@@ -1518,8 +1639,24 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                         .addParameter(String.class, "clientId")
                         .addParameter(String.class, "clientSecret")
                         .returns(credentialsAuthClassName)
-                        .addStatement("return new _CredentialsAuth(clientId, clientSecret)")
-                        .build());
+                        .addStatement("_CredentialsAuth auth = new _CredentialsAuth(clientId, clientSecret)")
+                        .beginControlFlow("if (this.environment != null)")
+                        .addStatement("auth.environment = this.environment")
+                        .endControlFlow()
+                        .beginControlFlow("if (this.timeout.isPresent())")
+                        .addStatement("auth.timeout(this.timeout.get())")
+                        .endControlFlow()
+                        .beginControlFlow("if (this.maxRetries.isPresent())")
+                        .addStatement("auth.maxRetries(this.maxRetries.get())")
+                        .endControlFlow()
+                        .beginControlFlow("if (this.httpClient != null)")
+                        .addStatement("auth.httpClient(this.httpClient)")
+                        .endControlFlow()
+                        .beginControlFlow("for ($T.Entry<String, String> header : this.headers.entrySet())", Map.class)
+                        .addStatement("auth.addHeader(header.getKey(), header.getValue())")
+                        .endControlFlow()
+                        .addStatement("return auth");
+                builderStageBuilder.addMethod(credentialsMethodBuilder.build());
 
                 clientBuilder.addType(builderStageBuilder.build());
 

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -1491,8 +1491,7 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
 
                 // Add fields to store configuration values
-                builderStageBuilder.addField(FieldSpec.builder(
-                                generatedEnvironmentsClass.getClassName(), "environment")
+                builderStageBuilder.addField(FieldSpec.builder(generatedEnvironmentsClass.getClassName(), "environment")
                         .addModifiers(Modifier.PRIVATE)
                         .build());
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.29.1
+  changelogEntry:
+    - summary: |
+        Fix `_Builder` class to support all builder methods (url, timeout, environment, maxRetries,
+        httpClient, addHeader) so method chaining works in any order. This allows customers upgrading
+        from 3.18.x who wrote `builder().url().token()` to continue working without compile errors.
+        Configuration values set on `_Builder` are now properly passed through to `_TokenAuth` and
+        `_CredentialsAuth` when `token()` or `credentials()` is called.
+      type: fix
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.29.0
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/AsyncSeedOauthClientCredentialsClientBuilder.java
@@ -262,6 +262,56 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
     }
 
     public static final class _Builder {
+        private Environment environment;
+
+        private Optional<Integer> timeout = Optional.empty();
+
+        private Optional<Integer> maxRetries = Optional.empty();
+
+        private OkHttpClient httpClient;
+
+        private final Map<String, String> headers = new HashMap<>();
+
+        public _Builder url(String url) {
+            this.environment = Environment.custom(url);
+            return this;
+        }
+
+        /**
+         * Sets the timeout (in seconds) for the client. Defaults to 60 seconds.
+         */
+        public _Builder timeout(int timeout) {
+            this.timeout = Optional.of(timeout);
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of retries for the client. Defaults to 2 retries.
+         */
+        public _Builder maxRetries(int maxRetries) {
+            this.maxRetries = Optional.of(maxRetries);
+            return this;
+        }
+
+        /**
+         * Sets the underlying OkHttp client
+         */
+        public _Builder httpClient(OkHttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        /**
+         * Add a custom header to be sent with all requests.
+         * @param name The header name
+         * @param value The header value
+         * @return This builder for method chaining
+         */
+        public _Builder addHeader(String name, String value) {
+            this.headers.put(name, value);
+            return this;
+        }
+
         /**
          * Configure the client to use a pre-generated access token for authentication.
          * Use this when you already have a valid access token and want to bypass
@@ -271,7 +321,23 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
          * @return A builder configured for token authentication
          */
         public _TokenAuth token(String token) {
-            return new _TokenAuth(token);
+            _TokenAuth auth = new _TokenAuth(token);
+            if (this.environment != null) {
+                auth.environment = this.environment;
+            }
+            if (this.timeout.isPresent()) {
+                auth.timeout(this.timeout.get());
+            }
+            if (this.maxRetries.isPresent()) {
+                auth.maxRetries(this.maxRetries.get());
+            }
+            if (this.httpClient != null) {
+                auth.httpClient(this.httpClient);
+            }
+            for (Map.Entry<String, String> header : this.headers.entrySet()) {
+                auth.addHeader(header.getKey(), header.getValue());
+            }
+            return auth;
         }
 
         /**
@@ -283,7 +349,23 @@ public class AsyncSeedOauthClientCredentialsClientBuilder {
          * @return A builder configured for OAuth client credentials authentication
          */
         public _CredentialsAuth credentials(String clientId, String clientSecret) {
-            return new _CredentialsAuth(clientId, clientSecret);
+            _CredentialsAuth auth = new _CredentialsAuth(clientId, clientSecret);
+            if (this.environment != null) {
+                auth.environment = this.environment;
+            }
+            if (this.timeout.isPresent()) {
+                auth.timeout(this.timeout.get());
+            }
+            if (this.maxRetries.isPresent()) {
+                auth.maxRetries(this.maxRetries.get());
+            }
+            if (this.httpClient != null) {
+                auth.httpClient(this.httpClient);
+            }
+            for (Map.Entry<String, String> header : this.headers.entrySet()) {
+                auth.addHeader(header.getKey(), header.getValue());
+            }
+            return auth;
         }
     }
 }

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/SeedOauthClientCredentialsClientBuilder.java
@@ -262,6 +262,56 @@ public class SeedOauthClientCredentialsClientBuilder {
     }
 
     public static final class _Builder {
+        private Environment environment;
+
+        private Optional<Integer> timeout = Optional.empty();
+
+        private Optional<Integer> maxRetries = Optional.empty();
+
+        private OkHttpClient httpClient;
+
+        private final Map<String, String> headers = new HashMap<>();
+
+        public _Builder url(String url) {
+            this.environment = Environment.custom(url);
+            return this;
+        }
+
+        /**
+         * Sets the timeout (in seconds) for the client. Defaults to 60 seconds.
+         */
+        public _Builder timeout(int timeout) {
+            this.timeout = Optional.of(timeout);
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of retries for the client. Defaults to 2 retries.
+         */
+        public _Builder maxRetries(int maxRetries) {
+            this.maxRetries = Optional.of(maxRetries);
+            return this;
+        }
+
+        /**
+         * Sets the underlying OkHttp client
+         */
+        public _Builder httpClient(OkHttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        /**
+         * Add a custom header to be sent with all requests.
+         * @param name The header name
+         * @param value The header value
+         * @return This builder for method chaining
+         */
+        public _Builder addHeader(String name, String value) {
+            this.headers.put(name, value);
+            return this;
+        }
+
         /**
          * Configure the client to use a pre-generated access token for authentication.
          * Use this when you already have a valid access token and want to bypass
@@ -271,7 +321,23 @@ public class SeedOauthClientCredentialsClientBuilder {
          * @return A builder configured for token authentication
          */
         public _TokenAuth token(String token) {
-            return new _TokenAuth(token);
+            _TokenAuth auth = new _TokenAuth(token);
+            if (this.environment != null) {
+                auth.environment = this.environment;
+            }
+            if (this.timeout.isPresent()) {
+                auth.timeout(this.timeout.get());
+            }
+            if (this.maxRetries.isPresent()) {
+                auth.maxRetries(this.maxRetries.get());
+            }
+            if (this.httpClient != null) {
+                auth.httpClient(this.httpClient);
+            }
+            for (Map.Entry<String, String> header : this.headers.entrySet()) {
+                auth.addHeader(header.getKey(), header.getValue());
+            }
+            return auth;
         }
 
         /**
@@ -283,7 +349,23 @@ public class SeedOauthClientCredentialsClientBuilder {
          * @return A builder configured for OAuth client credentials authentication
          */
         public _CredentialsAuth credentials(String clientId, String clientSecret) {
-            return new _CredentialsAuth(clientId, clientSecret);
+            _CredentialsAuth auth = new _CredentialsAuth(clientId, clientSecret);
+            if (this.environment != null) {
+                auth.environment = this.environment;
+            }
+            if (this.timeout.isPresent()) {
+                auth.timeout(this.timeout.get());
+            }
+            if (this.maxRetries.isPresent()) {
+                auth.maxRetries(this.maxRetries.get());
+            }
+            if (this.httpClient != null) {
+                auth.httpClient(this.httpClient);
+            }
+            for (Map.Entry<String, String> header : this.headers.entrySet()) {
+                auth.addHeader(header.getKey(), header.getValue());
+            }
+            return auth;
         }
     }
 }


### PR DESCRIPTION
## Description

Refs: Slack request from @tstanmay13

**Link to Devin run:** https://app.devin.ai/sessions/410b340fa7244ddda6108ffd4c922d0d

Fixes the `_Builder` class introduced in 3.29.0 to support all builder methods so method chaining works in any order. Previously, `_Builder` only had `token()` and `credentials()` methods, forcing customers to call authentication first. Customers upgrading from 3.18.x who wrote `builder().url().token()` would get compile errors.

## Changes Made

- Added fields to `_Builder` class to store configuration values (environment, timeout, maxRetries, httpClient, headers)
- Added all builder methods to `_Builder`: `url()`, `timeout()`, `environment()`, `maxRetries()`, `httpClient()`, `addHeader()`
- Modified `token()` and `credentials()` methods to copy stored configuration to `_TokenAuth` and `_CredentialsAuth`
- Updated versions.yml to 3.29.1 with changelog entry

## Testing

- [x] Ran `pnpm seed test --generator java-sdk --fixture oauth-client-credentials` - test passes
- [x] Lint checks pass (`pnpm run check`)

## Human Review Checklist

- [ ] Verify the configuration copying logic in `token()` and `credentials()` methods handles edge cases correctly
- [ ] Note: `environment` uses direct field assignment (`auth.environment = this.environment`) while other fields use setter methods - this is intentional because `environment` is a protected field in the parent class