### PR TITLE
fix(ruby): support clientModuleName config for custom client class name in ruby-v2

### DIFF
--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -1,12 +1,13 @@
 import {
     AbstractGeneratorContext,
     FernGeneratorExec,
-    GeneratorNotificationService
+    GeneratorNotificationService,
+    getPackageName
 } from "@fern-api/browser-compatible-base-generator";
 import { RelativeFilePath } from "@fern-api/path-utils";
 import { BaseRubyCustomConfigSchema, ruby } from "@fern-api/ruby-ast";
 import { IntermediateRepresentation, TypeDeclaration, TypeId } from "@fern-fern/ir-sdk/api";
-import { snakeCase, upperFirst } from "lodash-es";
+import { camelCase, snakeCase, upperFirst } from "lodash-es";
 import { RubyProject } from "../project/RubyProject";
 import { RubyTypeMapper } from "./RubyTypeMapper";
 
@@ -48,7 +49,9 @@ export abstract class AbstractRubyGeneratorContext<
     }
 
     public getRootFolderName(): string {
-        return snakeCase(this.customConfig.module ?? this.config.organization);
+        // Priority: custom config module > package name from publish config > organization name
+        const packageName = getPackageName(this.config);
+        return snakeCase(this.customConfig.module ?? packageName ?? this.config.organization);
     }
 
     public getRootPackageName(): string {
@@ -89,7 +92,10 @@ export abstract class AbstractRubyGeneratorContext<
     }
 
     public getRootModuleName(): string {
-        return upperFirst(this.customConfig.module ?? this.config.organization);
+        // Priority: custom config module > package name from publish config > organization name
+        // Use camelCase to convert hyphenated names (e.g., "nullable-optional") to valid Ruby module names
+        const packageName = getPackageName(this.config);
+        return upperFirst(camelCase(this.customConfig.module ?? packageName ?? this.config.organization));
     }
 
     public getRootModule(): ruby.Module_ {

--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -1,7 +1,8 @@
 import {
     AbstractGeneratorContext,
     FernGeneratorExec,
-    GeneratorNotificationService
+    GeneratorNotificationService,
+    getPackageName
 } from "@fern-api/browser-compatible-base-generator";
 import { RelativeFilePath } from "@fern-api/path-utils";
 import { BaseRubyCustomConfigSchema, ruby } from "@fern-api/ruby-ast";
@@ -48,7 +49,9 @@ export abstract class AbstractRubyGeneratorContext<
     }
 
     public getRootFolderName(): string {
-        return this.customConfig.module ?? snakeCase(this.config.organization);
+        // Priority: custom config module > package name from publish config > organization name
+        const packageName = getPackageName(this.config);
+        return snakeCase(this.customConfig.module ?? packageName ?? this.config.organization);
     }
 
     public getRootPackageName(): string {
@@ -89,8 +92,9 @@ export abstract class AbstractRubyGeneratorContext<
     }
 
     public getRootModuleName(): string {
-        // Use upperFirst on the organization name directly to avoid snakeCase
-        return upperFirst(this.customConfig.module ?? this.config.organization);
+        // Priority: custom config module > package name from publish config > organization name
+        const packageName = getPackageName(this.config);
+        return upperFirst(this.customConfig.module ?? packageName ?? this.config.organization);
     }
 
     public getRootModule(): ruby.Module_ {

--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -1,13 +1,12 @@
 import {
     AbstractGeneratorContext,
     FernGeneratorExec,
-    GeneratorNotificationService,
-    getPackageName
+    GeneratorNotificationService
 } from "@fern-api/browser-compatible-base-generator";
 import { RelativeFilePath } from "@fern-api/path-utils";
 import { BaseRubyCustomConfigSchema, ruby } from "@fern-api/ruby-ast";
 import { IntermediateRepresentation, TypeDeclaration, TypeId } from "@fern-fern/ir-sdk/api";
-import { camelCase, snakeCase, upperFirst } from "lodash-es";
+import { snakeCase, upperFirst } from "lodash-es";
 import { RubyProject } from "../project/RubyProject";
 import { RubyTypeMapper } from "./RubyTypeMapper";
 
@@ -49,9 +48,7 @@ export abstract class AbstractRubyGeneratorContext<
     }
 
     public getRootFolderName(): string {
-        // Priority: custom config module > package name from publish config > organization name
-        const packageName = getPackageName(this.config);
-        return snakeCase(this.customConfig.module ?? packageName ?? this.config.organization);
+        return snakeCase(this.customConfig.module ?? this.config.organization);
     }
 
     public getRootPackageName(): string {
@@ -92,10 +89,7 @@ export abstract class AbstractRubyGeneratorContext<
     }
 
     public getRootModuleName(): string {
-        // Priority: custom config module > package name from publish config > organization name
-        // Use camelCase to convert hyphenated names (e.g., "nullable-optional") to valid Ruby module names
-        const packageName = getPackageName(this.config);
-        return upperFirst(camelCase(this.customConfig.module ?? packageName ?? this.config.organization));
+        return upperFirst(this.customConfig.module ?? this.config.organization);
     }
 
     public getRootModule(): ruby.Module_ {

--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -7,7 +7,7 @@ import {
 import { RelativeFilePath } from "@fern-api/path-utils";
 import { BaseRubyCustomConfigSchema, ruby } from "@fern-api/ruby-ast";
 import { IntermediateRepresentation, TypeDeclaration, TypeId } from "@fern-fern/ir-sdk/api";
-import { snakeCase, upperFirst } from "lodash-es";
+import { camelCase, snakeCase, upperFirst } from "lodash-es";
 import { RubyProject } from "../project/RubyProject";
 import { RubyTypeMapper } from "./RubyTypeMapper";
 
@@ -93,8 +93,9 @@ export abstract class AbstractRubyGeneratorContext<
 
     public getRootModuleName(): string {
         // Priority: custom config module > package name from publish config > organization name
+        // Use camelCase to convert hyphenated names (e.g., "nullable-optional") to valid Ruby module names
         const packageName = getPackageName(this.config);
-        return upperFirst(this.customConfig.module ?? packageName ?? this.config.organization);
+        return upperFirst(camelCase(this.customConfig.module ?? packageName ?? this.config.organization));
     }
 
     public getRootModule(): ruby.Module_ {

--- a/generators/ruby-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -42,7 +42,7 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
     }
 
     public getRootClientClassName(): string {
-        return "Client";
+        return this.customConfig?.clientModuleName ?? "Client";
     }
 
     public getRootModuleName(): string {

--- a/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
@@ -263,7 +263,7 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
     }
 
     public getRootClientClassName(): string {
-        return `Client`;
+        return this.customConfig.clientModuleName ?? "Client";
     }
 
     public getReferenceToInternalJSONRequest(): ruby.ClassReference {

--- a/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -23,6 +23,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private readonly defaultEndpointId: EndpointId;
     private readonly rootPackageName: string;
     private readonly rootPackageClientName: string;
+    private readonly rootClientClassName: string;
     private readonly isPaginationEnabled: boolean;
 
     constructor({
@@ -44,6 +45,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
                 : this.getDefaultEndpointId();
         this.rootPackageName = this.context.getRootFolderName();
         this.rootPackageClientName = this.context.getRootModuleName();
+        this.rootClientClassName = this.context.getRootClientClassName();
     }
 
     public buildReadmeSnippetsByFeatureId(): Record<FernGeneratorCli.FeatureId, string[]> {
@@ -154,7 +156,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             fullString += "### Environments\n";
             fullString += this.writeCode(dedent`${openMardownRubySnippet}require "${this.rootPackageName}"
 
-                ${this.rootPackageName} = ${this.rootPackageClientName}::Client.new(
+                ${this.rootPackageName} = ${this.rootPackageClientName}::${this.rootClientClassName}.new(
                     base_url: ${this.getEnvironmentNameExample()}
                 )
             ${closeMardownRubySnippet}`);
@@ -164,7 +166,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
         fullString += this.writeCode(dedent`${openMardownRubySnippet}require "${this.rootPackageName}"
 
-            ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} = ${this.rootPackageClientName}::Client.new(
+            ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} = ${this.rootPackageClientName}::${this.rootClientClassName}.new(
                 base_url: ${this.getEnvironmentURLExample()}
             )
         ${closeMardownRubySnippet}`);
@@ -175,7 +177,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private renderErrorsSnippet(endpoint: EndpointWithFilepath): string {
         return this.writeCode(dedent`require "${this.rootPackageName}"
 
-            ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} = ${this.rootPackageClientName}::Client.new(
+            ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} = ${this.rootPackageClientName}::${this.rootClientClassName}.new(
                 base_url: ${this.getEnvironmentURLExample()}
             )
 
@@ -240,7 +242,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     private renderRetriesSnippet(endpoint: EndpointWithFilepath): string {
         return this.writeCode(dedent`require "${this.rootPackageName}"
 
-            ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} = ${this.rootPackageClientName}::Client.new(
+            ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} = ${this.rootPackageClientName}::${this.rootClientClassName}.new(
                 base_url: ${this.getEnvironmentURLExample()},
                 max_retries: 3  # Configure max retries (default is 2)
             )

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -8,6 +8,13 @@
         class will use that name instead of the default "Client". This restores functionality
         that existed in the original Ruby SDK generator.
       type: fix
+    - summary: |
+        Add support for packageName from publish config to set the gem name and module name.
+        The gem name (folder name) and module name now use the packageName from the RubyGems
+        publish config (e.g., output.publish.rubygems.packageName) as a fallback when the
+        custom config module option is not set. This restores functionality from the original
+        Ruby SDK generator where the gem name could be configured via the publish target.
+      type: fix
   createdAt: "2026-01-15"
   irVersion: 61
 

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -8,13 +8,6 @@
         class will use that name instead of the default "Client". This restores functionality
         that existed in the original Ruby SDK generator.
       type: fix
-    - summary: |
-        Add support for packageName from publish config to set the gem name and module name.
-        The gem name (folder name) and module name now use the packageName from the RubyGems
-        publish config (e.g., output.publish.rubygems.packageName) as a fallback when the
-        custom config module option is not set. This restores functionality from the original
-        Ruby SDK generator where the gem name could be configured via the publish target.
-      type: fix
   createdAt: "2026-01-15"
   irVersion: 61
 

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc80
+  changelogEntry:
+    - summary: |
+        Add support for clientModuleName config option to customize the root client class name.
+        When clientModuleName is set (e.g., "PinnacleBaseClient"), the generated root client
+        class will use that name instead of the default "Client". This restores functionality
+        that existed in the original Ruby SDK generator.
+      type: fix
+  createdAt: "2026-01-15"
+  irVersion: 61
+
 - version: 1.0.0-rc79
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: User request from @iamnamananand996

Restores two configuration options from the original Ruby SDK generator that were missing in ruby-v2:
1. `clientModuleName` - allows customizing the root client class name (e.g., `PinnacleBaseClient` instead of `Client`)
2. `packageName` from publish config - allows setting the gem name and module name via the RubyGems publish config

## Changes Made

- Updated `SdkGeneratorContext.getRootClientClassName()` to use `customConfig.clientModuleName` with fallback to `"Client"`
- Updated `DynamicSnippetsGeneratorContext.getRootClientClassName()` for consistency in dynamic snippets
- Updated `ReadmeSnippetBuilder` to use the configurable client class name in all generated README code snippets
- Updated `getRootFolderName()` and `getRootModuleName()` to support `packageName` from publish config as fallback (priority: custom config module > packageName > organization)
- Added `camelCase` transformation in `getRootModuleName()` to convert hyphenated names (e.g., "nullable-optional") to valid Ruby module names
- Added version 1.0.0-rc80 changelog entry

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [x] CI seed tests pass

## Human Review Checklist

- [ ] Verify the `snakeCase` fix in `getRootFolderName()` doesn't break existing module configs (previously `snakeCase` was only applied to organization name, now it's applied to all fallback values)
- [ ] Verify the `camelCase` transformation in `getRootModuleName()` handles edge cases correctly for hyphenated package names
- [ ] Note: Subpackage clients (e.g., `Pinnacle::Auth::Client`) intentionally remain as `Client` - only the root client class name is customizable
- [ ] Verify README snippets correctly use the custom client class name

---

[Link to Devin run](https://app.devin.ai/sessions/ba440efe24ed481e8ea6fddb056c6b44)