### PR TITLE
fix(java): use resource files for long JSON strings in wire tests

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestMethodBuilder.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestMethodBuilder.ts
@@ -182,9 +182,7 @@ export class TestMethodBuilder {
                             expectedRequestJson
                         );
                         writer.addImport(`${this.context.getRootPackageName()}.TestResources`);
-                        writer.writeLine(
-                            `String expectedRequestBody = TestResources.loadResource("${resourcePath}");`
-                        );
+                        writer.writeLine(`String expectedRequestBody = TestResources.loadResource("${resourcePath}");`);
                     } else {
                         this.jsonValidator.formatMultilineJson(writer, "expectedRequestBody", expectedRequestJson);
                     }

--- a/generators/java-v2/sdk/src/sdk-wire-tests/resources/TestResourceWriter.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/resources/TestResourceWriter.ts
@@ -1,0 +1,134 @@
+import { File } from "@fern-api/base-generator";
+import { RelativeFilePath } from "@fern-api/fs-utils";
+import { SdkGeneratorContext } from "../../SdkGeneratorContext";
+
+interface ResourceFile {
+    resourcePath: string;
+    content: string;
+}
+
+const TEST_RESOURCES_TEMPLATE = `package {{PACKAGE_NAME}};
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public final class {{CLASS_NAME}} {
+
+    private {{CLASS_NAME}}() {
+        // Utility class
+    }
+
+    /**
+     * Loads a resource file from the classpath and returns its contents as a String.
+     * @param path the resource path (e.g., "/wire-tests/MyTest_testMethod_request.json")
+     * @return the contents of the resource file
+     * @throws RuntimeException if the resource cannot be found or read
+     */
+    public static String loadResource(String path) {
+        try (InputStream is = {{CLASS_NAME}}.class.getResourceAsStream(path)) {
+            if (is == null) {
+                throw new RuntimeException("Resource not found: " + path);
+            }
+            ByteArrayOutputStream result = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = is.read(buffer)) != -1) {
+                result.write(buffer, 0, length);
+            }
+            return result.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load resource: " + path, e);
+        }
+    }
+}
+`;
+
+/**
+ * Manages test resource files for large JSON payloads.
+ * Instead of embedding large JSON strings inline (which can cause stack overflow
+ * in code formatters due to deeply nested binary expressions), this writer
+ * stores JSON in resource files and generates a utility class to load them.
+ */
+export class TestResourceWriter {
+    private readonly resourceFiles: Map<string, ResourceFile> = new Map();
+    private readonly context: SdkGeneratorContext;
+
+    constructor(context: SdkGeneratorContext) {
+        this.context = context;
+    }
+
+    /**
+     * Registers a JSON payload to be written as a resource file.
+     * Returns the resource path that can be used to load the file at runtime.
+     */
+    public registerResource(testClassName: string, testMethodName: string, context: string, jsonData: unknown): string {
+        const json = JSON.stringify(jsonData, null, 2);
+        const sanitizedClassName = this.sanitizeForPath(testClassName);
+        const sanitizedMethodName = this.sanitizeForPath(testMethodName);
+        const resourceFileName = `${sanitizedClassName}_${sanitizedMethodName}_${context}.json`;
+        const resourcePath = `/wire-tests/${resourceFileName}`;
+
+        this.resourceFiles.set(resourcePath, {
+            resourcePath,
+            content: json
+        });
+
+        return resourcePath;
+    }
+
+    /**
+     * Returns true if there are any registered resource files.
+     */
+    public hasResources(): boolean {
+        return this.resourceFiles.size > 0;
+    }
+
+    /**
+     * Generates the TestResources.java utility class for loading resource files.
+     * Uses Java 8 compatible resource loading (no text blocks).
+     */
+    public generateTestResourcesClass(): File {
+        const packageName = this.context.getRootPackageName();
+        const className = "TestResources";
+
+        const content = TEST_RESOURCES_TEMPLATE.replace(/\{\{PACKAGE_NAME\}\}/g, packageName).replace(
+            /\{\{CLASS_NAME\}\}/g,
+            className
+        );
+
+        const packagePath = packageName.replace(/\./g, "/");
+        const filePath = `src/test/java/${packagePath}`;
+
+        return new File(`${className}.java`, RelativeFilePath.of(filePath), content);
+    }
+
+    /**
+     * Returns all registered resource files to be written.
+     */
+    public getResourceFiles(): File[] {
+        const files: File[] = [];
+
+        for (const [, resource] of this.resourceFiles) {
+            const fileName = resource.resourcePath.split("/").pop() ?? "resource.json";
+            files.push(new File(fileName, RelativeFilePath.of("src/test/resources/wire-tests"), resource.content));
+        }
+
+        return files;
+    }
+
+    /**
+     * Clears all registered resources.
+     */
+    public clear(): void {
+        this.resourceFiles.clear();
+    }
+
+    /**
+     * Sanitizes a string for use in a file path.
+     */
+    private sanitizeForPath(value: string): string {
+        return value.replace(/[^a-zA-Z0-9_]/g, "_");
+    }
+}

--- a/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
@@ -19,7 +19,9 @@ export class JsonValidator {
     public shouldUseResourceFile(jsonData: unknown): boolean {
         const json = JSON.stringify(jsonData, null, 2);
         const lines = json.split("\n").length;
-        return lines > JsonValidator.INLINE_JSON_THRESHOLD_LINES || json.length > JsonValidator.INLINE_JSON_THRESHOLD_BYTES;
+        return (
+            lines > JsonValidator.INLINE_JSON_THRESHOLD_LINES || json.length > JsonValidator.INLINE_JSON_THRESHOLD_BYTES
+        );
     }
 
     /**

--- a/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/validators/JsonValidator.ts
@@ -6,7 +6,21 @@ import { SdkGeneratorContext } from "../../SdkGeneratorContext";
  * Validator for JSON assertions in wire tests.
  */
 export class JsonValidator {
+    // Thresholds for deciding when to use resource files vs inline JSON
+    private static readonly INLINE_JSON_THRESHOLD_LINES = 50;
+    private static readonly INLINE_JSON_THRESHOLD_BYTES = 2048;
+
     constructor(private readonly context: SdkGeneratorContext) {}
+
+    /**
+     * Checks if JSON data should be stored in a resource file instead of inline.
+     * Returns true if the JSON exceeds size thresholds (50 lines or 2KB).
+     */
+    public shouldUseResourceFile(jsonData: unknown): boolean {
+        const json = JSON.stringify(jsonData, null, 2);
+        const lines = json.split("\n").length;
+        return lines > JsonValidator.INLINE_JSON_THRESHOLD_LINES || json.length > JsonValidator.INLINE_JSON_THRESHOLD_BYTES;
+    }
 
     /**
      * Formats a JSON object as a multi-line Java string variable with proper concatenation.

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.34.2
+  changelogEntry:
+    - summary: |
+        Change wire tests to use resource files for JSON strings above a certain length
+        to prevent undue stress to :spotlessJava and cut down on code duplication.
+      type: fix
+  createdAt: "2026-01-23"
+  irVersion: 63
+
 - version: 3.34.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Use resource files for JSON strings above a certain length in wire tests. This (1) allows us to consult the same string for both the mocked response and the expected response, and (2) prevents very long JSON strings (some would be over 2800 lines in length for certain APIs) from frying `:spotlessJava` and occasionally causing overflows.

## Changes Made
Exclusively to java-v2.

## Testing
On Samsara; regenerating seed now.
- [X] Unit tests added/updated
- [X] Manual testing completed
