### PR TITLE
fix(java): correct request declaration fernFilepath in wire test service correction

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
@@ -415,13 +415,17 @@ export class SdkWireTestGenerator {
             // Correct both the endpoint declaration and the request declaration's fernFilepath
             // This ensures that both the service chain (e.g., client.proxy().proxyV1Service())
             // and the request type imports (e.g., FetchServiceRequest) use the correct package
-            const correctedRequest = {
-                ...dynamicEndpoint.request,
-                declaration: {
-                    ...dynamicEndpoint.request.declaration,
-                    fernFilepath: correctedFernFilepath
-                }
-            };
+            // Only inlined requests have a declaration property; body requests do not
+            const correctedRequest =
+                dynamicEndpoint.request.type === "inlined"
+                    ? {
+                          ...dynamicEndpoint.request,
+                          declaration: {
+                              ...dynamicEndpoint.request.declaration,
+                              fernFilepath: correctedFernFilepath
+                          }
+                      }
+                    : dynamicEndpoint.request;
 
             const correctedDynamicEndpoint = {
                 ...dynamicEndpoint,

--- a/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
@@ -385,36 +385,51 @@ export class SdkWireTestGenerator {
             const serviceNamePascal = serviceName;
             const serviceNameLower = expectedServiceName;
 
+            // Build the corrected fernFilepath for the expected service
+            const correctedFernFilepath = {
+                allParts: [
+                    {
+                        originalName: serviceNamePascal,
+                        camelCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
+                        snakeCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
+                        screamingSnakeCase: {
+                            unsafeName: serviceNamePascal.toUpperCase(),
+                            safeName: serviceNamePascal.toUpperCase()
+                        },
+                        pascalCase: { unsafeName: serviceNamePascal, safeName: serviceNamePascal }
+                    }
+                ],
+                packagePath: [],
+                file: {
+                    originalName: serviceNamePascal,
+                    camelCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
+                    snakeCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
+                    screamingSnakeCase: {
+                        unsafeName: serviceNamePascal.toUpperCase(),
+                        safeName: serviceNamePascal.toUpperCase()
+                    },
+                    pascalCase: { unsafeName: serviceNamePascal, safeName: serviceNamePascal }
+                }
+            };
+
+            // Correct both the endpoint declaration and the request declaration's fernFilepath
+            // This ensures that both the service chain (e.g., client.proxy().proxyV1Service())
+            // and the request type imports (e.g., FetchServiceRequest) use the correct package
+            const correctedRequest = {
+                ...dynamicEndpoint.request,
+                declaration: {
+                    ...dynamicEndpoint.request.declaration,
+                    fernFilepath: correctedFernFilepath
+                }
+            };
+
             const correctedDynamicEndpoint = {
                 ...dynamicEndpoint,
                 declaration: {
                     ...dynamicEndpoint.declaration,
-                    fernFilepath: {
-                        allParts: [
-                            {
-                                originalName: serviceNamePascal,
-                                camelCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
-                                snakeCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
-                                screamingSnakeCase: {
-                                    unsafeName: serviceNamePascal.toUpperCase(),
-                                    safeName: serviceNamePascal.toUpperCase()
-                                },
-                                pascalCase: { unsafeName: serviceNamePascal, safeName: serviceNamePascal }
-                            }
-                        ],
-                        packagePath: [],
-                        file: {
-                            originalName: serviceNamePascal,
-                            camelCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
-                            snakeCase: { unsafeName: serviceNameLower, safeName: serviceNameLower },
-                            screamingSnakeCase: {
-                                unsafeName: serviceNamePascal.toUpperCase(),
-                                safeName: serviceNamePascal.toUpperCase()
-                            },
-                            pascalCase: { unsafeName: serviceNamePascal, safeName: serviceNamePascal }
-                        }
-                    }
-                }
+                    fernFilepath: correctedFernFilepath
+                },
+                request: correctedRequest
             };
 
             const originalDynamicEndpoint = dynamicIr.endpoints[endpoint.id];

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.29.3
+  changelogEntry:
+    - summary: |
+        Fix wire test import conflicts when multiple services have types with the same simple name.
+        The service correction logic now also updates the request declaration's fernFilepath,
+        ensuring that request type imports (e.g., FetchServiceRequest) use the correct package
+        when there are naming conflicts across services.
+      type: fix
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.29.2
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/custom-client-class-name/snippet.json
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/custom-dependency/snippet.json
+++ b/seed/java-sdk/exhaustive/custom-dependency/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/custom-error-names/snippet.json
+++ b/seed/java-sdk/exhaustive/custom-error-names/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/custom-license/snippet.json
+++ b/seed/java-sdk/exhaustive/custom-license/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/enable-public-constructors/snippet.json
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/flat-package-layout/snippet.json
+++ b/seed/java-sdk/exhaustive/flat-package-layout/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/snippet.json
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/json-include-non-empty/snippet.json
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/local-files/snippet.json
+++ b/seed/java-sdk/exhaustive/local-files/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/no-custom-config/snippet.json
+++ b/seed/java-sdk/exhaustive/no-custom-config/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/publish-to/snippet.json
+++ b/seed/java-sdk/exhaustive/publish-to/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",

--- a/seed/java-sdk/exhaustive/signed_publish/snippet.json
+++ b/seed/java-sdk/exhaustive/signed_publish/snippet.json
@@ -92,7 +92,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/bar",
@@ -105,7 +105,7 @@
             }
         },
         {
-            "example_identifier": "dab60b6f",
+            "example_identifier": "223a937e",
             "id": {
                 "method": "POST",
                 "path": "/foo/baz",
@@ -144,7 +144,7 @@
             }
         },
         {
-            "example_identifier": "bb5ed0ec",
+            "example_identifier": "d9970e69",
             "id": {
                 "method": "POST",
                 "path": "/http-methods",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "example_identifier": "cd2a85b",
+            "example_identifier": "6ef2f5b0",
             "id": {
                 "method": "PUT",
                 "path": "/http-methods/{id}",
@@ -170,7 +170,7 @@
             }
         },
         {
-            "example_identifier": "29f14718",
+            "example_identifier": "c172f9b8",
             "id": {
                 "method": "PATCH",
                 "path": "/http-methods/{id}",
@@ -196,7 +196,7 @@
             }
         },
         {
-            "example_identifier": "a69fd89f",
+            "example_identifier": "d2cd67c3",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-with-optional-field",
@@ -235,7 +235,7 @@
             }
         },
         {
-            "example_identifier": "45543f",
+            "example_identifier": "406e217",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-optional-field",
@@ -248,7 +248,7 @@
             }
         },
         {
-            "example_identifier": "a61a451c",
+            "example_identifier": "f47a7ce8",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field/{string}",
@@ -261,7 +261,7 @@
             }
         },
         {
-            "example_identifier": "25673284",
+            "example_identifier": "69040cf1",
             "id": {
                 "method": "POST",
                 "path": "/object/get-and-return-nested-with-required-field-list",
@@ -573,7 +573,7 @@
             }
         },
         {
-            "example_identifier": "8afb875f",
+            "example_identifier": "fe3f1d03",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -586,7 +586,7 @@
             }
         },
         {
-            "example_identifier": "24e4c794",
+            "example_identifier": "17e2c1ef",
             "id": {
                 "method": "POST",
                 "path": "/req-bodies/object",
@@ -625,7 +625,7 @@
             }
         },
         {
-            "example_identifier": "9e112462",
+            "example_identifier": "aef36167",
             "id": {
                 "method": "GET",
                 "path": "/no-req-body",


### PR DESCRIPTION
## Description

Refs https://github.com/fern-demo/twilio-core-java-sdk (wire test compilation failures)

Fixes wire test import conflicts when multiple services have types with the same simple name (e.g., `FetchServiceRequest` in both `conversations` and `proxy` packages). The generated wire tests were importing request types from the wrong package, causing compilation errors.

**Root cause:** When correcting service name mismatches in the dynamic IR, only the endpoint declaration's `fernFilepath` was being updated, but not the request declaration's `fernFilepath`. This caused request type imports to use the wrong package.

Link to Devin run: https://app.devin.ai/sessions/5d2a625b7fed4a42a79e4a6398671b6b
Requested by: @tjb9dc

## Changes Made

- Extract `correctedFernFilepath` into a reusable variable in `generateSnippetWithServiceCorrection`
- Create `correctedRequest` that updates `request.declaration.fernFilepath` to match the corrected service
- Handle the `Request` union type correctly: only `inlined` requests have a `declaration` property, `body` requests are passed through unchanged
- Include `correctedRequest` in the `correctedDynamicEndpoint` object
- Updated `versions.yml` with version 3.29.3 changelog entry

## Testing

- [x] Seed tests pass for `java-sdk:exhaustive` (all 12 configurations)
- [x] All CI checks passing
- [ ] Manual testing on twilio-core-java-sdk repo (requires regeneration)

## Human Review Checklist

- [ ] Verify the type guard `dynamicEndpoint.request.type === "inlined"` correctly handles the `Request` union type (only `Inlined` has `declaration`, `Body` does not)
- [ ] Confirm the `example_identifier` changes in snippet.json files are expected (hash changes from different request paths)
- [ ] Consider whether body requests could also have naming conflicts that this fix doesn't address