### PR TITLE
chore(docs): add tests for icon attribute handling in MDX components

### DIFF
--- a/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
+++ b/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
@@ -2,6 +2,10 @@ import { docsYml } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import path from "path";
 
+function isAbsoluteFilePath(iconPath: string | AbsoluteFilePath): iconPath is AbsoluteFilePath {
+    return typeof iconPath === "string" && path.isAbsolute(iconPath);
+}
+
 async function addIconToFilepaths({
     iconPath,
     filepaths
@@ -13,8 +17,8 @@ async function addIconToFilepaths({
         return;
     }
 
-    if (typeof iconPath === "string" && path.isAbsolute(iconPath)) {
-        filepaths.add(iconPath as AbsoluteFilePath);
+    if (isAbsoluteFilePath(iconPath)) {
+        filepaths.add(iconPath);
     }
 }
 


### PR DESCRIPTION
## Description

Refs investigation into icon path resolution in MDX components

Adds comprehensive test coverage for icon attribute handling in `parseImagePaths` and `replaceImagePathsAndUrls` functions. These tests document and verify the expected behavior when processing MDX components like `<Card icon="./play.svg">`.

**Link to Devin run:** https://app.devin.ai/sessions/6323ce68ec5342c5a561949f3e91ca23
**Requested by:** Sarah Bawabe (@sbawabe)

## Changes Made

- Added 8 new tests for icon attribute handling in `parseImagePaths.test.ts`:
  - Relative paths (`./play.svg`, `../icons/play.svg`)
  - Absolute paths (`/icons/play.svg`)
  - JSX expressions (`icon={"./play.svg"}`)
  - Font Awesome icon names (should not be processed)
  - External URLs (should not be processed)
  - Full flow: parse → replace with file ID
- Added 2 tests for AST/streaming parser consistency with icon attributes
- Minor refactor: extracted `isAbsoluteFilePath` type guard in `getImageFilepathsToUpload.ts`

- [ ] Updated README.md generator (if applicable) - N/A

## Testing

- [x] Unit tests added/updated
- [x] All 157 tests pass locally
- [x] Lint passes

## Notes for Reviewer

⚠️ **Important:** These tests all pass, confirming the existing code should handle icon attributes correctly. However, the user reported that icon paths are not being replaced with `file:fileId` in production. The tests may not cover the exact edge case the user is experiencing. Further investigation may be needed if the issue persists.