### PR TITLE
feat(ruby): add support for self-hosted mode in ruby-v2 generator

### DIFF
--- a/generators/ruby-v2/sdk/src/RubyGeneratorAgent.ts
+++ b/generators/ruby-v2/sdk/src/RubyGeneratorAgent.ts
@@ -21,7 +21,7 @@ export class RubyGeneratorAgent extends AbstractGeneratorAgent<SdkGeneratorConte
         readmeConfigBuilder: ReadmeConfigBuilder;
         ir: IntermediateRepresentation;
     }) {
-        super({ logger, config, selfHosted: false }); // TODO: upgrade IR and add self hosted
+        super({ logger, config, selfHosted: ir.selfHosted });
         this.readmeConfigBuilder = readmeConfigBuilder;
     }
 

--- a/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
@@ -384,6 +384,10 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
         return undefined;
     }
 
+    public get selfHosted(): boolean {
+        return this.ir.selfHosted ?? false;
+    }
+
     public isMultipleBaseUrlsEnvironment(): boolean {
         return this.ir.environments?.environments.type === "multipleBaseUrls";
     }

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc81
+  changelogEntry:
+    - summary: |
+        Add support for self-hosted mode. When enabled, the generator can clone the user's GitHub
+        repository, generate SDK code, and commit/push changes or create a PR directly to the user's
+        repo. This feature respects .fernignore files to preserve user customizations. The generator
+        now passes ir.selfHosted to the base generator agent instead of hardcoding false.
+      type: feat
+  createdAt: "2026-01-16"
+  irVersion: 61
+
 - version: 1.0.0-rc80
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: User request to add self-hosted mode support to Ruby-v2 generator

Enables self-hosted mode for the Ruby-v2 SDK generator, allowing users to generate SDKs and push them directly to their own GitHub repositories instead of downloading files locally.

## Changes Made

- Updated `RubyGeneratorAgent.ts` to pass `ir.selfHosted` to the base generator agent instead of hardcoding `false`
- Added `selfHosted` getter to `SdkGeneratorContext.ts` for consistency with other generators (Python, Java, Go, Swift, PHP, Rust, C#)
- Added version 1.0.0-rc81 changelog entry

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing - requires actual GitHub integration to test self-hosted mode

## Human Review Checklist

- [ ] Verify the pattern matches other generators (e.g., `generators/python-v2/sdk/src/PythonGeneratorAgent.ts`)
- [ ] Confirm `ir.selfHosted` is available on the `IntermediateRepresentation` type

---

Link to Devin run: https://app.devin.ai/sessions/1cd517f5fc4d4c18bdb0064ee6e5a825
Requested by: @iamnamananand996