### PR TITLE
feat(java): add enable-gradle-profiling config option for debugging slow Gradle builds

### DIFF
--- a/generators/java-v2/ast/src/custom-config/BaseJavaCustomConfigSchema.ts
+++ b/generators/java-v2/ast/src/custom-config/BaseJavaCustomConfigSchema.ts
@@ -31,6 +31,9 @@ export const BaseJavaCustomConfigSchema = z.object({
     "gradle-plugin-management": z.string().optional(),
     "gradle-central-dependency-management": z.boolean().optional(),
 
+    // Hidden options (for debugging).
+    "enable-gradle-profiling": z.boolean().optional(),
+
     // Deprecated.
     "wrapped-aliases": z.boolean().optional()
 });

--- a/generators/java-v2/base/src/project/JavaProject.ts
+++ b/generators/java-v2/base/src/project/JavaProject.ts
@@ -42,12 +42,22 @@ export class JavaProject extends AbstractProject<AbstractJavaGeneratorContext<Ba
             // Apply gradle-distribution-url override if configured
             await this.applyGradleDistributionUrlOverride();
 
-            this.context.logger.debug(`JavaProject: Running spotlessApply`);
-            await loggingExeca(this.context.logger, "./gradlew", [":spotlessApply"], {
+            const enableProfiling = this.context.customConfig["enable-gradle-profiling"] === true;
+            const gradleArgs = [":spotlessApply"];
+            if (enableProfiling) {
+                gradleArgs.push("--profile");
+                this.context.logger.info(`JavaProject: Running spotlessApply with profiling enabled`);
+            } else {
+                this.context.logger.debug(`JavaProject: Running spotlessApply`);
+            }
+            await loggingExeca(this.context.logger, "./gradlew", gradleArgs, {
                 doNotPipeOutput: false,
                 cwd: this.absolutePathToOutputDirectory
             });
             this.context.logger.debug(`JavaProject: Successfully ran spotlessApply`);
+            if (enableProfiling) {
+                this.context.logger.info(`JavaProject: Gradle profiling report generated in build/reports/profile/`);
+            }
         }
     }
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.29.3
+- version: 3.30.0
   changelogEntry:
     - summary: |
         Add hidden `enable-gradle-profiling` configuration option for debugging slow Gradle builds.

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -2,9 +2,7 @@
 - version: 3.30.0
   changelogEntry:
     - summary: |
-        Add hidden `enable-gradle-profiling` configuration option for debugging slow Gradle builds.
-        When enabled, the `spotlessApply` command runs with `--profile` flag and generates a profiling
-        report in `build/reports/profile/` within the generated SDK.
+        Add `enable-gradle-profiling` configuration option for profiling Gradle commands during generation.
       type: feat
   createdAt: "2026-01-15"
   irVersion: 63

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.29.3
+  changelogEntry:
+    - summary: |
+        Add hidden `enable-gradle-profiling` configuration option for debugging slow Gradle builds.
+        When enabled, the `spotlessApply` command runs with `--profile` flag and generates a profiling
+        report in `build/reports/profile/` within the generated SDK.
+      type: feat
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.29.2
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,8 +2,7 @@
 - version: 3.43.0
   changelogEntry:
     - summary: |
-        Add support for `enable-gradle-profiling` configuration option in Java dynamic snippets test generation.
-        When enabled, the `spotlessApply` command runs with `--profile` flag for debugging slow Gradle builds.
+        Add `enable-gradle-profiling` flag for gradle commands run during generation.
       type: feat
   createdAt: "2026-01-15"
   irVersion: 63

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.42.5
+- version: 3.43.0
   changelogEntry:
     - summary: |
         Add support for `enable-gradle-profiling` configuration option in Java dynamic snippets test generation.

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,12 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.43.0
-  changelogEntry:
-    - summary: |
-        Add `enable-gradle-profiling` flag for gradle commands run during generation.
-      type: feat
-  createdAt: "2026-01-15"
-  irVersion: 63
-
 - version: 3.42.4
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.5
+  changelogEntry:
+    - summary: |
+        Add support for `enable-gradle-profiling` configuration option in Java dynamic snippets test generation.
+        When enabled, the `spotlessApply` command runs with `--profile` flag for debugging slow Gradle builds.
+      type: feat
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.42.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Slack thread request from @tjb9dc

Adds a hidden `enable-gradle-profiling` configuration option to help debug slow `spotlessApply` Gradle builds in the Java v2 generator.

Link to Devin run: https://app.devin.ai/sessions/621a2808f1b04ce68a2b6905d0943864
Requested by: @tjb9dc

## Changes Made

- Added `enable-gradle-profiling` boolean config option to `BaseJavaCustomConfigSchema.ts`
- Modified `JavaProject.ts` to pass `--profile` flag to gradlew when profiling is enabled
- Modified `DynamicSnippetsJavaTestGenerator.ts` to support the same profiling flag for dynamic snippets test generation
- Updated `generators/java/sdk/versions.yml` (3.30.0) and `packages/cli/cli/versions.yml` (3.43.0) with changelog entries
- Profiling reports are copied from `build/reports/` to `reports/` at the SDK root so they are not gitignored

When enabled, the Gradle profiling report is generated and copied to `reports/` at the root of the generated SDK output directory.

## Testing

- [ ] Manual testing completed (requires running Java SDK generation with the config flag enabled)

## Human Review Checklist

- [ ] Verify the type cast in `DynamicSnippetsJavaTestGenerator.ts` (`customConfig as Record<string, unknown> | undefined`) is appropriate
- [ ] Confirm the `cp` function with `{ recursive: true }` correctly copies the reports directory
- [ ] Verify `doesPathExist(path, "directory")` correctly detects the build/reports directory