### PR TITLE
feat(cli): Add fern.yml with source code info

### DIFF
--- a/packages/cli/cli-v2/src/__test__/loadFernYml.test.ts
+++ b/packages/cli/cli-v2/src/__test__/loadFernYml.test.ts
@@ -1,0 +1,277 @@
+import { mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadFernYml } from "../config/loadFernYml";
+import { ValidationError } from "../errors/ValidationError";
+
+const SAMPLE_FERN_YML = `edition: 2026-01-01
+org: acme
+
+cli:
+  version: 3.38.0
+
+sdks:
+  autorelease: true
+  defaultGroup: public
+  targets:
+    node:
+      lang: typescript
+      version: "1.4.0"
+`;
+
+describe("loadFernYml", () => {
+    let testDir: string;
+    let nestedDir: string;
+
+    beforeEach(async () => {
+        testDir = join(tmpdir(), `fern-test-${Date.now()}`);
+        nestedDir = join(testDir, "nested", "deep");
+        await mkdir(nestedDir, { recursive: true });
+        await writeFile(join(testDir, "fern.yml"), SAMPLE_FERN_YML);
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("finds fern.yml in the current directory", async () => {
+        const fernYml = await loadFernYml({ cwd: testDir });
+
+        expect(fernYml.edition).toBe("2026-01-01");
+        expect(fernYml.org).toBe("acme");
+    });
+
+    it("crawls up the directory tree to find fern.yml", async () => {
+        const fernYml = await loadFernYml({ cwd: nestedDir });
+
+        expect(fernYml.edition).toBe("2026-01-01");
+        expect(fernYml.org).toBe("acme");
+    });
+
+    it("preserves source location for the root object via source property", async () => {
+        const fernYml = await loadFernYml({ cwd: testDir });
+
+        expect(fernYml.source.$loc.absoluteFilePath.toString()).toContain("fern.yml");
+        expect(fernYml.source.$loc.line).toBe(1);
+        expect(fernYml.source.$loc.column).toBe(1);
+    });
+
+    it("preserves source location for top-level values via source property", async () => {
+        const fernYml = await loadFernYml({ cwd: testDir });
+
+        expect(fernYml.source.edition.$loc.line).toBe(1);
+        expect(fernYml.source.edition.$loc.column).toBe(10);
+        expect(fernYml.source.org.$loc.line).toBe(2);
+        expect(fernYml.source.org.$loc.column).toBe(6);
+    });
+
+    it("preserves source location for nested values via source property", async () => {
+        const fernYml = await loadFernYml({ cwd: testDir });
+
+        const cli = fernYml.source.cli;
+        expect(cli).toBeDefined();
+        if (cli && "version" in cli) {
+            expect(cli.version?.$loc.line).toBe(5);
+        }
+    });
+
+    it("preserves source location for deeply nested values via source property", async () => {
+        const fernYml = await loadFernYml({ cwd: testDir });
+
+        const sdks = fernYml.source.sdks;
+        expect(sdks).toBeDefined();
+        if (sdks && "targets" in sdks) {
+            const nodeTarget = sdks.targets?.node;
+            expect(nodeTarget).toBeDefined();
+            expect(nodeTarget?.lang?.$loc.line).toBe(12);
+        }
+    });
+
+    it("converts nested config values to plain types", async () => {
+        const fernYml = await loadFernYml({ cwd: testDir });
+        expect(fernYml.cli?.version).toBe("3.38.0");
+        expect(fernYml.sdks?.autorelease).toBe(true);
+        expect(fernYml.sdks?.defaultGroup).toBe("public");
+        expect(fernYml.sdks?.targets?.node?.lang).toBe("typescript");
+        expect(fernYml.sdks?.targets?.node?.version).toBe("1.4.0");
+    });
+
+    it("throws when fern.yml is not found", async () => {
+        const emptyDir = join(tmpdir(), `fern-empty-${Date.now()}`);
+        await mkdir(emptyDir, { recursive: true });
+        try {
+            await expect(loadFernYml({ cwd: emptyDir })).rejects.toThrow("fern.yml");
+        } finally {
+            await rm(emptyDir, { recursive: true, force: true });
+        }
+    });
+
+    describe("validation errors", () => {
+        it("throws ValidationError with descriptive messages for missing required fields", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+# Missing edition and org
+cli:
+  version: 3.38.0
+`
+            );
+
+            try {
+                await loadFernYml({ cwd: testDir });
+                expect.fail("Expected ValidationError to be thrown");
+            } catch (error) {
+                expect(error).toBeInstanceOf(ValidationError);
+
+                const validationError = error as ValidationError;
+                expect(validationError.issues.length).toBeGreaterThanOrEqual(2);
+                expect(validationError.issues[0]?.message).toContain("edition is required");
+                expect(validationError.issues[1]?.message).toContain("org is required");
+            }
+        });
+
+        it("provides ValidationIssue with toString() for CLI output", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+sdks:
+  targets:
+    node:
+      lang: 12345
+`
+            );
+
+            try {
+                await loadFernYml({ cwd: testDir });
+                expect.fail("Expected ValidationError to be thrown");
+            } catch (error) {
+                expect(error).toBeInstanceOf(ValidationError);
+                const validationError = error as ValidationError;
+
+                const [issue] = validationError.issues;
+                if (issue == null) {
+                    expect.fail("Expected at least one issue");
+                }
+
+                const issueString = issue.toString();
+                expect(issueString).toBe("fern.yml:7:13: sdks.targets.node.lang must be a string");
+            }
+        });
+
+        it("provides yamlPath for validation issues", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+sdks:
+  targets:
+    node:
+      lang: 12345
+`
+            );
+
+            try {
+                await loadFernYml({ cwd: testDir });
+                expect.fail("Expected ValidationError to be thrown");
+            } catch (error) {
+                expect(error).toBeInstanceOf(ValidationError);
+
+                const validationError = error as ValidationError;
+                expect(validationError.issues.length).toBeGreaterThan(0);
+
+                const [issue] = validationError.issues;
+                if (issue == null) {
+                    expect.fail("Expected at least one issue");
+                }
+
+                expect(issue.yamlPath).toEqual(["sdks", "targets", "node", "lang"]);
+            }
+        });
+
+        it("provides source location with line and column for invalid values", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+sdks:
+  targets:
+    node:
+      lang: 12345
+`
+            );
+
+            try {
+                await loadFernYml({ cwd: testDir });
+                expect.fail("Expected ValidationError to be thrown");
+            } catch (error) {
+                expect(error).toBeInstanceOf(ValidationError);
+                const validationError = error as ValidationError;
+                const issueWithLocation = validationError.issues.find((i) => i.location.line > 0);
+                expect(issueWithLocation).toBeDefined();
+                expect(issueWithLocation?.location.line).toBeGreaterThan(0);
+                expect(issueWithLocation?.location.column).toBeGreaterThan(0);
+            }
+        });
+
+        it("error message is issues joined by newlines", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+sdks:
+  targets:
+    node:
+      lang: 12345
+`
+            );
+
+            try {
+                await loadFernYml({ cwd: testDir });
+                expect.fail("Expected ValidationError to be thrown");
+            } catch (error) {
+                expect(error).toBeInstanceOf(ValidationError);
+                const validationError = error as ValidationError;
+
+                // Error message is all issue.toString() joined by newlines.
+                const expectedMessage = validationError.issues.map((i) => i.toString()).join("\n");
+                expect(validationError.message).toBe(expectedMessage);
+            }
+        });
+
+        it("CLI can iterate issues and write each to stderr", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+sdks:
+  targets:
+    node:
+      lang: 12345
+`
+            );
+
+            try {
+                await loadFernYml({ cwd: testDir });
+                expect.fail("Expected ValidationError to be thrown");
+            } catch (error) {
+                expect(error).toBeInstanceOf(ValidationError);
+                const validationError = error as ValidationError;
+
+                // Simulate CLI writing each issue to stderr
+                const output: string[] = [];
+                for (const issue of validationError.issues) {
+                    output.push(issue.toString());
+                }
+
+                expect(output).toEqual(["fern.yml:7:13: sdks.targets.node.lang must be a string"]);
+            }
+        });
+    });
+});

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -2,6 +2,8 @@ import type { Argv } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { addAuthCommand } from "./commands/auth";
+import { addCheckCommand } from "./commands/check";
+import { addSdkCommand } from "./commands/sdk";
 import { GlobalArgs } from "./context/GlobalArgs";
 
 export async function runCliV2(argv?: string[]): Promise<void> {
@@ -21,9 +23,22 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
         })
         .strict()
         .demandCommand()
-        .recommendCommands();
+        .recommendCommands()
+        .fail((msg, err, yargs) => {
+            if (err != null) {
+                process.stderr.write(`${err.message}\n`);
+                process.exit(1);
+            }
+            if (msg != null) {
+                process.stderr.write(`Error: ${msg}\n\n`);
+            }
+            yargs.showHelp();
+            process.exit(1);
+        });
 
     addAuthCommand(cli);
+    addCheckCommand(cli);
+    addSdkCommand(cli);
 
     return cli;
 }

--- a/packages/cli/cli-v2/src/commands/check.ts
+++ b/packages/cli/cli-v2/src/commands/check.ts
@@ -1,0 +1,30 @@
+import type { Argv } from "yargs";
+import { loadFernYml } from "../config/loadFernYml";
+import type { Context } from "../context/Context";
+import type { GlobalArgs } from "../context/GlobalArgs";
+import { withContext } from "../context/withContext";
+import { ValidationError } from "../errors/ValidationError";
+
+export interface CheckArgs extends GlobalArgs {}
+
+export function addCheckCommand(cli: Argv<GlobalArgs>): void {
+    cli.command(
+        "check",
+        "Validate your API, docs, and SDK configuration",
+        (yargs) => yargs,
+        withContext<CheckArgs>(handleCheck)
+    );
+}
+
+async function handleCheck(context: Context, _args: CheckArgs): Promise<void> {
+    try {
+        await loadFernYml({ cwd: context.cwd });
+    } catch (error) {
+        if (error instanceof ValidationError) {
+            for (const issue of error.issues) {
+                context.stderr.info(issue.toString());
+            }
+        }
+        process.exit(1);
+    }
+}

--- a/packages/cli/cli-v2/src/commands/sdk.ts
+++ b/packages/cli/cli-v2/src/commands/sdk.ts
@@ -1,14 +1,10 @@
 import type { Argv } from "yargs";
 import type { GlobalArgs } from "../context/GlobalArgs";
-import { addLoginCommand } from "./auth/login";
-import { addLogoutCommand } from "./auth/logout";
-import { addTokenCommand } from "./auth/token";
+import { addGenerateCommand } from "./sdk/generate";
 
-export function addAuthCommand(cli: Argv<GlobalArgs>): void {
-    cli.command("auth", "Authenticate fern", (yargs) => {
-        addLoginCommand(yargs);
-        addLogoutCommand(yargs);
-        addTokenCommand(yargs);
+export function addSdkCommand(cli: Argv<GlobalArgs>): void {
+    cli.command("sdk", "Configure and generate SDKs", (yargs) => {
+        addGenerateCommand(yargs);
         return yargs.demandCommand(1).fail((msg, err, yargs) => {
             if (err != null) {
                 process.stderr.write(`${err.message}\n`);

--- a/packages/cli/cli-v2/src/commands/sdk/generate.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate.ts
@@ -1,0 +1,19 @@
+import type { Argv } from "yargs";
+import type { Context } from "../../context/Context";
+import type { GlobalArgs } from "../../context/GlobalArgs";
+import { withContext } from "../../context/withContext";
+
+export interface GenerateArgs extends GlobalArgs {}
+
+export function addGenerateCommand(cli: Argv<GlobalArgs>): void {
+    cli.command(
+        "generate",
+        "Generate SDKs configured in fern.yml",
+        (yargs) => yargs,
+        withContext<GenerateArgs>(handleGenerate)
+    );
+}
+
+async function handleGenerate(context: Context, _args: GenerateArgs): Promise<void> {
+    context.stdout.info("Generating SDKs...");
+}

--- a/packages/cli/cli-v2/src/config/FernYmlConverter.ts
+++ b/packages/cli/cli-v2/src/config/FernYmlConverter.ts
@@ -1,0 +1,110 @@
+import type {
+    CliConfig,
+    FernYml,
+    GitOutputConfig,
+    NpmPublishConfig,
+    OutputConfig,
+    PublishConfig,
+    ReadmeConfig,
+    SdksConfig,
+    SdkTarget,
+    SdkTargetsConfig,
+    schemas
+} from "@fern-api/config";
+import type { Sourced, SourcedNullish, SourcedObject } from "@fern-api/source";
+
+export class FernYmlConverter {
+    /**
+     * Converts a sourced fern.yml schema to a FernYml configuration, performing
+     * validation beyond what zod can provide (e.g. does the SDK version actually
+     * exist, etc).
+     *
+     * Extracts plain values from the sourced schema while preserving
+     * access to the original sourced data for error reporting.
+     */
+    public convert(sourced: Sourced<schemas.FernYmlSchema>): FernYml {
+        return {
+            source: sourced,
+            edition: sourced.edition.value,
+            org: sourced.org.value,
+            cli: this.ifPresent(sourced.cli, (cli) => this.convertCli(cli)),
+            sdks: this.ifPresent(sourced.sdks, (sdks) => this.convertSdks(sdks))
+        };
+    }
+
+    private convertCli(cli: SourcedObject<schemas.CliSchema>): CliConfig {
+        return {
+            version: cli.version?.value
+        };
+    }
+
+    private convertSdks(sourced: SourcedObject<schemas.SdksSchema>): SdksConfig {
+        return {
+            autorelease: sourced.autorelease?.value,
+            defaultGroup: sourced.defaultGroup?.value,
+            readme: this.ifPresent(sourced.readme, (readme) => this.convertReadme(readme)),
+            targets: this.ifPresent(sourced.targets, (targets) => this.convertTargets(targets))
+        };
+    }
+
+    private convertReadme(readme: SourcedObject<schemas.ReadmeSchema>): ReadmeConfig {
+        return {
+            defaultEndpoint: readme.defaultEndpoint?.value
+        };
+    }
+
+    private convertTargets(sourced: SourcedObject<Record<string, schemas.SdkTargetSchema>>): SdkTargetsConfig {
+        return Object.fromEntries(Object.entries(sourced).map(([name, target]) => [name, this.convertTarget(target)]));
+    }
+
+    private convertTarget(sourced: Sourced<schemas.SdkTargetSchema>): SdkTarget {
+        return {
+            lang: sourced.lang?.value,
+            version: sourced.version?.value,
+            config: sourced.config?.value,
+            publish: this.ifPresent(sourced.publish, (publish) => this.convertPublish(publish)),
+            output: this.ifPresent(sourced.output, (output) => this.convertOutput(output))
+        };
+    }
+
+    private convertPublish(publish: SourcedObject<schemas.PublishSchema>): PublishConfig {
+        return {
+            npm: this.ifPresent(publish.npm, (npm) => this.convertNpm(npm))
+        };
+    }
+
+    private convertNpm(npm: SourcedObject<schemas.NpmPublishSchema>): NpmPublishConfig {
+        return {
+            packageName: npm.packageName.value
+        };
+    }
+
+    private convertOutput(output: SourcedObject<schemas.OutputSchema>): OutputConfig {
+        return {
+            path: output.path?.value,
+            git: this.ifPresent(output.git, (git) => this.convertGit(git))
+        };
+    }
+
+    private convertGit(git: SourcedObject<schemas.GitOutputSchema>): GitOutputConfig {
+        return {
+            repository: git.repository.value
+        };
+    }
+
+    /**
+     * Helper to handle optional sourced objects. The Sourced<T | undefined> type
+     * creates a union of SourcedObject<T> | SourcedNullish<undefined>. At runtime,
+     * missing properties return actual undefined (not SourcedNullish) due to proxy
+     * behavior, but TypeScript can't know this. This helper narrows the type safely.
+     */
+    private ifPresent<T extends object, R>(
+        value: SourcedObject<T> | SourcedNullish<undefined> | undefined,
+        convert: (v: SourcedObject<T>) => R
+    ): R | undefined {
+        if (value == null || "value" in value) {
+            return undefined;
+        }
+        return convert(value);
+    }
+}

--- a/packages/cli/cli-v2/src/config/FernYmlSchemaLoader.ts
+++ b/packages/cli/cli-v2/src/config/FernYmlSchemaLoader.ts
@@ -1,0 +1,37 @@
+import { FernYml, FernYmlSchema } from "@fern-api/config";
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { YamlConfigLoader } from "@fern-api/yaml-loader";
+import { FileFinder } from "./FileFinder";
+
+export namespace FernYmlSchemaLoader {
+    export interface Options {
+        /**
+         * The directory to start searching from. Defaults to process.cwd().
+         */
+        cwd?: string;
+    }
+
+    export type Result = YamlConfigLoader.Result<FernYmlSchema>;
+}
+
+export class FernYmlSchemaLoader {
+    private readonly finder: FileFinder;
+    private readonly loader: YamlConfigLoader;
+
+    constructor(options: FernYmlSchemaLoader.Options = {}) {
+        const cwd = AbsoluteFilePath.of(options.cwd ?? process.cwd());
+        this.finder = new FileFinder({ from: cwd });
+        this.loader = new YamlConfigLoader({ cwd });
+    }
+
+    /**
+     * Finds, loads, and validates a fern.yml configuration file.
+     *
+     * @returns Result with either the parsed config or validation errors.
+     * @throws Error if fern.yml is not found.
+     */
+    public async load(): Promise<FernYmlSchemaLoader.Result> {
+        const absoluteFilePath = await this.finder.findOrThrow(FernYml.FILENAME);
+        return await this.loader.load({ absoluteFilePath, schema: FernYmlSchema });
+    }
+}

--- a/packages/cli/cli-v2/src/config/FileFinder.ts
+++ b/packages/cli/cli-v2/src/config/FileFinder.ts
@@ -1,0 +1,56 @@
+import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
+import { findUp } from "find-up";
+
+export namespace FileFinder {
+    export interface Options {
+        /**
+         * The directory to start searching from (e.g. the current working directory).
+         */
+        from: AbsoluteFilePath;
+    }
+}
+
+export class FileFinder {
+    private readonly from: string;
+
+    constructor(options: FileFinder.Options) {
+        this.from = options.from;
+    }
+
+    /**
+     * Searches for a file by ascending from the starting directory until
+     * the file is found or the filesystem root is reached.
+     *
+     * Throws an error if the file is not found.
+     *
+     * @param filename - The name of the file to find (e.g., "fern.yml")
+     * @returns The absolute path to the file if found, undefined otherwise.
+     * @throws Error if the file is not found.
+     */
+    public async findOrThrow(filename: string): Promise<AbsoluteFilePath> {
+        const filepath = await this.find(filename);
+        if (filepath == null) {
+            throw new Error(`File ${filename} not found in any parent directory from ${this.from}`);
+        }
+        return filepath;
+    }
+
+    /**
+     * Searches for a file by ascending from the starting directory until
+     * the file is found or the filesystem root is reached.
+     *
+     * @param filename - The name of the file to find (e.g., "fern.yml")
+     * @returns The absolute path to the file if found, undefined otherwise.
+     */
+    public async find(filename: string): Promise<AbsoluteFilePath | undefined> {
+        const filepath = await findUp(filename, { cwd: this.from, type: "file" });
+        if (filepath == null) {
+            return undefined;
+        }
+        const absoluteFilepath = AbsoluteFilePath.of(filepath);
+        if (await doesPathExist(absoluteFilepath)) {
+            return absoluteFilepath;
+        }
+        return undefined;
+    }
+}

--- a/packages/cli/cli-v2/src/config/loadFernYml.ts
+++ b/packages/cli/cli-v2/src/config/loadFernYml.ts
@@ -1,0 +1,17 @@
+import { FernYml } from "@fern-api/config";
+import { ValidationError } from "../errors/ValidationError";
+import { FernYmlConverter } from "./FernYmlConverter";
+import { FernYmlSchemaLoader } from "./FernYmlSchemaLoader";
+
+/**
+ * Loads and validates a fern.yml configuration file.
+ */
+export async function loadFernYml({ cwd }: { cwd?: string }): Promise<FernYml> {
+    const schemaLoader = new FernYmlSchemaLoader({ cwd });
+    const result = await schemaLoader.load();
+    if (!result.success) {
+        throw new ValidationError(result.issues);
+    }
+    const converter = new FernYmlConverter();
+    return converter.convert(result.sourced);
+}

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -4,18 +4,22 @@ import { createLogger, LOG_LEVELS, Logger, LogLevel } from "@fern-api/logger";
 export class Context {
     private logLevel: LogLevel;
     private ttyAwareLogger: TtyAwareLogger;
+    public readonly cwd: string;
     public readonly stdout: Logger;
     public readonly stderr: Logger;
 
     constructor({
         stdout,
         stderr,
+        cwd,
         logLevel
     }: {
         stdout: NodeJS.WriteStream;
         stderr: NodeJS.WriteStream;
+        cwd?: string;
         logLevel?: LogLevel;
     }) {
+        this.cwd = cwd ?? process.cwd();
         this.logLevel = logLevel ?? LogLevel.Info;
         this.ttyAwareLogger = new TtyAwareLogger(stdout, stderr);
         this.stdout = createLogger((level: LogLevel, ...args: string[]) => this.log(level, ...args));

--- a/packages/cli/cli-v2/src/errors/ValidationError.ts
+++ b/packages/cli/cli-v2/src/errors/ValidationError.ts
@@ -1,0 +1,15 @@
+import { ValidationIssue } from "@fern-api/yaml-loader";
+
+/**
+ * A validation error that contains source code for each validation issue.
+ *
+ * These errors should be written to stderr.
+ */
+export class ValidationError extends Error {
+    public readonly issues: ValidationIssue[];
+
+    constructor(issues: ValidationIssue[]) {
+        super(issues.map((issue) => issue.toString()).join("\n"));
+        this.issues = issues;
+    }
+}

--- a/packages/cli/config/.depcheckrc.json
+++ b/packages/cli/config/.depcheckrc.json
@@ -1,0 +1,4 @@
+{
+  "ignores": [],
+  "ignore-patterns": ["lib", "dist"]
+}

--- a/packages/cli/config/package.json
+++ b/packages/cli/config/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fern-api/cli-v2",
+  "name": "@fern-api/config",
   "version": "0.0.0",
   "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern.git",
-    "directory": "packages/cli/cli-v2"
+    "directory": "packages/cli/config"
   },
   "sideEffects": false,
   "type": "module",
@@ -23,32 +23,21 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
+    "clean": "rm -rf ./lib && tsc --build --clean",
     "compile": "tsc --build",
     "compile:debug": "tsc --build --sourceMap",
-    "depcheck": "depcheck",
-    "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
-    "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
-    "lint:eslint": "eslint --max-warnings 0 . --ignore-pattern=../../../.eslintignore",
-    "lint:eslint:fix": "pnpm lint:eslint --fix",
+    "depcheck": "depcheck --ignores=readable-stream",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "devDependencies": {
-    "@fern-api/cli-logger": "workspace:*",
-    "@fern-api/config": "workspace:*",
     "@fern-api/configs": "workspace:*",
-    "@fern-api/fs-utils": "workspace:*",
-    "@fern-api/logger": "workspace:*",
     "@fern-api/source": "workspace:*",
-    "@fern-api/yaml-loader": "workspace:*",
     "@types/node": "18.15.3",
-    "@types/yargs": "^17.0.28",
     "depcheck": "^1.4.7",
-    "find-up": "^6.3.0",
     "typescript": "5.9.3",
     "vitest": "^4.0.8",
-    "yargs": "^17.4.1"
+    "zod": "^4.3.5"
   }
 }

--- a/packages/cli/config/src/FernYml.ts
+++ b/packages/cli/config/src/FernYml.ts
@@ -1,0 +1,61 @@
+import type { Sourced } from "@fern-api/source";
+import type { FernYmlSchema } from "./schemas/FernYmlSchema";
+
+export namespace FernYml {
+    export const FILENAME = "fern.yml";
+}
+
+export interface FernYml {
+    /** Tracks the original source of the fern.yml */
+    source: Sourced<FernYmlSchema>;
+
+    edition: string;
+    org: string;
+    cli?: CliConfig;
+    sdks?: SdksConfig;
+}
+
+export interface CliConfig {
+    version?: string;
+}
+
+export interface SdksConfig {
+    autorelease?: boolean;
+    defaultGroup?: string;
+    readme?: ReadmeConfig;
+    targets?: SdkTargetsConfig;
+}
+
+export interface ReadmeConfig {
+    defaultEndpoint?: string;
+}
+
+export type SdkTargetsConfig = {
+    [targetName: string]: SdkTarget;
+};
+
+export interface SdkTarget {
+    lang?: string;
+    version?: string;
+    config?: unknown;
+    publish?: PublishConfig;
+    output?: OutputConfig;
+    group?: string[];
+}
+
+export interface PublishConfig {
+    npm?: NpmPublishConfig;
+}
+
+export interface NpmPublishConfig {
+    packageName: string;
+}
+
+export interface OutputConfig {
+    path?: string;
+    git?: GitOutputConfig;
+}
+
+export interface GitOutputConfig {
+    repository: string;
+}

--- a/packages/cli/config/src/index.ts
+++ b/packages/cli/config/src/index.ts
@@ -1,0 +1,14 @@
+export type {
+    CliConfig,
+    GitOutputConfig,
+    NpmPublishConfig,
+    OutputConfig,
+    PublishConfig,
+    ReadmeConfig,
+    SdksConfig,
+    SdkTarget,
+    SdkTargetsConfig
+} from "./FernYml";
+export { FernYml } from "./FernYml";
+export * as schemas from "./schemas";
+export { FernYmlSchema } from "./schemas";

--- a/packages/cli/config/src/schemas/CliSchema.ts
+++ b/packages/cli/config/src/schemas/CliSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const CliSchema = z.object({
+    version: z.string().optional()
+});
+
+export type CliSchema = z.infer<typeof CliSchema>;

--- a/packages/cli/config/src/schemas/FernYmlSchema.ts
+++ b/packages/cli/config/src/schemas/FernYmlSchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { CliSchema } from "./CliSchema";
+import { SdksSchema } from "./SdksSchema";
+
+export const FernYmlSchema = z.object({
+    edition: z.string(),
+    org: z.string(),
+    cli: CliSchema.optional(),
+    sdks: SdksSchema.optional()
+});
+
+export type FernYmlSchema = z.infer<typeof FernYmlSchema>;

--- a/packages/cli/config/src/schemas/GitOutputSchema.ts
+++ b/packages/cli/config/src/schemas/GitOutputSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const GitOutputSchema = z.object({
+    repository: z.string()
+});
+
+export type GitOutputSchema = z.infer<typeof GitOutputSchema>;

--- a/packages/cli/config/src/schemas/NpmPublishSchema.ts
+++ b/packages/cli/config/src/schemas/NpmPublishSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const NpmPublishSchema = z.object({
+    packageName: z.string()
+});
+
+export type NpmPublishSchema = z.infer<typeof NpmPublishSchema>;

--- a/packages/cli/config/src/schemas/OutputSchema.ts
+++ b/packages/cli/config/src/schemas/OutputSchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { GitOutputSchema } from "./GitOutputSchema";
+
+export const OutputSchema = z.object({
+    path: z.string().optional(),
+    git: GitOutputSchema.optional()
+});
+
+export type OutputSchema = z.infer<typeof OutputSchema>;

--- a/packages/cli/config/src/schemas/PublishSchema.ts
+++ b/packages/cli/config/src/schemas/PublishSchema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { NpmPublishSchema } from "./NpmPublishSchema";
+
+export const PublishSchema = z.object({
+    npm: NpmPublishSchema.optional()
+});
+
+export type PublishSchema = z.infer<typeof PublishSchema>;

--- a/packages/cli/config/src/schemas/ReadmeSchema.ts
+++ b/packages/cli/config/src/schemas/ReadmeSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const ReadmeSchema = z.object({
+    defaultEndpoint: z.string().optional()
+});
+
+export type ReadmeSchema = z.infer<typeof ReadmeSchema>;

--- a/packages/cli/config/src/schemas/SdkTargetSchema.ts
+++ b/packages/cli/config/src/schemas/SdkTargetSchema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { OutputSchema } from "./OutputSchema";
+import { PublishSchema } from "./PublishSchema";
+
+export const SdkTargetSchema = z.object({
+    lang: z.string().optional(),
+    version: z.string().optional(),
+    config: z.record(z.string(), z.unknown()).optional(),
+    publish: PublishSchema.optional(),
+    output: OutputSchema.optional(),
+    group: z.array(z.string()).optional()
+});
+
+export type SdkTargetSchema = z.infer<typeof SdkTargetSchema>;

--- a/packages/cli/config/src/schemas/SdksSchema.ts
+++ b/packages/cli/config/src/schemas/SdksSchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { ReadmeSchema } from "./ReadmeSchema";
+import { SdkTargetSchema } from "./SdkTargetSchema";
+
+export const SdksSchema = z.object({
+    autorelease: z.boolean().optional(),
+    defaultGroup: z.string().optional(),
+    readme: ReadmeSchema.optional(),
+    targets: z.record(z.string(), SdkTargetSchema)
+});
+
+export type SdksSchema = z.infer<typeof SdksSchema>;

--- a/packages/cli/config/src/schemas/index.ts
+++ b/packages/cli/config/src/schemas/index.ts
@@ -1,0 +1,9 @@
+export { CliSchema } from "./CliSchema";
+export { FernYmlSchema } from "./FernYmlSchema";
+export { GitOutputSchema } from "./GitOutputSchema";
+export { NpmPublishSchema } from "./NpmPublishSchema";
+export { OutputSchema } from "./OutputSchema";
+export { PublishSchema } from "./PublishSchema";
+export { ReadmeSchema } from "./ReadmeSchema";
+export { SdksSchema } from "./SdksSchema";
+export { SdkTargetSchema } from "./SdkTargetSchema";

--- a/packages/cli/config/tsconfig.json
+++ b/packages/cli/config/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@fern-api/configs/tsconfig/main.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "moduleResolution": "bundler"
+  },
+  "include": ["./src/**/*"],
+  "references": [
+    {
+      "path": "../../commons/core-utils"
+    },
+    {
+      "path": "../source"
+    }
+  ]
+}

--- a/packages/cli/config/vitest.config.ts
+++ b/packages/cli/config/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/ete-tests/src/tests/v2/fixtures/simple/fern.yml
+++ b/packages/cli/ete-tests/src/tests/v2/fixtures/simple/fern.yml
@@ -1,0 +1,15 @@
+edition: 2026-01-01
+
+org: acme
+
+cli:
+  version: 0.1.0
+
+sdks:
+  autorelease: true
+  targets:
+    node:
+      lang: typescript
+      version: "1.4.0"
+      output:
+        path: ./sdks/typescript-sdk

--- a/packages/cli/ete-tests/src/tests/v2/v2.test.ts
+++ b/packages/cli/ete-tests/src/tests/v2/v2.test.ts
@@ -1,0 +1,50 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import tmp from "tmp-promise";
+import { describe, expect, it } from "vitest";
+import { runFernCli } from "../../utils/runFernCli";
+
+const VALID_FERN_YML = `edition: 2026-01-01
+org: acme
+
+cli:
+  version: 3.38.0
+
+sdks:
+  autorelease: true
+  targets:
+    typescript:
+      lang: typescript
+      version: "1.0.0"
+`;
+
+const INVALID_FERN_YML = `org: 12345`;
+
+describe("fern v2", () => {
+    it("fern check (success)", async () => {
+        const tmpDir = await tmp.dir();
+        const directory = AbsoluteFilePath.of(tmpDir.path);
+        await writeFile(join(tmpDir.path, "fern.yml"), VALID_FERN_YML);
+
+        const { stdout } = await runFernCli(["v2", "check"], {
+            cwd: directory
+        });
+        expect(stdout).to.be.empty;
+    });
+
+    it("fern check (failure)", async () => {
+        const tmpDir = await tmp.dir();
+        const directory = AbsoluteFilePath.of(tmpDir.path);
+        await writeFile(join(tmpDir.path, "fern.yml"), INVALID_FERN_YML);
+
+        const { stdout, stderr, exitCode } = await runFernCli(["v2", "check"], {
+            cwd: directory,
+            reject: false
+        });
+        expect(exitCode).to.equal(1);
+        expect(stdout).to.be.empty;
+        expect(stderr).to.contain("fern.yml:1:1: edition is required");
+        expect(stderr).to.contain("fern.yml:1:6: org must be a string");
+    });
+}, 90_000);

--- a/packages/cli/source/.depcheckrc.json
+++ b/packages/cli/source/.depcheckrc.json
@@ -1,0 +1,4 @@
+{
+  "ignores": [],
+  "ignore-patterns": ["lib", "dist"]
+}

--- a/packages/cli/source/package.json
+++ b/packages/cli/source/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fern-api/cli-v2",
+  "name": "@fern-api/source",
   "version": "0.0.0",
   "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern.git",
-    "directory": "packages/cli/cli-v2"
+    "directory": "packages/cli/source"
   },
   "sideEffects": false,
   "type": "module",
@@ -23,32 +23,20 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
+    "clean": "rm -rf ./lib && tsc --build --clean",
     "compile": "tsc --build",
     "compile:debug": "tsc --build --sourceMap",
-    "depcheck": "depcheck",
-    "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
-    "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
-    "lint:eslint": "eslint --max-warnings 0 . --ignore-pattern=../../../.eslintignore",
-    "lint:eslint:fix": "pnpm lint:eslint --fix",
+    "depcheck": "depcheck --ignores=readable-stream",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "devDependencies": {
-    "@fern-api/cli-logger": "workspace:*",
-    "@fern-api/config": "workspace:*",
     "@fern-api/configs": "workspace:*",
-    "@fern-api/fs-utils": "workspace:*",
-    "@fern-api/logger": "workspace:*",
-    "@fern-api/source": "workspace:*",
-    "@fern-api/yaml-loader": "workspace:*",
+    "@fern-api/path-utils": "workspace:*",
     "@types/node": "18.15.3",
-    "@types/yargs": "^17.0.28",
     "depcheck": "^1.4.7",
-    "find-up": "^6.3.0",
     "typescript": "5.9.3",
-    "vitest": "^4.0.8",
-    "yargs": "^17.4.1"
+    "vitest": "^4.0.8"
   }
 }

--- a/packages/cli/source/src/Locatable.ts
+++ b/packages/cli/source/src/Locatable.ts
@@ -1,0 +1,8 @@
+import type { SourceLocation } from "./SourceLocation";
+
+/**
+ * A value with source location tracking.
+ */
+export interface Locatable {
+    readonly $loc: SourceLocation;
+}

--- a/packages/cli/source/src/SourceLocation.ts
+++ b/packages/cli/source/src/SourceLocation.ts
@@ -1,0 +1,49 @@
+import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/path-utils";
+
+/**
+ * Represents a location in a source file.
+ */
+export class SourceLocation {
+    public readonly absoluteFilePath: AbsoluteFilePath;
+    public readonly relativeFilePath: RelativeFilePath;
+    public readonly line: number;
+    public readonly column: number;
+
+    constructor({
+        absoluteFilePath,
+        relativeFilePath,
+        line,
+        column
+    }: {
+        absoluteFilePath: AbsoluteFilePath;
+        relativeFilePath: RelativeFilePath;
+        line: number;
+        column: number;
+    }) {
+        this.absoluteFilePath = absoluteFilePath;
+        this.relativeFilePath = relativeFilePath;
+        this.line = line;
+        this.column = column;
+    }
+
+    /**
+     * Formats as "filepath:line:column" using the relative file path.
+     */
+    public toString(): string {
+        return this.toRelativeString();
+    }
+
+    /**
+     * Formats using the relative file path.
+     */
+    public toRelativeString(): string {
+        return `${this.relativeFilePath}:${this.line}:${this.column}`;
+    }
+
+    /**
+     * Formats using the absolute file path.
+     */
+    public toAbsoluteString(): string {
+        return `${this.absoluteFilePath}:${this.line}:${this.column}`;
+    }
+}

--- a/packages/cli/source/src/SourceNodeWrapper.ts
+++ b/packages/cli/source/src/SourceNodeWrapper.ts
@@ -1,0 +1,6 @@
+import type { Sourced } from "./Sourced";
+
+/**
+ * A function that wraps a child node value with source tracking.
+ */
+export type SourceNodeWrapper = <T>(value: T, key: string | number) => Sourced<T>;

--- a/packages/cli/source/src/Sourced.ts
+++ b/packages/cli/source/src/Sourced.ts
@@ -1,0 +1,156 @@
+import type { Locatable } from "./Locatable";
+import type { SourceLocation } from "./SourceLocation";
+
+/**
+ * The Sourced type wraps any value with source location tracking.
+ */
+export type Sourced<T> = T extends string
+    ? SourcedString
+    : T extends number
+      ? SourcedNumber
+      : T extends boolean
+        ? SourcedBoolean
+        : T extends null
+          ? SourcedNullish<null>
+          : T extends undefined
+            ? SourcedNullish<undefined>
+            : T extends Array<infer U>
+              ? SourcedArray<U>
+              : T extends object
+                ? SourcedObject<T>
+                : never;
+
+/**
+ * A sourced string constrained to a specific set of literal values.
+ * Useful for enums in YAML.
+ */
+export type SourcedLiteral<T extends string> = SourcedString & {
+    readonly value: T;
+};
+
+/**
+ * A primitive value with source location tracking.
+ * Use `valueOf()` for implicit conversion, or `.value` for explicit access.
+ */
+export class SourcedString implements Locatable {
+    constructor(
+        private readonly _value: string,
+        public readonly $loc: SourceLocation
+    ) {}
+
+    public get value(): string {
+        return this._value;
+    }
+
+    public get length(): number {
+        return this._value.length;
+    }
+
+    public valueOf(): string {
+        return this._value;
+    }
+
+    public toString(): string {
+        return this._value;
+    }
+
+    public toLowerCase(): string {
+        return this._value.toLowerCase();
+    }
+
+    public toUpperCase(): string {
+        return this._value.toUpperCase();
+    }
+
+    public trim(): string {
+        return this._value.trim();
+    }
+
+    public startsWith(searchString: string, position?: number): boolean {
+        return this._value.startsWith(searchString, position);
+    }
+
+    public endsWith(searchString: string, endPosition?: number): boolean {
+        return this._value.endsWith(searchString, endPosition);
+    }
+
+    public includes(searchString: string, position?: number): boolean {
+        return this._value.includes(searchString, position);
+    }
+
+    public split(separator: string | RegExp, limit?: number): string[] {
+        return this._value.split(separator, limit);
+    }
+}
+
+export class SourcedNumber implements Locatable {
+    constructor(
+        private readonly _value: number,
+        public readonly $loc: SourceLocation
+    ) {}
+
+    public get value(): number {
+        return this._value;
+    }
+
+    public valueOf(): number {
+        return this._value;
+    }
+
+    public toString(): string {
+        return String(this._value);
+    }
+
+    public toFixed(fractionDigits?: number): string {
+        return this._value.toFixed(fractionDigits);
+    }
+}
+
+export class SourcedBoolean implements Locatable {
+    constructor(
+        private readonly _value: boolean,
+        public readonly $loc: SourceLocation
+    ) {}
+
+    public get value(): boolean {
+        return this._value;
+    }
+
+    public valueOf(): boolean {
+        return this._value;
+    }
+
+    public toString(): string {
+        return String(this._value);
+    }
+}
+
+/**
+ * A null/undefined value with source location tracking.
+ */
+export class SourcedNullish<T extends null | undefined> implements Locatable {
+    constructor(
+        private readonly _value: T,
+        public readonly $loc: SourceLocation
+    ) {}
+
+    public get value(): T {
+        return this._value;
+    }
+
+    public valueOf(): T {
+        return this._value;
+    }
+}
+
+/**
+ * An object with source location tracking.
+ */
+export type SourcedObject<T extends object> = {
+    [K in keyof T]: Sourced<T[K]>;
+} & Locatable;
+
+/**
+ * An array of elements with source location tracking.
+ */
+export type SourcedArray<T> = Array<Sourced<T>> & Locatable;

--- a/packages/cli/source/src/constants.ts
+++ b/packages/cli/source/src/constants.ts
@@ -1,0 +1,1 @@
+export const LOCATION_PROPERTY = "$loc";

--- a/packages/cli/source/src/createSourcedArray.ts
+++ b/packages/cli/source/src/createSourcedArray.ts
@@ -1,0 +1,49 @@
+import { LOCATION_PROPERTY } from "./constants";
+import type { SourcedArray } from "./Sourced";
+import type { SourceLocation } from "./SourceLocation";
+import type { SourceNodeWrapper } from "./SourceNodeWrapper";
+
+/**
+ * Creates a sourced proxy for an array that adds $loc and recursively wraps elements.
+ */
+export function createSourcedArray<T>({
+    value,
+    wrapChild,
+    location
+}: {
+    value: T[];
+    wrapChild: SourceNodeWrapper;
+    location: SourceLocation;
+}): SourcedArray<T> {
+    const cache = new Map<number, unknown>();
+    return new Proxy(value, {
+        get(target, prop, receiver) {
+            if (prop === LOCATION_PROPERTY) {
+                return location;
+            }
+
+            // Handle array index access.
+            const index = typeof prop === "string" ? parseInt(prop, 10) : undefined;
+            if (index !== undefined && !isNaN(index) && index >= 0 && index < target.length) {
+                if (cache.has(index)) {
+                    return cache.get(index);
+                }
+
+                const rawValue = target[index];
+                const wrapped = wrapChild(rawValue, index);
+                cache.set(index, wrapped);
+                return wrapped;
+            }
+
+            // Forward other property access (length, methods, etc).
+            return Reflect.get(target, prop, receiver);
+        },
+
+        has(target, prop) {
+            if (prop === LOCATION_PROPERTY) {
+                return true;
+            }
+            return Reflect.has(target, prop);
+        }
+    }) as unknown as SourcedArray<T>;
+}

--- a/packages/cli/source/src/createSourcedObject.ts
+++ b/packages/cli/source/src/createSourcedObject.ts
@@ -1,0 +1,59 @@
+import { LOCATION_PROPERTY } from "./constants";
+import type { SourcedObject } from "./Sourced";
+import type { SourceLocation } from "./SourceLocation";
+import type { SourceNodeWrapper } from "./SourceNodeWrapper";
+
+/**
+ * Creates a sourced proxy for an object that adds $loc and recursively wraps properties.
+ */
+export function createSourcedObject<T extends object>({
+    value,
+    wrapChild,
+    location
+}: {
+    value: T;
+    wrapChild: SourceNodeWrapper;
+    location: SourceLocation;
+}): SourcedObject<T> {
+    const cache = new Map<string | symbol, unknown>();
+    return new Proxy(value, {
+        get(target, prop, receiver) {
+            if (prop === LOCATION_PROPERTY) {
+                return location;
+            }
+
+            if (cache.has(prop)) {
+                return cache.get(prop);
+            }
+
+            // Don't wrap undefined for missing properties.
+            const rawValue = Reflect.get(target, prop, receiver);
+            if (rawValue === undefined && !(prop in target)) {
+                return undefined;
+            }
+
+            const propKey = typeof prop === "symbol" ? String(prop) : prop;
+            const wrapped = wrapChild(rawValue, propKey as string | number);
+            cache.set(prop, wrapped);
+            return wrapped;
+        },
+
+        has(target, prop) {
+            if (prop === LOCATION_PROPERTY) {
+                return true;
+            }
+            return Reflect.has(target, prop);
+        },
+
+        ownKeys(target) {
+            return [...Reflect.ownKeys(target), "$loc"];
+        },
+
+        getOwnPropertyDescriptor(target, prop) {
+            if (prop === LOCATION_PROPERTY) {
+                return { configurable: true, enumerable: false, value: location };
+            }
+            return Reflect.getOwnPropertyDescriptor(target, prop);
+        }
+    }) as SourcedObject<T>;
+}

--- a/packages/cli/source/src/index.ts
+++ b/packages/cli/source/src/index.ts
@@ -1,0 +1,14 @@
+export { createSourcedArray } from "./createSourcedArray";
+export { createSourcedObject } from "./createSourcedObject";
+export { type Locatable } from "./Locatable";
+export {
+    type Sourced,
+    type SourcedArray,
+    SourcedBoolean,
+    SourcedNullish,
+    SourcedNumber,
+    type SourcedObject,
+    SourcedString
+} from "./Sourced";
+export { SourceLocation } from "./SourceLocation";
+export { type SourceNodeWrapper } from "./SourceNodeWrapper";

--- a/packages/cli/source/tsconfig.json
+++ b/packages/cli/source/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@fern-api/configs/tsconfig/main.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "moduleResolution": "bundler"
+  },
+  "include": ["./src/**/*"],
+  "references": [
+    {
+      "path": "../../commons/core-utils"
+    },
+    {
+      "path": "../../commons/path-utils"
+    }
+  ]
+}

--- a/packages/cli/source/vitest.config.ts
+++ b/packages/cli/source/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/packages/cli/yaml/loader/.depcheckrc.json
+++ b/packages/cli/yaml/loader/.depcheckrc.json
@@ -1,0 +1,4 @@
+{
+  "ignores": [],
+  "ignore-patterns": ["lib", "dist"]
+}

--- a/packages/cli/yaml/loader/package.json
+++ b/packages/cli/yaml/loader/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fern-api/cli-v2",
+  "name": "@fern-api/yaml-loader",
   "version": "0.0.0",
   "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern.git",
-    "directory": "packages/cli/cli-v2"
+    "directory": "packages/cli/yaml/loader"
   },
   "sideEffects": false,
   "type": "module",
@@ -23,32 +23,24 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
+    "clean": "rm -rf ./lib && tsc --build --clean",
     "compile": "tsc --build",
     "compile:debug": "tsc --build --sourceMap",
     "depcheck": "depcheck",
-    "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
-    "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
-    "lint:eslint": "eslint --max-warnings 0 . --ignore-pattern=../../../.eslintignore",
-    "lint:eslint:fix": "pnpm lint:eslint --fix",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "devDependencies": {
-    "@fern-api/cli-logger": "workspace:*",
-    "@fern-api/config": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
-    "@fern-api/logger": "workspace:*",
+    "@fern-api/path-utils": "workspace:*",
     "@fern-api/source": "workspace:*",
-    "@fern-api/yaml-loader": "workspace:*",
     "@types/node": "18.15.3",
-    "@types/yargs": "^17.0.28",
     "depcheck": "^1.4.7",
-    "find-up": "^6.3.0",
     "typescript": "5.9.3",
     "vitest": "^4.0.8",
-    "yargs": "^17.4.1"
+    "yaml": "^2.4.5",
+    "zod": "^4.3.5"
   }
 }

--- a/packages/cli/yaml/loader/src/ValidationIssue.ts
+++ b/packages/cli/yaml/loader/src/ValidationIssue.ts
@@ -1,0 +1,41 @@
+import type { SourceLocation } from "@fern-api/source";
+
+/**
+ * Represents a validation issue found when parsing a YAML configuration file.
+ *
+ * Use `toString()` to format as `<file>:<line>:<col>: <message>` for CLI output.
+ */
+export class ValidationIssue {
+    /** The validation error message */
+    public readonly message: string;
+    /** The source location where the issue was found */
+    public readonly location: SourceLocation;
+    /** The path to the value in the YAML document (e.g., ["cli", "version"]) */
+    public readonly yamlPath: ReadonlyArray<string | number>;
+
+    constructor({
+        message,
+        location,
+        yamlPath
+    }: {
+        message: string;
+        location: SourceLocation;
+        yamlPath: ReadonlyArray<string | number>;
+    }) {
+        this.message = message;
+        this.location = location;
+        this.yamlPath = yamlPath;
+    }
+
+    /**
+     * Formats as `<file>:<line>:<col>: <message>` for CLI output.
+     *
+     * @example
+     * ```
+     * fern.yml:6:13: org must be a string
+     * ```
+     */
+    public toString(): string {
+        return `${this.location}: ${this.message}`;
+    }
+}

--- a/packages/cli/yaml/loader/src/YamlConfigLoader.ts
+++ b/packages/cli/yaml/loader/src/YamlConfigLoader.ts
@@ -1,0 +1,152 @@
+import { AbsoluteFilePath, RelativeFilePath, relative } from "@fern-api/fs-utils";
+import type { Sourced } from "@fern-api/source";
+import { z } from "zod";
+import { ValidationIssue } from "./ValidationIssue";
+import type { YamlDocument } from "./YamlDocument";
+import { YamlParser } from "./YamlParser";
+import { YamlSourceResolver } from "./YamlSourceResolver";
+
+export namespace YamlConfigLoader {
+    export type Result<T> = Success<T> | Failure;
+
+    export interface Success<T> {
+        success: true;
+        /** The validated config data */
+        data: T;
+        /** The config with source location wrappers for error reporting */
+        sourced: Sourced<T>;
+        /** The absolute path to the loaded config file */
+        absoluteFilePath: AbsoluteFilePath;
+        /** The relative path to the loaded config file */
+        relativeFilePath: RelativeFilePath;
+    }
+
+    export interface Failure {
+        success: false;
+        /** The validation issues found in the YAML file */
+        issues: ValidationIssue[];
+    }
+}
+
+export class YamlConfigLoader {
+    private readonly parser: YamlParser;
+    private readonly cwd: AbsoluteFilePath;
+
+    constructor({ cwd }: { cwd: AbsoluteFilePath }) {
+        this.parser = new YamlParser();
+        this.cwd = cwd;
+    }
+
+    /**
+     * Loads and validates a YAML configuration file with source location tracking.
+     *
+     * @param absoluteFilePath - The absolute path to the YAML file.
+     * @param schema - The zod schema to validate against.
+     * @returns Result with either the parsed config (both plain and sourced) or validation errors.
+     *
+     * @example
+     * ```typescript
+     * const loader = new YamlConfigLoader({ cwd });
+     * const result = await loader.load(path, FernYmlSchema);
+     * if (result.success) {
+     *   console.log(result.data.edition);           // Plain value
+     *   console.log(result.sourced.edition.$loc);   // Source location
+     * }
+     * ```
+     */
+    public async load<S extends z.ZodSchema>({
+        absoluteFilePath,
+        schema
+    }: {
+        absoluteFilePath: AbsoluteFilePath;
+        schema: S;
+    }): Promise<YamlConfigLoader.Result<z.infer<S>>> {
+        const document = await this.parseDocument(absoluteFilePath);
+
+        const parseResult = schema.safeParse(document.toJS());
+        if (!parseResult.success) {
+            const issues = parseResult.error.issues.map((issue) => {
+                // Zod paths are PropertyKey[] but YAML paths are string | number
+                const yamlPath = issue.path.filter((p): p is string | number => typeof p !== "symbol");
+                return new ValidationIssue({
+                    yamlPath,
+                    message: this.formatZodIssue(issue),
+                    location: document.getSourceLocation(yamlPath)
+                });
+            });
+
+            return {
+                success: false,
+                issues
+            };
+        }
+
+        const resolver = new YamlSourceResolver(document);
+        return {
+            success: true,
+            data: parseResult.data,
+            sourced: resolver.toSourced(parseResult.data),
+            absoluteFilePath,
+            relativeFilePath: RelativeFilePath.of(relative(this.cwd, absoluteFilePath))
+        };
+    }
+
+    private async parseDocument(absoluteFilePath: AbsoluteFilePath): Promise<YamlDocument> {
+        try {
+            return await this.parser.parseDocument({ absoluteFilePath, cwd: this.cwd });
+        } catch (err) {
+            throw new Error(
+                `Failed to parse YAML file ${absoluteFilePath}: ${err instanceof Error ? err.message : String(err)}`
+            );
+        }
+    }
+
+    private formatZodIssue(issue: z.core.$ZodIssue): string {
+        const path = issue.path.join(".");
+
+        switch (issue.code) {
+            case "invalid_type":
+                // In Zod 4, the received type is only in the message, not a separate property.
+                //
+                // Message format: "Invalid input: expected {type}, received {type}"
+                if (issue.message.endsWith("received undefined")) {
+                    return path.length > 0 ? `${path} is required` : "value is required";
+                }
+                return path.length > 0 ? `${path} must be a ${issue.expected}` : `must be a ${issue.expected}`;
+
+            case "invalid_value": {
+                if (issue.values != null) {
+                    const options = issue.values.join(", ");
+                    return path.length > 0 ? `${path} must be one of: ${options}` : `must be one of: ${options}`;
+                }
+                return issue.message;
+            }
+
+            case "unrecognized_keys":
+                return `unknown key(s): ${issue.keys.join(", ")}`;
+
+            case "invalid_union": {
+                // For union errors, collect unique expected types from nested errors
+                const expectedTypes = new Set<string>();
+                for (const errorGroup of issue.errors) {
+                    for (const err of errorGroup) {
+                        if (err.code === "invalid_type") {
+                            expectedTypes.add(err.expected);
+                        }
+                    }
+                }
+                if (expectedTypes.size > 0) {
+                    const types = Array.from(expectedTypes).join(" or ");
+                    return path.length > 0 ? `${path} must be a ${types}` : `must be a ${types}`;
+                }
+                return path.length > 0 ? `${path} has an invalid value` : "invalid value";
+            }
+
+            case "invalid_format":
+                return path.length > 0 ? `${path} must be a valid ${issue.format}` : `must be a valid ${issue.format}`;
+
+            default:
+                return issue.message;
+        }
+    }
+}

--- a/packages/cli/yaml/loader/src/YamlDocument.ts
+++ b/packages/cli/yaml/loader/src/YamlDocument.ts
@@ -1,0 +1,95 @@
+import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import type { RelativeFilePath } from "@fern-api/path-utils";
+import { SourceLocation } from "@fern-api/source";
+import { type Document, isNode } from "yaml";
+
+/**
+ * A path to a value within a YAML document. Each element is either
+ * a string (object key) or number (array index).
+ */
+export type YamlPath = ReadonlyArray<string | number>;
+
+/**
+ * Wraps a parsed YAML Document to provide source location lookups.
+ */
+export class YamlDocument {
+    private readonly absoluteFilePath: AbsoluteFilePath;
+    private readonly relativeFilePath: RelativeFilePath;
+    private readonly document: Document;
+    private readonly source: string;
+
+    constructor({
+        absoluteFilePath,
+        relativeFilePath,
+        document,
+        source
+    }: {
+        absoluteFilePath: AbsoluteFilePath;
+        relativeFilePath: RelativeFilePath;
+        document: Document;
+        source: string;
+    }) {
+        this.absoluteFilePath = absoluteFilePath;
+        this.relativeFilePath = relativeFilePath;
+        this.document = document;
+        this.source = source;
+    }
+
+    /**
+     * Returns the parsed YAML content as a plain JavaScript value.
+     */
+    public toJS(): unknown {
+        return this.document.toJS();
+    }
+
+    /**
+     * Returns the source location for a value at the given path.
+     * Falls back to the document root location if the path doesn't exist.
+     *
+     * @param path - Path to the value (e.g., ["sdks", "targets", "node", 0, "lang"])
+     * @returns The source location, or the document root if the path doesn't exist.
+     */
+    public getSourceLocation(path: YamlPath): SourceLocation {
+        const node = this.document.getIn(path, true);
+        if (!isNode(node)) {
+            return this.getRootSourceLocation();
+        }
+
+        const range = node.range;
+        if (range == null) {
+            return this.getRootSourceLocation();
+        }
+
+        // range[0] is the start offset.
+        return this.offsetToLocation(range[0]);
+    }
+
+    /**
+     * Returns the source location for the document root.
+     */
+    public getRootSourceLocation(): SourceLocation {
+        return new SourceLocation({
+            absoluteFilePath: this.absoluteFilePath,
+            relativeFilePath: this.relativeFilePath,
+            line: 1,
+            column: 1
+        });
+    }
+
+    private offsetToLocation(offset: number): SourceLocation {
+        let line = 1;
+        let lastNewline = -1;
+        for (let i = 0; i < offset && i < this.source.length; i++) {
+            if (this.source[i] === "\n") {
+                line++;
+                lastNewline = i;
+            }
+        }
+        return new SourceLocation({
+            absoluteFilePath: this.absoluteFilePath,
+            relativeFilePath: this.relativeFilePath,
+            line,
+            column: offset - lastNewline
+        });
+    }
+}

--- a/packages/cli/yaml/loader/src/YamlParser.ts
+++ b/packages/cli/yaml/loader/src/YamlParser.ts
@@ -1,0 +1,47 @@
+import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { RelativeFilePath, relative } from "@fern-api/path-utils";
+import { readFile } from "fs/promises";
+import { parse, parseDocument } from "yaml";
+import { YamlDocument } from "./YamlDocument";
+
+export class YamlParser {
+    /**
+     * Loads and parses a YAML file.
+     *
+     * @param filepath - The absolute path to the YAML file.
+     * @returns The parsed YAML content as a plain JavaScript value.
+     * @throws Error if the file cannot be read or contains invalid YAML.
+     */
+    public async parse(absoluteFilePath: AbsoluteFilePath): Promise<unknown> {
+        const source = await readFile(absoluteFilePath, "utf-8");
+        return parse(source);
+    }
+
+    /**
+     * Loads and parses a YAML file, preserving source location information.
+     *
+     * Use this method when you need to report errors with line/column numbers.
+     *
+     * @param absoluteFilePath - The absolute path to the YAML file.
+     * @param cwd - The current working directory, used to compute relative paths for error messages.
+     * @returns A YamlDocument that provides source location lookups.
+     * @throws Error if the file cannot be read or contains invalid YAML.
+     */
+    public async parseDocument({
+        absoluteFilePath,
+        cwd
+    }: {
+        absoluteFilePath: AbsoluteFilePath;
+        cwd: AbsoluteFilePath;
+    }): Promise<YamlDocument> {
+        const source = await readFile(absoluteFilePath, "utf-8");
+        const document = parseDocument(source);
+        const relativeFilePath = RelativeFilePath.of(relative(cwd, absoluteFilePath));
+        return new YamlDocument({
+            absoluteFilePath,
+            relativeFilePath,
+            document,
+            source
+        });
+    }
+}

--- a/packages/cli/yaml/loader/src/YamlSourceResolver.ts
+++ b/packages/cli/yaml/loader/src/YamlSourceResolver.ts
@@ -1,0 +1,52 @@
+import {
+    createSourcedArray,
+    createSourcedObject,
+    type Sourced,
+    SourcedBoolean,
+    SourcedNullish,
+    SourcedNumber,
+    SourcedString
+} from "@fern-api/source";
+import type { YamlDocument, YamlPath } from "./YamlDocument";
+
+export class YamlSourceResolver {
+    constructor(private readonly document: YamlDocument) {}
+
+    public toSourced<T>(value: T): Sourced<T> {
+        return this.toSourcedInternal(value, []);
+    }
+
+    private toSourcedInternal<T>(value: T, path: YamlPath): Sourced<T> {
+        const location = this.document.getSourceLocation(path);
+        if (value === null) {
+            return new SourcedNullish(null, location) as Sourced<T>;
+        }
+        if (value === undefined) {
+            return new SourcedNullish(undefined, location) as Sourced<T>;
+        }
+        if (Array.isArray(value)) {
+            return createSourcedArray({
+                value: value,
+                location: location,
+                wrapChild: (childValue, index) => this.toSourcedInternal(childValue, [...path, index])
+            }) as Sourced<T>;
+        }
+        if (value instanceof Object) {
+            return createSourcedObject({
+                value: value as object,
+                location: location,
+                wrapChild: (childValue, key) => this.toSourcedInternal(childValue, [...path, key])
+            }) as Sourced<T>;
+        }
+        switch (typeof value) {
+            case "string":
+                return new SourcedString(value, location) as Sourced<T>;
+            case "number":
+                return new SourcedNumber(value, location) as Sourced<T>;
+            case "boolean":
+                return new SourcedBoolean(value, location) as Sourced<T>;
+            default:
+                throw new Error(`Unexpected value type: ${typeof value}`);
+        }
+    }
+}

--- a/packages/cli/yaml/loader/src/__test__/YamlDocument.test.ts
+++ b/packages/cli/yaml/loader/src/__test__/YamlDocument.test.ts
@@ -1,0 +1,99 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { RelativeFilePath } from "@fern-api/path-utils";
+import { beforeEach, describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+import { YamlDocument } from "../YamlDocument";
+
+const SAMPLE_YAML = `edition: 2026-01-01
+org: acme
+
+cli:
+  version: 3.38.0
+
+sdks:
+  autorelease: true
+  defaultGroup: public
+  targets:
+    node:
+      - lang: typescript
+        version: "1.4.0"
+`;
+
+const TEST_FILE_PATH = AbsoluteFilePath.of("/test/sample.yaml");
+const TEST_RELATIVE_PATH = RelativeFilePath.of("sample.yaml");
+
+describe("YamlDocument", () => {
+    let yamlDoc: YamlDocument;
+
+    beforeEach(() => {
+        const document = parseDocument(SAMPLE_YAML);
+        yamlDoc = new YamlDocument({
+            absoluteFilePath: TEST_FILE_PATH,
+            relativeFilePath: TEST_RELATIVE_PATH,
+            document,
+            source: SAMPLE_YAML
+        });
+    });
+
+    it("returns correct source location for top-level values", () => {
+        const editionLoc = yamlDoc.getSourceLocation(["edition"]);
+        expect(editionLoc).toMatchObject({ line: 1, column: 10 });
+
+        const orgLoc = yamlDoc.getSourceLocation(["org"]);
+        expect(orgLoc).toMatchObject({ line: 2, column: 6 });
+
+        const cliLoc = yamlDoc.getSourceLocation(["cli"]);
+        expect(cliLoc).toMatchObject({ line: 5, column: 3 });
+    });
+
+    it("returns correct source location for nested values", () => {
+        const versionLoc = yamlDoc.getSourceLocation(["cli", "version"]);
+        expect(versionLoc).toMatchObject({ line: 5, column: 12 });
+
+        const autoreleaseLoc = yamlDoc.getSourceLocation(["sdks", "autorelease"]);
+        expect(autoreleaseLoc).toMatchObject({ line: 8, column: 16 });
+    });
+
+    it("returns correct source location for array elements", () => {
+        const firstTargetLoc = yamlDoc.getSourceLocation(["sdks", "targets", "node", 0]);
+        expect(firstTargetLoc).toMatchObject({ line: 12, column: 9 });
+
+        const langLoc = yamlDoc.getSourceLocation(["sdks", "targets", "node", 0, "lang"]);
+        expect(langLoc).toMatchObject({ line: 12, column: 15 });
+    });
+
+    it("returns root location for non-existent paths", () => {
+        const rootLoc = yamlDoc.getRootSourceLocation();
+
+        const nonexistentLoc = yamlDoc.getSourceLocation(["nonexistent"]);
+        expect(nonexistentLoc.line).toBe(rootLoc.line);
+        expect(nonexistentLoc.column).toBe(rootLoc.column);
+
+        const invalidArrayIndexLoc = yamlDoc.getSourceLocation(["sdks", "targets", "node", 99]);
+        expect(invalidArrayIndexLoc.line).toBe(rootLoc.line);
+        expect(invalidArrayIndexLoc.column).toBe(rootLoc.column);
+    });
+
+    it("converts to plain JS object", () => {
+        const js = yamlDoc.toJS();
+        expect(js).toEqual({
+            edition: "2026-01-01",
+            org: "acme",
+            cli: {
+                version: "3.38.0"
+            },
+            sdks: {
+                autorelease: true,
+                defaultGroup: "public",
+                targets: {
+                    node: [
+                        {
+                            lang: "typescript",
+                            version: "1.4.0"
+                        }
+                    ]
+                }
+            }
+        });
+    });
+});

--- a/packages/cli/yaml/loader/src/__test__/YamlSourceResolver.test.ts
+++ b/packages/cli/yaml/loader/src/__test__/YamlSourceResolver.test.ts
@@ -1,0 +1,95 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { RelativeFilePath } from "@fern-api/path-utils";
+import type { Sourced } from "@fern-api/source";
+import { beforeEach, describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+import { YamlDocument } from "../YamlDocument";
+import { YamlSourceResolver } from "../YamlSourceResolver";
+
+const TEST_FILE_PATH = AbsoluteFilePath.of("/test/sample.yaml");
+const TEST_RELATIVE_PATH = RelativeFilePath.of("sample.yaml");
+const TEST_YAML = `edition: 2026-01-01
+org: acme
+
+cli:
+  version: 3.38.0
+
+sdks:
+  autorelease: true
+  targets:
+    node:
+      lang: typescript
+      version: "1.4.0"
+`;
+
+/**
+ * Type definitions for the sample YAML structure.
+ */
+interface TestConfig {
+    edition: string;
+    org: string;
+    cli: {
+        version: string;
+    };
+    sdks: {
+        autorelease: boolean;
+        targets: {
+            node: {
+                lang: string;
+                version: string;
+            };
+        };
+    };
+}
+
+describe("YamlSourceResolver", () => {
+    let sourced: Sourced<TestConfig>;
+
+    beforeEach(() => {
+        sourced = createSourcedConfig();
+    });
+
+    it("wraps primitive values with $loc and valueOf()", () => {
+        expect(sourced.$loc).toBeDefined();
+        expect(sourced.edition.$loc).toMatchObject({ line: 1, column: 10 });
+        expect(sourced.edition + "").toBe("2026-01-01");
+        expect(sourced.edition.value).toBe("2026-01-01");
+        expect(String(sourced.edition)).toBe("2026-01-01");
+        expect(sourced.org.$loc).toMatchObject({ line: 2, column: 6 });
+        expect(sourced.org.value).toBe("acme");
+    });
+
+    it("provides $loc on objects via proxy", () => {
+        expect(sourced.cli.$loc).toMatchObject({ line: 5, column: 3 });
+        expect(sourced.cli.version.$loc).toMatchObject({ line: 5, column: 12 });
+        expect(sourced.cli.version.value).toBe("3.38.0");
+        expect(sourced.sdks.$loc).toMatchObject({ line: 8, column: 3 });
+        expect(sourced.sdks.autorelease.$loc).toMatchObject({ line: 8, column: 16 });
+        expect(sourced.sdks.autorelease.value).toBe(true);
+    });
+
+    it("provides $loc on nested objects", () => {
+        const nodeConfig = sourced.sdks.targets.node;
+        expect(nodeConfig.$loc).toMatchObject({ line: 11, column: 7 });
+        expect(nodeConfig.lang.$loc).toMatchObject({ line: 11, column: 13 });
+        expect(nodeConfig.lang.value).toBe("typescript");
+        expect(nodeConfig.version.$loc).toMatchObject({ line: 12, column: 16 });
+        expect(nodeConfig.version.value).toBe("1.4.0");
+    });
+
+    it("valueOf() allows primitives to work in expressions", () => {
+        expect(sourced.edition + " test").toBe("2026-01-01 test");
+        expect(sourced.sdks.autorelease ? "yes" : "no").toBe("yes");
+    });
+});
+
+function createSourcedConfig(): Sourced<TestConfig> {
+    const yamlDoc = new YamlDocument({
+        absoluteFilePath: TEST_FILE_PATH,
+        relativeFilePath: TEST_RELATIVE_PATH,
+        source: TEST_YAML,
+        document: parseDocument(TEST_YAML)
+    });
+    const value = yamlDoc.toJS() as TestConfig;
+    return new YamlSourceResolver(yamlDoc).toSourced(value);
+}

--- a/packages/cli/yaml/loader/src/index.ts
+++ b/packages/cli/yaml/loader/src/index.ts
@@ -1,0 +1,6 @@
+export { ValidationIssue } from "./ValidationIssue";
+export { YamlConfigLoader } from "./YamlConfigLoader";
+export type { YamlPath } from "./YamlDocument";
+export { YamlDocument } from "./YamlDocument";
+export { YamlParser } from "./YamlParser";
+export { YamlSourceResolver } from "./YamlSourceResolver";

--- a/packages/cli/yaml/loader/tsconfig.json
+++ b/packages/cli/yaml/loader/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@fern-api/configs/tsconfig/main.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["./src/**/*"],
+  "references": [
+    {
+      "path": "../../source"
+    }
+  ]
+}

--- a/packages/cli/yaml/loader/vitest.config.ts
+++ b/packages/cli/yaml/loader/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@fern-api/configs/vitest/base.mjs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4883,12 +4883,24 @@ importers:
       '@fern-api/cli-logger':
         specifier: workspace:*
         version: link:../cli-logger
+      '@fern-api/config':
+        specifier: workspace:*
+        version: link:../config
       '@fern-api/configs':
         specifier: workspace:*
         version: link:../../configs
+      '@fern-api/fs-utils':
+        specifier: workspace:*
+        version: link:../../commons/fs-utils
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../logger
+      '@fern-api/source':
+        specifier: workspace:*
+        version: link:../source
+      '@fern-api/yaml-loader':
+        specifier: workspace:*
+        version: link:../yaml/loader
       '@types/node':
         specifier: 18.15.3
         version: 18.15.3
@@ -4898,6 +4910,9 @@ importers:
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
+      find-up:
+        specifier: ^6.3.0
+        version: 6.3.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -4907,6 +4922,30 @@ importers:
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
+
+  packages/cli/config:
+    devDependencies:
+      '@fern-api/configs':
+        specifier: workspace:*
+        version: link:../../configs
+      '@fern-api/source':
+        specifier: workspace:*
+        version: link:../source
+      '@types/node':
+        specifier: 18.15.3
+        version: 18.15.3
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.8
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.5
 
   packages/cli/configuration:
     dependencies:
@@ -6867,6 +6906,27 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
+  packages/cli/source:
+    devDependencies:
+      '@fern-api/configs':
+        specifier: workspace:*
+        version: link:../../configs
+      '@fern-api/path-utils':
+        specifier: workspace:*
+        version: link:../../commons/path-utils
+      '@types/node':
+        specifier: 18.15.3
+        version: 18.15.3
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.8
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+
   packages/cli/task-context:
     dependencies:
       '@fern-api/logger':
@@ -7439,6 +7499,39 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
 
+  packages/cli/yaml/loader:
+    devDependencies:
+      '@fern-api/configs':
+        specifier: workspace:*
+        version: link:../../../configs
+      '@fern-api/fs-utils':
+        specifier: workspace:*
+        version: link:../../../commons/fs-utils
+      '@fern-api/path-utils':
+        specifier: workspace:*
+        version: link:../../../commons/path-utils
+      '@fern-api/source':
+        specifier: workspace:*
+        version: link:../../source
+      '@types/node':
+        specifier: 18.15.3
+        version: 18.15.3
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.8
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@18.15.3)(jsdom@27.1.0)(msw@2.12.1(@types/node@18.15.3)(typescript@5.9.3))(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.3.3)
+      yaml:
+        specifier: 2.3.3
+        version: 2.3.3
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.5
+
   packages/commons/casings-generator:
     dependencies:
       '@fern-api/configuration':
@@ -7733,7 +7826,7 @@ importers:
         version: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -16035,6 +16128,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.5:
+    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -25229,7 +25325,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -25247,6 +25343,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       babel-jest: 30.2.0(@babel/core@7.28.5)
+      esbuild: 0.25.12
       jest-util: 30.2.0
 
   ts-morph@27.0.2:
@@ -26089,5 +26186,7 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   zod@3.25.76: {}
+
+  zod@4.3.5: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Description

Linear ticket: Closes https://linear.app/buildwithfern/issue/FER-8259/cli-v2-implement-yaml-source-code-info

This introduces the initial schema for the `fern.yml` configuration file with source code info tracking, backed by [yaml](https://www.npmjs.com/package/yaml) and [zod](https://zod.dev/) (v4). This change is primarily focused on wiring up _YAML source code info_, so only the following subset of configuration is included for now:

```yaml
# fern.yml
edition: 2026-01-01
org: acme
sdks:
  autorelease: true
  targets:
    node:
      lang: typescript
```

With this, the CLI can provide far better diagnostics which are compatible with all IDEs. For example, suppose you provided the following invalid config:

```yaml
# fern.yml
edition: 2026-01-01
org: acme
sdks:
  autorelease: xyz
  targets:
    node:
      lang: 12345
```

```sh
$ fern v2 check
../fern.yml:5:16: sdks.autorelease must be a boolean
../fern.yml:8:13: sdks.targets.node.lang must be a string
```

## Changes Made

This introduces the [yaml](https://www.npmjs.com/package/yaml) library instead of [js-yaml](https://www.npmjs.com/package/js-yaml) because it includes source code information tracking. The new `@fern-api/yaml-loader` and `@fern-api/source` packages are used to map the YAML nodes to the respective Zod schema definition. The generic `Sourced` type is used to map YAML paths to their respective `<line, column>` numbers. 

From there, the `FernYmlConverter` will be able to refer to specific source paths if it encounters any validation errors beyond what `zod` is capable of (i.e. does a particular SDK version actually exist)?

With the help of TypeScript's [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) type, the UX for this is shown below:

```typescript
const loader = new YamlConfigLoader({ cwd });
const result = await loader.load(path, FernYmlSchema);
if (result.success) {
    console.log(result.sourced.edition);        // Plain value
    console.log(result.sourced.edition.$loc);   // Source location
}
```

We intentionally do _not_ attempt to track source code info in the converted `FernYml` because it will soon be typed in terms of internal abstractions (e.g. `Workspace`), and it will become impossible to reliably map these constructs back to a single source.

Note that `$ref` support, along with source code tracking between referenced files, will be added in a follow-up.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
