### PR TITLE
fix(php): generate default file values for missing file parameters in wire tests

### DIFF
--- a/generators/php/codegen/src/ast/TypeLiteral.ts
+++ b/generators/php/codegen/src/ast/TypeLiteral.ts
@@ -45,6 +45,7 @@ interface DateTime {
 interface File {
     type: "file";
     value: string;
+    namespace?: string;
 }
 
 interface Float {
@@ -115,7 +116,9 @@ export class TypeLiteral extends AstNode {
                 break;
             }
             case "file": {
-                writer.writeNode(buildFileFromString({ writer, value: this.internalType.value }));
+                writer.writeNode(
+                    buildFileFromString({ writer, value: this.internalType.value, namespace: this.internalType.namespace })
+                );
                 break;
             }
             case "float": {
@@ -257,8 +260,8 @@ export class TypeLiteral extends AstNode {
         return new this({ type: "class", reference, fields });
     }
 
-    public static file(value: string): TypeLiteral {
-        return new this({ type: "file", value });
+    public static file(value: string, namespace?: string): TypeLiteral {
+        return new this({ type: "file", value, namespace });
     }
 
     public static float(value: number): TypeLiteral {
@@ -386,14 +389,23 @@ function buildDateTimeFromString({ writer, value }: { writer: Writer; value: str
         arguments_: [new CodeBlock(`'${value}'`)]
     });
 }
-function buildFileFromString({ writer, value }: { writer: Writer; value: string }): MethodInvocation {
+function buildFileFromString({
+    writer,
+    value,
+    namespace
+}: {
+    writer: Writer;
+    value: string;
+    namespace?: string;
+}): MethodInvocation {
     return new MethodInvocation({
         on: new ClassReference({
             name: "File",
-            namespace: `${writer.rootNamespace}\\Utils`
+            namespace: namespace != null ? `${namespace}\\Utils` : `${writer.rootNamespace}\\Utils`
         }),
         method: "createFromString",
-        arguments_: [new CodeBlock(`"${value}"`)]
+        arguments_: [new CodeBlock(`"${value}"`), new CodeBlock(`"${value}"`)],
+        static_: true
     });
 }
 

--- a/generators/php/codegen/src/ast/TypeLiteral.ts
+++ b/generators/php/codegen/src/ast/TypeLiteral.ts
@@ -117,7 +117,11 @@ export class TypeLiteral extends AstNode {
             }
             case "file": {
                 writer.writeNode(
-                    buildFileFromString({ writer, value: this.internalType.value, namespace: this.internalType.namespace })
+                    buildFileFromString({
+                        writer,
+                        value: this.internalType.value,
+                        namespace: this.internalType.namespace
+                    })
                 );
                 break;
             }

--- a/generators/php/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/php/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -283,19 +283,19 @@ namespace Example;
 
 use Acme\\AcmeClient;
 use Acme\\Service\\Requests\\MyRequest;
-use Example\\Utils\\File;
+use Acme\\Utils\\File;
 
 $client = new AcmeClient();
 $client->service->post(
     new MyRequest([
-        'file' => File->createFromString("Hello, world!"),
+        'file' => File::createFromString("Hello, world!", "Hello, world!"),
         'fileList' => [
-            File->createFromString("First"),
-            File->createFromString("Second"),
+            File::createFromString("First", "First"),
+            File::createFromString("Second", "Second"),
         ],
-        'maybeFile' => File->createFromString("example_maybe_file"),
+        'maybeFile' => File::createFromString("example_maybe_file", "example_maybe_file"),
         'maybeFileList' => [
-            File->createFromString("example_maybe_file_list"),
+            File::createFromString("example_maybe_file_list", "example_maybe_file_list"),
         ],
     ]),
 );
@@ -309,12 +309,12 @@ namespace Example;
 
 use Acme\\AcmeClient;
 use Acme\\Service\\Requests\\JustFileRequest;
-use Example\\Utils\\File;
+use Acme\\Utils\\File;
 
 $client = new AcmeClient();
 $client->service->justFile(
     new JustFileRequest([
-        'file' => File->createFromString("Hello, world!"),
+        'file' => File::createFromString("Hello, world!", "Hello, world!"),
     ]),
 );
 "
@@ -327,14 +327,14 @@ namespace Example;
 
 use Acme\\AcmeClient;
 use Acme\\Service\\Requests\\JustFileWithQueryParamsRequest;
-use Example\\Utils\\File;
+use Acme\\Utils\\File;
 
 $client = new AcmeClient();
 $client->service->justFileWithQueryParams(
     new JustFileWithQueryParamsRequest([
         'integer' => 42,
         'maybeString' => 'exists',
-        'file' => File->createFromString("Hello, world!"),
+        'file' => File::createFromString("Hello, world!", "Hello, world!"),
     ]),
 );
 "

--- a/generators/php/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/php/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -293,6 +293,10 @@ $client->service->post(
             File->createFromString("First"),
             File->createFromString("Second"),
         ],
+        'maybeFile' => File->createFromString("example_maybe_file"),
+        'maybeFileList' => [
+            File->createFromString("example_maybe_file_list"),
+        ],
     ]),
 );
 "

--- a/generators/php/dynamic-snippets/src/context/FilePropertyMapper.ts
+++ b/generators/php/dynamic-snippets/src/context/FilePropertyMapper.ts
@@ -66,7 +66,7 @@ export class FilePropertyMapper {
         if (fileValue == null) {
             fileValue = `example_${property.wireValue ?? "file"}`;
         }
-        return php.TypeLiteral.file(fileValue);
+        return php.TypeLiteral.file(fileValue, this.context.rootNamespace);
     }
 
     private getArrayFileProperty({
@@ -79,9 +79,11 @@ export class FilePropertyMapper {
         const fileValues = this.context.getFileArrayValues({ property, record });
         if (fileValues == null) {
             const fallback = `example_${property.wireValue ?? "files"}`;
-            return php.TypeLiteral.list({ values: [php.TypeLiteral.file(fallback)] });
+            return php.TypeLiteral.list({ values: [php.TypeLiteral.file(fallback, this.context.rootNamespace)] });
         }
-        return php.TypeLiteral.list({ values: fileValues.map((value) => php.TypeLiteral.file(value)) });
+        return php.TypeLiteral.list({
+            values: fileValues.map((value) => php.TypeLiteral.file(value, this.context.rootNamespace))
+        });
     }
 
     private getBodyProperty({

--- a/generators/php/dynamic-snippets/src/context/FilePropertyMapper.ts
+++ b/generators/php/dynamic-snippets/src/context/FilePropertyMapper.ts
@@ -62,9 +62,9 @@ export class FilePropertyMapper {
         property: FernIr.dynamic.FileUploadRequestBodyProperty.File_;
         record: Record<string, unknown>;
     }): php.TypeLiteral {
-        const fileValue = this.context.getSingleFileValue({ property, record });
+        let fileValue = this.context.getSingleFileValue({ property, record });
         if (fileValue == null) {
-            return php.TypeLiteral.nop();
+            fileValue = `example_${property.wireValue ?? "file"}`;
         }
         return php.TypeLiteral.file(fileValue);
     }
@@ -78,7 +78,8 @@ export class FilePropertyMapper {
     }): php.TypeLiteral {
         const fileValues = this.context.getFileArrayValues({ property, record });
         if (fileValues == null) {
-            return php.TypeLiteral.nop();
+            const fallback = `example_${property.wireValue ?? "files"}`;
+            return php.TypeLiteral.list({ values: [php.TypeLiteral.file(fallback)] });
         }
         return php.TypeLiteral.list({ values: fileValues.map((value) => php.TypeLiteral.file(value)) });
     }

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.25.3
+  changelogEntry:
+    - summary: |
+        Fix wire test generation for file upload endpoints. When file parameters are required but no example value is provided, the generator now creates a default file using `File::createFromString()` instead of omitting the field, which caused TypeError when assigning null to non-nullable File properties.
+      type: fix
+  createdAt: "2026-01-23"
+  irVersion: 62
+
 - version: 1.25.2
   changelogEntry:
     - summary: |

--- a/seed/php-sdk/file-upload-openapi/README.md
+++ b/seed/php-sdk/file-upload-openapi/README.md
@@ -38,10 +38,12 @@ namespace Example;
 
 use Seed\SeedClient;
 use Seed\FileUploadExample\Requests\UploadFileRequest;
+use Seed\Utils\File;
 
 $client = new SeedClient();
 $client->fileUploadExample->uploadFile(
     new UploadFileRequest([
+        'file' => File::createFromString("example_file", "example_file"),
         'name' => 'name',
     ]),
 );

--- a/seed/php-sdk/file-upload-openapi/reference.md
+++ b/seed/php-sdk/file-upload-openapi/reference.md
@@ -29,6 +29,7 @@ Upload a file to the database
 ```php
 $client->fileUploadExample->uploadFile(
     new UploadFileRequest([
+        'file' => File::createFromString("example_file", "example_file"),
         'name' => 'name',
     ]),
 );

--- a/seed/php-sdk/file-upload-openapi/src/dynamic-snippets/example0/snippet.php
+++ b/seed/php-sdk/file-upload-openapi/src/dynamic-snippets/example0/snippet.php
@@ -4,6 +4,7 @@ namespace Example;
 
 use Seed\SeedClient;
 use Seed\FileUploadExample\Requests\UploadFileRequest;
+use Seed\Utils\File;
 
 $client = new SeedClient(
     options: [
@@ -12,6 +13,7 @@ $client = new SeedClient(
 );
 $client->fileUploadExample->uploadFile(
     new UploadFileRequest([
+        'file' => File::createFromString("example_file", "example_file"),
         'name' => 'name',
     ]),
 );


### PR DESCRIPTION
## Description

Refs: User-reported issue with PHP wire tests failing on file upload endpoints

Fixes a TypeError that occurred when generating wire tests for file upload endpoints where the file parameter is required but no example value is provided in the IR.

**Link to Devin run:** https://app.devin.ai/sessions/c1df43274cc54d429c979fa3d423b245
**Requested by:** @iamnamananand996

## Changes Made

- Modified `FilePropertyMapper.ts` to generate default file values instead of returning `nop()` when file values are missing
  - For single file properties: generates `example_{wireValue}` (e.g., `example_file`)
  - For file array properties: generates a list with a single default file
- Modified `TypeLiteral.ts` to fix File class generation in dynamic snippets:
  - Added optional `namespace` parameter to use SDK namespace instead of snippet namespace
  - Added `static_: true` to use `::` operator instead of `->` for static method calls
  - Added required filename parameter to `createFromString()` calls (PHP SDK requires 2-3 params)
- Added changelog entry for version 1.25.3
- Updated snapshot tests to reflect correct generated code

This aligns the PHP generator behavior with the Python generator, which already handles missing file values this way.

## Updates Since Last Revision

- Fixed File class import to use SDK namespace (`Seed\Utils\File`) instead of snippet namespace (`Example\Utils\File`)
- Fixed static method call syntax: `File::createFromString()` instead of `File->createFromString()`
- Added required filename parameter to `createFromString()` calls to match PHP SDK method signature
- Updated seed test output for `file-upload-openapi` fixture

## Testing

- [ ] Unit tests added/updated
- [x] Snapshot tests updated and passing locally
- [x] Seed test `php-sdk:file-upload-openapi` passing locally (build + PHPStan + tests)
- [x] Manual testing completed (user reported the fix resolves the Payroc wire test failures)

## Human Review Checklist

- [ ] Verify that generating default values for **both required and optional** file parameters is the intended behavior (previously optional files were omitted)
- [ ] Confirm the default file naming convention (`example_{wireValue}`) is appropriate for generated test code
- [ ] Verify using the same value for both content and filename in `File::createFromString("example_file", "example_file")` is acceptable for example code
- [ ] Confirm this change won't affect production SDK code (only affects dynamic snippets/wire tests)