### PR TITLE
fix(cli): add airgapped checks to all external FDR/Venus service calls during fern generate

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.51.2
+  changelogEntry:
+    - summary: |
+        Fix air-gapped environment support for `fern generate --docs`. Added airgapped detection to skip external services that don't have local equivalents (Python docs generation, Venus organization lookup). Fixed protobuf air-gapped detection to use `detectAirGappedModeForProtobuf()` instead of `detectAirGappedMode()`. Added Venus-specific connectivity check for AI example enhancement that doesn't rely on the global cache.
+      type: fix
+  createdAt: "2026-01-26"
+  irVersion: 63
+
 - version: 3.51.1
   changelogEntry:
     - summary: |
@@ -216,14 +224,6 @@
         Add edit this page launch target
       type: feat
   createdAt: "2026-01-16"
-  irVersion: 63
-
-- version: 3.46.1
-  changelogEntry:
-    - summary: |
-        Fix protobuf air-gapped detection to use the correct function. Both `ProtobufOpenAPIGenerator` and `ProtobufIRGenerator` were incorrectly calling `detectAirGappedMode()` with a file path instead of a URL, causing air-gapped detection to fail. They now use `detectAirGappedModeForProtobuf()` which properly tests network connectivity using `buf dep update`.
-      type: fix
-  createdAt: "2026-01-20"
   irVersion: 63
 
 - version: 3.46.0

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -218,6 +218,14 @@
   createdAt: "2026-01-16"
   irVersion: 63
 
+- version: 3.46.1
+  changelogEntry:
+    - summary: |
+        Fix protobuf air-gapped detection to use the correct function. Both `ProtobufOpenAPIGenerator` and `ProtobufIRGenerator` were incorrectly calling `detectAirGappedMode()` with a file path instead of a URL, causing air-gapped detection to fail. They now use `detectAirGappedModeForProtobuf()` which properly tests network connectivity using `buf dep update`.
+      type: fix
+  createdAt: "2026-01-20"
+  irVersion: 63
+
 - version: 3.46.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -44,6 +44,7 @@
     "@fern-api/ir-generator": "workspace:*",
     "@fern-api/ir-migrations": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
+    "@fern-api/lazy-fern-workspace": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-api/register": "workspace:*",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -172,12 +172,6 @@ export async function publishDocs({
             const hashNonImageTime = performance.now() - hashNonImageStart;
             context.logger.debug(`Hashed ${filepaths.length} non-image files in ${hashNonImageTime.toFixed(0)}ms`);
 
-            if (isAirGapped) {
-                context.logger.debug("Skipping FDR docs registration in air-gapped environment");
-                docsRegistrationId = "air-gapped-local";
-                return [];
-            }
-
             if (preview) {
                 const startDocsRegisterResponse = await fdr.docs.v2.write.startDocsPreviewRegister({
                     orgId: CjsFdrSdk.OrgId(organization),
@@ -278,13 +272,6 @@ export async function publishDocs({
             }
         },
         registerApi: async ({ ir, snippetsConfig, playgroundConfig, apiName, workspace }) => {
-            if (isAirGapped) {
-                context.logger.debug(
-                    `Skipping FDR API registration for ${apiName ?? ir.apiName.originalName} in air-gapped environment`
-                );
-                return CjsFdrSdk.ApiDefinitionId(`air-gapped-${ir.apiName.originalName}`);
-            }
-
             // Use apiName from docs.yml (folder name) as the API identifier for FDR
             // This ensures users can reference APIs by their folder name in docs components
             let apiDefinition = convertIrToFdrApi({
@@ -509,14 +496,6 @@ export async function publishDocs({
         if (pollAttempts >= MAX_POLL_ATTEMPTS) {
             return context.failAndThrow("Python docs generation timed out");
         }
-    }
-
-    if (isAirGapped) {
-        context.logger.info("Skipping FDR docs publishing in air-gapped environment");
-        const url = wrapWithHttps(urlToOutput);
-        const link = terminalLink(url, url);
-        context.logger.info(chalk.green(`Docs resolved locally for ${link} (air-gapped mode)`));
-        return;
     }
 
     context.logger.info("Publishing docs to FDR...");

--- a/packages/cli/register/src/registerApi.ts
+++ b/packages/cli/register/src/registerApi.ts
@@ -6,7 +6,6 @@ import { createFdrService } from "@fern-api/core";
 import { FdrAPI as FdrCjsSdk } from "@fern-api/fdr-sdk";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
-import { detectAirGappedMode } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
 
 import { AIExampleEnhancerConfig, enhanceExamplesWithAI } from "./ai-example-enhancer";
@@ -32,9 +31,6 @@ export async function registerApi({
     playgroundConfig?: PlaygroundConfig;
     aiEnhancerConfig?: AIExampleEnhancerConfig;
 }): Promise<{ id: FdrCjsSdk.ApiDefinitionId; ir: IntermediateRepresentation }> {
-    const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
-    const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
-
     const ir = generateIntermediateRepresentation({
         workspace,
         audiences,
@@ -52,11 +48,6 @@ export async function registerApi({
     const fdrService = createFdrService({
         token: token.value
     });
-
-    if (isAirGapped) {
-        context.logger.debug(`Skipping FDR API registration for ${ir.apiName.originalName} in air-gapped environment`);
-        return { id: FdrCjsSdk.ApiDefinitionId(`air-gapped-${ir.apiName.originalName}`), ir };
-    }
 
     let apiDefinition = convertIrToFdrApi({ ir, snippetsConfig, playgroundConfig, context });
 

--- a/packages/cli/register/src/registerApi.ts
+++ b/packages/cli/register/src/registerApi.ts
@@ -6,6 +6,7 @@ import { createFdrService } from "@fern-api/core";
 import { FdrAPI as FdrCjsSdk } from "@fern-api/fdr-sdk";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
+import { detectAirGappedMode } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
 
 import { AIExampleEnhancerConfig, enhanceExamplesWithAI } from "./ai-example-enhancer";
@@ -31,6 +32,9 @@ export async function registerApi({
     playgroundConfig?: PlaygroundConfig;
     aiEnhancerConfig?: AIExampleEnhancerConfig;
 }): Promise<{ id: FdrCjsSdk.ApiDefinitionId; ir: IntermediateRepresentation }> {
+    const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
+    const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
+
     const ir = generateIntermediateRepresentation({
         workspace,
         audiences,
@@ -48,6 +52,11 @@ export async function registerApi({
     const fdrService = createFdrService({
         token: token.value
     });
+
+    if (isAirGapped) {
+        context.logger.debug(`Skipping FDR API registration for ${ir.apiName.originalName} in air-gapped environment`);
+        return { id: FdrCjsSdk.ApiDefinitionId(`air-gapped-${ir.apiName.originalName}`), ir };
+    }
 
     let apiDefinition = convertIrToFdrApi({ ir, snippetsConfig, playgroundConfig, context });
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
@@ -6,7 +6,7 @@ import path from "path";
 import tmp from "tmp-promise";
 
 import {
-    detectAirGappedMode,
+    detectAirGappedModeForProtobuf,
     getProtobufYamlV1,
     PROTOBUF_EXPORT_CONFIG_V1,
     PROTOBUF_EXPORT_CONFIG_V2,
@@ -58,7 +58,10 @@ export class ProtobufIRGenerator {
     }): Promise<AbsoluteFilePath> {
         // Detect air-gapped mode once at the start if we have dependencies
         if (deps.length > 0 && this.isAirGapped === undefined) {
-            this.isAirGapped = await detectAirGappedMode(absoluteFilepathToProtobufRoot, this.context.logger);
+            this.isAirGapped = await detectAirGappedModeForProtobuf(
+                absoluteFilepathToProtobufRoot,
+                this.context.logger
+            );
         }
 
         const protobufGeneratorConfigPath = await this.setupProtobufGeneratorConfig({

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
@@ -3,7 +3,7 @@ import { createLoggingExecutable } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
 import { access, cp, readFile, unlink, writeFile } from "fs/promises";
 import tmp from "tmp-promise";
-import { detectAirGappedMode, getProtobufYamlV1 } from "./utils";
+import { detectAirGappedModeForProtobuf, getProtobufYamlV1 } from "./utils";
 
 const PROTOBUF_GENERATOR_CONFIG_FILENAME = "buf.gen.yaml";
 const PROTOBUF_GENERATOR_OUTPUT_PATH = "output";
@@ -59,7 +59,10 @@ export class ProtobufOpenAPIGenerator {
     }): Promise<{ absoluteFilepath: AbsoluteFilePath; bufLockContents: string | undefined }> {
         // Detect air-gapped mode once at the start if we have dependencies
         if (deps.length > 0 && this.isAirGapped === undefined) {
-            this.isAirGapped = await detectAirGappedMode(absoluteFilepathToProtobufRoot, this.context.logger);
+            this.isAirGapped = await detectAirGappedModeForProtobuf(
+                absoluteFilepathToProtobufRoot,
+                this.context.logger
+            );
         }
 
         const protobufGeneratorConfigPath = await this.setupProtobufGeneratorConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6403,6 +6403,9 @@ importers:
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../../../ir-sdk
+      '@fern-api/lazy-fern-workspace':
+        specifier: workspace:*
+        version: link:../../../workspace/lazy-fern-workspace
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../logger


### PR DESCRIPTION
## Description

Refs: Slack thread about airgapped environment failures

Fixes the "FDR registerApiDefinition failed: fetch failed" error that occurs when running `fern generate --docs` in air-gapped/self-hosted environments. Also fixes the `buf dep update` "server hosted at that remote is unavailable" error for protobuf generation, and the "Failed to obtain JWT from Venus" warning for AI example enhancement.

**Revised Approach**: After discussion, the fix was updated to keep FDR calls working (they should use the local FDR server via `DEFAULT_FDR_ORIGIN`) and only skip external services that don't have local equivalents.

## Changes Made

- **publishDocs.ts**: Added airgapped detection and skip Python docs generation (`startLibraryDocsGeneration`) - this external service has no local equivalent
- **runRemoteGenerationForGenerator.ts**: Added airgapped detection and skip Venus organization lookup - there's no local Venus server
- **package.json**: Added `@fern-api/lazy-fern-workspace` dependency to remote-workspace-runner
- **ProtobufIRGenerator.ts & ProtobufOpenAPIGenerator.ts**: Fixed air-gapped detection to use `detectAirGappedModeForProtobuf()` instead of `detectAirGappedMode()` - the original function expected a URL but was being passed a file path
- **lambdaClient.ts**: Added Venus-specific connectivity check (`isVenusAirGapped()`) that doesn't rely on the global cache - fixes issue where local FDR being reachable caused Venus checks to incorrectly return "not airgapped"
- **versions.yml**: Added changelog entry for CLI version 3.51.2

**What's NOT skipped**: FDR calls (registerApiDefinition, startDocsRegister, finishDocsRegister, etc.) are NOT skipped because they should work with the local FDR server when `DEFAULT_FDR_ORIGIN` is properly configured.

## Updates since last revision

Updated versions.yml to make this the latest version (3.51.2) instead of inserting at an older version number.

## Testing

- [ ] Unit tests added/updated
- [x] Manual lint/format checks passed (`pnpm run check`, `pnpm format`)
- [x] CI checks passing

## Human Review Checklist

- [ ] Verify `DEFAULT_FDR_ORIGIN` is properly set in self-hosted environments to point to local FDR server
- [ ] Verify the `/health` endpoint exists on Venus (used for Venus-specific air-gapped detection)
- [ ] Confirm skipping Venus lookup doesn't break whitelabel or self-hosted SDK features (these IR fields won't be set in airgapped mode)
- [ ] Verify skipping Python docs generation is acceptable behavior in airgapped environments
- [ ] Confirm self-hosted deployments have `buf.lock` pre-cached at build time (required for air-gapped protobuf generation)
- [ ] Verify the 5-second timeout for Venus connectivity check is appropriate

---


Link to Devin run: https://app.devin.ai/sessions/7aca72cdf3e44a27878b2f9655970f4e
Requested by: Sandeep Dinesh (@thesandlord)