### PR TITLE
chore(cli): add exclude-apis experimental flag for docs generation

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -3788,6 +3788,16 @@
               "type": "null"
             }
           ]
+        },
+        "exclude-apis": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -1662,6 +1662,11 @@ types:
           Custom styling instructions for AI-generated examples. When provided, these instructions will guide the AI in generating examples that match your preferred style, naming conventions, or domain-specific terminology. Limited to 500 characters.
 
           DEPRECATED: Use the top-level `ai-example-style-instructions` property instead.
+      exclude-apis:
+        type: optional<boolean>
+        availability: pre-release
+        docs: |
+          Experimental flag to exclude API reference sections from documentation generation. When enabled, API reference content will be omitted from the generated documentation.
 
   PlaygroundSettings:
     properties:

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.4
+  changelogEntry:
+    - summary: |
+        Update experimental flag options to support `exclude-apis`
+      type: feat
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.42.3
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ExperimentalConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ExperimentalConfig.ts
@@ -36,4 +36,6 @@ export interface ExperimentalConfig {
      * DEPRECATED: Use the top-level `ai-example-style-instructions` property instead.
      */
     aiExampleStyleInstructions?: string;
+    /** Experimental flag to exclude API reference sections from documentation generation. When enabled, API reference content will be omitted from the generated documentation. */
+    excludeApis?: boolean;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ExperimentalConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ExperimentalConfig.ts
@@ -23,6 +23,7 @@ export const ExperimentalConfig: core.serialization.ObjectSchema<
         "ai-example-style-instructions",
         core.serialization.string().optional(),
     ),
+    excludeApis: core.serialization.property("exclude-apis", core.serialization.boolean().optional()),
 });
 
 export declare namespace ExperimentalConfig {
@@ -34,5 +35,6 @@ export declare namespace ExperimentalConfig {
         "dynamic-snippets"?: boolean | null;
         "ai-examples"?: boolean | null;
         "ai-example-style-instructions"?: string | null;
+        "exclude-apis"?: boolean | null;
     }
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -58,6 +58,7 @@ export async function publishDocs({
     disableTemplates = false,
     skipUpload = false,
     withAiExamples = true,
+    excludeApis = false,
     targetAudiences
 }: {
     token: FernToken;
@@ -74,10 +75,17 @@ export async function publishDocs({
     disableTemplates: boolean | undefined;
     skipUpload: boolean | undefined;
     withAiExamples?: boolean;
+    excludeApis?: boolean;
     targetAudiences?: string[];
 }): Promise<void> {
     const fdr = createFdrService({ token: token.value });
     const authConfig: DocsV2Write.AuthConfig = isPrivate ? { type: "private", authType: "sso" } : { type: "public" };
+
+    if (excludeApis) {
+        context.logger.debug(
+            "Experimental flag 'exclude-apis' is enabled - API references will be excluded from S3 upload"
+        );
+    }
 
     let docsRegistrationId: string | undefined;
     let urlToOutput = customDomains[0] ?? domain;
@@ -164,6 +172,8 @@ export async function publishDocs({
                     filepaths: filepaths,
                     images,
                     basePath
+                    // TODO: Add excludeApis once FDR API supports it
+                    // excludeApis
                 });
                 if (startDocsRegisterResponse.ok) {
                     urlToOutput = startDocsRegisterResponse.body.previewUrl;
@@ -211,6 +221,8 @@ export async function publishDocs({
                     orgId: CjsFdrSdk.OrgId(organization),
                     filepaths: filepaths,
                     images
+                    // TODO: Add excludeApis once FDR API supports it
+                    // excludeApis
                 });
                 if (startDocsRegisterResponse.ok) {
                     docsRegistrationId = startDocsRegisterResponse.body.docsRegistrationId;

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -172,8 +172,6 @@ export async function publishDocs({
                     filepaths: filepaths,
                     images,
                     basePath
-                    // TODO: Add excludeApis once FDR API supports it
-                    // excludeApis
                 });
                 if (startDocsRegisterResponse.ok) {
                     urlToOutput = startDocsRegisterResponse.body.previewUrl;
@@ -221,8 +219,6 @@ export async function publishDocs({
                     orgId: CjsFdrSdk.OrgId(organization),
                     filepaths: filepaths,
                     images
-                    // TODO: Add excludeApis once FDR API supports it
-                    // excludeApis
                 });
                 if (startDocsRegisterResponse.ok) {
                     docsRegistrationId = startDocsRegisterResponse.body.docsRegistrationId;
@@ -488,7 +484,7 @@ export async function publishDocs({
         DocsV1Write.DocsRegistrationId(docsRegistrationId),
         {
             docsDefinition,
-            excludeApis: false,
+            excludeApis,
             libraryDocs: libraryDocsConfig
         }
     );

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -102,6 +102,7 @@ export async function runRemoteGenerationForDocsWorkspace({
             skipUpload,
             withAiExamples:
                 docsWorkspace.config.aiExamples?.enabled ?? docsWorkspace.config.experimental?.aiExamples ?? true,
+            excludeApis: docsWorkspace.config.experimental?.excludeApis ?? false,
             targetAudiences: maybeInstance.audiences
                 ? Array.isArray(maybeInstance.audiences)
                     ? maybeInstance.audiences

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -3788,6 +3788,16 @@
               "type": "null"
             }
           ]
+        },
+        "exclude-apis": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Adds a new experimental flag `exclude-apis` to the docs configuration that will exclude API reference sections from documentation generation when enabled.

## Usage

Users can enable this experimental flag in their `docs.yml`:

```yaml
experimental:
  exclude-apis: true
```