### PR TITLE
fix(python): merge additional_query_parameters into WebSocket URL

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.48.2
+  changelogEntry:
+    - summary: |
+        Fix WebSocket connections to merge `additional_query_parameters` from `request_options` into the
+        WebSocket URL. Previously, `request_options.additional_query_parameters` was ignored for WebSocket
+        connections, only `additional_headers` was being applied.
+      type: fix
+  createdAt: "2026-01-22"
+  irVersion: 62
+
 - version: 4.48.1
   changelogEntry:
     - summary: |

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/empty/empty_realtime/client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/empty/empty_realtime/client.py
@@ -3,6 +3,7 @@
 import typing
 from contextlib import asynccontextmanager, contextmanager
 
+import httpx
 import websockets.exceptions
 import websockets.sync.client as websockets_sync_client
 from ...core.api_error import ApiError
@@ -47,6 +48,12 @@ class EmptyRealtimeClient:
         EmptyRealtimeSocketClient
         """
         ws_url = self._raw_client._client_wrapper.get_base_url() + "/empty/realtime/"
+        query_params = httpx.QueryParams()
+        if request_options and "additional_query_parameters" in request_options:
+            for key, value in request_options["additional_query_parameters"].items():
+                query_params = query_params.add(key, value)
+        if len(query_params) > 0:
+            ws_url = ws_url + f"?{query_params}"
         headers = self._raw_client._client_wrapper.get_headers()
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])
@@ -98,6 +105,12 @@ class AsyncEmptyRealtimeClient:
         AsyncEmptyRealtimeSocketClient
         """
         ws_url = self._raw_client._client_wrapper.get_base_url() + "/empty/realtime/"
+        query_params = httpx.QueryParams()
+        if request_options and "additional_query_parameters" in request_options:
+            for key, value in request_options["additional_query_parameters"].items():
+                query_params = query_params.add(key, value)
+        if len(query_params) > 0:
+            ws_url = ws_url + f"?{query_params}"
         headers = self._raw_client._client_wrapper.get_headers()
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/empty/empty_realtime/raw_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/empty/empty_realtime/raw_client.py
@@ -3,6 +3,7 @@
 import typing
 from contextlib import asynccontextmanager, contextmanager
 
+import httpx
 import websockets.exceptions
 import websockets.sync.client as websockets_sync_client
 from ...core.api_error import ApiError
@@ -35,6 +36,12 @@ class RawEmptyRealtimeClient:
         EmptyRealtimeSocketClient
         """
         ws_url = self._client_wrapper.get_base_url() + "/empty/realtime/"
+        query_params = httpx.QueryParams()
+        if request_options and "additional_query_parameters" in request_options:
+            for key, value in request_options["additional_query_parameters"].items():
+                query_params = query_params.add(key, value)
+        if len(query_params) > 0:
+            ws_url = ws_url + f"?{query_params}"
         headers = self._client_wrapper.get_headers()
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])
@@ -75,6 +82,12 @@ class AsyncRawEmptyRealtimeClient:
         AsyncEmptyRealtimeSocketClient
         """
         ws_url = self._client_wrapper.get_base_url() + "/empty/realtime/"
+        query_params = httpx.QueryParams()
+        if request_options and "additional_query_parameters" in request_options:
+            for key, value in request_options["additional_query_parameters"].items():
+                query_params = query_params.add(key, value)
+        if len(query_params) > 0:
+            ws_url = ws_url + f"?{query_params}"
         headers = self._client_wrapper.get_headers()
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/client.py
@@ -69,7 +69,11 @@ class RealtimeClient:
             query_params = query_params.add("temperature", temperature)
         if language_code is not None:
             query_params = query_params.add("language-code", language_code)
-        ws_url = ws_url + f"?{query_params}"
+        if request_options and "additional_query_parameters" in request_options:
+            for key, value in request_options["additional_query_parameters"].items():
+                query_params = query_params.add(key, value)
+        if len(query_params) > 0:
+            ws_url = ws_url + f"?{query_params}"
         headers = self._raw_client._client_wrapper.get_headers()
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])
@@ -142,7 +146,11 @@ class AsyncRealtimeClient:
             query_params = query_params.add("temperature", temperature)
         if language_code is not None:
             query_params = query_params.add("language-code", language_code)
-        ws_url = ws_url + f"?{query_params}"
+        if request_options and "additional_query_parameters" in request_options:
+            for key, value in request_options["additional_query_parameters"].items():
+                query_params = query_params.add(key, value)
+        if len(query_params) > 0:
+            ws_url = ws_url + f"?{query_params}"
         headers = self._raw_client._client_wrapper.get_headers()
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/raw_client.py
@@ -57,7 +57,11 @@ class RawRealtimeClient:
             query_params = query_params.add("temperature", temperature)
         if language_code is not None:
             query_params = query_params.add("language-code", language_code)
-        ws_url = ws_url + f"?{query_params}"
+        if request_options and "additional_query_parameters" in request_options:
+            for key, value in request_options["additional_query_parameters"].items():
+                query_params = query_params.add(key, value)
+        if len(query_params) > 0:
+            ws_url = ws_url + f"?{query_params}"
         headers = self._client_wrapper.get_headers()
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])
@@ -119,7 +123,11 @@ class AsyncRawRealtimeClient:
             query_params = query_params.add("temperature", temperature)
         if language_code is not None:
             query_params = query_params.add("language-code", language_code)
-        ws_url = ws_url + f"?{query_params}"
+        if request_options and "additional_query_parameters" in request_options:
+            for key, value in request_options["additional_query_parameters"].items():
+                query_params = query_params.add(key, value)
+        if len(query_params) > 0:
+            ws_url = ws_url + f"?{query_params}"
         headers = self._client_wrapper.get_headers()
         if request_options and "additional_headers" in request_options:
             headers.update(request_options["additional_headers"])


### PR DESCRIPTION
## Description

Refs https://buildwithfern.slack.com/archives/C07TPFNNB8W/p1769072437727359

Fixes a bug where `request_options.additional_query_parameters` was ignored for WebSocket connections in the Python SDK. Previously, only `additional_headers` was being applied to WebSocket URLs.

Link to Devin run: https://app.devin.ai/sessions/e341f94cef9f4e99a7e3ac92b2724d61
Requested by: @tjb9dc

## Changes Made

- Modified `websocket_connect_method_generator.py` to always initialize `query_params` and merge `additional_query_parameters` from `request_options`
- Query string is only appended to the URL when there are actual query parameters (`len(query_params) > 0`)
- Updated seed test fixtures to reflect the generated code changes

## Testing

- [x] Seed tests pass for `websocket`, `websocket-bearer-auth`, and `websocket-inferred-auth` fixtures
- [x] Pre-commit hooks pass
- [ ] Manual testing with actual WebSocket connection (not performed)

## Human Review Checklist

- [ ] Verify the iteration over `additional_query_parameters.items()` handles edge cases (list values, None values)
- [ ] Confirm this matches how the HTTP client handles `additional_query_parameters` in `http_client.py`