### PR TITLE
fix(openapi): handle missing schema references gracefully in example builder

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/ExampleWebsocketSessionFactory.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/ExampleWebsocketSessionFactory.ts
@@ -238,14 +238,21 @@ export class ExampleWebsocketSessionFactory {
     }
 
     private isSchemaRequired(schema: SchemaWithExample): boolean {
-        return isSchemaRequired(this.getResolvedSchema(schema));
+        const resolved = this.getResolvedSchema(schema);
+        if (resolved == null) {
+            // If schema can't be resolved, treat as not required to avoid errors
+            return false;
+        }
+        return isSchemaRequired(resolved);
     }
 
-    private getResolvedSchema(schema: SchemaWithExample): SchemaWithExample {
+    private getResolvedSchema(schema: SchemaWithExample): SchemaWithExample | undefined {
         while (schema.type === "reference") {
             const resolvedSchema = this.schemas[schema.schema];
             if (resolvedSchema == null) {
-                throw new Error(`Unexpected error: Failed to resolve schema reference: ${schema.schema}`);
+                // Return undefined instead of throwing to gracefully handle
+                // missing schema references (e.g., schemas marked with x-fern-ignore)
+                return undefined;
             }
             schema = resolvedSchema;
         }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/examples/ExampleTypeFactory.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/examples/ExampleTypeFactory.ts
@@ -233,7 +233,11 @@ export class ExampleTypeFactory {
                         for (const commonProperty of schema.value.commonProperties) {
                             allProperties[commonProperty.key] = { schema: commonProperty.schema, readonly: false };
                             const resolvedSchema = this.getResolvedSchema(commonProperty.schema);
-                            if (resolvedSchema.type !== "optional" && resolvedSchema.type !== "nullable") {
+                            if (
+                                resolvedSchema != null &&
+                                resolvedSchema.type !== "optional" &&
+                                resolvedSchema.type !== "nullable"
+                            ) {
                                 requiredProperties[commonProperty.key] = commonProperty.schema;
                             }
                         }
@@ -842,7 +846,7 @@ export class ExampleTypeFactory {
                 continue;
             }
             const resolvedAllOfSchema = this.getResolvedSchema(allOfSchema);
-            if (resolvedAllOfSchema.type !== "object") {
+            if (resolvedAllOfSchema == null || resolvedAllOfSchema.type !== "object") {
                 continue;
             }
             properties = {
@@ -857,7 +861,7 @@ export class ExampleTypeFactory {
         let requiredProperties: Record<string, SchemaWithExample> = {};
         for (const property of object.properties) {
             const resolvedSchema = this.getResolvedSchema(property.schema);
-            if (resolvedSchema.type !== "optional" && resolvedSchema.type !== "nullable") {
+            if (resolvedSchema != null && resolvedSchema.type !== "optional" && resolvedSchema.type !== "nullable") {
                 requiredProperties[property.key] = property.schema;
             }
         }
@@ -867,7 +871,7 @@ export class ExampleTypeFactory {
                 continue;
             }
             const resolvedAllOfSchema = this.getResolvedSchema(allOfSchema);
-            if (resolvedAllOfSchema.type !== "object") {
+            if (resolvedAllOfSchema == null || resolvedAllOfSchema.type !== "object") {
                 continue;
             }
             requiredProperties = {
@@ -878,11 +882,13 @@ export class ExampleTypeFactory {
         return requiredProperties;
     }
 
-    private getResolvedSchema(schema: SchemaWithExample) {
+    private getResolvedSchema(schema: SchemaWithExample): SchemaWithExample | undefined {
         while (schema.type === "reference") {
             const resolvedSchema = this.schemas[schema.schema];
             if (resolvedSchema == null) {
-                throw new Error(`Unexpected error: Failed to resolve schema reference: ${schema.schema}`);
+                // Return undefined instead of throwing to gracefully handle
+                // missing schema references (e.g., schemas marked with x-fern-ignore)
+                return undefined;
             }
             schema = resolvedSchema;
         }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.48.1
+  changelogEntry:
+    - summary: |
+        Fix OpenAPI parsing to gracefully handle missing schema references. When a schema reference cannot be resolved (e.g., schemas marked with `x-fern-ignore`), the example builder now returns undefined instead of throwing an error. This prevents entire API documents from being skipped during parsing when they contain schemas with unresolvable references.
+      type: fix
+  createdAt: "2026-01-21"
+  irVersion: 63
+
 - version: 3.48.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Refs: Devin session https://app.devin.ai/sessions/e48eebd0e7b847dcb3aec2b358138d82
Requested by: @fern-support

Fixes an issue where entire API documents were being skipped during OpenAPI parsing when they contained schemas with unresolvable references (e.g., schemas marked with `x-fern-ignore`).

The specific case was the Algolia Search API, where `highlightResult` was marked with `x-fern-ignore: true`, but other schemas still referenced it. When the example builder tried to resolve these references, it threw an error that caused the entire Search API to be skipped.

## Changes Made
- Modified `getResolvedSchema()` in `ExampleTypeFactory.ts` to return `undefined` instead of throwing when a schema reference cannot be resolved
- Updated all callers of `getResolvedSchema()` in `ExampleTypeFactory.ts` to handle the `undefined` case with null checks:
  - `getAllProperties()` - skips allOf schemas that can't be resolved
  - `getAllRequiredProperties()` - skips properties/allOf schemas that can't be resolved
  - Discriminated union common property handling - skips marking properties as required if schema can't be resolved
- Applied the same fix to `ExampleWebsocketSessionFactory.ts`:
  - Modified `getResolvedSchema()` to return `undefined` instead of throwing
  - Updated `isSchemaRequired()` to return `false` when schema can't be resolved
- Added changelog entry for version 3.48.2

## Testing
- [x] Existing unit tests pass (`pnpm test --filter "@fern-api/openapi-ir-parser"`)
- [x] Integration tests pass (`pnpm test --filter "@fern-api/openapi-ir-to-fern-tests"`)
- [x] Lint checks pass (`pnpm run check`)

## Human Review Checklist
- [ ] Verify returning `undefined` instead of throwing is appropriate for all call sites
- [ ] Verify that returning `false` from `isSchemaRequired()` when schema can't be resolved is the correct semantic behavior
- [ ] Check if there are other similar `getResolvedSchema` methods elsewhere in the codebase that might need the same fix
- [ ] Consider whether a debug log should be added when schema resolution fails