### PR TITLE
chore(deps): fix java sdk CVEs

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -82,9 +82,10 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     rm glob-11.1.0.tgz
 
 # Patch npm's bundled tar to 7.5.3 to fix CVE-2026-23745 (path traversal via hardlinks/symlinks)
+# Note: We use curl instead of npm pack because npm pack depends on tar itself
 RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     rm -rf tar && \
-    npm pack tar@7.5.3 && \
+    curl -sL https://registry.npmjs.org/tar/-/tar-7.5.3.tgz -o tar-7.5.3.tgz && \
     tar -xzf tar-7.5.3.tgz && \
     mv package tar && \
     rm tar-7.5.3.tgz

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -27,7 +27,7 @@ RUN rm -f /opt/gradle/lib/plugins/org.eclipse.jgit-*.jar \
 # CVE-2024-46901: subversion vulnerability
 # Go stdlib CVEs (60+): git-lfs 3.0.2 embeds Go 1.18.1 with many critical vulnerabilities
 # CVE-2024-10524, CVE-2021-31879: wget vulnerabilities
-# CVE-2025-64720, CVE-2025-65018, CVE-2025-64505, CVE-2025-64506: libpng16-16 vulnerabilities
+# CVE-2025-64720, CVE-2025-65018, CVE-2025-64505, CVE-2025-64506, CVE-2025-66293: libpng16-16 vulnerabilities
 # CVE-2021-46848, CVE-2025-13151: libtasn1-6 vulnerabilities
 # CVE-2025-68973: gnupg/gpg vulnerabilities
 # Use purge instead of remove to fully remove packages from dpkg database
@@ -80,6 +80,14 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     tar -xzf glob-11.1.0.tgz && \
     mv package glob && \
     rm glob-11.1.0.tgz
+
+# Patch npm's bundled tar to 7.5.3 to fix CVE-2026-23745 (path traversal via hardlinks/symlinks)
+RUN cd /usr/local/lib/node_modules/npm/node_modules && \
+    rm -rf tar && \
+    npm pack tar@7.5.3 && \
+    tar -xzf tar-7.5.3.tgz && \
+    mv package tar && \
+    rm tar-7.5.3.tgz
 
 # Copy Node CLI from first stage and rename it /bin/java-v2
 COPY --from=node /dist/cli.cjs /bin/java-v2

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.32.1
+  changelogEntry:
+    - summary: |
+        Update container to fix CVE-2026-23745 (node-tar path traversal via hardlinks/symlinks) and
+        CVE-2025-66293 (libpng out-of-bounds read). Patches npm's bundled tar to 7.5.3 and updates
+        libpng16-16 to the latest available version.
+      type: fix
+  createdAt: "2026-01-20"
+  irVersion: 63
+
 - version: 3.32.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes two security vulnerabilities in the java-sdk-generator Docker container:
- **CVE-2026-23745**: node-tar path traversal vulnerability via hardlinks/symlinks (affects versions ≤7.5.2)
- **CVE-2025-66293**: libpng out-of-bounds read vulnerability (affects versions <1.6.52)

Requested by @davidkonigsberg

[Link to Devin run](https://app.devin.ai/sessions/e96c167edee1421487386c369ffaaba0)

## Changes Made

- Patched npm's bundled tar package to version 7.5.3 using curl to download directly from npm registry
  - Note: We use `curl` instead of `npm pack` because npm pack itself depends on the tar module
- Added CVE-2025-66293 to the libpng comment (the existing `apt-get --only-upgrade` for libpng16-16 addresses this)
- Added version 3.32.1 entry to versions.yml documenting the security fixes

## Testing

- [ ] Unit tests added/updated (N/A - Dockerfile changes only)
- [ ] Manual testing completed (N/A - CI will verify Docker build)

## Human Review Checklist

- [ ] Verify tar@7.5.3 is available on npm and fixes CVE-2026-23745
- [ ] Verify the curl URL format (`https://registry.npmjs.org/tar/-/tar-7.5.3.tgz`) is correct
- [ ] Verify Docker build succeeds in CI
- [ ] Verify libpng16-16 in Ubuntu jammy repos includes fix for CVE-2025-66293