### PR TITLE
fix(java): add notify, notifyAll, wait to reserved method names

### DIFF
--- a/generators/java-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -25,9 +25,11 @@ const RESERVED_NAMES = new Set([
     "import",
     "for",
     "assert",
-    "switch",
-    "getClass"
+    "switch"
 ]);
+
+// Method names that conflict with final methods in Java's Object class
+const RESERVED_METHOD_NAMES = new Set(["getClass", "notify", "notifyAll", "wait"]);
 
 export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGeneratorContext {
     public ir: FernIr.dynamic.DynamicIntermediateRepresentation;
@@ -74,7 +76,12 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
     }
 
     public getMethodName(name: FernIr.Name): string {
-        return this.getName(name.camelCase.safeName);
+        const methodName = name.camelCase.safeName;
+        // Use suffix for reserved method names to match Java v1 generator behavior
+        if (this.isReservedMethodName(methodName)) {
+            return methodName + "_";
+        }
+        return this.getName(methodName);
     }
 
     public getRootClientClassReference(): java.ClassReference {
@@ -445,5 +452,9 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
 
     private isReservedName(name: string): boolean {
         return RESERVED_NAMES.has(name);
+    }
+
+    private isReservedMethodName(name: string): boolean {
+        return RESERVED_METHOD_NAMES.has(name);
     }
 }

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -937,7 +937,8 @@ ${clientClassName} client = ${clientClassName}.builder()
 
         // Get access path to WebSocket client from root client
         const clientAccessParts = fernFilepath.allParts.map(
-            (part: { camelCase: { safeName: string } }) => this.getKeyWordCompatibleMethodName(part.camelCase.safeName) + "()"
+            (part: { camelCase: { safeName: string } }) =>
+                this.getKeyWordCompatibleMethodName(part.camelCase.safeName) + "()"
         );
         const wsClientAccess =
             clientAccessParts.length > 0

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -810,7 +810,9 @@ ${clientClassName} client = ${clientClassName}.builder()
     }
 
     private getAccessFromRootClient(fernFilepath: FernFilepath): java.AstNode {
-        const clientAccessParts = fernFilepath.allParts.map((part) => part.camelCase.safeName + "()");
+        const clientAccessParts = fernFilepath.allParts.map(
+            (part) => this.getKeyWordCompatibleMethodName(part.camelCase.safeName) + "()"
+        );
         return clientAccessParts.length > 0
             ? java.codeblock(`${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME}.${clientAccessParts.join(".")}`)
             : java.codeblock(ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME);
@@ -935,7 +937,7 @@ ${clientClassName} client = ${clientClassName}.builder()
 
         // Get access path to WebSocket client from root client
         const clientAccessParts = fernFilepath.allParts.map(
-            (part: { camelCase: { safeName: string } }) => part.camelCase.safeName + "()"
+            (part: { camelCase: { safeName: string } }) => this.getKeyWordCompatibleMethodName(part.camelCase.safeName) + "()"
         );
         const wsClientAccess =
             clientAccessParts.length > 0
@@ -1078,5 +1080,14 @@ ${clientClassName} client = ${clientClassName}.builder()
         });
 
         return this.renderSnippet(snippet);
+    }
+
+    private static RESERVED_METHOD_NAMES = new Set(["getClass", "notify", "notifyAll", "wait"]);
+
+    private getKeyWordCompatibleMethodName(methodName: string): string {
+        if (ReadmeSnippetBuilder.RESERVED_METHOD_NAMES.has(methodName)) {
+            return methodName + "_";
+        }
+        return methodName;
     }
 }

--- a/generators/java/generator-utils/src/main/java/com/fern/java/utils/KeyWordUtils.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/utils/KeyWordUtils.java
@@ -33,7 +33,7 @@ public final class KeyWordUtils {
             "assert",
             "switch");
 
-    private static final Set<String> RESERVED_METHOD_NAMES = Set.of("getClass");
+    private static final Set<String> RESERVED_METHOD_NAMES = Set.of("getClass", "notify", "notifyAll", "wait");
 
     private KeyWordUtils() {}
 

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractClientGeneratorUtils.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractClientGeneratorUtils.java
@@ -35,6 +35,7 @@ import com.fern.java.client.generators.endpoint.RawHttpEndpointMethodSpecs;
 import com.fern.java.output.GeneratedJavaFile;
 import com.fern.java.output.GeneratedJavaInterface;
 import com.fern.java.output.GeneratedObjectMapper;
+import com.fern.java.utils.KeyWordUtils;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
@@ -373,7 +374,8 @@ public abstract class AbstractClientGeneratorUtils {
     }
 
     private MethodSpec.Builder getBaseSubpackageMethod(Subpackage subpackage, ClassName subpackageClientInterface) {
-        return MethodSpec.methodBuilder(subpackage.getName().getCamelCase().getSafeName())
+        return MethodSpec.methodBuilder(KeyWordUtils.getKeyWordCompatibleMethodName(
+                        subpackage.getName().getCamelCase().getSafeName()))
                 .addModifiers(Modifier.PUBLIC)
                 .returns(subpackageClientInterface);
     }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.29.2
+  changelogEntry:
+    - summary: |
+        Add `notify`, `notifyAll`, and `wait` to reserved method names to prevent generated SDK
+        methods from conflicting with final methods in Java's Object class. This fixes compilation
+        errors when an API has a subpackage named "notify" (e.g., Twilio's Notify API).
+      type: fix
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.29.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes compilation errors in generated Java SDKs when an API has a subpackage named "notify" (or similar names that conflict with Java's `Object` class final methods).

**Link to Devin run:** https://app.devin.ai/sessions/c077da3169cc47a5b2ed4ac9519b6933
**Requested by:** @tjb9dc

## Changes Made

### Java v1 Generator
- Added `notify`, `notifyAll`, and `wait` to `RESERVED_METHOD_NAMES` in `KeyWordUtils.java` - these are final methods in Java's `Object` class that cannot be overridden
- Updated `getBaseSubpackageMethod` in `AbstractClientGeneratorUtils.java` to sanitize subpackage method names using `KeyWordUtils.getKeyWordCompatibleMethodName()`, which appends an underscore suffix to reserved names (e.g., `notify` → `notify_`)
- Added changelog entry for version 3.29.2

### Java v2 Generator (Snippet/Wire Test Generation)
- Added `RESERVED_METHOD_NAMES` set and `isReservedMethodName()` helper in `DynamicSnippetsGeneratorContext.ts`
- Updated `getMethodName()` to use suffix for reserved method names (matching v1 behavior)
- Added `RESERVED_METHOD_NAMES` set and `getKeyWordCompatibleMethodName()` helper in `ReadmeSnippetBuilder.ts`
- Updated `getAccessFromRootClient()` and WebSocket client access to sanitize method names

## Context

The error occurred in Twilio's Java SDK where a subpackage named "notify" generated a method `notify()` that conflicted with `Object.notify()`:

```
error: notify() in TwilioApi cannot override notify() in Object
    public NotifyClient notify() {
                        ^
  overridden method is final
```

## Testing

- [x] Java generator compiles successfully with `./gradlew compileJava`
- [ ] No seed test fixture added (existing pattern follows `getClass` which was already reserved)

## Human Review Checklist

- [ ] Verify the underscore suffix approach (`notify_`) is acceptable for SDK users
- [ ] Note: `RESERVED_METHOD_NAMES` is defined in 3 places (KeyWordUtils.java, DynamicSnippetsGeneratorContext.ts, ReadmeSnippetBuilder.ts) - consider if this should be centralized
- [ ] Check if there are other places in the Java generators that generate method names and might need similar treatment