### PR TITLE
fix(python): escape backslashes in OAuth client credentials docstrings

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.48.2
+  changelogEntry:
+    - summary: |
+        Fix backslash escaping in OAuth client credentials docstrings. Parameter docs in the
+        root client class docstring now properly escape backslashes to avoid Python SyntaxWarning
+        for invalid escape sequences.
+      type: fix
+  createdAt: "2026-01-20"
+  irVersion: 62
+
 - version: 4.48.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -12,6 +12,7 @@ from .base_wrapped_client_generator import BaseWrappedClientGenerator
 from .endpoint_function_generator import EndpointFunctionGenerator
 from .generated_root_client import GeneratedRootClient, RootClient
 from fern_python.codegen import AST, SourceFile
+from fern_python.codegen.ast.nodes.docstring import escape_docstring
 from fern_python.codegen.ast.nodes.code_writer.code_writer import CodeWriterFunction
 from fern_python.external_dependencies import HttpX
 from fern_python.generators.sdk.client_generator.base_client_generator import BaseClientGeneratorKwargs
@@ -246,7 +247,7 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                         writer.write_node(param.type_hint)
                 if param.docs is not None:
                     with writer.indent():
-                        writer.write_line(param.docs)
+                        writer.write_line(escape_docstring(param.docs))
 
         # Overload 1: client_id + client_secret
         overload_1_param_names: list[str] = [

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -2,7 +2,7 @@ import typing
 from dataclasses import dataclass
 from typing import List, Optional
 
-import fern.ir.resources as ir_types
+import fern_python.generators.sdk.names as names
 from ..environment_generators import (
     GeneratedEnvironment,
     MultipleBaseUrlsEnvironmentGenerator,
@@ -11,9 +11,6 @@ from ..environment_generators import (
 from .base_wrapped_client_generator import BaseWrappedClientGenerator
 from .endpoint_function_generator import EndpointFunctionGenerator
 from .generated_root_client import GeneratedRootClient, RootClient
-from typing_extensions import Unpack
-
-import fern_python.generators.sdk.names as names
 from fern_python.codegen import AST, SourceFile
 from fern_python.codegen.ast.nodes.code_writer.code_writer import CodeWriterFunction
 from fern_python.codegen.ast.nodes.docstring import escape_docstring
@@ -23,6 +20,9 @@ from fern_python.generators.sdk.core_utilities.client_wrapper_generator import (
     ClientWrapperGenerator,
     ConstructorParameter,
 )
+from typing_extensions import Unpack
+
+import fern.ir.resources as ir_types
 
 
 @dataclass

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -2,7 +2,7 @@ import typing
 from dataclasses import dataclass
 from typing import List, Optional
 
-import fern_python.generators.sdk.names as names
+import fern.ir.resources as ir_types
 from ..environment_generators import (
     GeneratedEnvironment,
     MultipleBaseUrlsEnvironmentGenerator,
@@ -11,18 +11,18 @@ from ..environment_generators import (
 from .base_wrapped_client_generator import BaseWrappedClientGenerator
 from .endpoint_function_generator import EndpointFunctionGenerator
 from .generated_root_client import GeneratedRootClient, RootClient
+from typing_extensions import Unpack
+
+import fern_python.generators.sdk.names as names
 from fern_python.codegen import AST, SourceFile
-from fern_python.codegen.ast.nodes.docstring import escape_docstring
 from fern_python.codegen.ast.nodes.code_writer.code_writer import CodeWriterFunction
+from fern_python.codegen.ast.nodes.docstring import escape_docstring
 from fern_python.external_dependencies import HttpX
 from fern_python.generators.sdk.client_generator.base_client_generator import BaseClientGeneratorKwargs
 from fern_python.generators.sdk.core_utilities.client_wrapper_generator import (
     ClientWrapperGenerator,
     ConstructorParameter,
 )
-from typing_extensions import Unpack
-
-import fern.ir.resources as ir_types
 
 
 @dataclass

--- a/seed/python-sdk/python-backslash-escape/README.md
+++ b/seed/python-sdk/python-backslash-escape/README.md
@@ -37,6 +37,7 @@ Instantiate and use the client with the following:
 from seed import SeedPythonBackslashEscape
 
 client = SeedPythonBackslashEscape(
+    api_key="YOUR_API_KEY",
     base_url="https://yourhost.com/path/to/api",
 )
 client.user.get(
@@ -55,6 +56,7 @@ import asyncio
 from seed import AsyncSeedPythonBackslashEscape
 
 client = AsyncSeedPythonBackslashEscape(
+    api_key="YOUR_API_KEY",
     base_url="https://yourhost.com/path/to/api",
 )
 

--- a/seed/python-sdk/python-backslash-escape/reference.md
+++ b/seed/python-sdk/python-backslash-escape/reference.md
@@ -32,6 +32,7 @@ Other backslash examples: FOO\_BAR, path\to\file, C:\Users\name
 from seed import SeedPythonBackslashEscape
 
 client = SeedPythonBackslashEscape(
+    api_key="YOUR_API_KEY",
     base_url="https://yourhost.com/path/to/api",
 )
 client.user.get(

--- a/seed/python-sdk/python-backslash-escape/snippet.json
+++ b/seed/python-sdk/python-backslash-escape/snippet.json
@@ -9,8 +9,8 @@
                 "identifier_override": "endpoint_user.get"
             },
             "snippet": {
-                "sync_client": "from seed import SeedPythonBackslashEscape\n\nclient = SeedPythonBackslashEscape(\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.user.get(\n    id=\"id\",\n    domain=\"domain\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedPythonBackslashEscape\n\nclient = AsyncSeedPythonBackslashEscape(\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.user.get(\n        id=\"id\",\n        domain=\"domain\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import SeedPythonBackslashEscape\n\nclient = SeedPythonBackslashEscape(\n    api_key=\"YOUR_API_KEY\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\nclient.user.get(\n    id=\"id\",\n    domain=\"domain\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncSeedPythonBackslashEscape\n\nclient = AsyncSeedPythonBackslashEscape(\n    api_key=\"YOUR_API_KEY\",\n    base_url=\"https://yourhost.com/path/to/api\",\n)\n\n\nasync def main() -> None:\n    await client.user.get(\n        id=\"id\",\n        domain=\"domain\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         }

--- a/seed/python-sdk/python-backslash-escape/src/seed/client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/client.py
@@ -20,6 +20,13 @@ class SeedPythonBackslashEscape:
     base_url : str
         The base url to use for requests from the client.
 
+    api_key : str
+        The API key for authentication.
+
+        Use DOMAIN\\username format for Windows authentication.
+
+        Other backslash examples: FOO\\_BAR, path\\to\\file, C:\\Users\\name
+
     headers : typing.Optional[typing.Dict[str, str]]
         Additional headers to send with every request.
 
@@ -37,6 +44,7 @@ class SeedPythonBackslashEscape:
     from seed import SeedPythonBackslashEscape
 
     client = SeedPythonBackslashEscape(
+        api_key="YOUR_API_KEY",
         base_url="https://yourhost.com/path/to/api",
     )
     """
@@ -45,6 +53,7 @@ class SeedPythonBackslashEscape:
         self,
         *,
         base_url: str,
+        api_key: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -55,6 +64,7 @@ class SeedPythonBackslashEscape:
         )
         self._client_wrapper = SyncClientWrapper(
             base_url=base_url,
+            api_key=api_key,
             headers=headers,
             httpx_client=httpx_client
             if httpx_client is not None
@@ -83,6 +93,13 @@ class AsyncSeedPythonBackslashEscape:
     base_url : str
         The base url to use for requests from the client.
 
+    api_key : str
+        The API key for authentication.
+
+        Use DOMAIN\\username format for Windows authentication.
+
+        Other backslash examples: FOO\\_BAR, path\\to\\file, C:\\Users\\name
+
     headers : typing.Optional[typing.Dict[str, str]]
         Additional headers to send with every request.
 
@@ -100,6 +117,7 @@ class AsyncSeedPythonBackslashEscape:
     from seed import AsyncSeedPythonBackslashEscape
 
     client = AsyncSeedPythonBackslashEscape(
+        api_key="YOUR_API_KEY",
         base_url="https://yourhost.com/path/to/api",
     )
     """
@@ -108,6 +126,7 @@ class AsyncSeedPythonBackslashEscape:
         self,
         *,
         base_url: str,
+        api_key: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -118,6 +137,7 @@ class AsyncSeedPythonBackslashEscape:
         )
         self._client_wrapper = AsyncClientWrapper(
             base_url=base_url,
+            api_key=api_key,
             headers=headers,
             httpx_client=httpx_client
             if httpx_client is not None

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/client_wrapper.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/client_wrapper.py
@@ -10,10 +10,12 @@ class BaseClientWrapper:
     def __init__(
         self,
         *,
+        api_key: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
     ):
+        self._api_key = api_key
         self._headers = headers
         self._base_url = base_url
         self._timeout = timeout
@@ -46,12 +48,13 @@ class SyncClientWrapper(BaseClientWrapper):
     def __init__(
         self,
         *,
+        api_key: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
         httpx_client: httpx.Client,
     ):
-        super().__init__(headers=headers, base_url=base_url, timeout=timeout)
+        super().__init__(api_key=api_key, headers=headers, base_url=base_url, timeout=timeout)
         self.httpx_client = HttpClient(
             httpx_client=httpx_client,
             base_headers=self.get_headers,
@@ -64,13 +67,14 @@ class AsyncClientWrapper(BaseClientWrapper):
     def __init__(
         self,
         *,
+        api_key: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
         base_url: str,
         timeout: typing.Optional[float] = None,
         async_token: typing.Optional[typing.Callable[[], typing.Awaitable[str]]] = None,
         httpx_client: httpx.AsyncClient,
     ):
-        super().__init__(headers=headers, base_url=base_url, timeout=timeout)
+        super().__init__(api_key=api_key, headers=headers, base_url=base_url, timeout=timeout)
         self._async_token = async_token
         self.httpx_client = AsyncHttpClient(
             httpx_client=httpx_client,

--- a/seed/python-sdk/python-backslash-escape/src/seed/user/client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/user/client.py
@@ -53,6 +53,7 @@ class UserClient:
         from seed import SeedPythonBackslashEscape
 
         client = SeedPythonBackslashEscape(
+            api_key="YOUR_API_KEY",
             base_url="https://yourhost.com/path/to/api",
         )
         client.user.get(
@@ -111,6 +112,7 @@ class AsyncUserClient:
         from seed import AsyncSeedPythonBackslashEscape
 
         client = AsyncSeedPythonBackslashEscape(
+            api_key="YOUR_API_KEY",
             base_url="https://yourhost.com/path/to/api",
         )
 

--- a/test-definitions/fern/apis/python-backslash-escape/definition/api.yml
+++ b/test-definitions/fern/apis/python-backslash-escape/definition/api.yml
@@ -1,1 +1,9 @@
 name: python-backslash-escape
+
+variables:
+  apiKey:
+    type: string
+    docs: |
+      The API key for authentication.
+      Use DOMAIN\username format for Windows authentication.
+      Other backslash examples: FOO\_BAR, path\to\file, C:\Users\name


### PR DESCRIPTION
## Description

Refs: Related to PR #11625

**Link to Devin run:** https://app.devin.ai/sessions/e8834c249c9c4ea29e9a9caa50977276
**Requested by:** @jsklan

Adds `escape_docstring` call to the `_write_root_class_docstring` method in `root_client_generator.py` to properly escape backslashes in parameter docs for OAuth client credentials docstrings. This prevents potential Python SyntaxWarning for invalid escape sequences.

## Changes Made

- Added import for `escape_docstring` from `fern_python.codegen.ast.nodes.docstring`
- Wrapped `param.docs` with `escape_docstring()` in the `write_param_block` function (line 250)
- Updated `python-backslash-escape` test fixture to include a variable with backslash-containing docs
- Regenerated test fixture output showing proper escaping (e.g., `DOMAIN\\username`, `FOO\\_BAR`)
- Added version 4.48.2 changelog entry

## Testing

- [x] Ran `pnpm run check` - passes
- [x] Ran `poetry run mypy .` on generated fixture - no issues found
- [x] Ran `poetry run pre-commit run -a` to fix import ordering
- [x] Regenerated `python-backslash-escape` fixture successfully

## Human Review Checklist

- [ ] **Important**: The fix is in the OAuth client credentials docstring path, but the test fixture uses a variable which goes through a different code path (`class_declaration.py`). The fix is defensive - it ensures consistency with other places that call `escape_docstring`, but the current OAuth parameters have hardcoded docs without backslashes.
- [ ] Verify the `escape_docstring` import path is correct
- [ ] Confirm the fix aligns with similar escaping in `endpoint_function_generator.py` (line 784) and `websocket_connect_method_generator.py` (line 416)