### PR TITLE
feat(cli): Add command library and error handler

### DIFF
--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -24,7 +24,7 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
         .strict()
         .demandCommand()
         .recommendCommands()
-        .fail((msg, err, yargs) => {
+        .fail((msg, err, y) => {
             if (err != null) {
                 process.stderr.write(`${err.message}\n`);
                 process.exit(1);
@@ -32,7 +32,7 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
             if (msg != null) {
                 process.stderr.write(`Error: ${msg}\n\n`);
             }
-            yargs.showHelp();
+            y.showHelp();
             process.exit(1);
         });
 

--- a/packages/cli/cli-v2/src/commands/_internal/command.ts
+++ b/packages/cli/cli-v2/src/commands/_internal/command.ts
@@ -1,0 +1,36 @@
+import type { Argv, BuilderCallback } from "yargs";
+import type { Context } from "../../context/Context";
+import type { GlobalArgs } from "../../context/GlobalArgs";
+import { withContext } from "../../context/withContext";
+
+type CommandHandler<T extends GlobalArgs = GlobalArgs> = (context: Context, args: T) => Promise<void>;
+
+/**
+ * Registers a leaf command with a handler.
+ *
+ * @example
+ * ```ts
+ * command(cli, "generate", "Generate SDKs", handleGenerate, (yargs) =>
+ *     yargs
+ *         .option("group", { type: "string", description: "Generator group" })
+ *         .option("local", { type: "boolean", default: false })
+ * );
+ * ```
+ */
+export function command<T extends GlobalArgs = GlobalArgs>(
+    cli: Argv<GlobalArgs>,
+    name: string,
+    description: string,
+    handler: CommandHandler<T>,
+    builder?: BuilderCallback<GlobalArgs, T>
+): void {
+    cli.command(
+        name,
+        description,
+        (yargs) => {
+            const configured = yargs.usage(`$0 ${name} [options]\n\n${description}`);
+            return builder != null ? builder(configured) : configured;
+        },
+        withContext(handler) as unknown as () => void
+    );
+}

--- a/packages/cli/cli-v2/src/commands/_internal/commandGroup.ts
+++ b/packages/cli/cli-v2/src/commands/_internal/commandGroup.ts
@@ -1,0 +1,42 @@
+import type { Argv } from "yargs";
+import type { GlobalArgs } from "../../context/GlobalArgs";
+
+type CommandAdder = (cli: Argv<GlobalArgs>) => void;
+
+/**
+ * Registers a command group with subcommands.
+ *
+ * @example
+ * ```ts
+ * commandGroup(cli, "auth", "Authenticate fern", [
+ *     addLoginCommand,
+ *     addLogoutCommand,
+ * ]);
+ * ```
+ */
+export function commandGroup(
+    cli: Argv<GlobalArgs>,
+    name: string,
+    description: string,
+    subcommands: CommandAdder[]
+): void {
+    cli.command(name, description, (yargs) => {
+        for (const add of subcommands) {
+            add(yargs);
+        }
+        return yargs
+            .usage(`$0 ${name}\n\n${description}`)
+            .demandCommand(1)
+            .fail((msg, err, y) => {
+                if (err != null) {
+                    process.stderr.write(`${err.message}\n`);
+                    process.exit(1);
+                }
+                if (msg != null) {
+                    process.stderr.write(`Error: ${msg}\n\n`);
+                }
+                y.showHelp();
+                process.exit(1);
+            });
+    });
+}

--- a/packages/cli/cli-v2/src/commands/auth.ts
+++ b/packages/cli/cli-v2/src/commands/auth.ts
@@ -1,24 +1,10 @@
 import type { Argv } from "yargs";
 import type { GlobalArgs } from "../context/GlobalArgs";
+import { commandGroup } from "./_internal/commandGroup";
 import { addLoginCommand } from "./auth/login";
 import { addLogoutCommand } from "./auth/logout";
 import { addTokenCommand } from "./auth/token";
 
 export function addAuthCommand(cli: Argv<GlobalArgs>): void {
-    cli.command("auth", "Authenticate fern", (yargs) => {
-        addLoginCommand(yargs);
-        addLogoutCommand(yargs);
-        addTokenCommand(yargs);
-        return yargs.demandCommand(1).fail((msg, err, yargs) => {
-            if (err != null) {
-                process.stderr.write(`${err.message}\n`);
-                process.exit(1);
-            }
-            if (msg != null) {
-                process.stderr.write(`Error: ${msg}\n\n`);
-            }
-            yargs.showHelp();
-            process.exit(1);
-        });
-    });
+    commandGroup(cli, "auth <command>", "Authenticate fern", [addLoginCommand, addLogoutCommand, addTokenCommand]);
 }

--- a/packages/cli/cli-v2/src/commands/auth/login.ts
+++ b/packages/cli/cli-v2/src/commands/auth/login.ts
@@ -1,14 +1,12 @@
 import type { Argv } from "yargs";
-import { Context } from "../../context/Context";
+import type { Context } from "../../context/Context";
 import type { GlobalArgs } from "../../context/GlobalArgs";
-import { withContext } from "../../context/withContext";
-
-export interface LoginArgs extends GlobalArgs {}
+import { command } from "../_internal/command";
 
 export function addLoginCommand(cli: Argv<GlobalArgs>): void {
-    cli.command("login", "Log in to fern", (yargs) => yargs, withContext<LoginArgs>(handleLogin));
+    command(cli, "login", "Log in to fern", handleLogin);
 }
 
-async function handleLogin(context: Context, _args: LoginArgs): Promise<void> {
+async function handleLogin(context: Context, _args: GlobalArgs): Promise<void> {
     context.stdout.info("Logging in...");
 }

--- a/packages/cli/cli-v2/src/commands/auth/logout.ts
+++ b/packages/cli/cli-v2/src/commands/auth/logout.ts
@@ -1,14 +1,12 @@
 import type { Argv } from "yargs";
-import { Context } from "../../context/Context";
+import type { Context } from "../../context/Context";
 import type { GlobalArgs } from "../../context/GlobalArgs";
-import { withContext } from "../../context/withContext";
-
-export interface LogoutArgs extends GlobalArgs {}
+import { command } from "../_internal/command";
 
 export function addLogoutCommand(cli: Argv<GlobalArgs>): void {
-    cli.command("logout", "Log out of fern", (yargs) => yargs, withContext<LogoutArgs>(handleLogout));
+    command(cli, "logout", "Log out of fern", handleLogout);
 }
 
-async function handleLogout(context: Context, _args: LogoutArgs): Promise<void> {
+async function handleLogout(context: Context, _args: GlobalArgs): Promise<void> {
     context.stdout.info("Logging out...");
 }

--- a/packages/cli/cli-v2/src/commands/auth/token.ts
+++ b/packages/cli/cli-v2/src/commands/auth/token.ts
@@ -1,19 +1,12 @@
 import type { Argv } from "yargs";
-import { Context } from "../../context/Context";
+import type { Context } from "../../context/Context";
 import type { GlobalArgs } from "../../context/GlobalArgs";
-import { withContext } from "../../context/withContext";
-
-export interface TokenArgs extends GlobalArgs {}
+import { command } from "../_internal/command";
 
 export function addTokenCommand(cli: Argv<GlobalArgs>): void {
-    cli.command(
-        "token",
-        "Print the user's authentication token",
-        (yargs) => yargs,
-        withContext<TokenArgs>(handleToken)
-    );
+    command(cli, "token", "Print the user's authentication token", handleToken);
 }
 
-async function handleToken(context: Context, _args: TokenArgs): Promise<void> {
+async function handleToken(context: Context, _args: GlobalArgs): Promise<void> {
     context.stdout.info("unimplemented");
 }

--- a/packages/cli/cli-v2/src/commands/check.ts
+++ b/packages/cli/cli-v2/src/commands/check.ts
@@ -2,29 +2,14 @@ import type { Argv } from "yargs";
 import { loadFernYml } from "../config/loadFernYml";
 import type { Context } from "../context/Context";
 import type { GlobalArgs } from "../context/GlobalArgs";
-import { withContext } from "../context/withContext";
-import { ValidationError } from "../errors/ValidationError";
+import { command } from "./_internal/command";
 
-export interface CheckArgs extends GlobalArgs {}
+interface CheckArgs extends GlobalArgs {}
 
 export function addCheckCommand(cli: Argv<GlobalArgs>): void {
-    cli.command(
-        "check",
-        "Validate your API, docs, and SDK configuration",
-        (yargs) => yargs,
-        withContext<CheckArgs>(handleCheck)
-    );
+    command(cli, "check", "Validate your API, docs, and SDK configuration", handleCheck);
 }
 
 async function handleCheck(context: Context, _args: CheckArgs): Promise<void> {
-    try {
-        await loadFernYml({ cwd: context.cwd });
-    } catch (error) {
-        if (error instanceof ValidationError) {
-            for (const issue of error.issues) {
-                context.stderr.info(issue.toString());
-            }
-        }
-        process.exit(1);
-    }
+    await loadFernYml({ cwd: context.cwd });
 }

--- a/packages/cli/cli-v2/src/commands/sdk.ts
+++ b/packages/cli/cli-v2/src/commands/sdk.ts
@@ -1,20 +1,8 @@
 import type { Argv } from "yargs";
 import type { GlobalArgs } from "../context/GlobalArgs";
+import { commandGroup } from "./_internal/commandGroup";
 import { addGenerateCommand } from "./sdk/generate";
 
 export function addSdkCommand(cli: Argv<GlobalArgs>): void {
-    cli.command("sdk", "Configure and generate SDKs", (yargs) => {
-        addGenerateCommand(yargs);
-        return yargs.demandCommand(1).fail((msg, err, yargs) => {
-            if (err != null) {
-                process.stderr.write(`${err.message}\n`);
-                process.exit(1);
-            }
-            if (msg != null) {
-                process.stderr.write(`Error: ${msg}\n\n`);
-            }
-            yargs.showHelp();
-            process.exit(1);
-        });
-    });
+    commandGroup(cli, "sdk <command>", "Configure and generate SDKs", [addGenerateCommand]);
 }

--- a/packages/cli/cli-v2/src/commands/sdk/generate.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate.ts
@@ -1,17 +1,12 @@
 import type { Argv } from "yargs";
 import type { Context } from "../../context/Context";
 import type { GlobalArgs } from "../../context/GlobalArgs";
-import { withContext } from "../../context/withContext";
+import { command } from "../_internal/command";
 
-export interface GenerateArgs extends GlobalArgs {}
+interface GenerateArgs extends GlobalArgs {}
 
 export function addGenerateCommand(cli: Argv<GlobalArgs>): void {
-    cli.command(
-        "generate",
-        "Generate SDKs configured in fern.yml",
-        (yargs) => yargs,
-        withContext<GenerateArgs>(handleGenerate)
-    );
+    command(cli, "generate", "Generate SDKs configured in fern.yml", handleGenerate);
 }
 
 async function handleGenerate(context: Context, _args: GenerateArgs): Promise<void> {

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -1,13 +1,25 @@
 import { LogLevel } from "@fern-api/logger";
+import { ValidationError } from "../errors/ValidationError";
 import { Context } from "./Context";
 import type { GlobalArgs } from "./GlobalArgs";
 
+/**
+ * Wraps a command handler with context creation and error handling.
+ *
+ * This centralizes exit logic so command handlers don't have to
+ * independently handle errors and call process.exit() directly.
+ */
 export function withContext<T extends GlobalArgs>(
     handler: (context: Context, args: T) => Promise<void>
 ): (args: T) => Promise<void> {
     return async (args: T) => {
         const context = createContext(args);
-        return handler(context, args);
+        try {
+            await handler(context, args);
+        } catch (error) {
+            handleError(context, error);
+            process.exit(1);
+        }
     };
 }
 
@@ -18,6 +30,28 @@ function createContext(options: GlobalArgs): Context {
         stderr: process.stderr,
         logLevel
     });
+}
+
+/**
+ * Handles errors by writing appropriate output to stderr.
+ */
+function handleError(context: Context, error: unknown): void {
+    if (error instanceof ValidationError) {
+        for (const issue of error.issues) {
+            context.stderr.info(issue.toString());
+        }
+        return;
+    }
+
+    if (error instanceof Error) {
+        context.stderr.error(error.message);
+        if (error.stack != null) {
+            context.stderr.debug(error.stack);
+        }
+        return;
+    }
+
+    context.stderr.error(String(error));
 }
 
 function parseLogLevel(level: string): LogLevel {

--- a/packages/cli/cli-v2/src/errors/ValidationError.ts
+++ b/packages/cli/cli-v2/src/errors/ValidationError.ts
@@ -3,7 +3,7 @@ import { ValidationIssue } from "@fern-api/yaml-loader";
 /**
  * A validation error that contains source code for each validation issue.
  *
- * These errors should be written to stderr.
+ * When displayed, each issue is shown on its own line with file:line:col prefix.
  */
 export class ValidationError extends Error {
     public readonly issues: ValidationIssue[];

--- a/packages/cli/cli-v2/src/errors/index.ts
+++ b/packages/cli/cli-v2/src/errors/index.ts
@@ -1,0 +1,1 @@
+export { ValidationError } from "./ValidationError";


### PR DESCRIPTION
## Description

This introduces a few lightweight abstractions that wrap the `yargs` library to standardize our creation of group and standalone sub-commands. 

With this, every group command and single command has a standardized `--help` text output, like those shown below (notice the `<command>` and `[options]` placeholders):

```sh
$ ferndev v2 sdk --help
fern sdk <command>

Configure and generate SDKs

Commands:
  fern sdk generate  Generate SDKs configured in fern.yml

Options:
  --help       Show help                                               [boolean]
  --version    Show version number                                     [boolean]
  --log-level  Set log level
          [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
```

```sh
$ ferndev v2 sdk generate --help
fern generate [options]

Generate SDKs configured in fern.yml

Options:
  --help       Show help                                               [boolean]
  --version    Show version number                                     [boolean]
  --log-level  Set log level
          [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
```

This also adds centralized error handling to the CLI `Context` type so that all errors that funnel through the CLI are caught and handled in a single place. To start, we handle the `ValidationError`, which writes every error on a separate newline to `stderr` (re: IDE compatibility). We'll continue to iterate on additional standardized error types as we continue to develop more of the core commands.

## Changes Made

- Updated the CLI commands to use a new `_internal/command` library.
- Centralized the CLI's error handling.

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed
