### PR TITLE
fix(cli): fix group-multi-api-environments to accumulate all URLs

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-many-urls.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-many-urls.json
@@ -1,0 +1,283 @@
+{
+  "title": "API One",
+  "servers": [
+    {
+      "type": "grouped",
+      "name": "default",
+      "description": "default environment",
+      "urls": {
+        "one": {
+          "url": "https://one.example.com"
+        },
+        "two": {
+          "url": "https://two.example.com"
+        },
+        "three": {
+          "url": "https://three.example.com"
+        },
+        "four": {
+          "url": "https://four.example.com"
+        }
+      }
+    }
+  ],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "getOne",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetOneRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetOneResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../api-one.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "GET",
+      "path": "/one",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../api-one.yml",
+        "type": "openapi"
+      },
+      "__apiName": "one",
+      "servers": [
+        {
+          "name": "one"
+        }
+      ]
+    },
+    {
+      "audiences": [],
+      "operationId": "getTwo",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetTwoRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetTwoResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../api-two.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "GET",
+      "path": "/two",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../api-two.yml",
+        "type": "openapi"
+      },
+      "__apiName": "two",
+      "servers": [
+        {
+          "name": "two"
+        }
+      ]
+    },
+    {
+      "audiences": [],
+      "operationId": "getThree",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetThreeRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetThreeResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../api-three.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "GET",
+      "path": "/three",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../api-three.yml",
+        "type": "openapi"
+      },
+      "__apiName": "three",
+      "servers": [
+        {
+          "name": "three"
+        }
+      ]
+    },
+    {
+      "audiences": [],
+      "operationId": "getFour",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetFourRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "GetFourResponse",
+          "groupName": [],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../api-four.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "GET",
+      "path": "/four",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../api-four.yml",
+        "type": "openapi"
+      },
+      "__apiName": "four",
+      "servers": [
+        {
+          "name": "four"
+        }
+      ]
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-many-urls.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-many-urls.json
@@ -1,0 +1,208 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "getFour": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/four",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../api-four.yml",
+              },
+              "url": "four",
+            },
+            "getOne": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/one",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../api-one.yml",
+              },
+              "url": "one",
+            },
+            "getThree": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/three",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../api-three.yml",
+              },
+              "url": "three",
+            },
+            "getTwo": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/two",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../api-two.yml",
+              },
+              "url": "two",
+            },
+          },
+          "source": {
+            "openapi": "../api-four.yml",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    getOne:
+      path: /one
+      method: GET
+      source:
+        openapi: ../api-one.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      url: one
+      examples:
+        - response:
+            body: string
+    getTwo:
+      path: /two
+      method: GET
+      source:
+        openapi: ../api-two.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      url: two
+      examples:
+        - response:
+            body: string
+    getThree:
+      path: /three
+      method: GET
+      source:
+        openapi: ../api-three.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      url: three
+      examples:
+        - response:
+            body: string
+    getFour:
+      path: /four
+      method: GET
+      source:
+        openapi: ../api-four.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      url: four
+      examples:
+        - response:
+            body: string
+  source:
+    openapi: ../api-four.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "default",
+      "default-url": "one",
+      "display-name": "API One",
+      "environments": {
+        "default": {
+          "urls": {
+            "four": "https://four.example.com",
+            "one": "https://one.example.com",
+            "three": "https://three.example.com",
+            "two": "https://two.example.com",
+          },
+        },
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": "one",
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: API One
+environments:
+  default:
+    urls:
+      one: https://one.example.com
+      two: https://two.example.com
+      three: https://three.example.com
+      four: https://four.example.com
+default-environment: default
+default-url: one
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/api-four.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/api-four.yml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: API Four
+  version: 1.0.0
+servers:
+  - url: https://four.example.com
+paths:
+  /four:
+    get:
+      operationId: getFour
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/api-one.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/api-one.yml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: API One
+  version: 1.0.0
+servers:
+  - url: https://one.example.com
+paths:
+  /one:
+    get:
+      operationId: getOne
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/api-three.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/api-three.yml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: API Three
+  version: 1.0.0
+servers:
+  - url: https://three.example.com
+paths:
+  /three:
+    get:
+      operationId: getThree
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/api-two.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/api-two.yml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: API Two
+  version: 1.0.0
+servers:
+  - url: https://two.example.com
+paths:
+  /two:
+    get:
+      operationId: getTwo
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "seed",
+  "version": "0.0.0"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-many-urls/fern/generators.yml
@@ -1,0 +1,8 @@
+api:
+  specs:
+    - openapi: ../api-one.yml
+    - openapi: ../api-two.yml
+    - openapi: ../api-three.yml
+    - openapi: ../api-four.yml
+  settings:
+    group-multi-api-environments: true

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.49.6
+  changelogEntry:
+    - summary: |
+        Fix `group-multi-api-environments` to properly accumulate all URLs when merging many OpenAPI specs. Previously only the first two URLs were preserved.
+      type: fix
+    - summary: |
+        Fix `group-multi-api-environments` setting to be inherited from global `api.settings`.
+      type: fix
+  createdAt: "2026-01-23"
+  irVersion: 63
+
 - version: 3.49.5
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -10,6 +10,15 @@ import path from "path";
 
 import { addDefaultDockerOrgIfNotPresent } from "./getGeneratorName";
 
+/**
+ * Union type representing any spec-level settings schema.
+ * Used for parsing global api.settings which may contain settings from any spec type.
+ */
+type AnySpecSettingsSchema =
+    | generatorsYml.OpenApiSettingsSchema
+    | generatorsYml.AsyncApiSettingsSchema
+    | generatorsYml.BaseApiSettingsSchema;
+
 const UNDEFINED_API_DEFINITION_SETTINGS: generatorsYml.APIDefinitionSettings = {
     shouldUseTitleAsName: undefined,
     shouldUseUndiscriminatedUnionsWithLiterals: undefined,
@@ -145,7 +154,7 @@ function parseAsyncApiDefinitionSettingsSchema(
 }
 
 export function parseBaseApiDefinitionSettingsSchema(
-    settings: generatorsYml.BaseApiSettingsSchema | undefined
+    settings: AnySpecSettingsSchema | undefined
 ): generatorsYml.APIDefinitionSettings {
     return {
         ...UNDEFINED_API_DEFINITION_SETTINGS,
@@ -157,6 +166,10 @@ export function parseBaseApiDefinitionSettingsSchema(
         wrapReferencesToNullableInOptional: settings?.["wrap-references-to-nullable-in-optional"],
         coerceOptionalSchemasToNullable: settings?.["coerce-optional-schemas-to-nullable"],
         groupEnvironmentsByHost: settings?.["group-environments-by-host"],
+        groupMultiApiEnvironments:
+            settings != null && "group-multi-api-environments" in settings
+                ? settings["group-multi-api-environments"]
+                : undefined,
         removeDiscriminantsFromSchemas: parseRemoveDiscriminantsFromSchemas(
             settings?.["remove-discriminants-from-schemas"]
         ),


### PR DESCRIPTION
## Summary

- Fix iterative merge to preserve already-grouped servers when merging many OpenAPI specs (previously only kept first two URLs)
- Fix global `api.settings` inheritance for `group-multi-api-environments`
- Refactor server types to use clean discriminated union (`AnyServerInput`)

## Test plan

- [x] Existing tests pass (251 openapi-ir-to-fern tests)
- [ ] Manual testing with Twilio config (~40 OpenAPI specs)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)