### PR TITLE
fix(cli): handle recoverable MDX JSX parsing errors gracefully

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.42.5
+  changelogEntry:
+    - summary: |
+        Fix MDX validation to handle recoverable JSX parsing errors gracefully. Errors like plain text content inside JSX components (e.g., `<Card>`) that would be handled during rendering are no longer treated as fatal validation errors.
+      type: fix
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.42.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-demo/square-docs/pull/111

Fixes MDX validation errors that occur when plain text content is placed inside JSX components like `<Card>`. These errors were being treated as fatal validation failures even though fern-platform handles them gracefully during rendering via `sanitizeMdxExpression`.

**Link to Devin run:** https://app.devin.ai/sessions/6ccc769883704fd7874719f0cb635990
**Requested by:** @Ryan-Amirthan

## Changes Made

- Added `isRecoverableMdxError` function that identifies MDX parsing errors that fern-platform can handle during rendering
- Modified `parseMarkdown` to return success for recoverable errors instead of failing validation
- Recoverable errors are identified by:
  - Known rule IDs: `end-tag-mismatch`, `unexpected-eof`, `unexpected-character`, `unexpected-lazy`, `acorn`, `spread-extra`
  - Error message patterns related to paragraph/JSX conflicts (e.g., "Expected the closing tag", "before the end of `paragraph`")

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed (lint checks pass)

## Human Review Checklist

- [ ] Verify the `RECOVERABLE_MDX_ERRORS` list aligns with what fern-platform's `sanitizeMdxExpression` handles
- [ ] Review error message pattern matching for potential false positives that could suppress real errors
- [ ] Consider whether this could allow invalid MDX to pass validation but fail at render time