### PR TITLE
feat(cli): Add standalone CLI v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "fern:build:unminified": "cross-env POSTHOG_API_KEY=\"\" turbo run dist:cli:prod:unminified --filter @fern-api/cli && echo 'Run node --enable-source-maps packages/cli/cli/dist/prod/cli.cjs'",
     "fern-dev:build": "turbo run dist:cli:dev --filter=@fern-api/cli && echo 'Run node --enable-source-maps packages/cli/cli/dist/dev/cli.cjs'",
     "fern-local:build": "turbo run dist:cli:local --filter @fern-api/cli && echo 'Run node --enable-source-maps packages/cli/cli/dist/local/cli.cjs'",
+    "fern-v2-dev:build": "turbo run dist:cli:dev --filter=@fern-api/cli-v2 && echo 'Run node --enable-source-maps packages/cli/cli-v2/dist/dev/cli.cjs'",
+    "fern-v2-dev:local": "FERN_NO_VERSION_REDIRECTION=true node --enable-source-maps ./packages/cli/cli-v2/dist/dev/cli.cjs",
     "generator-cli:generate": "pnpm fern:build && pnpm fern generate --api generator-cli --local && turbo run dist:cli --filter=@fern-api/generator-cli",
     "seed:build": "turbo run dist:cli --filter=@fern-api/seed-cli && echo 'Run node --enable-source-maps packages/seed/dist/cli.cjs'",
     "publish": "pnpm -r publish --access public --no-git-checks --loglevel=verbose",

--- a/packages/cli/cli-v2/build-utils.mjs
+++ b/packages/cli/cli-v2/build-utils.mjs
@@ -1,0 +1,118 @@
+import { exec } from "child_process";
+import { writeFile } from "fs/promises";
+import path from "path";
+import tsup from "tsup";
+import { fileURLToPath } from "url";
+import { promisify } from "util";
+import packageJson from "./package.json" with { type: "json" };
+
+const execAsync = promisify(exec);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Get a dependency version from package.json, preferring dependencies over devDependencies.
+ * This ensures we don't miss runtime dependencies regardless of where they're declared.
+ */
+function getDependencyVersion(packageName) {
+    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName];
+}
+
+/**
+ * Common external dependencies for full builds (dev/prod with extensive externals)
+ */
+export const FULL_EXTERNALS = [
+    /^prettier(?:\/.*)?$/,
+    /^prettier2(?:\/.*)?$/,
+    /^vitest(?:\/.*)?$/,
+    /^depcheck(?:\/.*)?$/,
+    /^tsup(?:\/.*)?$/,
+    /^typescript(?:\/.*)?$/,
+    /^@types\/.*$/
+];
+
+/**
+ * Minimal external dependencies for local/unminified builds
+ */
+export const MINIMAL_EXTERNALS = [];
+
+/**
+ * Common tsup overrides for production-like builds with optimization
+ */
+export const PRODUCTION_TSUP_OVERRIDES = {
+    platform: "node",
+    target: "node18",
+    external: FULL_EXTERNALS,
+    metafile: true
+};
+
+/**
+ * Build the Fern CLI v2 with the specified configuration
+ * @param {Object} config - Build configuration
+ * @param {string} config.outDir - Output directory (e.g., 'dist/prod', 'dist/dev')
+ * @param {boolean} config.minify - Whether to minify the output
+ * @param {Object} [config.env] - Environment variables to inject
+ * @param {string[]} [config.runtimeDependencies] - List of runtime dependencies to include in package.json
+ * @param {Object} [config.packageJsonOverrides] - Overrides for the generated package.json
+ * @param {Object} [config.tsupOverrides] - Additional tsup configuration options
+ */
+export async function buildCli(config) {
+    const {
+        outDir,
+        minify,
+        env = {},
+        runtimeDependencies = [],
+        packageJsonOverrides = {},
+        tsupOverrides = {}
+    } = config;
+
+    // Build with tsup
+    await tsup.build({
+        entry: { cli: "src/main.ts" },
+        format: ["cjs"],
+        minify,
+        outDir,
+        sourcemap: true,
+        clean: true,
+        env: {
+            ...env,
+            CLI_VERSION: process.argv[2] || packageJson.version
+        },
+        ...tsupOverrides
+    });
+
+    // Change to output directory
+    process.chdir(path.join(__dirname, outDir));
+
+    // Collect runtime dependencies
+    const dependencies = {};
+    for (const dep of runtimeDependencies) {
+        const version = getDependencyVersion(dep);
+        if (version) {
+            dependencies[dep] = version;
+        }
+    }
+
+    // Validate that all required dependencies were found
+    const missingDeps = runtimeDependencies.filter((dep) => !dependencies[dep]);
+    if (missingDeps.length > 0) {
+        throw new Error(
+            `Missing required runtime dependencies in package.json: ${missingDeps.join(", ")}. ` +
+                `These must be declared in either dependencies or devDependencies.`
+        );
+    }
+
+    // Write package.json
+    const outputPackageJson = {
+        version: process.argv[2] || packageJson.version,
+        repository: packageJson.repository,
+        files: ["cli.cjs"],
+        ...(Object.keys(dependencies).length > 0 && { dependencies }),
+        ...packageJsonOverrides
+    };
+
+    await writeFile("package.json", JSON.stringify(outputPackageJson, undefined, 2));
+
+    // Run npm pkg fix to format and fix the package.json
+    await execAsync("npm pkg fix");
+}

--- a/packages/cli/cli-v2/build.dev.mjs
+++ b/packages/cli/cli-v2/build.dev.mjs
@@ -1,0 +1,14 @@
+import { buildCli, PRODUCTION_TSUP_OVERRIDES } from "./build-utils.mjs";
+
+buildCli({
+    outDir: "dist/dev",
+    minify: false,
+    env: {
+        CLI_NAME: "fern-v2"
+    },
+    packageJsonOverrides: {
+        name: "@fern-api/fern-v2-dev",
+        bin: { "fern-v2": "cli.cjs" }
+    },
+    tsupOverrides: PRODUCTION_TSUP_OVERRIDES
+});

--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -27,6 +27,7 @@
     "compile": "tsc --build",
     "compile:debug": "tsc --build --sourceMap",
     "depcheck": "depcheck",
+    "dist:cli:dev": "node build.dev.mjs",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "lint:eslint": "eslint --max-warnings 0 . --ignore-pattern=../../../.eslintignore",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@fern-api/cli-logger": "workspace:*",
+    "tsup": "^8.5.0",
     "@fern-api/config": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",

--- a/packages/cli/cli-v2/src/main.ts
+++ b/packages/cli/cli-v2/src/main.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runCliV2 } from "./cli";
+
+void runCliV2();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4913,6 +4913,9 @@ importers:
       find-up:
         specifier: ^6.3.0
         version: 6.3.0
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(@microsoft/api-extractor@7.55.2(@types/node@18.15.3))(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.3.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -4922,6 +4925,8 @@ importers:
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
+
+  packages/cli/cli-v2/dist/dev: {}
 
   packages/cli/config:
     devDependencies:
@@ -7826,7 +7831,7 @@ importers:
         version: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -25325,7 +25330,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -25343,7 +25348,6 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       babel-jest: 30.2.0(@babel/core@7.28.5)
-      esbuild: 0.25.12
       jest-util: 30.2.0
 
   ts-morph@27.0.2:


### PR DESCRIPTION
## Description

This adds a couple new `package.json` scripts to build a standalone binary for CLI v2. We already ship the rewrite under the `v2` sub-command (i.e. `fern v2 check`), but this will help us assess how the CLI looks and feels on its own.

I use a lightweight `alias` to make it easy to call the in-development CLI from anywhere in my filesystem:

```sh
alias fern-v2="node ~/path/to/fern/packages/cli/cli-v2/dist/dev/cli.cjs"
```

For example, you can already see how much lighter the CLI should feel:

```sh
$ time fern-v2 check
../fern.yml:4:16: sdks.autorelease must be a boolean
../fern.yml:7:13: sdks.targets.node.lang must be a string

real	0m0.093s
user	0m0.058s
sys	    0m0.015s
```

```sh
$ time fern-v2 --help
fern <command>

Commands:
  fern auth   Authenticate fern
  fern check  Validate your API, docs, and SDK configuration
  fern sdk    Configure and generate SDKs

Options:
  --help       Show help                                               [boolean]
  --version    Show version number                                     [boolean]
  --log-level  Set log level
          [string] [choices: "debug", "info", "warn", "error"] [default: "info"]

real	0m0.065s
user	0m0.046s
sys	    0m0.016s
```

```sh
$ time fern-v2 --version
0.0.1

real	0m0.061s
user	0m0.043s
sys	    0m0.013s
```

## Changes Made

- Adds a `build-utils.mjs` and `build-dev.mjs` file to `packages/cli/cli-v2`, directly inspired by the setup in `packages/cli/cli`.
- Adds two new `package.json` scripts: `fern-dev-v2:build` and `fern-dev-v2:local`.

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed

Manual testing shown in the description above.