### PR TITLE
feat(cli): `--indent` flag on commands that generate specs

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1159,11 +1159,17 @@ function addUpdateApiSpecCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCon
         "api update",
         `Pulls the latest OpenAPI spec from the specified origin in ${GENERATORS_CONFIGURATION_FILENAME} and updates the local spec.`,
         (yargs) =>
-            yargs.option("api", {
-                string: true,
-                description:
-                    "The API to update the spec for. If not specified, all APIs with a declared origin will be updated."
-            }),
+            yargs
+                .option("api", {
+                    string: true,
+                    description:
+                        "The API to update the spec for. If not specified, all APIs with a declared origin will be updated."
+                })
+                .option("indent", {
+                    type: "number",
+                    description: "Indentation width in spaces (default: 2)",
+                    default: 2
+                }),
         async (argv) => {
             await cliContext.instrumentPostHogEvent({
                 command: "fern api update"
@@ -1173,7 +1179,8 @@ function addUpdateApiSpecCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCon
                 project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
                     commandLineApiWorkspace: argv.api,
                     defaultToAllApiWorkspaces: true
-                })
+                }),
+                indent: argv.indent
             });
         }
     );

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1780,6 +1780,11 @@ function addExportCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                 .option("api", {
                     string: true,
                     description: "Only run the command on the provided API"
+                })
+                .option("indent", {
+                    type: "number",
+                    description: "Indentation width in spaces (default: 2)",
+                    default: 2
                 }),
         async (argv) => {
             await cliContext.instrumentPostHogEvent({
@@ -1795,7 +1800,8 @@ function addExportCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     defaultToAllApiWorkspaces: false
                 }),
                 cliContext,
-                outputPath: resolve(cwd(), argv.outputPath)
+                outputPath: resolve(cwd(), argv.outputPath),
+                indent: argv.indent
             });
         }
     );

--- a/packages/cli/cli/src/commands/export/generateOpenAPIForWorkspaces.ts
+++ b/packages/cli/cli/src/commands/export/generateOpenAPIForWorkspaces.ts
@@ -45,7 +45,9 @@ export async function generateOpenAPIForWorkspaces({
                 await mkdir(dirname(outputPath), { recursive: true });
                 await writeFile(
                     outputPath,
-                    outputPath.endsWith(".json") ? JSON.stringify(openapi, undefined, indent) : yaml.dump(openapi, { indent })
+                    outputPath.endsWith(".json")
+                        ? JSON.stringify(openapi, undefined, indent)
+                        : yaml.dump(openapi, { indent })
                 );
             });
         })

--- a/packages/cli/cli/src/commands/export/generateOpenAPIForWorkspaces.ts
+++ b/packages/cli/cli/src/commands/export/generateOpenAPIForWorkspaces.ts
@@ -11,11 +11,13 @@ import { convertIrToOpenApi } from "./convertIrToOpenApi";
 export async function generateOpenAPIForWorkspaces({
     project,
     cliContext,
-    outputPath
+    outputPath,
+    indent
 }: {
     project: Project;
     cliContext: CliContext;
     outputPath: AbsoluteFilePath;
+    indent: number;
 }): Promise<void> {
     await Promise.all(
         project.apiWorkspaces.map(async (workspace) => {
@@ -43,7 +45,7 @@ export async function generateOpenAPIForWorkspaces({
                 await mkdir(dirname(outputPath), { recursive: true });
                 await writeFile(
                     outputPath,
-                    outputPath.endsWith(".json") ? JSON.stringify(openapi, undefined, 2) : yaml.dump(openapi)
+                    outputPath.endsWith(".json") ? JSON.stringify(openapi, undefined, indent) : yaml.dump(openapi, { indent })
                 );
             });
         })

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.43.0
+  changelogEntry:
+    - summary: |
+        Add --indent flag to 'fern api update' to allow specification of indent size in spaces.
+      type: feat
+    - summary: |
+        Add --indent flag to 'fern export' to allow specification of indent size in spaces.
+      type: feat
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.42.4
   changelogEntry:
     - summary: |

--- a/packages/cli/ete-tests/src/tests/export/__snapshots__/export.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/export/__snapshots__/export.test.ts.snap
@@ -1,5 +1,797 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`overrides > simple --indent 8 1`] = `
+"openapi: 3.0.1
+info:
+        title: api
+        version: ''
+        description: foo bar baz
+paths:
+        /test/{rootPathParam}/movies:
+                post:
+                        operationId: imdb_createMovie
+                        tags:
+                                - Imdb
+                        parameters:
+                                -
+                                        name: rootPathParam
+                                        in: path
+                                        required: true
+                                        schema:
+                                                type: string
+                        responses:
+                                '200':
+                                        description: ''
+                                        content:
+                                                application/json:
+                                                        schema:
+                                                                $ref: '#/components/schemas/MovieId'
+                                '400':
+                                        description: ''
+                                        content:
+                                                application/json:
+                                                        schema:
+                                                                oneOf:
+                                                                        -
+                                                                                type: object
+                                                                                properties:
+                                                                                        error:
+                                                                                                type: string
+                                                                                                enum:
+                                                                                                        - BadRequestError
+                        security:
+                                -
+                                        ApiKeyAuth: []
+                        requestBody:
+                                required: true
+                                content:
+                                        application/json:
+                                                schema:
+                                                        $ref: '#/components/schemas/CreateMovieRequest'
+        /test/{rootPathParam}/movies/{movieId}:
+                get:
+                        operationId: imdb_getMovie
+                        tags:
+                                - Imdb
+                        parameters:
+                                -
+                                        name: rootPathParam
+                                        in: path
+                                        required: true
+                                        schema:
+                                                type: string
+                                -
+                                        name: movieId
+                                        in: path
+                                        required: true
+                                        schema:
+                                                $ref: '#/components/schemas/MovieId'
+                                -
+                                        name: movieName
+                                        in: query
+                                        required: true
+                                        schema:
+                                                type: array
+                                                items:
+                                                        type: string
+                        responses:
+                                '200':
+                                        description: ''
+                                        content:
+                                                application/json:
+                                                        schema:
+                                                                $ref: '#/components/schemas/Movie'
+                                '400':
+                                        description: ''
+                                        content:
+                                                application/json:
+                                                        schema:
+                                                                oneOf:
+                                                                        -
+                                                                                type: object
+                                                                                properties:
+                                                                                        error:
+                                                                                                type: string
+                                                                                                enum:
+                                                                                                        - BadRequestError
+                                '404':
+                                        description: ''
+                                        content:
+                                                application/json:
+                                                        schema:
+                                                                oneOf:
+                                                                        -
+                                                                                type: object
+                                                                                properties:
+                                                                                        error:
+                                                                                                type: string
+                                                                                                enum:
+                                                                                                        - NotFoundError
+                                                                                        content:
+                                                                                                type: string
+                        summary: Get Movie by Id
+                delete:
+                        operationId: imdb_delete
+                        tags:
+                                - Imdb
+                        parameters:
+                                -
+                                        name: rootPathParam
+                                        in: path
+                                        required: true
+                                        schema:
+                                                type: string
+                                -
+                                        name: movieId
+                                        in: path
+                                        required: true
+                                        schema:
+                                                $ref: '#/components/schemas/MovieId'
+                        responses:
+                                '204':
+                                        description: ''
+                                '400':
+                                        description: ''
+                                        content:
+                                                application/json:
+                                                        schema:
+                                                                oneOf:
+                                                                        -
+                                                                                type: object
+                                                                                properties:
+                                                                                        error:
+                                                                                                type: string
+                                                                                                enum:
+                                                                                                        - BadRequestError
+components:
+        schemas:
+                UndiscriminatedUnion:
+                        title: UndiscriminatedUnion
+                        oneOf:
+                                -
+                                        type: string
+                                -
+                                        type: array
+                                        items:
+                                                type: string
+                                -
+                                        type: integer
+                                -
+                                        type: array
+                                        items:
+                                                type: array
+                                                items:
+                                                        type: integer
+                Director:
+                        title: Director
+                        type: object
+                        properties:
+                                name:
+                                        type: string
+                                age:
+                                        $ref: '#/components/schemas/Age'
+                        required:
+                                - name
+                                - age
+                Age:
+                        title: Age
+                        type: integer
+                LiteralString:
+                        title: LiteralString
+                        type: string
+                        const: hello
+                CurrencyAmount:
+                        title: CurrencyAmount
+                        type: string
+                MovieId:
+                        title: MovieId
+                        type: string
+                ActorId:
+                        title: ActorId
+                        type: string
+                Movie:
+                        title: Movie
+                        type: object
+                        properties:
+                                id:
+                                        $ref: '#/components/schemas/MovieId'
+                                title:
+                                        type: string
+                                rating:
+                                        type: number
+                                        format: double
+                        required:
+                                - id
+                                - title
+                                - rating
+                CreateMovieRequest:
+                        title: CreateMovieRequest
+                        type: object
+                        properties:
+                                title:
+                                        type: string
+                                ratings:
+                                        type: array
+                                        items:
+                                                type: number
+                                                format: double
+                        required:
+                                - title
+                                - ratings
+                DirectorWrapper:
+                        title: DirectorWrapper
+                        type: object
+                        properties:
+                                director:
+                                        $ref: '#/components/schemas/Director'
+                        required:
+                                - director
+                EmptyObject:
+                        title: EmptyObject
+                        type: object
+                        properties: {}
+                Person:
+                        title: Person
+                        oneOf:
+                                -
+                                        type: object
+                                        properties:
+                                                type:
+                                                        type: string
+                                                        enum:
+                                                                - actor
+                                                value:
+                                                        $ref: '#/components/schemas/ActorId'
+                                        required:
+                                                - type
+                                -
+                                        type: object
+                                        allOf:
+                                                -
+                                                        type: object
+                                                        properties:
+                                                                type:
+                                                                        type: string
+                                                                        enum:
+                                                                                - director
+                                                -
+                                                        $ref: '#/components/schemas/Director'
+                                        required:
+                                                - type
+                                -
+                                        type: object
+                                        allOf:
+                                                -
+                                                        type: object
+                                                        properties:
+                                                                type:
+                                                                        type: string
+                                                                        enum:
+                                                                                - producer
+                                                -
+                                                        $ref: '#/components/schemas/EmptyObject'
+                                        required:
+                                                - type
+                                -
+                                        type: object
+                                        allOf:
+                                                -
+                                                        type: object
+                                                        properties:
+                                                                type:
+                                                                        type: string
+                                                                        enum:
+                                                                                - cinematographer
+                                                -
+                                                        $ref: '#/components/schemas/EmptyObject'
+                                        required:
+                                                - type
+                RecursiveType:
+                        title: RecursiveType
+                        type: object
+                        properties:
+                                selfReferencing:
+                                        type: array
+                                        items:
+                                                $ref: '#/components/schemas/RecursiveType'
+                        required:
+                                - selfReferencing
+                        allOf:
+                                -
+                                        $ref: '#/components/schemas/CreateMovieRequest'
+        securitySchemes:
+                ApiKeyAuth:
+                        type: apiKey
+                        in: header
+                        name: X_API_KEY
+servers:
+        -
+                url: https://buildwithfern.com
+                description: Production
+        -
+                url: https://staging.buildwithfern.com
+                description: Staging
+"
+`;
+
+exports[`overrides > simple --indent 8 2`] = `
+"{
+        "openapi": "3.0.1",
+        "info": {
+                "title": "api",
+                "version": "",
+                "description": "foo bar baz"
+        },
+        "paths": {
+                "/test/{rootPathParam}/movies": {
+                        "post": {
+                                "operationId": "imdb_createMovie",
+                                "tags": [
+                                        "Imdb"
+                                ],
+                                "parameters": [
+                                        {
+                                                "name": "rootPathParam",
+                                                "in": "path",
+                                                "required": true,
+                                                "schema": {
+                                                        "type": "string"
+                                                }
+                                        }
+                                ],
+                                "responses": {
+                                        "200": {
+                                                "description": "",
+                                                "content": {
+                                                        "application/json": {
+                                                                "schema": {
+                                                                        "$ref": "#/components/schemas/MovieId"
+                                                                }
+                                                        }
+                                                }
+                                        },
+                                        "400": {
+                                                "description": "",
+                                                "content": {
+                                                        "application/json": {
+                                                                "schema": {
+                                                                        "oneOf": [
+                                                                                {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                                "error": {
+                                                                                                        "type": "string",
+                                                                                                        "enum": [
+                                                                                                                "BadRequestError"
+                                                                                                        ]
+                                                                                                }
+                                                                                        }
+                                                                                }
+                                                                        ]
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                },
+                                "security": [
+                                        {
+                                                "ApiKeyAuth": []
+                                        }
+                                ],
+                                "requestBody": {
+                                        "required": true,
+                                        "content": {
+                                                "application/json": {
+                                                        "schema": {
+                                                                "$ref": "#/components/schemas/CreateMovieRequest"
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                },
+                "/test/{rootPathParam}/movies/{movieId}": {
+                        "get": {
+                                "operationId": "imdb_getMovie",
+                                "tags": [
+                                        "Imdb"
+                                ],
+                                "parameters": [
+                                        {
+                                                "name": "rootPathParam",
+                                                "in": "path",
+                                                "required": true,
+                                                "schema": {
+                                                        "type": "string"
+                                                }
+                                        },
+                                        {
+                                                "name": "movieId",
+                                                "in": "path",
+                                                "required": true,
+                                                "schema": {
+                                                        "$ref": "#/components/schemas/MovieId"
+                                                }
+                                        },
+                                        {
+                                                "name": "movieName",
+                                                "in": "query",
+                                                "required": true,
+                                                "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                                "type": "string"
+                                                        }
+                                                }
+                                        }
+                                ],
+                                "responses": {
+                                        "200": {
+                                                "description": "",
+                                                "content": {
+                                                        "application/json": {
+                                                                "schema": {
+                                                                        "$ref": "#/components/schemas/Movie"
+                                                                }
+                                                        }
+                                                }
+                                        },
+                                        "400": {
+                                                "description": "",
+                                                "content": {
+                                                        "application/json": {
+                                                                "schema": {
+                                                                        "oneOf": [
+                                                                                {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                                "error": {
+                                                                                                        "type": "string",
+                                                                                                        "enum": [
+                                                                                                                "BadRequestError"
+                                                                                                        ]
+                                                                                                }
+                                                                                        }
+                                                                                }
+                                                                        ]
+                                                                }
+                                                        }
+                                                }
+                                        },
+                                        "404": {
+                                                "description": "",
+                                                "content": {
+                                                        "application/json": {
+                                                                "schema": {
+                                                                        "oneOf": [
+                                                                                {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                                "error": {
+                                                                                                        "type": "string",
+                                                                                                        "enum": [
+                                                                                                                "NotFoundError"
+                                                                                                        ]
+                                                                                                },
+                                                                                                "content": {
+                                                                                                        "type": "string"
+                                                                                                }
+                                                                                        }
+                                                                                }
+                                                                        ]
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                },
+                                "summary": "Get Movie by Id"
+                        },
+                        "delete": {
+                                "operationId": "imdb_delete",
+                                "tags": [
+                                        "Imdb"
+                                ],
+                                "parameters": [
+                                        {
+                                                "name": "rootPathParam",
+                                                "in": "path",
+                                                "required": true,
+                                                "schema": {
+                                                        "type": "string"
+                                                }
+                                        },
+                                        {
+                                                "name": "movieId",
+                                                "in": "path",
+                                                "required": true,
+                                                "schema": {
+                                                        "$ref": "#/components/schemas/MovieId"
+                                                }
+                                        }
+                                ],
+                                "responses": {
+                                        "204": {
+                                                "description": ""
+                                        },
+                                        "400": {
+                                                "description": "",
+                                                "content": {
+                                                        "application/json": {
+                                                                "schema": {
+                                                                        "oneOf": [
+                                                                                {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                                "error": {
+                                                                                                        "type": "string",
+                                                                                                        "enum": [
+                                                                                                                "BadRequestError"
+                                                                                                        ]
+                                                                                                }
+                                                                                        }
+                                                                                }
+                                                                        ]
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                }
+        },
+        "components": {
+                "schemas": {
+                        "UndiscriminatedUnion": {
+                                "title": "UndiscriminatedUnion",
+                                "oneOf": [
+                                        {
+                                                "type": "string"
+                                        },
+                                        {
+                                                "type": "array",
+                                                "items": {
+                                                        "type": "string"
+                                                }
+                                        },
+                                        {
+                                                "type": "integer"
+                                        },
+                                        {
+                                                "type": "array",
+                                                "items": {
+                                                        "type": "array",
+                                                        "items": {
+                                                                "type": "integer"
+                                                        }
+                                                }
+                                        }
+                                ]
+                        },
+                        "Director": {
+                                "title": "Director",
+                                "type": "object",
+                                "properties": {
+                                        "name": {
+                                                "type": "string"
+                                        },
+                                        "age": {
+                                                "$ref": "#/components/schemas/Age"
+                                        }
+                                },
+                                "required": [
+                                        "name",
+                                        "age"
+                                ]
+                        },
+                        "Age": {
+                                "title": "Age",
+                                "type": "integer"
+                        },
+                        "LiteralString": {
+                                "title": "LiteralString",
+                                "type": "string",
+                                "const": "hello"
+                        },
+                        "CurrencyAmount": {
+                                "title": "CurrencyAmount",
+                                "type": "string"
+                        },
+                        "MovieId": {
+                                "title": "MovieId",
+                                "type": "string"
+                        },
+                        "ActorId": {
+                                "title": "ActorId",
+                                "type": "string"
+                        },
+                        "Movie": {
+                                "title": "Movie",
+                                "type": "object",
+                                "properties": {
+                                        "id": {
+                                                "$ref": "#/components/schemas/MovieId"
+                                        },
+                                        "title": {
+                                                "type": "string"
+                                        },
+                                        "rating": {
+                                                "type": "number",
+                                                "format": "double"
+                                        }
+                                },
+                                "required": [
+                                        "id",
+                                        "title",
+                                        "rating"
+                                ]
+                        },
+                        "CreateMovieRequest": {
+                                "title": "CreateMovieRequest",
+                                "type": "object",
+                                "properties": {
+                                        "title": {
+                                                "type": "string"
+                                        },
+                                        "ratings": {
+                                                "type": "array",
+                                                "items": {
+                                                        "type": "number",
+                                                        "format": "double"
+                                                }
+                                        }
+                                },
+                                "required": [
+                                        "title",
+                                        "ratings"
+                                ]
+                        },
+                        "DirectorWrapper": {
+                                "title": "DirectorWrapper",
+                                "type": "object",
+                                "properties": {
+                                        "director": {
+                                                "$ref": "#/components/schemas/Director"
+                                        }
+                                },
+                                "required": [
+                                        "director"
+                                ]
+                        },
+                        "EmptyObject": {
+                                "title": "EmptyObject",
+                                "type": "object",
+                                "properties": {}
+                        },
+                        "Person": {
+                                "title": "Person",
+                                "oneOf": [
+                                        {
+                                                "type": "object",
+                                                "properties": {
+                                                        "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                        "actor"
+                                                                ]
+                                                        },
+                                                        "value": {
+                                                                "$ref": "#/components/schemas/ActorId"
+                                                        }
+                                                },
+                                                "required": [
+                                                        "type"
+                                                ]
+                                        },
+                                        {
+                                                "type": "object",
+                                                "allOf": [
+                                                        {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                        "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                        "director"
+                                                                                ]
+                                                                        }
+                                                                }
+                                                        },
+                                                        {
+                                                                "$ref": "#/components/schemas/Director"
+                                                        }
+                                                ],
+                                                "required": [
+                                                        "type"
+                                                ]
+                                        },
+                                        {
+                                                "type": "object",
+                                                "allOf": [
+                                                        {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                        "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                        "producer"
+                                                                                ]
+                                                                        }
+                                                                }
+                                                        },
+                                                        {
+                                                                "$ref": "#/components/schemas/EmptyObject"
+                                                        }
+                                                ],
+                                                "required": [
+                                                        "type"
+                                                ]
+                                        },
+                                        {
+                                                "type": "object",
+                                                "allOf": [
+                                                        {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                        "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                        "cinematographer"
+                                                                                ]
+                                                                        }
+                                                                }
+                                                        },
+                                                        {
+                                                                "$ref": "#/components/schemas/EmptyObject"
+                                                        }
+                                                ],
+                                                "required": [
+                                                        "type"
+                                                ]
+                                        }
+                                ]
+                        },
+                        "RecursiveType": {
+                                "title": "RecursiveType",
+                                "type": "object",
+                                "properties": {
+                                        "selfReferencing": {
+                                                "type": "array",
+                                                "items": {
+                                                        "$ref": "#/components/schemas/RecursiveType"
+                                                }
+                                        }
+                                },
+                                "required": [
+                                        "selfReferencing"
+                                ],
+                                "allOf": [
+                                        {
+                                                "$ref": "#/components/schemas/CreateMovieRequest"
+                                        }
+                                ]
+                        }
+                },
+                "securitySchemes": {
+                        "ApiKeyAuth": {
+                                "type": "apiKey",
+                                "in": "header",
+                                "name": "X_API_KEY"
+                        }
+                }
+        },
+        "servers": [
+                {
+                        "url": "https://buildwithfern.com",
+                        "description": "Production"
+                },
+                {
+                        "url": "https://staging.buildwithfern.com",
+                        "description": "Staging"
+                }
+        ]
+}"
+`;
+
 exports[`overrides > simple 1`] = `
 "openapi: 3.0.1
 info:

--- a/packages/cli/ete-tests/src/tests/export/export.test.ts
+++ b/packages/cli/ete-tests/src/tests/export/export.test.ts
@@ -8,6 +8,7 @@ const FIXTURES_DIR = path.join(__dirname, "fixtures");
 
 describe("overrides", () => {
     itFixture("simple");
+    itFixtureWithIndent("simple", 8);
 });
 
 function itFixture(fixtureName: string) {
@@ -17,6 +18,20 @@ function itFixture(fixtureName: string) {
         for (const filename of ["openapi.yml", "openapi.json"]) {
             const outputPath = path.join(fixturePath, "output", filename);
             await runFernCli(["export", outputPath], {
+                cwd: fixturePath
+            });
+            expect((await readFile(AbsoluteFilePath.of(outputPath))).toString()).toMatchSnapshot();
+        }
+    }, 90_000);
+}
+
+function itFixtureWithIndent(fixtureName: string, indent: number) {
+    it(// eslint-disable-next-line jest/valid-title
+    `${fixtureName} --indent ${indent}`, async () => {
+        const fixturePath = path.join(FIXTURES_DIR, fixtureName);
+        for (const filename of ["openapi.yml", "openapi.json"]) {
+            const outputPath = path.join(fixturePath, "output", filename);
+            await runFernCli(["export", outputPath, "--indent", String(indent)], {
                 cwd: fixturePath
             });
             expect((await readFile(AbsoluteFilePath.of(outputPath))).toString()).toMatchSnapshot();

--- a/packages/cli/ete-tests/src/tests/update-api/__snapshots__/update-api.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/update-api/__snapshots__/update-api.test.ts.snap
@@ -1,5 +1,103 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`fern api update > fern api update --indent 4 1`] = `
+[
+  {
+    "contents": "{
+    "version": "*",
+    "organization": "fern"
+}",
+    "name": "fern.config.json",
+    "type": "file",
+  },
+  {
+    "contents": "# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+default-group: local
+api:
+  specs:
+    - openapi: ./openapi/openapi.json
+      origin: http://localhost:4567/openapi.json
+groups:
+  local:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+        version: 0.9.5
+        config: {}
+        output:
+          location: local-file-system
+          path: ../sdks/typescript
+",
+    "name": "generators.yml",
+    "type": "file",
+  },
+  {
+    "contents": [
+      {
+        "contents": "{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Test API",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/testdata": {
+            "get": {
+                "summary": "Retrieve test data",
+                "operationId": "getTestData",
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/filtered": {
+            "get": {
+                "summary": "This endpoint should be filtered out",
+                "operationId": "filtered",
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}",
+        "name": "openapi.json",
+        "type": "file",
+      },
+    ],
+    "name": "openapi",
+    "type": "directory",
+  },
+]
+`;
+
 exports[`fern api update > fern api update 1`] = `
 [
   {

--- a/packages/cli/ete-tests/src/tests/update-api/update-api.test.ts
+++ b/packages/cli/ete-tests/src/tests/update-api/update-api.test.ts
@@ -27,4 +27,23 @@ describe("fern api update", () => {
         // Shutdown the server now that we're done.
         await cleanup();
     }, 60_000);
+
+    it("fern api update --indent 4", async () => {
+        // Start express server that will respond with the OpenAPI spec.
+        const { cleanup } = setupOpenAPIServer();
+
+        const tmpDir = await tmp.dir();
+        const directory = AbsoluteFilePath.of(tmpDir.path);
+        const outputPath = AbsoluteFilePath.of(path.join(directory, "fern"));
+
+        await cp(FIXTURES_DIR, directory, { recursive: true });
+        await runFernCli(["api", "update", "--indent", "4"], {
+            cwd: directory
+        });
+
+        expect(await getDirectoryContentsForSnapshot(outputPath)).toMatchSnapshot();
+
+        // Shutdown the server now that we're done.
+        await cleanup();
+    }, 60_000);
 });


### PR DESCRIPTION
## Description
Adds an `--indent x` command line option to `fern api update` and `fern export` that sets indentation for the generated `.json` or `.yaml` file at `x` spaces.

## Changes Made
Changes to the CLI.

## Testing
Two new ETE tests testing `--indent` on each of these commands.
- [X] Unit tests added/updated
- [X] Manual testing completed
