### PR TITLE
fix(python): respect pyproject_python_version in CI workflow and classifiers

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.48.2
+  changelogEntry:
+    - summary: |
+        Fix generated CI workflow and pyproject.toml classifiers to respect the `pyproject_python_version`
+        configuration. Previously, the CI workflow always used Python 3.9 and classifiers always included
+        Python 3.8 regardless of the configured version constraint. Now, when `pyproject_python_version`
+        is set (e.g., `>=3.9,<3.14`), the CI workflow uses the minimum version from the constraint and
+        classifiers only include Python versions within the specified range.
+      type: fix
+  createdAt: "2026-01-20"
+  irVersion: 62
+
 - version: 4.48.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -310,7 +310,7 @@ class AbstractGenerator(ABC):
         logger.debug("Finished writing files for GitHub repository.")
 
     def _get_github_workflow_legacy(
-        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.8"
+        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.9"
     ) -> str:
         workflow_yaml = f"""name: ci
 on: [push]
@@ -395,7 +395,7 @@ jobs:
         return workflow_yaml
 
     def _get_github_workflow(
-        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.8"
+        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.9"
     ) -> str:
         # new workflow that supports automated OIDC-attestation signing and publishing to PyPI
         workflow_yaml = f"""name: ci

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -6,12 +6,8 @@ import textwrap
 from abc import ABC, abstractmethod
 from typing import Literal, Optional, Sequence, Tuple, cast
 
-from .publisher import Publisher
-from fern_python.codegen.project import Project, ProjectConfig
-from fern_python.external_dependencies.ruff import RUFF_DEPENDENCY
-from fern_python.generator_exec_wrapper import GeneratorExecWrapper
-
 import fern.ir.resources as ir_types
+from .publisher import Publisher
 from fern.generator_exec import (
     GeneratorConfig,
     PypiMetadata,
@@ -22,6 +18,11 @@ from fern.generator_exec.config import (
     OutputMode,
     PypiGithubPublishInfo,
 )
+
+from fern_python.codegen.project import Project, ProjectConfig
+from fern_python.codegen.pyproject_toml import parse_python_version_constraint
+from fern_python.external_dependencies.ruff import RUFF_DEPENDENCY
+from fern_python.generator_exec_wrapper import GeneratorExecWrapper
 
 
 class AbstractGenerator(ABC):
@@ -150,6 +151,7 @@ class AbstractGenerator(ABC):
                     write_unit_tests=(
                         self.project_type() == "sdk" and include_legacy_wire_tests and generator_config.write_unit_tests
                     ),
+                    python_version=python_version,
                 ),
                 publish=lambda x: None,
             )
@@ -237,6 +239,7 @@ class AbstractGenerator(ABC):
         output_mode: GithubOutputMode,
         write_unit_tests: bool,
         publish_config: GeneratorPublishConfig | None,
+        python_version: str = "^3.8",
     ) -> None:
         import logging
 
@@ -283,13 +286,15 @@ class AbstractGenerator(ABC):
             logger.info("publish_config is None; not using OIDC workflow.")
 
         # Add the CI workflow with logs for which workflow logic is selected.
+        # Parse the python_version constraint to get the minimum version for CI
+        min_python_version, _ = parse_python_version_constraint(python_version)
         workflow_path = ".github/workflows/ci.yml"
         logger.debug(f"Adding workflow file: {workflow_path} (use_oidc_workflow={use_oidc_workflow})")
         if use_oidc_workflow:
-            workflow_content = self._get_github_workflow(output_mode, write_unit_tests)
+            workflow_content = self._get_github_workflow(output_mode, write_unit_tests, min_python_version)
             logger.debug(f"CI workflow content from _get_github_workflow (OIDC):\n{workflow_content}")
         else:
-            workflow_content = self._get_github_workflow_legacy(output_mode, write_unit_tests)
+            workflow_content = self._get_github_workflow_legacy(output_mode, write_unit_tests, min_python_version)
             logger.debug(f"CI workflow content from _get_github_workflow_legacy (legacy):\n{workflow_content}")
 
         project.add_file(
@@ -304,8 +309,10 @@ class AbstractGenerator(ABC):
         project.add_source_file("tests/custom/test_client.py", client_test_content)
         logger.debug("Finished writing files for GitHub repository.")
 
-    def _get_github_workflow_legacy(self, output_mode: GithubOutputMode, write_unit_tests: bool) -> str:
-        workflow_yaml = """name: ci
+    def _get_github_workflow_legacy(
+        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.9"
+    ) -> str:
+        workflow_yaml = f"""name: ci
 on: [push]
 jobs:
   compile:
@@ -316,7 +323,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: {min_python_version}
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -332,7 +339,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: {min_python_version}
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -371,7 +378,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: {min_python_version}
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -387,9 +394,11 @@ jobs:
 """
         return workflow_yaml
 
-    def _get_github_workflow(self, output_mode: GithubOutputMode, write_unit_tests: bool) -> str:
+    def _get_github_workflow(
+        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.9"
+    ) -> str:
         # new workflow that supports automated OIDC-attestation signing and publishing to PyPI
-        workflow_yaml = """name: ci
+        workflow_yaml = f"""name: ci
 
 on: [push]
 jobs:
@@ -401,7 +410,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: {min_python_version}
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -417,7 +426,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: {min_python_version}
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -445,7 +454,7 @@ jobs:
                 publish_info_union.should_generate_publish_workflow is None
                 or publish_info_union.should_generate_publish_workflow
             ):
-                workflow_yaml += """
+                workflow_yaml += f"""
   build:
     name: Build distribution
     runs-on: ubuntu-latest
@@ -455,7 +464,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: {min_python_version}
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -310,7 +310,7 @@ class AbstractGenerator(ABC):
         logger.debug("Finished writing files for GitHub repository.")
 
     def _get_github_workflow_legacy(
-        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.9"
+        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.8"
     ) -> str:
         workflow_yaml = f"""name: ci
 on: [push]
@@ -395,7 +395,7 @@ jobs:
         return workflow_yaml
 
     def _get_github_workflow(
-        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.9"
+        self, output_mode: GithubOutputMode, write_unit_tests: bool, min_python_version: str = "3.8"
     ) -> str:
         # new workflow that supports automated OIDC-attestation signing and publishing to PyPI
         workflow_yaml = f"""name: ci

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -6,8 +6,13 @@ import textwrap
 from abc import ABC, abstractmethod
 from typing import Literal, Optional, Sequence, Tuple, cast
 
-import fern.ir.resources as ir_types
 from .publisher import Publisher
+from fern_python.codegen.project import Project, ProjectConfig
+from fern_python.codegen.pyproject_toml import parse_python_version_constraint
+from fern_python.external_dependencies.ruff import RUFF_DEPENDENCY
+from fern_python.generator_exec_wrapper import GeneratorExecWrapper
+
+import fern.ir.resources as ir_types
 from fern.generator_exec import (
     GeneratorConfig,
     PypiMetadata,
@@ -18,11 +23,6 @@ from fern.generator_exec.config import (
     OutputMode,
     PypiGithubPublishInfo,
 )
-
-from fern_python.codegen.project import Project, ProjectConfig
-from fern_python.codegen.pyproject_toml import parse_python_version_constraint
-from fern_python.external_dependencies.ruff import RUFF_DEPENDENCY
-from fern_python.generator_exec_wrapper import GeneratorExecWrapper
 
 
 class AbstractGenerator(ABC):

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -8,6 +8,12 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, cast
 
+from fern_python.codegen.ast.dependency.dependency import (
+    Dependency,
+    DependencyCompatibility,
+)
+from fern_python.codegen.dependency_manager import DependencyManager
+
 from fern.generator_exec import (
     BasicLicense,
     GithubOutputMode,
@@ -15,12 +21,6 @@ from fern.generator_exec import (
     LicenseId,
     PypiMetadata,
 )
-
-from fern_python.codegen.ast.dependency.dependency import (
-    Dependency,
-    DependencyCompatibility,
-)
-from fern_python.codegen.dependency_manager import DependencyManager
 
 # All known Python 3.x minor versions for classifier generation
 ALL_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -2,16 +2,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional, Set, cast
-
-from fern_python.codegen.ast.dependency.dependency import (
-    Dependency,
-    DependencyCompatibility,
-)
-from fern_python.codegen.dependency_manager import DependencyManager
+from typing import List, Optional, Set, Tuple, cast
 
 from fern.generator_exec import (
     BasicLicense,
@@ -20,6 +15,107 @@ from fern.generator_exec import (
     LicenseId,
     PypiMetadata,
 )
+
+from fern_python.codegen.ast.dependency.dependency import (
+    Dependency,
+    DependencyCompatibility,
+)
+from fern_python.codegen.dependency_manager import DependencyManager
+
+# All known Python 3.x minor versions for classifier generation
+ALL_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+
+
+def parse_python_version_constraint(version_constraint: str) -> Tuple[str, List[str]]:
+    """
+    Parse a Python version constraint and return the minimum version and list of supported versions.
+
+    Supports formats like:
+    - ">=3.9,<3.14" - Range with min and max
+    - "^3.8" - Caret constraint (compatible with 3.8.x, 3.9.x, etc.)
+    - "~3.9" - Tilde constraint (compatible with 3.9.x)
+    - ">=3.9" - Minimum only
+    - "3.9" - Exact version
+
+    Returns:
+        Tuple of (minimum_version, list_of_supported_versions)
+    """
+    min_version: Optional[str] = None
+    max_version: Optional[str] = None
+
+    # Handle caret constraint (^3.8 means >=3.8.0 <4.0.0)
+    caret_match = re.match(r"^\^(\d+)\.(\d+)", version_constraint)
+    if caret_match:
+        major = int(caret_match.group(1))
+        minor = int(caret_match.group(2))
+        min_version = f"{major}.{minor}"
+        # Caret allows all minor versions up to next major
+        max_version = f"{major + 1}.0"
+
+    # Handle tilde constraint (~3.9 means >=3.9.0 <3.10.0)
+    tilde_match = re.match(r"^~(\d+)\.(\d+)", version_constraint)
+    if tilde_match:
+        major = int(tilde_match.group(1))
+        minor = int(tilde_match.group(2))
+        min_version = f"{major}.{minor}"
+        max_version = f"{major}.{minor + 1}"
+
+    # Handle range constraints (>=3.9,<3.14 or >=3.9, <3.14)
+    if min_version is None:
+        # Look for >= or > constraint
+        ge_match = re.search(r">=?\s*(\d+)\.(\d+)", version_constraint)
+        if ge_match:
+            min_version = f"{ge_match.group(1)}.{ge_match.group(2)}"
+
+        # Look for < or <= constraint
+        lt_match = re.search(r"<\s*(\d+)\.(\d+)", version_constraint)
+        if lt_match:
+            max_version = f"{lt_match.group(1)}.{lt_match.group(2)}"
+
+        le_match = re.search(r"<=\s*(\d+)\.(\d+)", version_constraint)
+        if le_match:
+            major = int(le_match.group(1))
+            minor = int(le_match.group(2))
+            # <= 3.12 means we include 3.12, so max is 3.13
+            max_version = f"{major}.{minor + 1}"
+
+    # Handle exact version (just "3.9" or "3.9.0")
+    if min_version is None:
+        exact_match = re.match(r"^(\d+)\.(\d+)", version_constraint)
+        if exact_match:
+            min_version = f"{exact_match.group(1)}.{exact_match.group(2)}"
+
+    # Default to 3.8 if we couldn't parse
+    if min_version is None:
+        min_version = "3.8"
+
+    # Filter ALL_PYTHON_VERSIONS based on min and max
+    supported_versions: List[str] = []
+    for version in ALL_PYTHON_VERSIONS:
+        parts = version.split(".")
+        major, minor = int(parts[0]), int(parts[1])
+
+        # Check minimum
+        if min_version:
+            min_parts = min_version.split(".")
+            min_major, min_minor = int(min_parts[0]), int(min_parts[1])
+            if (major, minor) < (min_major, min_minor):
+                continue
+
+        # Check maximum (exclusive)
+        if max_version:
+            max_parts = max_version.split(".")
+            max_major, max_minor = int(max_parts[0]), int(max_parts[1])
+            if (major, minor) >= (max_major, max_minor):
+                continue
+
+        supported_versions.append(version)
+
+    # If no versions matched, default to the minimum version
+    if not supported_versions:
+        supported_versions = [min_version]
+
+    return min_version, supported_versions
 
 
 @dataclass(frozen=True)
@@ -53,6 +149,7 @@ class PyProjectToml:
             pypi_metadata=pypi_metadata,
             github_output_mode=github_output_mode,
             license_=license_,
+            python_version=python_version,
         )
         self._dependency_manager = dependency_manager
         self._path = path
@@ -110,6 +207,7 @@ dynamic = ["version"]
         pypi_metadata: Optional[PypiMetadata]
         github_output_mode: Optional[GithubOutputMode]
         license_: Optional[LicenseConfig]
+        python_version: str = "^3.8"
 
         def to_string(self) -> str:
             s = f'''[tool.poetry]
@@ -121,23 +219,27 @@ name = "{self.name}"'''
             authors: List[str] = []
             keywords: List[str] = []
             project_urls: List[str] = []
+
+            # Generate classifiers based on the python_version constraint
+            _, supported_versions = parse_python_version_constraint(self.python_version)
             classifiers = [
                 "Intended Audience :: Developers",
                 "Programming Language :: Python",
                 "Programming Language :: Python :: 3",
-                "Programming Language :: Python :: 3.8",
-                "Programming Language :: Python :: 3.9",
-                "Programming Language :: Python :: 3.10",
-                "Programming Language :: Python :: 3.11",
-                "Programming Language :: Python :: 3.12",
-                "Operating System :: OS Independent",
-                "Operating System :: POSIX",
-                "Operating System :: MacOS",
-                "Operating System :: POSIX :: Linux",
-                "Operating System :: Microsoft :: Windows",
-                "Topic :: Software Development :: Libraries :: Python Modules",
-                "Typing :: Typed",
             ]
+            for version in supported_versions:
+                classifiers.append(f"Programming Language :: Python :: {version}")
+            classifiers.extend(
+                [
+                    "Operating System :: OS Independent",
+                    "Operating System :: POSIX",
+                    "Operating System :: MacOS",
+                    "Operating System :: POSIX :: Linux",
+                    "Operating System :: Microsoft :: Windows",
+                    "Topic :: Software Development :: Libraries :: Python Modules",
+                    "Typing :: Typed",
+                ]
+            )
             license_evaluated = ""
             if self.pypi_metadata is not None:
                 description = (


### PR DESCRIPTION
## Description

Refs customer support thread - fixes issue where `pyproject_python_version` configuration was being ignored in generated CI workflows and pyproject.toml classifiers.

**Link to Devin run**: https://app.devin.ai/sessions/90140afe6afd4e4391022f989c2405b6
**Requested by**: @tjb9dc

## Problem

When users set `pyproject_python_version: ">=3.9,<3.14"` in their generator config, the generated CI workflow still used Python 3.9 (hardcoded) and the pyproject.toml classifiers still included Python 3.8 regardless of the configured constraint. This caused CI failures when dependencies didn't support the hardcoded version.

## Changes Made

- Added `parse_python_version_constraint()` function in `pyproject_toml.py` to parse version constraints and extract:
  - Minimum Python version (for CI workflows)
  - List of supported versions (for classifiers)
- Supports constraint formats: `>=3.9,<3.14`, `^3.8`, `~3.9`, `>=3.9`, `3.9`
- Updated `_get_github_workflow()` and `_get_github_workflow_legacy()` to use the parsed minimum version
- Updated `PoetryBlock` to generate classifiers dynamically based on the version range
- Added version 4.48.2 changelog entry
- [ ] Updated README.md generator (if applicable)

## Human Review Checklist

- [ ] Verify the version constraint parsing logic handles edge cases correctly (e.g., `>3.9` vs `>=3.9` are treated the same, malformed inputs default to 3.8)
- [ ] Note: `ALL_PYTHON_VERSIONS` is hardcoded to 3.8-3.13 and will need updating when Python 3.14 releases
- [ ] Verify the f-string conversion in workflow YAML doesn't break existing functionality
- [ ] No unit tests added for `parse_python_version_constraint()` - consider if tests should be added
- [ ] Default `min_python_version` is `"3.9"` (not `"3.8"`) because pytest-xdist requires Python 3.9

## Testing

- [x] Ran `poetry run ruff check --fix` and `poetry run ruff format` to fix linting issues
- [x] Ran `poetry run pre-commit run --all-files` to verify all pre-commit hooks pass
- [x] All CI checks passing (python-sdk, pydantic, fastapi seed tests)
- [ ] Unit tests added/updated (not added - parsing function could benefit from tests)
- [ ] Manual testing completed