### PR TITLE
feat(ci): add IR version consistency validation and fix mismatches

### DIFF
--- a/.github/workflows/validate-ir-version-consistency.yml
+++ b/.github/workflows/validate-ir-version-consistency.yml
@@ -1,0 +1,40 @@
+name: Validate IR Version Consistency
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "seed/**/seed.yml"
+      - "generators/**/versions.yml"
+      - "scripts/validate-ir-version-consistency.sh"
+      - ".github/workflows/validate-ir-version-consistency.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "seed/**/seed.yml"
+      - "generators/**/versions.yml"
+      - "scripts/validate-ir-version-consistency.sh"
+      - ".github/workflows/validate-ir-version-consistency.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-ir-versions:
+    name: Validate IR Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            seed
+            generators
+            scripts
+            .github
+
+      - name: Validate IR version consistency
+        run: ./scripts/validate-ir-version-consistency.sh

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.22.9
+  changelogEntry:
+    - summary: Update IR version to 61 to support Generation Metadata feature and maintain consistency with seed configuration.
+      type: chore
+  createdAt: "2026-01-21"
+  irVersion: 61
+
 - version: 1.22.8
   changelogEntry:
     - summary: Fix internal v1-side failure to pass alwaysSendRequiredProperties when visiting inlined request bodies.

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.1.2
+  changelogEntry:
+    - summary: Update IR version to 61 to support Generation Metadata feature and maintain consistency with seed configuration.
+      type: chore
+  createdAt: "2026-01-21"
+  irVersion: 61
+
 - version: 0.1.1
   changelogEntry:
     - summary: Update Dockerfile to use the latest generator-cli with improve reference.md generation.

--- a/scripts/validate-ir-version-consistency.sh
+++ b/scripts/validate-ir-version-consistency.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Script to validate that the irVersion in each seed.yml matches the irVersion
+# of the latest release in the corresponding versions.yml file.
+#
+# Usage: ./validate-ir-version-consistency.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+errors=()
+
+# Function to extract irVersion from seed.yml
+get_seed_ir_version() {
+    local seed_file="$1"
+    # Extract irVersion value, removing the 'v' prefix if present
+    grep -E "^irVersion:" "$seed_file" | head -1 | sed 's/irVersion:[[:space:]]*//' | sed 's/^v//'
+}
+
+# Function to get the irVersion of the latest version from versions.yml
+# This includes RC versions since seed tests should match the current generator state
+get_latest_release_ir_version() {
+    local versions_file="$1"
+    
+    # Use awk to find the first version entry and extract its irVersion
+    awk '
+    BEGIN { in_version_block = 0 }
+    /^- version:/ {
+        in_version_block = 1
+    }
+    /^[[:space:]]+irVersion:/ && in_version_block {
+        ir = $0
+        gsub(/^[[:space:]]+irVersion:[[:space:]]*/, "", ir)
+        print ir
+        exit
+    }
+    ' "$versions_file"
+}
+
+# Function to get the latest version string from versions.yml (for error messages)
+get_latest_release_version() {
+    local versions_file="$1"
+    
+    awk '
+    /^- version:/ {
+        version = $0
+        gsub(/^- version:[[:space:]]*/, "", version)
+        print version
+        exit
+    }
+    ' "$versions_file"
+}
+
+echo "Validating irVersion consistency between seed.yml and versions.yml files..."
+echo ""
+
+# Find all seed.yml files
+for seed_file in "$REPO_ROOT"/seed/*/seed.yml; do
+    if [ ! -f "$seed_file" ]; then
+        continue
+    fi
+    
+    seed_dir=$(dirname "$seed_file")
+    seed_name=$(basename "$seed_dir")
+    
+    # Get changelogLocation from seed.yml
+    changelog_location=$(grep -E "^changelogLocation:" "$seed_file" | head -1 | sed 's/changelogLocation:[[:space:]]*//' || true)
+    
+    if [ -z "$changelog_location" ]; then
+        echo -e "${YELLOW}SKIP${NC} $seed_name: No changelogLocation specified"
+        continue
+    fi
+    
+    # Resolve the versions.yml path relative to the seed.yml file
+    versions_file="$seed_dir/$changelog_location"
+    
+    if [ ! -f "$versions_file" ]; then
+        echo -e "${YELLOW}SKIP${NC} $seed_name: versions.yml not found at $versions_file"
+        continue
+    fi
+    
+    # Get irVersion from seed.yml
+    seed_ir_version=$(get_seed_ir_version "$seed_file")
+    
+    if [ -z "$seed_ir_version" ]; then
+        echo -e "${YELLOW}SKIP${NC} $seed_name: No irVersion in seed.yml"
+        continue
+    fi
+    
+    # Get irVersion from the latest release in versions.yml
+    versions_ir_version=$(get_latest_release_ir_version "$versions_file")
+    
+    if [ -z "$versions_ir_version" ]; then
+        echo -e "${YELLOW}SKIP${NC} $seed_name: Could not find irVersion in versions.yml"
+        continue
+    fi
+    
+    # Compare the versions
+    if [ "$seed_ir_version" = "$versions_ir_version" ]; then
+        echo -e "${GREEN}PASS${NC} $seed_name: irVersion $seed_ir_version matches"
+    else
+        latest_version=$(get_latest_release_version "$versions_file")
+        echo -e "${RED}FAIL${NC} $seed_name: seed.yml has irVersion v$seed_ir_version but latest release ($latest_version) has irVersion $versions_ir_version"
+        errors+=("$seed_name: seed.yml has irVersion v$seed_ir_version but latest release ($latest_version) has irVersion $versions_ir_version")
+    fi
+done
+
+echo ""
+
+if [ ${#errors[@]} -gt 0 ]; then
+    echo -e "${RED}Validation failed with ${#errors[@]} error(s):${NC}"
+    echo ""
+    for error in "${errors[@]}"; do
+        echo "  - $error"
+    done
+    echo ""
+    echo "To fix: Update the irVersion in the seed.yml file to match the irVersion"
+    echo "of the latest release in the corresponding versions.yml file."
+    exit 1
+fi
+
+echo -e "${GREEN}All irVersion checks passed!${NC}"

--- a/scripts/validate-ir-version-consistency.sh
+++ b/scripts/validate-ir-version-consistency.sh
@@ -1,130 +1,68 @@
 #!/bin/bash
 
-# Script to validate that the irVersion in each seed.yml matches the irVersion
-# of the latest release in the corresponding versions.yml file.
-#
-# Usage: ./validate-ir-version-consistency.sh
+# Validate that irVersion in seed.yml matches irVersion of latest release in versions.yml
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
 errors=()
 
-# Function to extract irVersion from seed.yml
+# Extract irVersion from seed.yml
 get_seed_ir_version() {
-    local seed_file="$1"
-    # Extract irVersion value, removing the 'v' prefix if present
-    grep -E "^irVersion:" "$seed_file" | head -1 | sed 's/irVersion:[[:space:]]*//' | sed 's/^v//'
+    grep -E "^irVersion:" "$1" | head -1 | sed 's/irVersion:[[:space:]]*v\{0,1\}//'
 }
 
-# Function to get the irVersion of the latest version from versions.yml
-# This includes RC versions since seed tests should match the current generator state
-get_latest_release_ir_version() {
-    local versions_file="$1"
-    
-    # Use awk to find the first version entry and extract its irVersion
-    awk '
-    BEGIN { in_version_block = 0 }
-    /^- version:/ {
-        in_version_block = 1
-    }
-    /^[[:space:]]+irVersion:/ && in_version_block {
-        ir = $0
-        gsub(/^[[:space:]]+irVersion:[[:space:]]*/, "", ir)
-        print ir
-        exit
-    }
-    ' "$versions_file"
+# Extract irVersion from first version entry in versions.yml
+get_versions_ir_version() {
+    awk '/^- version:/{found=1; next} found && /^[[:space:]]+irVersion:/{gsub(/^[[:space:]]+irVersion:[[:space:]]*/, ""); print; exit}' "$1"
 }
 
-# Function to get the latest version string from versions.yml (for error messages)
-get_latest_release_version() {
-    local versions_file="$1"
-    
-    awk '
-    /^- version:/ {
-        version = $0
-        gsub(/^- version:[[:space:]]*/, "", version)
-        print version
-        exit
-    }
-    ' "$versions_file"
+# Extract version string from first version entry in versions.yml
+get_latest_version() {
+    awk '/^- version:/{gsub(/^- version:[[:space:]]*/, ""); print; exit}' "$1"
 }
 
-echo "Validating irVersion consistency between seed.yml and versions.yml files..."
-echo ""
-
-# Find all seed.yml files
 for seed_file in "$REPO_ROOT"/seed/*/seed.yml; do
-    if [ ! -f "$seed_file" ]; then
-        continue
-    fi
-    
+    [ -f "$seed_file" ] || continue
+
     seed_dir=$(dirname "$seed_file")
     seed_name=$(basename "$seed_dir")
-    
-    # Get changelogLocation from seed.yml
+
+    # Skip deprecated generators
+    case "$seed_name" in
+        ruby-model|ruby-sdk)
+            continue
+            ;;
+    esac
+
+    # Get changelogLocation and resolve versions.yml path
     changelog_location=$(grep -E "^changelogLocation:" "$seed_file" | head -1 | sed 's/changelogLocation:[[:space:]]*//' || true)
-    
-    if [ -z "$changelog_location" ]; then
-        echo -e "${YELLOW}SKIP${NC} $seed_name: No changelogLocation specified"
-        continue
-    fi
-    
-    # Resolve the versions.yml path relative to the seed.yml file
+    [ -n "$changelog_location" ] || continue
+
     versions_file="$seed_dir/$changelog_location"
-    
-    if [ ! -f "$versions_file" ]; then
-        echo -e "${YELLOW}SKIP${NC} $seed_name: versions.yml not found at $versions_file"
-        continue
-    fi
-    
-    # Get irVersion from seed.yml
+    [ -f "$versions_file" ] || continue
+
+    # Get irVersion from both files
     seed_ir_version=$(get_seed_ir_version "$seed_file")
-    
-    if [ -z "$seed_ir_version" ]; then
-        echo -e "${YELLOW}SKIP${NC} $seed_name: No irVersion in seed.yml"
-        continue
-    fi
-    
-    # Get irVersion from the latest release in versions.yml
-    versions_ir_version=$(get_latest_release_ir_version "$versions_file")
-    
-    if [ -z "$versions_ir_version" ]; then
-        echo -e "${YELLOW}SKIP${NC} $seed_name: Could not find irVersion in versions.yml"
-        continue
-    fi
-    
-    # Compare the versions
-    if [ "$seed_ir_version" = "$versions_ir_version" ]; then
-        echo -e "${GREEN}PASS${NC} $seed_name: irVersion $seed_ir_version matches"
-    else
-        latest_version=$(get_latest_release_version "$versions_file")
-        echo -e "${RED}FAIL${NC} $seed_name: seed.yml has irVersion v$seed_ir_version but latest release ($latest_version) has irVersion $versions_ir_version"
-        errors+=("$seed_name: seed.yml has irVersion v$seed_ir_version but latest release ($latest_version) has irVersion $versions_ir_version")
+    versions_ir_version=$(get_versions_ir_version "$versions_file")
+
+    [ -n "$seed_ir_version" ] && [ -n "$versions_ir_version" ] || continue
+
+    # Compare versions
+    if [ "$seed_ir_version" != "$versions_ir_version" ]; then
+        latest_version=$(get_latest_version "$versions_file")
+        errors+=("$seed_name: seed.yml has irVersion $seed_ir_version but latest release ($latest_version) has irVersion $versions_ir_version")
     fi
 done
 
-echo ""
-
 if [ ${#errors[@]} -gt 0 ]; then
-    echo -e "${RED}Validation failed with ${#errors[@]} error(s):${NC}"
+    echo "IR version consistency validation failed:"
+    printf '  - %s\n' "${errors[@]}"
     echo ""
-    for error in "${errors[@]}"; do
-        echo "  - $error"
-    done
-    echo ""
-    echo "To fix: Update the irVersion in the seed.yml file to match the irVersion"
-    echo "of the latest release in the corresponding versions.yml file."
+    echo "Fix: Update irVersion in seed.yml to match the latest release in versions.yml"
     exit 1
 fi
 
-echo -e "${GREEN}All irVersion checks passed!${NC}"
+echo "All IR versions are consistent"

--- a/seed/fastapi/seed.yml
+++ b/seed/fastapi/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v60
+irVersion: v61
 displayName: FastAPI
 image: fernapi/fern-fastapi-server
 changelogLocation: ../../generators/python/fastapi/versions.yml

--- a/seed/go-fiber/seed.yml
+++ b/seed/go-fiber/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v58
+irVersion: v60
 displayName: Fiber
 image: fernapi/fern-go-fiber
 changelogLocation: ../../generators/go/fiber/versions.yml

--- a/seed/pydantic-v2/seed.yml
+++ b/seed/pydantic-v2/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v60
+irVersion: v62
 displayName: Pydantic Model
 image: fernapi/fern-pydantic-model-v2
 changelogLocation: ../../generators/python/pydantic/versions.yml

--- a/seed/pydantic/seed.yml
+++ b/seed/pydantic/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v60
+irVersion: v62
 displayName: Pydantic Model
 image: fernapi/fern-pydantic-model
 changelogLocation: ../../generators/python/pydantic/versions.yml

--- a/seed/rust-sdk/seed.yml
+++ b/seed/rust-sdk/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v61
+irVersion: v62
 displayName: Rust SDK
 image: fernapi/fern-rust-sdk
 changelogLocation: ../../generators/rust/sdk/versions.yml


### PR DESCRIPTION
## Description

Adds CI validation to ensure irVersion consistency between seed.yml and versions.yml files, and fixes all existing mismatches found in the codebase.

The original validation script from Devin was simplified from 131 to 61 lines, removing verbose formatting and following the project's patterns of keeping validation logic simple and focused.

## Changes Made

- **Validation Script**: Added `scripts/validate-ir-version-consistency.sh` with simplified logic for checking irVersion consistency
- **CI Integration**: Added GitHub Actions workflow that runs validation on relevant file changes
- **Deprecated Generator Exclusion**: Script skips ruby v1 generators (ruby-model, ruby-sdk) as they are deprecated
- **Seed Configuration Fixes**: Updated 5 seed.yml files where version was lower than latest release:
  - fastapi: 60 → 61
  - go-fiber: 58 → 60  
  - pydantic-v2: 60 → 62
  - pydantic: 60 → 62
  - rust-sdk: 61 → 62
- **Generator Releases**: Published new patch versions for generators where seed was ahead:
  - go-sdk v1.22.9 with irVersion 61 (to support Generation Metadata feature)
  - rust-model v0.1.2 with irVersion 61

## Testing

- [x] Manual testing completed - script correctly identifies and resolves all mismatches
- [x] Validation now passes with all IR versions consistent across the codebase
- [x] Script handles edge cases (missing files, deprecated generators)