### PR TITLE
fix(python): Handle JSON string parsing for nested objects in SSE events

### DIFF
--- a/generators/python/core_utilities/shared/http_sse/__init__.py
+++ b/generators/python/core_utilities/shared/http_sse/__init__.py
@@ -1,6 +1,6 @@
 from ._api import EventSource, aconnect_sse, connect_sse
 from ._exceptions import SSEError
-from ._models import ServerSentEvent
+from ._models import ServerSentEvent, parse_sse_event
 
 __version__ = "0.4.1"
 
@@ -11,4 +11,5 @@ __all__ = [
     "aconnect_sse",
     "ServerSentEvent",
     "SSEError",
+    "parse_sse_event",
 ]

--- a/generators/python/core_utilities/shared/http_sse/_models.py
+++ b/generators/python/core_utilities/shared/http_sse/_models.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 
 @dataclass(frozen=True)
@@ -13,3 +13,30 @@ class ServerSentEvent:
     def json(self) -> Any:
         """Parse the data field as JSON."""
         return json.loads(self.data)
+
+
+def parse_sse_event(data: Any, fields_to_parse: Sequence[str] = ()) -> Any:
+    """
+    Parse JSON strings for specified fields in SSE event data.
+
+    When SSE events contain nested objects that arrive as JSON strings,
+    this function parses those string fields into Python objects.
+
+    Args:
+        data: The parsed SSE event data (typically from ServerSentEvent.json())
+        fields_to_parse: Field names that should be parsed from JSON strings to objects
+
+    Returns:
+        The data with specified fields parsed from JSON strings
+    """
+    if not isinstance(data, dict) or not fields_to_parse:
+        return data
+
+    result = dict(data)
+    for field in fields_to_parse:
+        if field in result and isinstance(result[field], str):
+            try:
+                result[field] = json.loads(result[field])
+            except (json.JSONDecodeError, ValueError):
+                pass
+    return result

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.48.2
+  changelogEntry:
+    - summary: |
+        Add automatic JSON string parsing for nested object fields in SSE events.
+        When SSE events contain nested objects that arrive as JSON strings (e.g., 
+        `'{"code": "TRANSFORM", "message": "..."}'`), the SDK now automatically parses
+        them before Pydantic validation. This is handled in the SSE response code at
+        runtime, scoped specifically to SSE handling without affecting normal JSON parsing.
+      type: fix
+  createdAt: "2026-01-22"
+  irVersion: 62
+
 - version: 4.48.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -315,7 +315,7 @@ class CoreUtilities:
         file_exports = {
             "_api.py": {"EventSource", "connect_sse", "aconnect_sse"},
             "_exceptions.py": {"SSEError"},
-            "_models.py": {"ServerSentEvent"},
+            "_models.py": {"ServerSentEvent", "parse_sse_event"},
         }
 
         # Walk through all files in the folder and copy them maintaining directory structure
@@ -812,6 +812,14 @@ class CoreUtilities:
             qualified_name_excluding_import=(),
             import_=AST.ReferenceImport(
                 module=AST.Module.local(*self._module_path, "events"), named_import="EventType"
+            ),
+        )
+
+    def get_parse_sse_event(self) -> AST.Reference:
+        return AST.Reference(
+            qualified_name_excluding_import=(),
+            import_=AST.ReferenceImport(
+                module=AST.Module.local(*self._module_path, "http_sse", "_models"), named_import="parse_sse_event"
             ),
         )
 


### PR DESCRIPTION
## Description

Refs: Slack thread about SSE parsing failures with nested object fields

When SSE events contain nested objects that arrive as JSON strings (e.g., `'{"code": "TRANSFORM", "message": "..."}'`), Pydantic validation fails because it expects a dict, not a string. This PR adds automatic JSON string parsing for object-typed fields, scoped specifically to SSE handling code without affecting normal JSON parsing.

**Link to Devin run**: https://app.devin.ai/sessions/35c33623b708405aadb407694ff8af39
**Requested by**: @aditya-arolkar-swe

## Changes Made

- Added `parse_sse_event()` helper function in `http_sse/_models.py` that parses JSON strings for specified fields
- Added `_get_sse_object_typed_fields()` method using the visitor pattern to analyze IR types and determine which fields are object-typed (handles objects, discriminated unions, and undiscriminated unions)
- Modified `_handle_success_stream()` to call `parse_sse_event()` with the list of object-typed fields before Pydantic validation
- Added `get_parse_sse_event()` reference getter in core utilities
- Updated `versions.yml` with changelog entry for v4.48.2

## Human Review Checklist

- [ ] Verify `_get_sse_object_typed_fields()` correctly handles all type shapes (objects, unions, aliases, nested types)
- [ ] Confirm the generated SSE handling code looks correct for endpoints with nested object fields
- [ ] Check that `parse_sse_event()` gracefully handles edge cases (invalid JSON, non-dict data)
- [ ] Note: JSON decode errors are silently caught and the original string value is preserved - verify this is desired behavior

## Testing

- [x] Lint checks passed (`pnpm run check`)
- [x] Python pre-commit hooks passed
- [x] mypy type checking passed
- [x] All CI checks passed (compile, seed tests, etc.)