### PR TITLE
fix(typescript): add support for additional query parameters in WebSocket connections

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -48,6 +48,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
     private static readonly DEBUG_PROPERTY_NAME = "debug";
     private static readonly HEADERS_PROPERTY_NAME = "headers";
     private static readonly HEADERS_VARIABLE_NAME = "_headers";
+    private static readonly QUERY_PARAMS_PROPERTY_NAME = "queryParams";
 
     private static readonly RECONNECT_ATTEMPTS_PROPERTY_NAME = "reconnectAttempts";
     private static readonly GENERATED_VERSION_PROPERTY_NAME = "fernSdkVersion";
@@ -204,6 +205,17 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                     docs: ["Arbitrary headers to send with the websocket connect request."]
                 },
                 {
+                    name: GeneratedDefaultWebsocketImplementation.QUERY_PARAMS_PROPERTY_NAME,
+                    type: getTextOfTsNode(
+                        ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Record"), [
+                            ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                            ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)
+                        ])
+                    ),
+                    hasQuestionToken: true,
+                    docs: ["Additional query parameters to send with the websocket connect request."]
+                },
+                {
                     name: GeneratedDefaultWebsocketImplementation.DEBUG_PROPERTY_NAME,
                     type: getTextOfTsNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword)),
                     hasQuestionToken: true,
@@ -289,6 +301,15 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 undefined,
                 undefined,
                 ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.HEADERS_PROPERTY_NAME)
+            )
+        );
+
+        // Add queryParams binding
+        bindingElements.push(
+            ts.factory.createBindingElement(
+                undefined,
+                undefined,
+                ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.QUERY_PARAMS_PROPERTY_NAME)
             )
         );
 
@@ -518,11 +539,32 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                 )
             ]),
             headers: ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.HEADERS_VARIABLE_NAME),
-            queryParameters:
-                this.channel.queryParameters.length > 0
-                    ? ts.factory.createIdentifier(GeneratedQueryParams.QUERY_PARAMS_VARIABLE_NAME)
-                    : ts.factory.createObjectLiteralExpression([], false)
+            queryParameters: this.getMergedQueryParameters()
         });
+    }
+
+    private getMergedQueryParameters(): ts.Expression {
+        const additionalQueryParams = ts.factory.createIdentifier(
+            GeneratedDefaultWebsocketImplementation.QUERY_PARAMS_PROPERTY_NAME
+        );
+
+        if (this.channel.queryParameters.length > 0) {
+            return ts.factory.createObjectLiteralExpression(
+                [
+                    ts.factory.createSpreadAssignment(
+                        ts.factory.createIdentifier(GeneratedQueryParams.QUERY_PARAMS_VARIABLE_NAME)
+                    ),
+                    ts.factory.createSpreadAssignment(additionalQueryParams)
+                ],
+                false
+            );
+        } else {
+            return ts.factory.createBinaryExpression(
+                additionalQueryParams,
+                ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                ts.factory.createObjectLiteralExpression([], false)
+            );
+        }
     }
 
     private getEnvironment(channel: WebSocketChannel, context: SdkContext): ts.Expression {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.43.14
+  changelogEntry:
+    - summary: |
+        Add support for additional query parameters in WebSocket connections. The `connect()` method
+        now accepts a `queryParams` option that allows passing arbitrary query parameters to be merged
+        into the WebSocket URL. This enables users to pass custom query parameters for authentication,
+        session tracking, or other purposes when establishing WebSocket connections.
+      type: fix
+  createdAt: "2026-01-22"
+  irVersion: 63
+
 - version: 3.43.13
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Refs [Slack bug report](https://buildwithfern.slack.com/archives/C07TPFNNB8W/p1769072437727359)

Fixes an issue where `additional_query_parameters` were not being merged into the WebSocket URL when establishing a connection. The WebSocket `connect()` method now accepts a `queryParams` option that allows passing arbitrary query parameters.

**Requested by:** @tjb9dc
**Link to Devin run:** https://app.devin.ai/sessions/40112c88104c492d93953763fa51a88b

## Changes Made
- Added `queryParams` property to the WebSocket `ConnectArgs` interface with type `Record<string, unknown>`
- Added destructuring binding for `queryParams` in the connect method
- Created `getMergedQueryParameters()` method that merges channel-defined query parameters with user-provided additional query parameters
- Updated `versions.yml` with version 3.43.14

## Human Review Checklist
- [ ] Verify behavior when `queryParams` is undefined - the code spreads it in an object literal which should be a no-op in modern JS, but worth confirming
- [ ] Confirm this API matches user expectations from the bug report (using `queryParams` on connect args vs `request_options.additional_query_parameters`)
- [ ] Consider if seed tests should be added for WebSocket query parameter merging

## Testing
- [ ] Unit tests added/updated - **Not added**
- [x] Lint checks pass
- [ ] Manual testing completed - **Not performed**