### PR TITLE
feat(cli): add site-level max-toc-depth support in docs.yml layout config

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -4737,6 +4737,16 @@
               "type": "null"
             }
           ]
+        },
+        "max-toc-depth": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -716,6 +716,12 @@ types:
         docs: |
           If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter.
 
+      max-toc-depth:
+        type: optional<integer>
+        availability: in-development
+        docs: |
+          Sets the maximum depth of the table of contents. This can be overridden for a specific page using the frontmatter.
+
   DocsSettingsConfig:
     properties:
       search-text:

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.47.3
+  changelogEntry:
+    - summary: |
+        Add support for `max-toc-depth` in the `layout` section of `docs.yml`. This allows setting the maximum depth of the table of contents at the site level, which can be overridden per-page using frontmatter.
+      type: feat
+  createdAt: "2026-01-20"
+  irVersion: 63
+
 - version: 3.47.2
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -454,8 +454,8 @@ function convertLayoutConfig(
                 : CjsFdrSdk.docs.v1.commons.HeaderPosition.Fixed,
         disableHeader: layout.disableHeader ?? false,
         hideNavLinks: layout.hideNavLinks ?? false,
-        hideFeedback: layout.hideFeedback ?? false,
-        maxTocDepth: layout.maxTocDepth
+        hideFeedback: layout.hideFeedback ?? false
+        // maxTocDepth will be added once @fern-api/fdr-sdk is updated with the new DocsLayoutConfig type
     };
 }
 

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -454,7 +454,8 @@ function convertLayoutConfig(
                 : CjsFdrSdk.docs.v1.commons.HeaderPosition.Fixed,
         disableHeader: layout.disableHeader ?? false,
         hideNavLinks: layout.hideNavLinks ?? false,
-        hideFeedback: layout.hideFeedback ?? false
+        hideFeedback: layout.hideFeedback ?? false,
+        maxTocDepth: layout.maxTocDepth
     };
 }
 

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/LayoutConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/LayoutConfig.ts
@@ -88,4 +88,6 @@ export interface LayoutConfig {
     hideNavLinks?: boolean;
     /** If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter. */
     hideFeedback?: boolean;
+    /** Sets the maximum depth of the table of contents. This can be overridden for a specific page using the frontmatter. */
+    maxTocDepth?: number;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/LayoutConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/LayoutConfig.ts
@@ -23,6 +23,7 @@ export const LayoutConfig: core.serialization.ObjectSchema<serializers.LayoutCon
         disableHeader: core.serialization.property("disable-header", core.serialization.boolean().optional()),
         hideNavLinks: core.serialization.property("hide-nav-links", core.serialization.boolean().optional()),
         hideFeedback: core.serialization.property("hide-feedback", core.serialization.boolean().optional()),
+        maxTocDepth: core.serialization.property("max-toc-depth", core.serialization.number().optional()),
     });
 
 export declare namespace LayoutConfig {
@@ -38,5 +39,6 @@ export declare namespace LayoutConfig {
         "disable-header"?: boolean | null;
         "hide-nav-links"?: boolean | null;
         "hide-feedback"?: boolean | null;
+        "max-toc-depth"?: number | null;
     }
 }

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -4737,6 +4737,16 @@
               "type": "null"
             }
           ]
+        },
+        "max-toc-depth": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Description
Refs https://github.com/fern-api/fern-platform/pull/6486

Adds support for `max-toc-depth` in the `layout` section of `docs.yml`, allowing users to set the maximum depth of the table of contents at the site level instead of having to specify it on every page via frontmatter.

**Note:** This PR adds the CLI's ability to parse `max-toc-depth` from `docs.yml`, but does not yet pass it to FDR. The value will be sent to FDR once the companion fern-platform PR is merged and `@fern-api/fdr-sdk` is updated with the new `DocsLayoutConfig` type.

## Changes Made
- Add `max-toc-depth` field to `LayoutConfig` in the docs-yml Fern API definition
- Manually update generated SDK types to include the new field (API type and serialization)
- Regenerate JSON schema files (`docs-yml.schema.json`) to include the new field
- Add placeholder comment in `convertLayoutConfig` for when FDR SDK is updated
- Add changelog entry for version 3.47.3

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed (compile, lint, format checks pass)

## Human Review Checklist
- [ ] **Generated files manually edited**: The SDK types in `packages/cli/configuration/src/docs-yml/schemas/sdk/` were manually updated because `fern generate` required authentication. Verify the changes match the pattern used by `hideNavLinks` and `hideFeedback`.
- [ ] **maxTocDepth not wired to FDR yet**: Confirm the comment in `parseDocsConfiguration.ts` (line 458) is acceptable - the field is parsed but not passed to FDR until the SDK is updated.
- [ ] **Companion PR required**: This PR depends on [fern-platform#6486](https://github.com/fern-api/fern-platform/pull/6486) which adds the `maxTocDepth` field to the FDR schema. After that PR merges and `@fern-api/fdr-sdk` is updated, a follow-up commit will be needed to add `maxTocDepth: layout.maxTocDepth` to the `convertLayoutConfig` return value.

---

Link to Devin run: https://app.devin.ai/sessions/c0f75490f75a47f68f522413a3f6c71d
Requested by: @jon-fern