### PR TITLE
chore(ci): add nightly cron trigger to security scanning workflow

### DIFF
--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -19,6 +19,9 @@ name: Create PRs to Remediate vulns
 # ============================================================
 
 on:
+  schedule:
+    # Run nightly at 8pm EST (1am UTC next day)
+    - cron: "0 1 * * *"
   workflow_dispatch: # Allow manual triggering
     inputs:
       scan_only:
@@ -30,6 +33,8 @@ on:
 jobs:
   create-dependabot-prs:
     name: Check Dependabot alerts
+    # Skip this job when triggered by cron schedule
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -392,13 +397,21 @@ jobs:
         run: |
           grype docker:java-sdk:grype-scan -o json > grype-report.json
 
+      - name: Upload grype scan results
+        uses: actions/upload-artifact@v4
+        with:
+          name: grype-scan-results-java-sdk
+          path: grype-report.json
+          retention-days: 30
+
       # ============================================================
       # IGNORED CVEs CONFIGURATION
       # Add CVEs here that have been reviewed and accepted as risks.
       # Format: One CVE ID per line in the ignored_cves input
       # ============================================================
       - name: Process vulnerabilities and create PR
-        if: ${{ inputs.scan_only != true }}
+        # Skip PR creation for cron runs (scan_only=true) or when explicitly set
+        if: ${{ github.event_name != 'schedule' && inputs.scan_only != true }}
         uses: ./.github/actions/process-grype-vulns
         with:
           container_name: java-sdk


### PR DESCRIPTION
## Description

Adds a nightly cron trigger to the security scanning workflow to run automated vulnerability scans at 8pm EST without creating PRs or sending notifications.

Link to Devin run: https://app.devin.ai/sessions/d1f6a8b44bf24e35a450be1ebcf9c528
Requested by: David Konigsberg (@davidkonigsberg)

## Changes Made

- Added cron schedule trigger to run nightly at 8pm EST (1am UTC)
- Added condition to skip `create-dependabot-prs` job when triggered by cron
- Updated "Process vulnerabilities and create PR" step to skip PR creation for cron runs (effectively `scan_only=true`)
- Added artifact upload step to save grype scan results (`grype-report.json`) on all runs with 30-day retention

## Human Review Checklist

- [ ] Verify cron timing: `0 1 * * *` = 1am UTC = 8pm EST (note: during daylight saving time, this would be 9pm EDT)
- [ ] Confirm the condition logic `github.event_name != 'schedule' && inputs.scan_only != true` correctly skips PR creation for cron runs
- [ ] Confirm 30-day artifact retention is acceptable

## Testing

- [ ] Manual testing not possible - workflow changes can only be verified when the workflow runs
- [ ] Logic review completed - conditions are straightforward boolean checks