### PR TITLE
feat(cli): Implement ref resolution in fern.yml

### DIFF
--- a/packages/cli/cli-v2/src/config/FernYmlSchemaLoader.ts
+++ b/packages/cli/cli-v2/src/config/FernYmlSchemaLoader.ts
@@ -26,12 +26,17 @@ export class FernYmlSchemaLoader {
 
     /**
      * Finds, loads, and validates a fern.yml configuration file.
+     * This also resolves and validates any `$ref` nodes in the
+     * configuration.
      *
      * @returns Result with either the parsed config or validation errors.
      * @throws Error if fern.yml is not found.
      */
     public async load(): Promise<FernYmlSchemaLoader.Result> {
         const absoluteFilePath = await this.finder.findOrThrow(FernYml.FILENAME);
-        return await this.loader.load({ absoluteFilePath, schema: FernYmlSchema });
+        return await this.loader.load({
+            absoluteFilePath,
+            schema: FernYmlSchema
+        });
     }
 }

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -16,6 +16,7 @@ export function withContext<T extends GlobalArgs>(
         const context = createContext(args);
         try {
             await handler(context, args);
+            process.exit(0);
         } catch (error) {
             handleError(context, error);
             process.exit(1);

--- a/packages/cli/source/src/SourceLocation.ts
+++ b/packages/cli/source/src/SourceLocation.ts
@@ -9,21 +9,30 @@ export class SourceLocation {
     public readonly line: number;
     public readonly column: number;
 
+    /**
+     * If this location was resolved from a `$ref`, this contains the location
+     * of the file that contained the `$ref` reference.
+     */
+    public readonly refFrom?: SourceLocation;
+
     constructor({
         absoluteFilePath,
         relativeFilePath,
         line,
-        column
+        column,
+        refFrom
     }: {
         absoluteFilePath: AbsoluteFilePath;
         relativeFilePath: RelativeFilePath;
         line: number;
         column: number;
+        refFrom?: SourceLocation;
     }) {
         this.absoluteFilePath = absoluteFilePath;
         this.relativeFilePath = relativeFilePath;
         this.line = line;
         this.column = column;
+        this.refFrom = refFrom;
     }
 
     /**
@@ -45,5 +54,20 @@ export class SourceLocation {
      */
     public toAbsoluteString(): string {
         return `${this.absoluteFilePath}:${this.line}:${this.column}`;
+    }
+
+    /**
+     * Creates a new SourceLocation with the given `$ref` location.
+     * This is used when resolving `$ref` references to track where
+     * the reference originated.
+     */
+    public withRefFrom(refFrom: SourceLocation): SourceLocation {
+        return new SourceLocation({
+            absoluteFilePath: this.absoluteFilePath,
+            relativeFilePath: this.relativeFilePath,
+            line: this.line,
+            column: this.column,
+            refFrom: refFrom
+        });
     }
 }

--- a/packages/cli/yaml/loader/src/ReferenceResolver.ts
+++ b/packages/cli/yaml/loader/src/ReferenceResolver.ts
@@ -1,0 +1,483 @@
+import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath, relative } from "@fern-api/fs-utils";
+import { SourceLocation } from "@fern-api/source";
+import { readFile } from "fs/promises";
+import { parseDocument } from "yaml";
+import { ValidationIssue } from "./ValidationIssue";
+import { YamlDocument, type YamlPath } from "./YamlDocument";
+
+const REF_KEY = "$ref";
+
+export namespace ReferenceResolver {
+    export type Result = Success | Failure;
+
+    export interface Success {
+        success: true;
+        /** The resolved YAML document with all `$ref` nodes replaced. */
+        data: unknown;
+        /** Mappings from path prefixes to their source documents (for referenced files). */
+        pathMappings: PathMapping[];
+    }
+
+    export interface Failure {
+        success: false;
+        issues: ValidationIssue[];
+    }
+
+    /**
+     * Maps a path prefix to the document that contains the content at that path.
+     *
+     * This is surfaced to the caller so that it can be used to look up source locations
+     * for errors associated with particular YAML paths (e.g. a Zod validation error).
+     */
+    export interface PathMapping {
+        /** The YAML path prefix where the $ref was located (without the $ref key). */
+        yamlPath: YamlPath;
+        /** The document that contains the content at this path. */
+        document: YamlDocument;
+        /** The location of the $ref that brought us to this document. */
+        refFromLocation: SourceLocation;
+    }
+
+    export interface ResolutionContext {
+        /** The current working directory for resolving relative file paths. */
+        cwd: AbsoluteFilePath;
+        /** The source document for location lookups (only valid for the original document). */
+        document: YamlDocument;
+        /** The original document's file path. */
+        originalFile: AbsoluteFilePath;
+        /** The current file being processed. */
+        currentFile: AbsoluteFilePath;
+        /** Set of file paths that are currently being resolved (for circular reference detection). */
+        resolutionStack: Set<string>;
+        /** Cache of YamlDocuments for referenced files (for source location tracking). */
+        referencedDocuments: Record<string, YamlDocument>;
+        /** The index in yamlPath where the current file's content starts. */
+        yamlPathIndex: number;
+        /** The location of the `$ref` that brought us into the current file (undefined for the original file). */
+        refFromLocation: SourceLocation | undefined;
+        /** Accumulated path mappings for source location lookup after resolution. */
+        pathMappings: PathMapping[];
+        /** Accumulated issues. */
+        issues: ValidationIssue[];
+    }
+}
+
+/**
+ * Resolves `$ref` references in YAML documents.
+ *
+ * Supports file-based references according to the following rules:
+ *  - `$ref` must be a string value that points to a valid YAML file.
+ *  - A node with `$ref` must not have any sibling keys.
+ *  - The `$ref` value is replaced entirely by the resolved content.
+ *  - Circular references are detected and reported as errors.
+ *
+ * Note that this is a subset of the behavior supported by OpenAPI so
+ * that it's better suited for non-recursive structures.
+ *
+ * @example
+ * ```yaml
+ * redirects:
+ *   $ref: "./redirects.yml"
+ * ```
+ */
+export class ReferenceResolver {
+    private readonly cwd: AbsoluteFilePath;
+
+    constructor({ cwd }: { cwd: AbsoluteFilePath }) {
+        this.cwd = cwd;
+    }
+
+    /**
+     * Resolves all `$ref` references in the given YAML document.
+     *
+     * @param document - The parsed YAML document
+     * @returns Result with either the resolved data or resolution issues
+     */
+    public async resolve({ document }: { document: YamlDocument }): Promise<ReferenceResolver.Result> {
+        const originalFile = document.absoluteFilePath;
+        const context: ReferenceResolver.ResolutionContext = {
+            cwd: this.cwd,
+            document,
+            originalFile,
+            currentFile: originalFile,
+            resolutionStack: new Set([originalFile]),
+            referencedDocuments: {},
+            issues: [],
+            pathMappings: [],
+            yamlPathIndex: 0,
+            refFromLocation: undefined
+        };
+
+        const resolved = await this.resolveValue({ context, yamlPath: [], value: document.toJS() });
+        if (context.issues.length > 0) {
+            return {
+                success: false,
+                issues: context.issues
+            };
+        }
+
+        return {
+            success: true,
+            data: resolved,
+            pathMappings: context.pathMappings
+        };
+    }
+
+    /**
+     * Looks up the source location for a path, checking path mappings for referenced files.
+     *
+     * @param document - The original document.
+     * @param pathMappings - Path mappings returned from resolution.
+     * @param yamlPath - The path to look up.
+     * @returns The source location, with refFrom attached if the path is in a referenced file.
+     */
+    public getSourceLocationWithMappings({
+        document,
+        pathMappings,
+        yamlPath
+    }: {
+        document: YamlDocument;
+        pathMappings: ReferenceResolver.PathMapping[];
+        yamlPath: YamlPath;
+    }): SourceLocation {
+        // Find the longest matching path prefix in the mappings.
+        let bestMatch: ReferenceResolver.PathMapping | undefined;
+        for (const mapping of pathMappings) {
+            if (this.yamlPathStartsWith(yamlPath, mapping.yamlPath)) {
+                if (bestMatch == null || mapping.yamlPath.length > bestMatch.yamlPath.length) {
+                    bestMatch = mapping;
+                }
+            }
+        }
+
+        if (bestMatch != null) {
+            const localYamlPath = yamlPath.slice(bestMatch.yamlPath.length);
+            const location = bestMatch.document.getSourceLocation(localYamlPath);
+            return location.withRefFrom(bestMatch.refFromLocation);
+        }
+
+        // Fall back to the original document.
+        return document.getSourceLocation(yamlPath);
+    }
+
+    private async resolveValue({
+        context,
+        yamlPath,
+        value
+    }: {
+        context: ReferenceResolver.ResolutionContext;
+        yamlPath: YamlPath;
+        value: unknown;
+    }): Promise<unknown> {
+        if (value == null) {
+            return value;
+        }
+        if (Array.isArray(value)) {
+            return Promise.all(
+                value.map((item, index) => this.resolveValue({ context, yamlPath: [...yamlPath, index], value: item }))
+            );
+        }
+        if (typeof value === "object") {
+            const obj = value as Record<string, unknown>;
+            if (REF_KEY in obj) {
+                const refYamlPath = [...yamlPath, REF_KEY];
+                return this.resolveRef({
+                    context,
+                    yamlPath: refYamlPath,
+                    location: this.getSourceLocation({ context, yamlPath: refYamlPath }),
+                    obj,
+                    refValue: obj[REF_KEY]
+                });
+            }
+            const resolved: Record<string, unknown> = {};
+            for (const key of Object.keys(obj)) {
+                resolved[key] = await this.resolveValue({ context, yamlPath: [...yamlPath, key], value: obj[key] });
+            }
+            return resolved;
+        }
+        return value;
+    }
+
+    private async resolveRef({
+        context,
+        yamlPath,
+        location,
+        obj,
+        refValue
+    }: {
+        context: ReferenceResolver.ResolutionContext;
+        yamlPath: YamlPath;
+        location: SourceLocation;
+        obj: Record<string, unknown>;
+        refValue: unknown;
+    }): Promise<Record<string, unknown>> {
+        // Validate $ref is a string.
+        if (typeof refValue !== "string") {
+            context.issues.push(
+                new ValidationIssue({
+                    message: `$ref must be a string, got ${typeof refValue}`,
+                    location,
+                    yamlPath
+                })
+            );
+            return obj;
+        }
+
+        // Validate no sibling keys.
+        const keys = Object.keys(obj);
+        if (keys.length > 1) {
+            const siblingKeys = keys.filter((k) => k !== REF_KEY);
+            context.issues.push(
+                new ValidationIssue({
+                    message: `$ref cannot have sibling keys; found ${siblingKeys.join(", ")}`,
+                    location,
+                    yamlPath
+                })
+            );
+            return obj;
+        }
+
+        // Validate no JSON pointer or in-document reference.
+        if (refValue.includes("#")) {
+            context.issues.push(
+                new ValidationIssue({
+                    message: `JSON pointer and in-document references are not supported: ${refValue}`,
+                    location,
+                    yamlPath
+                })
+            );
+            return obj;
+        }
+
+        const referencedFilePath = this.resolveFilePath({ currentFile: context.currentFile, refValue });
+
+        // Check for circular references.
+        if (context.resolutionStack.has(referencedFilePath)) {
+            const cycle = [...context.resolutionStack, referencedFilePath].join(" -> ");
+            context.issues.push(
+                new ValidationIssue({
+                    message: `Circular $ref detected: ${cycle}`,
+                    location,
+                    yamlPath
+                })
+            );
+            return obj;
+        }
+
+        // Load and parse the referenced file.
+        const resolvedReference = await this.parseFile({
+            context,
+            referencedFilePath,
+            yamlPath,
+            location,
+            refValue
+        });
+        if (resolvedReference === undefined) {
+            // An issue was already added by parseFile.
+            return obj;
+        }
+        if (resolvedReference === null) {
+            context.issues.push(
+                new ValidationIssue({
+                    message: `$ref resolves to null: ${refValue}`,
+                    location,
+                    yamlPath
+                })
+            );
+            return obj;
+        }
+
+        // The parent path is the path without the $ref key. This is the path
+        // where the resolved content will be placed in the final result.
+        const parentYamlPath = yamlPath.slice(0, -1);
+
+        // Record the path mapping for source location lookup after resolution.
+        const referencedDocument = context.referencedDocuments[referencedFilePath];
+        if (referencedDocument != null) {
+            context.pathMappings.push({
+                yamlPath: parentYamlPath,
+                document: referencedDocument,
+                refFromLocation: location
+            });
+        }
+
+        const fullyResolvedReference = await this.resolveReferencedFile({
+            context,
+            referencedFilePath,
+            refFromLocation: location,
+            yamlPath: parentYamlPath,
+            value: resolvedReference
+        });
+        return fullyResolvedReference as Record<string, unknown>;
+    }
+
+    /**
+     * Resolves a value within the context of a referenced file, handling
+     * the bookkeeping for tracking the current file and YAML path index.
+     */
+    private async resolveReferencedFile({
+        context,
+        referencedFilePath,
+        refFromLocation,
+        yamlPath,
+        value
+    }: {
+        context: ReferenceResolver.ResolutionContext;
+        referencedFilePath: AbsoluteFilePath;
+        refFromLocation: SourceLocation;
+        yamlPath: YamlPath;
+        value: unknown;
+    }): Promise<unknown> {
+        const previousFile = context.currentFile;
+        const previousYamlPathIndex = context.yamlPathIndex;
+        const previousRefFromLocation = context.refFromLocation;
+
+        context.currentFile = referencedFilePath;
+        context.yamlPathIndex = yamlPath.length;
+        context.refFromLocation = refFromLocation;
+        context.resolutionStack.add(referencedFilePath);
+
+        try {
+            return await this.resolveValue({ context, yamlPath, value });
+        } finally {
+            context.resolutionStack.delete(referencedFilePath);
+            context.currentFile = previousFile;
+            context.yamlPathIndex = previousYamlPathIndex;
+            context.refFromLocation = previousRefFromLocation;
+        }
+    }
+
+    private async parseFile({
+        context,
+        referencedFilePath,
+        yamlPath,
+        location,
+        refValue
+    }: {
+        context: ReferenceResolver.ResolutionContext;
+        referencedFilePath: AbsoluteFilePath;
+        yamlPath: YamlPath;
+        location: SourceLocation;
+        refValue: string;
+    }): Promise<unknown> {
+        if (!(await doesPathExist(referencedFilePath))) {
+            context.issues.push(
+                new ValidationIssue({
+                    message: `Referenced file does not exist: ${refValue}`,
+                    location,
+                    yamlPath
+                })
+            );
+            return undefined;
+        }
+
+        const content = await readFile(referencedFilePath, "utf-8");
+
+        const parsedDocument = parseDocument(content);
+        if (parsedDocument.errors.length > 0) {
+            const errorMessages = parsedDocument.errors.map((e) => e.message).join("; ");
+            context.issues.push(
+                new ValidationIssue({
+                    message: `Failed to parse referenced file ${refValue}: ${errorMessages}`,
+                    location,
+                    yamlPath
+                })
+            );
+            return undefined;
+        }
+
+        // Create and cache a YamlDocument for source location tracking.
+        const yamlDocument = new YamlDocument({
+            absoluteFilePath: referencedFilePath,
+            relativeFilePath: RelativeFilePath.of(relative(context.cwd, referencedFilePath)),
+            document: parsedDocument,
+            source: content
+        });
+        context.referencedDocuments[referencedFilePath] = yamlDocument;
+
+        return yamlDocument.toJS();
+    }
+
+    /**
+     * Returns the source location for a value at the given path.
+     *
+     * For the original document, we use the YamlDocument's precise location tracking.
+     * For referenced files, we look up the cached YamlDocument and compute the
+     * local path within that file, attaching the original `$ref` location via `withRefFrom`.
+     */
+    private getSourceLocation({
+        context,
+        yamlPath
+    }: {
+        context: ReferenceResolver.ResolutionContext;
+        yamlPath: YamlPath;
+    }): SourceLocation {
+        if (context.currentFile === context.originalFile) {
+            return context.document.getSourceLocation(yamlPath);
+        }
+        const location = this.getSourceLocationFromCurrentFile({ context, yamlPath });
+        if (context.refFromLocation != null) {
+            // Attach the original $ref location for better error reporting.
+            return location.withRefFrom(context.refFromLocation);
+        }
+        return location;
+    }
+
+    /**
+     * Checks if a YAML path starts with a given prefix.
+     */
+    private yamlPathStartsWith(path: YamlPath, prefix: YamlPath): boolean {
+        if (prefix.length > path.length) {
+            return false;
+        }
+        for (let i = 0; i < prefix.length; i++) {
+            if (path[i] !== prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private getSourceLocationFromCurrentFile({
+        context,
+        yamlPath
+    }: {
+        context: ReferenceResolver.ResolutionContext;
+        yamlPath: YamlPath;
+    }): SourceLocation {
+        const doc = context.referencedDocuments[context.currentFile];
+        if (doc != null) {
+            // Compute the YAML path within the referenced file.
+            const localYamlPath = yamlPath.slice(context.yamlPathIndex);
+            return doc.getSourceLocation(localYamlPath);
+        }
+        // Fallback that preserves the referenced file path.
+        return this.createLocationForReferencedFile({ context, absoluteFilePath: context.currentFile });
+    }
+
+    private createLocationForReferencedFile({
+        context,
+        absoluteFilePath
+    }: {
+        context: ReferenceResolver.ResolutionContext;
+        absoluteFilePath: AbsoluteFilePath;
+    }): SourceLocation {
+        return new SourceLocation({
+            absoluteFilePath,
+            relativeFilePath: RelativeFilePath.of(relative(context.cwd, absoluteFilePath)),
+            line: 1,
+            column: 1
+        });
+    }
+
+    private resolveFilePath({
+        currentFile,
+        refValue
+    }: {
+        currentFile: AbsoluteFilePath;
+        refValue: string;
+    }): AbsoluteFilePath {
+        const currentDir = dirname(currentFile);
+        return join(currentDir, RelativeFilePath.of(refValue));
+    }
+}

--- a/packages/cli/yaml/loader/src/YamlDocument.ts
+++ b/packages/cli/yaml/loader/src/YamlDocument.ts
@@ -13,8 +13,8 @@ export type YamlPath = ReadonlyArray<string | number>;
  * Wraps a parsed YAML Document to provide source location lookups.
  */
 export class YamlDocument {
-    private readonly absoluteFilePath: AbsoluteFilePath;
-    private readonly relativeFilePath: RelativeFilePath;
+    public readonly absoluteFilePath: AbsoluteFilePath;
+    public readonly relativeFilePath: RelativeFilePath;
     private readonly document: Document;
     private readonly source: string;
 

--- a/packages/cli/yaml/loader/src/__test__/ReferenceResolver.test.ts
+++ b/packages/cli/yaml/loader/src/__test__/ReferenceResolver.test.ts
@@ -1,0 +1,913 @@
+import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
+import { RelativeFilePath } from "@fern-api/path-utils";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+import { ReferenceResolver } from "../ReferenceResolver";
+import { YamlDocument } from "../YamlDocument";
+
+function createYamlDocument(yaml: string, absoluteFilePath: AbsoluteFilePath, cwd: AbsoluteFilePath): YamlDocument {
+    const document = parseDocument(yaml);
+    const relativeFilePath = RelativeFilePath.of(absoluteFilePath.replace(cwd + "/", ""));
+    return new YamlDocument({
+        absoluteFilePath,
+        relativeFilePath,
+        document,
+        source: yaml
+    });
+}
+
+describe("ReferenceResolver", () => {
+    let testDir: string;
+    let cwd: AbsoluteFilePath;
+
+    beforeEach(async () => {
+        testDir = join(tmpdir(), `ref-resolver-test-${Date.now()}`);
+        await mkdir(testDir, { recursive: true });
+        cwd = AbsoluteFilePath.of(testDir);
+    });
+
+    afterEach(async () => {
+        if (await doesPathExist(AbsoluteFilePath.of(testDir))) {
+            await rm(testDir, { recursive: true });
+        }
+    });
+
+    describe("valid cases", () => {
+        it("resolves a simple file reference", async () => {
+            const dbConfigPath = join(testDir, "database.yaml");
+            await writeFile(
+                dbConfigPath,
+                `
+host: localhost
+port: 5432
+name: db
+`
+            );
+
+            const mainYaml = `
+app: myapp
+database:
+  $ref: "./database.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    app: "myapp",
+                    database: {
+                        host: "localhost",
+                        port: 5432,
+                        name: "db"
+                    }
+                });
+            }
+        });
+
+        it("resolves multiple references in the same document", async () => {
+            await writeFile(
+                join(testDir, "db.yaml"),
+                `
+host: host
+port: 5432
+`
+            );
+            await writeFile(
+                join(testDir, "cache.yaml"),
+                `
+host: cachehost
+port: 6379
+`
+            );
+
+            const mainYaml = `
+database:
+  $ref: "./db.yaml"
+cache:
+  $ref: "./cache.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    database: { host: "host", port: 5432 },
+                    cache: { host: "cachehost", port: 6379 }
+                });
+            }
+        });
+
+        it("resolves a reference inside an array", async () => {
+            await writeFile(
+                join(testDir, "endpoint1.yaml"),
+                `
+path: /api/users
+method: GET
+`
+            );
+            await writeFile(
+                join(testDir, "endpoint2.yaml"),
+                `
+path: /api/posts
+method: POST
+`
+            );
+
+            const mainYaml = `
+endpoints:
+  - $ref: "./endpoint1.yaml"
+  - $ref: "./endpoint2.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    endpoints: [
+                        { path: "/api/users", method: "GET" },
+                        { path: "/api/posts", method: "POST" }
+                    ]
+                });
+            }
+        });
+
+        it("resolves references in nested subdirectories", async () => {
+            const commonDir = join(testDir, "common");
+            await mkdir(commonDir, { recursive: true });
+            await writeFile(
+                join(commonDir, "shared.yaml"),
+                `
+timeout: 30
+retries: 3
+`
+            );
+
+            const mainYaml = `
+config:
+  $ref: "./common/shared.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    config: { timeout: 30, retries: 3 }
+                });
+            }
+        });
+
+        it("resolves chained references (non-circular)", async () => {
+            await writeFile(
+                join(testDir, "c.yaml"),
+                `
+value: deep
+`
+            );
+            await writeFile(
+                join(testDir, "b.yaml"),
+                `
+nested:
+  $ref: "./c.yaml"
+`
+            );
+
+            const mainYaml = `
+root:
+  $ref: "./b.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    root: {
+                        nested: { value: "deep" }
+                    }
+                });
+            }
+        });
+
+        it("returns the document as-is when there are no references", async () => {
+            const mainYaml = `
+simple: value
+nested:
+  key: value
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    simple: "value",
+                    nested: { key: "value" }
+                });
+            }
+        });
+
+        it("resolves a reference to a primitive value", async () => {
+            await writeFile(
+                join(testDir, "version.yaml"),
+                `
+1.2.3
+`
+            );
+
+            const mainYaml = `
+version:
+  $ref: "./version.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    version: "1.2.3"
+                });
+            }
+        });
+
+        it("resolves a reference to an array value", async () => {
+            await writeFile(
+                join(testDir, "tags.yaml"),
+                `
+- tag1
+- tag2
+- tag3
+`
+            );
+
+            const mainYaml = `
+tags:
+  $ref: "./tags.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual({
+                    tags: ["tag1", "tag2", "tag3"]
+                });
+            }
+        });
+    });
+
+    describe("error cases", () => {
+        it("errors when $ref is not a string", async () => {
+            const mainYaml = `
+database:
+  $ref: 123
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            await writeFile(mainPath, mainYaml);
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                expect(error?.message).toContain("$ref must be a string");
+            }
+        });
+
+        it("errors when $ref has sibling properties", async () => {
+            await writeFile(
+                join(testDir, "db.yaml"),
+                `
+host: localhost
+`
+            );
+
+            const mainYaml = `
+database:
+  $ref: "./db.yaml"
+  poolSize: 10
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                expect(error?.message).toContain("$ref cannot have sibling keys");
+                expect(error?.message).toContain("poolSize");
+            }
+        });
+
+        it("errors when referenced file does not exist", async () => {
+            const mainYaml = `
+database:
+  $ref: "./nonexistent.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const issue = result.issues[0];
+                expect(issue).toBeDefined();
+                expect(issue?.message).toContain("Referenced file does not exist");
+                expect(issue?.message).toContain("./nonexistent.yaml");
+            }
+        });
+
+        it("errors on circular reference (direct)", async () => {
+            // main.yaml -> main.yaml
+            const mainYaml = `
+self:
+  $ref: "./main.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            await writeFile(mainPath, mainYaml);
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                expect(error?.message).toContain("Circular $ref detected");
+            }
+        });
+
+        it("errors on circular reference (indirect)", async () => {
+            // main.yaml -> a.yaml -> b.yaml -> main.yaml
+            await writeFile(
+                join(testDir, "b.yaml"),
+                `
+ref:
+  $ref: "./main.yaml"
+`
+            );
+            await writeFile(
+                join(testDir, "a.yaml"),
+                `
+ref:
+  $ref: "./b.yaml"
+`
+            );
+
+            const mainYaml = `
+root:
+  $ref: "./a.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            await writeFile(mainPath, mainYaml);
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                expect(error?.message).toContain("Circular $ref detected");
+            }
+        });
+
+        it("errors on JSON pointer reference", async () => {
+            await writeFile(
+                join(testDir, "data.yaml"),
+                `
+schemas:
+  User:
+    name: string
+`
+            );
+
+            const mainYaml = `
+user:
+  $ref: "./data.yaml#/schemas/User"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                expect(error?.message).toContain("JSON pointer and in-document references are not supported");
+            }
+        });
+
+        it("errors on in-document reference", async () => {
+            const mainYaml = `
+definitions:
+  User:
+    name: string
+user:
+  $ref: "#/definitions/User"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                expect(error?.message).toContain("JSON pointer and in-document references are not supported");
+            }
+        });
+
+        it("errors when $ref resolves to null", async () => {
+            await writeFile(
+                join(testDir, "null.yaml"),
+                `
+null
+`
+            );
+
+            const mainYaml = `
+value:
+  $ref: "./null.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                expect(error?.message).toContain("$ref resolves to null");
+            }
+        });
+
+        it("collects all errors instead of failing on the first one", async () => {
+            const mainYaml = `
+db1:
+  $ref: "./missing1.yaml"
+db2:
+  $ref: "./missing2.yaml"
+db3:
+  $ref: 123
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues.length).toBeGreaterThanOrEqual(3);
+            }
+        });
+
+        it("includes source file path in error message", async () => {
+            const mainYaml = `
+database:
+  $ref: "./nonexistent.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                const errorString = error?.toString();
+                expect(errorString).toContain("main.yaml");
+            }
+        });
+
+        it("errors when referenced file contains invalid YAML", async () => {
+            await writeFile(join(testDir, "invalid.yaml"), `this is not: valid: yaml: content`);
+
+            const mainYaml = `
+data:
+  $ref: "./invalid.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const error = result.issues[0];
+                expect(error).toBeDefined();
+                expect(error?.message).toContain("Failed to parse referenced file");
+            }
+        });
+    });
+
+    describe("ValidationIssue integration", () => {
+        it("formats issue with location and message", async () => {
+            const mainYaml = `
+database:
+  $ref: "./nonexistent.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                const issue = result.issues[0];
+                expect(issue).toBeDefined();
+                expect(issue?.location).toBeDefined();
+                expect(issue?.message).toBeDefined();
+                expect(issue?.yamlPath).toEqual(["database", "$ref"]);
+            }
+        });
+    });
+
+    describe("source location tracking in referenced files", () => {
+        it("provides accurate source location for errors in referenced files", async () => {
+            const nestedYaml = `
+first: value
+second:
+  nested:
+    $ref: "./missing.yaml"
+third: value
+`;
+            await writeFile(join(testDir, "nested.yaml"), nestedYaml);
+
+            const mainYaml = `
+config:
+  $ref: "./nested.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const issue = result.issues[0];
+                expect(issue).toBeDefined();
+                expect(issue?.location.relativeFilePath).toBe("nested.yaml");
+                expect(issue?.location.line).toBe(5);
+            }
+        });
+
+        it("provides accurate source location for chained references", async () => {
+            const bYaml = `
+value: good
+broken:
+  $ref: 123
+`;
+            await writeFile(join(testDir, "b.yaml"), bYaml);
+
+            const aYaml = `
+nested:
+  $ref: "./b.yaml"
+`;
+            await writeFile(join(testDir, "a.yaml"), aYaml);
+
+            const mainYaml = `
+root:
+  $ref: "./a.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const issue = result.issues[0];
+                expect(issue).toBeDefined();
+                expect(issue?.location.relativeFilePath).toBe("b.yaml");
+                expect(issue?.location.line).toBe(4);
+            }
+        });
+
+        it("includes refFrom location pointing to the original $ref", async () => {
+            const nestedYaml = `
+name: test
+data:
+  $ref: "./missing.yaml"
+`;
+            await writeFile(join(testDir, "nested.yaml"), nestedYaml);
+
+            const mainYaml = `
+first: value
+config:
+  $ref: "./nested.yaml"
+last: value
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const issue = result.issues[0];
+                expect(issue).toBeDefined();
+
+                expect(issue?.location.relativeFilePath).toBe("nested.yaml");
+                expect(issue?.location.line).toBe(4);
+
+                expect(issue?.location.refFrom).toBeDefined();
+                expect(issue?.location.refFrom?.relativeFilePath).toBe("main.yaml");
+                expect(issue?.location.refFrom?.line).toBe(4);
+            }
+        });
+
+        it("includes refFrom for chained references pointing to immediate parent $ref", async () => {
+            const bYaml = `
+value: good
+broken:
+  $ref: "./missing.yaml"
+`;
+            await writeFile(join(testDir, "b.yaml"), bYaml);
+
+            const aYaml = `
+nested:
+  $ref: "./b.yaml"
+`;
+            await writeFile(join(testDir, "a.yaml"), aYaml);
+
+            const mainYaml = `
+root:
+  $ref: "./a.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.issues).toHaveLength(1);
+                const issue = result.issues[0];
+                expect(issue).toBeDefined();
+
+                expect(issue?.location.relativeFilePath).toBe("b.yaml");
+                expect(issue?.location.line).toBe(4);
+
+                expect(issue?.location.refFrom).toBeDefined();
+                expect(issue?.location.refFrom?.relativeFilePath).toBe("a.yaml");
+                expect(issue?.location.refFrom?.line).toBe(3);
+            }
+        });
+    });
+
+    describe("path mappings for post-resolution source location lookup", () => {
+        it("returns path mappings for simple nested references", async () => {
+            const dbYaml = `
+host: localhost
+port: 5432
+`;
+            await writeFile(join(testDir, "db.yaml"), dbYaml);
+
+            const mainYaml = `
+app: myapp
+database:
+  $ref: "./db.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.pathMappings).toHaveLength(1);
+                expect(result.pathMappings[0]?.yamlPath).toEqual(["database"]);
+                expect(result.pathMappings[0]?.document.relativeFilePath).toBe("db.yaml");
+            }
+        });
+
+        it("returns path mappings for doubly nested references", async () => {
+            const typescriptYaml = `
+lang: typescript
+version: 1.0.0
+`;
+            await writeFile(join(testDir, "typescript.yaml"), typescriptYaml);
+
+            const sdksYaml = `
+targets:
+  typescript:
+    $ref: "./typescript.yaml"
+`;
+            await writeFile(join(testDir, "sdks.yaml"), sdksYaml);
+
+            const mainYaml = `
+edition: 2026-01-01
+sdks:
+  $ref: "./sdks.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.pathMappings).toHaveLength(2);
+
+                const sdksMapping = result.pathMappings.find(
+                    (m) => m.yamlPath.length === 1 && m.yamlPath[0] === "sdks"
+                );
+                expect(sdksMapping).toBeDefined();
+                expect(sdksMapping?.document.relativeFilePath).toBe("sdks.yaml");
+
+                const tsMapping = result.pathMappings.find((m) => m.yamlPath.length === 3);
+                expect(tsMapping).toBeDefined();
+                expect(tsMapping?.yamlPath).toEqual(["sdks", "targets", "typescript"]);
+                expect(tsMapping?.document.relativeFilePath).toBe("typescript.yaml");
+            }
+        });
+
+        it("getSourceLocationWithMappings resolves to correct file for doubly nested paths", async () => {
+            const typescriptYaml = `
+lang: typescript
+version: 1.0.0
+`;
+            await writeFile(join(testDir, "typescript.yaml"), typescriptYaml);
+
+            const sdksYaml = `
+targets:
+  typescript:
+    $ref: "./typescript.yaml"
+`;
+            await writeFile(join(testDir, "sdks.yaml"), sdksYaml);
+
+            const mainYaml = `
+edition: 2026-01-01
+sdks:
+  $ref: "./sdks.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                const location = resolver.getSourceLocationWithMappings({
+                    document,
+                    pathMappings: result.pathMappings,
+                    yamlPath: ["sdks", "targets", "typescript", "lang"]
+                });
+
+                expect(location.relativeFilePath).toBe("typescript.yaml");
+                expect(location.line).toBe(2);
+
+                expect(location.refFrom).toBeDefined();
+                expect(location.refFrom?.relativeFilePath).toBe("sdks.yaml");
+            }
+        });
+
+        it("getSourceLocationWithMappings resolves to correct file for singly nested paths", async () => {
+            const typescriptYaml = `
+lang: typescript
+version: 1.0.0
+`;
+            await writeFile(join(testDir, "typescript.yaml"), typescriptYaml);
+
+            const sdksYaml = `
+targets:
+  autorelease: xyz
+  typescript:
+    $ref: "./typescript.yaml"
+`;
+            await writeFile(join(testDir, "sdks.yaml"), sdksYaml);
+
+            const mainYaml = `
+edition: 2026-01-01
+sdks:
+  $ref: "./sdks.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                const location = resolver.getSourceLocationWithMappings({
+                    document,
+                    pathMappings: result.pathMappings,
+                    yamlPath: ["sdks", "targets", "autorelease"]
+                });
+
+                expect(location.relativeFilePath).toBe("sdks.yaml");
+                expect(location.line).toBe(3);
+
+                expect(location.refFrom).toBeDefined();
+                expect(location.refFrom?.relativeFilePath).toBe("main.yaml");
+            }
+        });
+
+        it("getSourceLocationWithMappings falls back to original document for non-referenced paths", async () => {
+            const sdksYaml = `
+targets:
+  typescript:
+    lang: typescript
+`;
+            await writeFile(join(testDir, "sdks.yaml"), sdksYaml);
+
+            const mainYaml = `
+edition: 2026-01-01
+org: myorg
+sdks:
+  $ref: "./sdks.yaml"
+`;
+            const mainPath = AbsoluteFilePath.of(join(testDir, "main.yaml"));
+            const document = createYamlDocument(mainYaml, mainPath, cwd);
+
+            const resolver = new ReferenceResolver({ cwd });
+            const result = await resolver.resolve({ document });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                const location = resolver.getSourceLocationWithMappings({
+                    document,
+                    pathMappings: result.pathMappings,
+                    yamlPath: ["org"]
+                });
+
+                expect(location.relativeFilePath).toBe("main.yaml");
+                expect(location.line).toBe(3);
+
+                expect(location.refFrom).toBeUndefined();
+            }
+        });
+    });
+});

--- a/packages/cli/yaml/loader/src/index.ts
+++ b/packages/cli/yaml/loader/src/index.ts
@@ -1,3 +1,4 @@
+export { ReferenceResolver } from "./ReferenceResolver";
 export { ValidationIssue } from "./ValidationIssue";
 export { YamlConfigLoader } from "./YamlConfigLoader";
 export type { YamlPath } from "./YamlDocument";


### PR DESCRIPTION
## Description

This adds support for `$ref` nodes in the `fern.yml`. With this, users can split out their configuration file in any way they please. For many SDK use cases, this won't be as necessary, but the necessity reveals itself for complex `docs.yml` use cases (i.e. a long tail of configured `redirects`).

Note that this implements an intentional subset of the OpenAPI `$ref` semantics. We do _not_ support the following features:
1. JSON pointer / same document resolution (e.g. `#/components/schemas/Thing`).
2. Recursive references (e.g. `$ref: docs.yml`, where `docs.yml` includes `$ref: docs.yml`).

Unlike OpenAPI, the `fern.yml` is _not_ a recursive data structure. If users really want to reference other nodes within the same YAML document, they can use [YAML anchors](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/) (but this is discouraged).

An example of the errors reported by the CLI are shown below (notice the source file is preserved):

```yaml
# fern.yml
edition: 2026-01-01
org: false
sdks:
  $ref: sdks.yml
```

```yaml
# sdks.yml
targets:
  autorelease: xyz
  typescript:
    $ref: typescript.yml
```

```yaml
# typescript.yml
lang: false
version: 1.4.0
output:
  path: ../sdks/typescript-sdk
```

```sh
$ fern check
../fern.yml:2:6: org must be a string
../sdks.yml:2:16: sdks.targets.autorelease must be a object
../typescript.yml:1:7: sdks.targets.typescript.lang must be a string
```
* The content of the error message will be improved in future changes; the file reference is the important part for now.

## Changes Made
- Implemented a new `ReferenceResolver` class.
- Added a variety of tests to `ReferenceResolver.test.ts` and `loadFernYml.test.ts`

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
