### PR TITLE
fix(cli): Async API preserves optional/nullable objects

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/parseAsyncAPIV2.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/parseAsyncAPIV2.ts
@@ -125,12 +125,16 @@ export function parseAsyncAPIV2({
                 for (const [name, schema] of Object.entries(channel.bindings.ws.headers.properties ?? {})) {
                     if (isReferenceObject(schema)) {
                         const resolvedSchema = context.resolveSchemaReference(schema);
+                        const isRequired = required.includes(name);
+                        const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
+                            ? [false, !isRequired]
+                            : [!isRequired, false];
                         headers.push({
                             name,
                             schema: convertReferenceObject(
                                 schema,
-                                false,
-                                false,
+                                isOptional,
+                                isNullable,
                                 context,
                                 breadcrumbs,
                                 undefined,
@@ -174,12 +178,16 @@ export function parseAsyncAPIV2({
                 for (const [name, schema] of Object.entries(channel.bindings.ws.query.properties ?? {})) {
                     if (isReferenceObject(schema)) {
                         const resolvedSchema = context.resolveSchemaReference(schema);
+                        const isRequired = required.includes(name);
+                        const [isOptional, isNullable] = context.options.coerceOptionalSchemasToNullable
+                            ? [false, !isRequired]
+                            : [!isRequired, false];
                         queryParameters.push({
                             name,
                             schema: convertReferenceObject(
                                 schema,
-                                false,
-                                false,
+                                isOptional,
+                                isNullable,
                                 context,
                                 breadcrumbs,
                                 undefined,

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.47.5
+  changelogEntry:
+    - summary: |
+        Fix AsyncAPI query parameters with `$ref` types being incorrectly marked as required.
+      type: fix
+  createdAt: "2026-01-20"
+  irVersion: 63
+
 - version: 3.47.4
   changelogEntry:
     - summary: |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4926,8 +4926,6 @@ importers:
         specifier: ^17.4.1
         version: 17.7.2
 
-  packages/cli/cli-v2/dist/dev: {}
-
   packages/cli/config:
     devDependencies:
       '@fern-api/configs':


### PR DESCRIPTION
We weren't properly plumbing optional/nullable for object query params