### PR TITLE
fix(cli): use workspace folder name for apiName field instead of api.yml name

### DIFF
--- a/packages/cli/cli/src/commands/generate-fdr/generateFdrApiDefinitionForWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate-fdr/generateFdrApiDefinitionForWorkspaces.ts
@@ -47,7 +47,8 @@ export async function generateFdrApiDefinitionForWorkspaces({
                         swiftSdk: undefined,
                         rustSdk: undefined
                     },
-                    context
+                    context,
+                    workspaceName: fernWorkspace.workspaceName
                 });
 
                 const resolvedOutputFilePath = AbsoluteFilePath.of(path.resolve(outputFilepath));

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.48.4
+  changelogEntry:
+    - summary: |
+        Use workspace folder name for API definition `apiName` field instead of the `name` from api.yml. This enables proper disambiguation of APIs in markdown components when multiple APIs have the same title (e.g., versioned APIs like `ticketing_v2`, `ticketing_v3`).
+      type: fix
+  createdAt: "2026-01-22"
+  irVersion: 63
+
 - version: 3.48.3
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -1269,7 +1269,8 @@ export class DocsDefinitionResolver {
             ir,
             apiDefinitionId,
             playgroundConfig: { oauth: item.playground?.oauth },
-            context: this.taskContext
+            context: this.taskContext,
+            workspaceName: workspace.workspaceName
         });
 
         const node = new ApiReferenceNodeConverter(

--- a/packages/cli/docs-resolver/src/utils/convertIrToApiDefinition.ts
+++ b/packages/cli/docs-resolver/src/utils/convertIrToApiDefinition.ts
@@ -16,12 +16,14 @@ export function convertIrToApiDefinition({
     ir,
     apiDefinitionId,
     playgroundConfig,
-    context
+    context,
+    workspaceName
 }: {
     ir: IntermediateRepresentation;
     apiDefinitionId: string;
     playgroundConfig?: PlaygroundConfig;
     context: TaskContext;
+    workspaceName?: string;
 }): APIV1Read.ApiDefinition {
     // the navigation constructor doesn't need to know about snippets, so we can pass an empty object
     return convertDbAPIDefinitionToRead(
@@ -40,7 +42,8 @@ export function convertIrToApiDefinition({
                     rustSdk: undefined
                 },
                 playgroundConfig,
-                context
+                context,
+                workspaceName
             }),
             APIV1Read.ApiDefinitionId(apiDefinitionId),
             EMPTY_SNIPPET_HOLDER

--- a/packages/cli/docs-resolver/src/utils/generateFdrFromOpenAPIWorkspaceV3.ts
+++ b/packages/cli/docs-resolver/src/utils/generateFdrFromOpenAPIWorkspaceV3.ts
@@ -41,6 +41,7 @@ export async function generateFdrFromOpenApiWorkspaceV3(
         playgroundConfig: {
             oauth: true
         },
-        context
+        context,
+        workspaceName: workspace.workspaceName
     });
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -265,7 +265,7 @@ export async function publishDocs({
             }
         },
         registerApi: async ({ ir, snippetsConfig, playgroundConfig, apiName, workspace }) => {
-            let apiDefinition = convertIrToFdrApi({ ir, snippetsConfig, playgroundConfig, context });
+            let apiDefinition = convertIrToFdrApi({ ir, snippetsConfig, playgroundConfig, context, workspaceName: workspace?.workspaceName });
 
             const aiEnhancerConfig = getAIEnhancerConfig(
                 withAiExamples,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -265,7 +265,13 @@ export async function publishDocs({
             }
         },
         registerApi: async ({ ir, snippetsConfig, playgroundConfig, apiName, workspace }) => {
-            let apiDefinition = convertIrToFdrApi({ ir, snippetsConfig, playgroundConfig, context, workspaceName: workspace?.workspaceName });
+            let apiDefinition = convertIrToFdrApi({
+                ir,
+                snippetsConfig,
+                playgroundConfig,
+                context,
+                workspaceName: workspace?.workspaceName
+            });
 
             const aiEnhancerConfig = getAIEnhancerConfig(
                 withAiExamples,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -127,7 +127,8 @@ export async function runRemoteGenerationForGenerator({
             swiftSdk: undefined,
             rustSdk: undefined
         },
-        context: interactiveTaskContext
+        context: interactiveTaskContext,
+        workspaceName: workspace.workspaceName
     });
     const response = await fdr.api.v1.register.registerApiDefinition({
         orgId: FdrAPI.OrgId(organization),

--- a/packages/cli/register/src/ir-to-fdr-converter/convertIrToFdrApi.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/convertIrToFdrApi.ts
@@ -9,18 +9,20 @@ export function convertIrToFdrApi({
     ir,
     snippetsConfig,
     playgroundConfig,
-    context
+    context,
+    workspaceName
 }: {
     ir: IntermediateRepresentation;
     snippetsConfig: FdrCjsSdk.api.v1.register.SnippetsConfig;
     playgroundConfig?: PlaygroundConfig;
     context: TaskContext;
+    workspaceName?: string;
 }): FdrCjsSdk.api.v1.register.ApiDefinition {
     const fdrApi: FdrCjsSdk.api.v1.register.ApiDefinition = {
         types: {},
         subpackages: {},
         rootPackage: convertPackage(ir.rootPackage, ir),
-        apiName: ir.apiName.originalName,
+        apiName: workspaceName ?? ir.apiName.originalName,
         auth: convertAuth({ auth: ir.auth, playgroundConfig, context }),
         authSchemes: convertAllAuthSchemes({ auth: ir.auth, playgroundConfig, context }),
         snippetsConfiguration: snippetsConfig,

--- a/packages/cli/register/src/registerApi.ts
+++ b/packages/cli/register/src/registerApi.ts
@@ -49,7 +49,13 @@ export async function registerApi({
         token: token.value
     });
 
-    let apiDefinition = convertIrToFdrApi({ ir, snippetsConfig, playgroundConfig, context, workspaceName: workspace.workspaceName });
+    let apiDefinition = convertIrToFdrApi({
+        ir,
+        snippetsConfig,
+        playgroundConfig,
+        context,
+        workspaceName: workspace.workspaceName
+    });
 
     if (aiEnhancerConfig) {
         const sources = workspace.getSources();

--- a/packages/cli/register/src/registerApi.ts
+++ b/packages/cli/register/src/registerApi.ts
@@ -49,7 +49,7 @@ export async function registerApi({
         token: token.value
     });
 
-    let apiDefinition = convertIrToFdrApi({ ir, snippetsConfig, playgroundConfig, context });
+    let apiDefinition = convertIrToFdrApi({ ir, snippetsConfig, playgroundConfig, context, workspaceName: workspace.workspaceName });
 
     if (aiEnhancerConfig) {
         const sources = workspace.getSources();


### PR DESCRIPTION
## Description

Refs: Follow-up to fern-platform PR #6533

This PR changes the `apiName` field in FDR API definitions to use the workspace folder name (e.g., `ticketing_v2`) instead of the `name` field from `api.yml` (e.g., `Ticketing API`). This enables proper disambiguation of APIs in markdown components when multiple APIs have the same title.

**Problem:** Customers with versioned APIs (like Square) have multiple API folders (`ticketing_v2`, `ticketing_v3`) that all have the same `name` in their `api.yml` files. When using markdown components like `<Schema type="Account" api="ticketing_v2"/>`, the `api` prop couldn't match the correct API because `apiName` was set to the identical title from `api.yml`.

**Solution:** Use the workspace folder name for `apiName` since folder names must be unique within `fern/apis/`.

Link to Devin run: https://app.devin.ai/sessions/9201edeee87546d797c618186beb9086
Requested by: @Ryan-Amirthan

## Changes Made

- Added optional `workspaceName` parameter to `convertIrToFdrApi` function
- Updated `convertIrToApiDefinition` to accept and pass through `workspaceName`
- Updated all call sites to pass `workspace.workspaceName`:
  - `publishDocs.ts`
  - `runRemoteGenerationForGenerator.ts`
  - `registerApi.ts`
  - `generateFdrApiDefinitionForWorkspaces.ts`
  - `generateFdrFromOpenAPIWorkspaceV3.ts`
  - `DocsDefinitionResolver.ts`
- `apiName` now uses `workspaceName ?? ir.apiName.originalName` (backward compatible fallback)
- Added changelog entry for version 3.48.4

## Testing

- [x] TypeScript compilation passes for affected packages
- [x] CI checks passing (biome, lint, compile, test, test-ete)
- [ ] Unit tests added/updated
- [ ] Manual testing completed

## Review Checklist

- [ ] Verify this doesn't break existing docs that rely on the old `apiName` value
- [ ] Confirm `workspaceName` is correctly populated across all workspace types (FernWorkspace, OpenAPIWorkspace)
- [ ] Note: This works in conjunction with fern-platform PR #6533 which uses `api.apiName` for filtering - both PRs needed for full fix