### PR TITLE
fix(ci): tweak seed update concurrency logic

### DIFF
--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -38,7 +38,7 @@ on:
 # Cancel previous workflows on previous push
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # These scope secrets.GITHUB_TOKEN
 permissions:


### PR DESCRIPTION
## Description
Cancelling in-progress jobs was causing updates not to happen. CI would run over and over again and just keep getting interrupted.

## Changes Made
Don't cancel in-progress jobs

## Testing
CI