### PR TITLE
fix(cli): convert ANY auth to multiAuth with each scheme in separate array

### DIFF
--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
@@ -199,8 +199,7 @@ export class OperationConverter extends AbstractOperationConverter {
             sdkRequest: undefined,
             errors,
             auth: this.computeEndpointAuth(),
-            security:
-                this.operation.security ?? this.context.spec.security ?? this.getDefaultSecurityFromAuthOverrides(),
+            security: this.computeEndpointSecurity(),
             availability: this.context.getAvailability({
                 node: this.operation,
                 breadcrumbs: this.breadcrumbs
@@ -483,6 +482,21 @@ export class OperationConverter extends AbstractOperationConverter {
         );
     }
 
+    private computeEndpointSecurity(): OpenAPIV3_1.SecurityRequirementObject[] | undefined {
+        // If endpoint explicitly has no auth (empty security array), respect that
+        if (this.operation.security != null && this.operation.security.length === 0) {
+            return [];
+        }
+
+        // When auth overrides are specified, use them instead of OpenAPI security
+        if (this.context.authOverrides?.auth != null) {
+            return this.getDefaultSecurityFromAuthOverrides();
+        }
+
+        // Fall back to OpenAPI security
+        return this.operation.security ?? this.context.spec.security;
+    }
+
     /**
      * Converts security scheme IDs to HTTP headers
      * @param securitySchemeIds - List of security scheme IDs
@@ -508,17 +522,29 @@ export class OperationConverter extends AbstractOperationConverter {
             return undefined;
         }
 
-        // The auth field from generators.yml contains the scheme name (e.g., "bearerAuth")
-        // Convert this to OpenAPI security requirement format
-        const authSchemeName = this.context.authOverrides.auth;
-        if (typeof authSchemeName !== "string") {
-            return undefined;
+        const authConfig = this.context.authOverrides.auth;
+
+        // Handle string auth (single scheme)
+        if (typeof authConfig === "string") {
+            const securityRequirement: OpenAPIV3_1.SecurityRequirementObject = {};
+            securityRequirement[authConfig] = [];
+            return [securityRequirement];
         }
 
-        // Return OpenAPI security requirement format: [{ "schemeName": [] }]
-        const securityRequirement: OpenAPIV3_1.SecurityRequirementObject = {};
-        securityRequirement[authSchemeName] = [];
-        return [securityRequirement];
+        // Handle "any" auth (OR semantics - each scheme in its own array element)
+        if (typeof authConfig === "object" && "any" in authConfig) {
+            const anySchemes = authConfig.any;
+            if (Array.isArray(anySchemes)) {
+                return anySchemes.map((scheme) => {
+                    const schemeName = typeof scheme === "string" ? scheme : scheme.scheme;
+                    const securityRequirement: OpenAPIV3_1.SecurityRequirementObject = {};
+                    securityRequirement[schemeName] = [];
+                    return securityRequirement;
+                });
+            }
+        }
+
+        return undefined;
     }
 
     private authSchemeToHeaders(securitySchemeIds: string[]): FernIr.HttpHeader[] {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -405,16 +405,11 @@ function convertEndpointAuth({
     endpoint: Endpoint;
     context: OpenApiIrConverterContext;
 }): true | undefined | HttpEndpointSecurity {
-    // When auth overrides are specified in the Fern Definition, use them instead of OpenAPI security
-    if (context.authOverrides?.auth != null) {
-        // explicit empty array means no auth
-        if (endpoint.security != null && endpoint.security.length === 0) {
-            return undefined;
-        }
-        return true;
-    }
-
     if (endpoint.security == null) {
+        if (context.authOverrides?.auth != null) {
+            return true;
+        }
+
         if (context.ir.security == null) {
             return undefined;
         }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -405,11 +405,16 @@ function convertEndpointAuth({
     endpoint: Endpoint;
     context: OpenApiIrConverterContext;
 }): true | undefined | HttpEndpointSecurity {
-    if (endpoint.security == null) {
-        if (context.authOverrides?.auth != null) {
-            return true;
+    // When auth overrides are specified in the Fern Definition, use them instead of OpenAPI security
+    if (context.authOverrides?.auth != null) {
+        // explicit empty array means no auth
+        if (endpoint.security != null && endpoint.security.length === 0) {
+            return undefined;
         }
+        return true;
+    }
 
+    if (endpoint.security == null) {
         if (context.ir.security == null) {
             return undefined;
         }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.49.4
+  changelogEntry:
+    - summary: |
+        Fix ANY auth conversion to FDR multiAuth format. When the IR has `AuthSchemesRequirement.ANY`, the converter now properly represents this as multiple auth options (OR semantics) with each scheme in its own array element, rather than all schemes grouped together (AND semantics).
+      type: fix
+  createdAt: "2026-01-22"
+  irVersion: 63
+
 - version: 3.49.3
   changelogEntry:
     - summary: |

--- a/packages/cli/register/src/ir-to-fdr-converter/convertPackage.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/convertPackage.ts
@@ -184,7 +184,7 @@ function convertService(
             availability: convertIrAvailability(irEndpoint.availability ?? irService.availability),
             auth: irEndpoint.auth,
             authV2: convertEndpointSecurity(irEndpoint.security),
-            multiAuth: convertMultiAuth(irEndpoint.security),
+            multiAuth: convertMultiAuth(irEndpoint.security, ir.auth),
             description: irEndpoint.docs ?? undefined,
             method: convertHttpMethod(irEndpoint.method),
             defaultEnvironment:
@@ -425,9 +425,15 @@ function convertEndpointSecurity(
 }
 
 function convertMultiAuth(
-    security: Ir.http.HttpEndpointSecurityItem[] | undefined
+    security: Ir.http.HttpEndpointSecurityItem[] | undefined,
+    apiAuth?: Ir.auth.ApiAuth
 ): FdrCjsSdk.MultipleAuthType[] | undefined {
     if (security == null) {
+        if (apiAuth != null && apiAuth.requirement === "ANY" && apiAuth.schemes.length > 0) {
+            return apiAuth.schemes.map((scheme) => ({
+                schemes: [FdrCjsSdk.AuthSchemeId(scheme.key)]
+            }));
+        }
         return undefined;
     }
 


### PR DESCRIPTION
## Description

Fixes how `any` auth is uploaded to FDR in the `ir-to-fdr-converter`. When the IR has `AuthSchemesRequirement.ANY`, the converter now properly represents this as multiple auth options (OR semantics) rather than all schemes required together (AND semantics).

**Before:** `multiAuth: [{ schemes: ["Basic", "Bearer"] }]` (AND - both required)
**After:** `multiAuth: [{ schemes: ["Basic"] }, { schemes: ["Bearer"] }]` (OR - either works)

Requested by @dsinghvi

Link to Devin run: https://app.devin.ai/sessions/60bad4a5bb8b45b6afd6301233abb10a

## Changes Made

- Modified `convertMultiAuth` function in `ir-to-fdr-converter` to accept optional `apiAuth` parameter
- When endpoint security is undefined and API-level auth has `requirement: "ANY"`, each auth scheme is now placed in its own array element
- Added changelog entry for CLI version 3.49.4
- **openapi-to-ir fix**: Modified `OperationConverter.ts` to:
  - Added `computeEndpointSecurity()` method that prioritizes auth overrides over OpenAPI security
  - Updated `getDefaultSecurityFromAuthOverrides()` to handle `any` auth config (e.g., `api.auth.any: [Basic, Bearer]`) by creating separate security requirements for each scheme (OR semantics)
  - Still respects explicit `security: []` (empty array) on endpoints to indicate no auth
- [ ] Updated README.md generator (if applicable)

## Testing

- [x] Lint checks pass
- [ ] No new test fixture added (existing tests cover the converter behavior)

## Human Review Checklist

- [ ] Verify the logic correctly handles endpoints that inherit API-level ANY auth (when `security == null`)
- [ ] Confirm this doesn't affect endpoints with explicit security defined (they use their own `security` array)
- [ ] Confirm APIs with ALL/ENDPOINT_SECURITY requirements are unaffected (condition checks for `requirement === "ANY"`)
- [ ] Verify the openapi-to-ir `computeEndpointSecurity` correctly prioritizes: explicit no-auth > auth overrides > OpenAPI security
- [ ] Verify `getDefaultSecurityFromAuthOverrides` correctly parses `{ any: ["Basic", "Bearer"] }` auth config format
- [ ] Confirm endpoints with explicit `security: []` (no auth) still work correctly when auth overrides are present