### PR TITLE
feat(rust): Add platform headers (X-Fern-Language, X-Fern-SDK-Name, X-Fern-SDK-Version)

### DIFF
--- a/generators/rust/sdk/src/__test__/snapshots/client-config-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/client-config-api-key.rs
@@ -23,7 +23,11 @@ impl Default for ClientConfig {
         password: None,
         timeout: Duration::from_secs(60),
         max_retries: 3,
-        custom_headers: HashMap::new(),
+        custom_headers: HashMap::from([
+            ("X-Fern-Language".to_string(), "Rust".to_string()),
+            ("X-Fern-SDK-Name".to_string(), "test_api".to_string()),
+            ("X-Fern-SDK-Version".to_string(), "0.1.0".to_string()),
+        ]),
         user_agent: "TestAPI Rust SDK".to_string()
     }
 }

--- a/generators/rust/sdk/src/__test__/util/createSampleGeneratorContext.ts
+++ b/generators/rust/sdk/src/__test__/util/createSampleGeneratorContext.ts
@@ -37,6 +37,8 @@ export function createSampleGeneratorContext(args: CreateSampleGeneratorContextA
         ir: mockIR,
         getClientName: () => "TestClient",
         getApiClientBuilderClientName: () => "TestClient",
+        getCrateName: () => "test_api",
+        getCrateVersion: () => "0.1.0",
         customConfig: {}
     } as SdkGeneratorContext;
 }

--- a/generators/rust/sdk/src/generators/ClientConfigGenerator.ts
+++ b/generators/rust/sdk/src/generators/ClientConfigGenerator.ts
@@ -102,6 +102,10 @@ export class ClientConfigGenerator {
         const environmentEnumName = this.getEnvironmentEnumName();
         const hasDefaultEnvironment = this.context.ir.environments?.defaultEnvironment !== undefined;
 
+        // Platform headers for Fern SDK identification
+        const sdkName = this.context.getCrateName();
+        const sdkVersion = this.context.getCrateVersion();
+
         const defaultMethod = rust.method({
             name: "default",
             parameters: [],
@@ -149,7 +153,13 @@ export class ClientConfigGenerator {
                     },
                     {
                         name: "custom_headers",
-                        value: Expression.functionCall("HashMap::new", [])
+                        value: Expression.raw(
+                            `HashMap::from([
+            ("X-Fern-Language".to_string(), "Rust".to_string()),
+            ("X-Fern-SDK-Name".to_string(), "${sdkName}".to_string()),
+            ("X-Fern-SDK-Version".to_string(), "${sdkVersion}".to_string()),
+        ])`
+                        )
                     },
                     {
                         name: "user_agent",

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.15.0
+  changelogEntry:
+    - summary: |
+        Add platform headers (X-Fern-Language, X-Fern-SDK-Name, X-Fern-SDK-Version) to all HTTP
+        requests. These headers help identify SDK usage and version for API analytics and debugging.
+      type: feat
+  createdAt: "2026-01-21"
+  irVersion: 62
+
 - version: 0.14.3
   changelogEntry:
     - summary: Update Dockerfile to use the latest generator-cli with improve reference.md generation.


### PR DESCRIPTION
## Description

Adds platform headers to all HTTP requests made by generated Rust SDKs, matching the behavior of the Ruby, TypeScript, and Python generators.

Refs: Requested by @iamnamananand996

## Changes Made

- Modified `ClientConfigGenerator.ts` to initialize `custom_headers` with platform headers instead of an empty HashMap
- Headers added:
  - `X-Fern-Language: Rust`
  - `X-Fern-SDK-Name: <crate_name>`
  - `X-Fern-SDK-Version: <crate_version>`
- Version bump: 0.14.3 → 0.15.0
- [ ] Updated README.md generator (if applicable)

## Updates Since Last Revision

- Added `getCrateName()` and `getCrateVersion()` methods to test mock context
- Updated snapshot file to reflect new platform headers in generated code

## Testing

- [x] Lint checks passed (`pnpm run check`)
- [x] Unit tests added/updated
- [ ] Seed tests (will run in CI)

## Human Review Checklist

- [ ] Verify the generated Rust code syntax is valid (uses `HashMap::from([...])`)
- [ ] Confirm crate name/version string interpolation handles edge cases correctly (special characters in crate names)
- [ ] Verify headers are actually sent in HTTP requests (not just initialized in config)

---

Link to Devin run: https://app.devin.ai/sessions/98570d0d35fe408a94bbe343c5168f9f