### PR TITLE
fix(ci): expand pre-build step to include more foundational packages

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -32,9 +32,21 @@ runs:
       env:
         FORCE_COLOR: "2"
       run: |
-        # Build core-utils first to avoid race conditions in parallel compilation
-        # This ensures the dependency output files are fully written before dependent packages start
-        pnpm turbo run compile --filter @fern-api/core-utils
+        # Build foundational packages first to avoid race conditions in parallel compilation.
+        # These packages are dependencies of many other packages in the monorepo.
+        # Building them sequentially ensures their output files are fully written
+        # before dependent packages start compiling.
+        # 
+        # Dependency order:
+        # 1. core-utils, path-utils (leaf packages with no workspace dependencies)
+        # 2. fs-utils (depends on core-utils, path-utils)
+        # 3. logger (depends on core-utils)
+        pnpm turbo run compile \
+          --filter @fern-api/core-utils \
+          --filter @fern-api/path-utils \
+          --filter @fern-api/fs-utils \
+          --filter @fern-api/logger \
+          --concurrency 1
 
     - uses: bufbuild/buf-setup-action@v1.34.0
       with:


### PR DESCRIPTION
## Description
Refs: https://github.com/fern-api/fern/actions/runs/21298381788/job/61309835788

Fixes intermittent CI failures where TypeScript compilation fails with `TS2306: File is not a module` errors for `core-utils/lib/index.d.ts`.

## Changes Made
- Expanded the pre-build step to include `path-utils`, `fs-utils`, and `logger` in addition to `core-utils`
- Added `--concurrency 1` to ensure sequential builds of foundational packages
- Added documentation explaining the dependency order

## Root Cause Analysis
The previous pre-build step only built `@fern-api/core-utils`, but race conditions were still occurring because:
1. `path-utils` (a leaf package) was being built in parallel with packages that depend on it
2. When `rust-base` compiled, it triggered compilation of `logger`, which tried to import from `core-utils` while files were potentially still being written

The fix pre-builds all foundational packages sequentially before parallel compilation begins.

## Testing
- [ ] Manual testing not possible for CI workflow changes
- Analysis based on CI failure logs showing the race condition pattern

## Human Review Checklist
- [ ] Verify the dependency analysis: `core-utils` and `path-utils` are leaf packages; `fs-utils` depends on both; `logger` depends on `core-utils`
- [ ] Consider if additional packages should be included in the pre-build
- [ ] Evaluate performance trade-off of sequential pre-builds vs. reliability

---
Requested by: David Konigsberg (@davidkonigsberg)
Link to Devin run: https://app.devin.ai/sessions/557fd9a0710846909fef8a0351ef63ea