### PR TITLE
fix(cli): skip AI example enhancement in self-hosted environments

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,7 +2,7 @@
 - version: 3.44.1
   changelogEntry:
     - summary: |
-        Skip AI example enhancement in self-hosted environments to prevent network errors in airgapped deployments. When `FERN_SELF_HOSTED=true` is set, the CLI no longer attempts to call Venus or FDR Lambda for AI enhancement.
+        Add air-gapped environment detection for AI example enhancement. The CLI now detects network availability before attempting AI enhancement by checking connectivity to Venus. In air-gapped environments, AI enhancement is automatically skipped to prevent network errors. This follows the same pattern used for protobuf generation air-gap detection.
       type: fix
   createdAt: "2026-01-15"
   irVersion: 63

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.44.1
+  changelogEntry:
+    - summary: |
+        Skip AI example enhancement in self-hosted environments to prevent network errors in airgapped deployments. When `FERN_SELF_HOSTED=true` is set, the CLI no longer attempts to call Venus or FDR Lambda for AI enhancement.
+      type: fix
+  createdAt: "2026-01-15"
+  irVersion: 63
+
 - version: 3.44.0
   changelogEntry:
     - summary: |

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -357,6 +357,13 @@ export async function enhanceExamplesWithAI(
         return apiDefinition;
     }
 
+    // Skip AI enhancement in self-hosted environments to avoid external network calls
+    // Self-hosted containers run in airgapped environments without access to Venus/Lambda
+    if (process.env.FERN_SELF_HOSTED === "true") {
+        context.logger.debug("AI example enhancement is skipped in self-hosted environments");
+        return apiDefinition;
+    }
+
     // Wrap the entire AI enhancement pipeline in try-catch to prevent CLI crashes
     try {
         return await performAIEnhancement(

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -357,13 +357,6 @@ export async function enhanceExamplesWithAI(
         return apiDefinition;
     }
 
-    // Skip AI enhancement in self-hosted environments to avoid external network calls
-    // Self-hosted containers run in airgapped environments without access to Venus/Lambda
-    if (process.env.FERN_SELF_HOSTED === "true") {
-        context.logger.debug("AI example enhancement is skipped in self-hosted environments");
-        return apiDefinition;
-    }
-
     // Wrap the entire AI enhancement pipeline in try-catch to prevent CLI crashes
     try {
         return await performAIEnhancement(

--- a/packages/cli/register/src/ai-example-enhancer/lambdaClient.ts
+++ b/packages/cli/register/src/ai-example-enhancer/lambdaClient.ts
@@ -1,4 +1,5 @@
 import { FernToken } from "@fern-api/auth";
+import { isNetworkError } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
 import { AIExampleEnhancerConfig, ExampleEnhancementRequest, ExampleEnhancementResponse } from "./types";
 
@@ -6,21 +7,6 @@ import { AIExampleEnhancerConfig, ExampleEnhancementRequest, ExampleEnhancementR
 const DEFAULT_AI_ENHANCEMENT_MAX_RETRIES = 0; // 0 retries = 1 attempt total
 const DEFAULT_AI_ENHANCEMENT_TIMEOUT_MS = 15000; // 15 seconds
 const AIRGAP_DETECTION_TIMEOUT_MS = 5000; // 5 second timeout for airgap detection
-
-function isNetworkError(errorMessage: string): boolean {
-    return (
-        errorMessage.includes("fetch failed") ||
-        errorMessage.includes("failed to connect") ||
-        errorMessage.includes("network") ||
-        errorMessage.includes("ENOTFOUND") ||
-        errorMessage.includes("ETIMEDOUT") ||
-        errorMessage.includes("TIMEDOUT") ||
-        errorMessage.includes("timed out") ||
-        errorMessage.includes("ECONNREFUSED") ||
-        errorMessage.includes("ECONNRESET") ||
-        errorMessage.includes("socket hang up")
-    );
-}
 
 type AIEnhancerResolvedConfig = Required<Omit<AIExampleEnhancerConfig, "openaiApiKey" | "styleInstructions">> &
     Pick<AIExampleEnhancerConfig, "openaiApiKey" | "styleInstructions">;

--- a/packages/cli/workspace/lazy-fern-workspace/src/index.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/index.ts
@@ -2,4 +2,5 @@ export * from "./ConjureWorkspace";
 export * from "./LazyFernWorkspace";
 export { OpenAPILoader } from "./loaders/OpenAPILoader";
 export * from "./OSSWorkspace";
+export { isNetworkError } from "./protobuf/utils";
 export * from "./utils";

--- a/packages/cli/workspace/lazy-fern-workspace/src/index.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/index.ts
@@ -2,5 +2,5 @@ export * from "./ConjureWorkspace";
 export * from "./LazyFernWorkspace";
 export { OpenAPILoader } from "./loaders/OpenAPILoader";
 export * from "./OSSWorkspace";
-export { isNetworkError } from "./protobuf/utils";
+export { detectAirGappedMode, isNetworkError } from "./protobuf/utils";
 export * from "./utils";

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
@@ -6,16 +6,21 @@ import tmp from "tmp-promise";
 
 /**
  * Check if an error message indicates a network error.
+ * Used by both protobuf generation and AI example enhancement for air-gap detection.
  */
 export function isNetworkError(errorMessage: string): boolean {
     return (
         errorMessage.includes("server hosted at that remote is unavailable") ||
+        errorMessage.includes("fetch failed") ||
         errorMessage.includes("failed to connect") ||
         errorMessage.includes("network") ||
         errorMessage.includes("ENOTFOUND") ||
         errorMessage.includes("ETIMEDOUT") ||
         errorMessage.includes("TIMEDOUT") ||
-        errorMessage.includes("timed out")
+        errorMessage.includes("timed out") ||
+        errorMessage.includes("ECONNREFUSED") ||
+        errorMessage.includes("ECONNRESET") ||
+        errorMessage.includes("socket hang up")
     );
 }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
@@ -24,11 +24,57 @@ export function isNetworkError(errorMessage: string): boolean {
     );
 }
 
+// Global cache for air-gap detection result
+let airGapDetectionResult: boolean | undefined;
+let airGapDetectionPromise: Promise<boolean> | undefined;
+
 /**
- * Detect if we're in an air-gapped environment by trying buf dep update once.
+ * Detect if we're in an air-gapped environment by trying to reach a URL via HTTP.
+ * The result is cached globally to avoid repeated detection attempts.
+ * Used by both protobuf generation and AI example enhancement.
+ */
+export async function detectAirGappedMode(url: string, logger: Logger, timeoutMs: number = 5000): Promise<boolean> {
+    if (airGapDetectionResult !== undefined) {
+        return airGapDetectionResult;
+    }
+
+    if (airGapDetectionPromise == null) {
+        airGapDetectionPromise = performAirGapDetection(url, logger, timeoutMs);
+    }
+
+    return airGapDetectionPromise;
+}
+
+async function performAirGapDetection(url: string, logger: Logger, timeoutMs: number): Promise<boolean> {
+    logger.debug(`Detecting air-gapped mode by checking connectivity to ${url}`);
+
+    try {
+        await fetch(url, {
+            method: "GET",
+            signal: AbortSignal.timeout(timeoutMs)
+        });
+
+        airGapDetectionResult = false;
+        logger.debug("Network check succeeded - not in air-gapped mode");
+        return false;
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        if (isNetworkError(errorMessage)) {
+            airGapDetectionResult = true;
+            logger.debug(`Network check failed - entering air-gapped mode: ${errorMessage}`);
+            return true;
+        }
+        airGapDetectionResult = false;
+        return false;
+    }
+}
+
+/**
+ * Detect if we're in an air-gapped environment for protobuf generation.
+ * Uses buf dep update to check network availability.
  * Returns true if air-gapped (network unavailable), false otherwise.
  */
-export async function detectAirGappedMode(
+export async function detectAirGappedModeForProtobuf(
     absoluteFilepathToProtobufRoot: AbsoluteFilePath,
     logger: Logger
 ): Promise<boolean> {


### PR DESCRIPTION
## Description
Refs: Customer reported self-hosted container failing in airgapped environments for Conjure APIs

Fixes an issue where the Fern CLI attempts to make external network calls to Venus (for JWT exchange) and FDR Lambda (for AI example enhancement) when running in air-gapped environments. These calls fail with "fetch failed" errors since the container cannot reach external servers.

## Changes Made
- Created a generic `detectAirGappedMode(url, logger, timeoutMs)` function in `@fern-api/lazy-fern-workspace` that can be used by both AI enhancement and protobuf generation
- Extended `isNetworkError()` with additional error patterns: "fetch failed", "ECONNREFUSED", "ECONNRESET", "socket hang up"
- Exported both `detectAirGappedMode` and `isNetworkError` from `@fern-api/lazy-fern-workspace` for shared use
- Detection result is cached globally (module-level variables) to avoid repeated network checks
- Uses 5-second timeout for the health check to Venus `/health` endpoint
- Renamed the protobuf-specific function to `detectAirGappedModeForProtobuf` to distinguish from the generic function
- Added version 3.44.1 entry to `versions.yml` to cut a release with this fix

## Updates since last revision
- Refactored to create a shared generic `detectAirGappedMode` function instead of duplicating detection logic
- The `LambdaExampleEnhancer` now imports and uses the shared function from `@fern-api/lazy-fern-workspace`
- Moved caching from static class variables to module-level global variables for broader reuse

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed - verified the code path logic
- Integration test PR: https://github.com/fern-api/fern-platform/pull/6424 (adds airgapped Conjure API test that fails without this fix)

## Human Review Checklist
- [ ] Verify Venus has a `/health` endpoint that responds appropriately for the connectivity check
- [ ] Confirm 5-second timeout is appropriate for detection
- [ ] Review extended `isNetworkError()` patterns - ensure new patterns don't cause false positives
- [ ] Verify global caching behavior is acceptable (once detected as air-gapped, won't re-check during CLI session)
- [ ] Confirm the protobuf generation still works correctly with `detectAirGappedModeForProtobuf` (unchanged logic)
- [ ] Verify version 3.44.1 entry format is correct in `versions.yml`

---

Link to Devin run: https://app.devin.ai/sessions/6b23c9f350a74cea8c212528282d2502
Requested by: Sandeep Dinesh (@thesandlord)