### PR TITLE
fix(csharp): normalize datetime strings in snippet generator

### DIFF
--- a/generators/csharp/model/src/object/ObjectSerializationTestGenerator.ts
+++ b/generators/csharp/model/src/object/ObjectSerializationTestGenerator.ts
@@ -1,5 +1,5 @@
 import { CSharpFile, FileGenerator } from "@fern-api/csharp-base";
-import { ast } from "@fern-api/csharp-codegen";
+import { ast, text } from "@fern-api/csharp-codegen";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 
 import { TypeDeclaration } from "@fern-fern/ir-sdk/api";
@@ -109,8 +109,8 @@ export class ObjectSerializationTestGenerator extends FileGenerator<CSharpFile> 
     }
 
     private convertToCSharpFriendlyJsonString(jsonObject: unknown): string {
-        // Convert object to JSON string with indentation
-        const jsonString = JSON.stringify(jsonObject, null, 2);
+        // Convert object to JSON string with indentation, normalizing dates for consistency
+        const jsonString = JSON.stringify(jsonObject, text.normalizeDates, 2);
 
         // Format it as a multi-line C# string
         return `"""

--- a/generators/csharp/model/src/snippets/ExampleGenerator.ts
+++ b/generators/csharp/model/src/snippets/ExampleGenerator.ts
@@ -245,7 +245,7 @@ export class ExampleGenerator extends WithGeneration {
             float: (p) => this.csharp.InstantiatedPrimitive.float(p),
             double: (p) => this.csharp.InstantiatedPrimitive.double(p),
             boolean: (p) => this.csharp.InstantiatedPrimitive.boolean(p),
-            string: (p) => this.csharp.InstantiatedPrimitive.string(p.original),
+            string: (p) => this.csharp.InstantiatedPrimitive.string(this.normalizeStringValue(p.original)),
             datetime: (example) => this.csharp.InstantiatedPrimitive.dateTime(example.datetime, parseDatetimes),
             date: (dateString) => this.csharp.InstantiatedPrimitive.date(dateString),
             uuid: (p) => this.csharp.InstantiatedPrimitive.uuid(p),
@@ -256,5 +256,16 @@ export class ExampleGenerator extends WithGeneration {
             }
         });
         return this.csharp.codeblock((writer) => writer.write(instantiatedPrimitive));
+    }
+
+    /**
+     * Normalizes string values that look like ISO datetime strings.
+     * This ensures consistency with the mock JSON which uses normalizeDates.
+     */
+    private normalizeStringValue(value: string): string {
+        if (is.isIsoDateTimeString(value) || is.isIsoDateString(value)) {
+            return new Date(value).toISOString();
+        }
+        return value;
     }
 }

--- a/generators/csharp/model/src/union/UnionSerializationTestGenerator.ts
+++ b/generators/csharp/model/src/union/UnionSerializationTestGenerator.ts
@@ -1,5 +1,5 @@
 import { CSharpFile, FileGenerator } from "@fern-api/csharp-base";
-import { ast } from "@fern-api/csharp-codegen";
+import { ast, text } from "@fern-api/csharp-codegen";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 
 import { TypeDeclaration } from "@fern-fern/ir-sdk/api";
@@ -111,8 +111,8 @@ export class UnionSerializationTestGenerator extends FileGenerator<CSharpFile> {
     }
 
     private convertToCSharpFriendlyJsonString(jsonObject: unknown): string {
-        // Convert object to JSON string with indentation
-        const jsonString = JSON.stringify(jsonObject, null, 2);
+        // Convert object to JSON string with indentation, normalizing dates for consistency
+        const jsonString = JSON.stringify(jsonObject, text.normalizeDates, 2);
 
         // Format it as a multi-line C# string
         return `"""

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.19.4
+  changelogEntry:
+    - summary: |
+        Fix DateTime formatting mismatch in generated snippets, which caused problems in mock server tests.
+      type: fix
+  createdAt: "2026-01-28"
+  irVersion: 62
+
 - version: 2.19.3
   changelogEntry:
     - summary: |
@@ -123,7 +131,6 @@
         properties in JSON responses.
       type: chore
   createdAt: "2026-01-22"
-  irVersion: 62
 
 - version: 2.17.5
   changelogEntry:

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -131,6 +131,7 @@
         properties in JSON responses.
       type: chore
   createdAt: "2026-01-22"
+  irVersion: 62
 
 - version: 2.17.5
   changelogEntry:

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithOptionalField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithOptionalField.json
@@ -171,6 +171,16 @@
               "type": "null"
             }
           ]
+        },
+        "datetimeinstring": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithOptionalField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithOptionalField.json
@@ -172,7 +172,7 @@
             }
           ]
         },
-        "datetimeinstring": {
+        "datetimeInString": {
           "oneOf": [
             {
               "type": "string"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithRequiredField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithRequiredField.json
@@ -161,6 +161,16 @@
               "type": "null"
             }
           ]
+        },
+        "datetimeinstring": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithRequiredField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithRequiredField.json
@@ -162,7 +162,7 @@
             }
           ]
         },
-        "datetimeinstring": {
+        "datetimeInString": {
           "oneOf": [
             {
               "type": "string"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithOptionalField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithOptionalField.json
@@ -146,7 +146,7 @@
         }
       ]
     },
-    "datetimeinstring": {
+    "datetimeInString": {
       "oneOf": [
         {
           "type": "string"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithOptionalField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithOptionalField.json
@@ -145,6 +145,16 @@
           "type": "null"
         }
       ]
+    },
+    "datetimeinstring": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "additionalProperties": false,

--- a/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions/exhaustive.json
+++ b/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions/exhaustive.json
@@ -1895,25 +1895,25 @@
                 {
                     "name": {
                         "name": {
-                            "originalName": "datetimeinstring",
+                            "originalName": "datetimeInString",
                             "camelCase": {
-                                "unsafeName": "datetimeinstring",
-                                "safeName": "datetimeinstring"
+                                "unsafeName": "datetimeInString",
+                                "safeName": "datetimeInString"
                             },
                             "snakeCase": {
-                                "unsafeName": "datetimeinstring",
-                                "safeName": "datetimeinstring"
+                                "unsafeName": "datetime_in_string",
+                                "safeName": "datetime_in_string"
                             },
                             "screamingSnakeCase": {
-                                "unsafeName": "DATETIMEINSTRING",
-                                "safeName": "DATETIMEINSTRING"
+                                "unsafeName": "DATETIME_IN_STRING",
+                                "safeName": "DATETIME_IN_STRING"
                             },
                             "pascalCase": {
-                                "unsafeName": "Datetimeinstring",
-                                "safeName": "Datetimeinstring"
+                                "unsafeName": "DatetimeInString",
+                                "safeName": "DatetimeInString"
                             }
                         },
-                        "wireValue": "datetimeinstring"
+                        "wireValue": "datetimeInString"
                     },
                     "typeReference": {
                         "type": "optional",

--- a/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions/exhaustive.json
+++ b/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions/exhaustive.json
@@ -1891,6 +1891,39 @@
                     },
                     "propertyAccess": null,
                     "variable": null
+                },
+                {
+                    "name": {
+                        "name": {
+                            "originalName": "datetimeinstring",
+                            "camelCase": {
+                                "unsafeName": "datetimeinstring",
+                                "safeName": "datetimeinstring"
+                            },
+                            "snakeCase": {
+                                "unsafeName": "datetimeinstring",
+                                "safeName": "datetimeinstring"
+                            },
+                            "screamingSnakeCase": {
+                                "unsafeName": "DATETIMEINSTRING",
+                                "safeName": "DATETIMEINSTRING"
+                            },
+                            "pascalCase": {
+                                "unsafeName": "Datetimeinstring",
+                                "safeName": "Datetimeinstring"
+                            }
+                        },
+                        "wireValue": "datetimeinstring"
+                    },
+                    "typeReference": {
+                        "type": "optional",
+                        "value": {
+                            "type": "primitive",
+                            "value": "STRING"
+                        }
+                    },
+                    "propertyAccess": null,
+                    "variable": null
                 }
             ],
             "extends": null,

--- a/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
+++ b/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
@@ -26,6 +26,13 @@ service:
       #         long: 9223372036854775807
       #         double: 3.14
       #         bool: true
+      examples:
+        - name: WithDatetimeInString
+          request:
+            datetimeinstring: "2024-01-15T09:30:00Z"
+          response:
+            body:
+              datetimeinstring: "2024-01-15T09:30:00Z"
 
     getAndReturnWithRequiredField:
       path: /get-and-return-with-required-field

--- a/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
+++ b/test-definitions/fern/apis/exhaustive/definition/endpoints/object.yml
@@ -29,10 +29,10 @@ service:
       examples:
         - name: WithDatetimeInString
           request:
-            datetimeinstring: "2024-01-15T09:30:00Z"
+            datetimeInString: "2024-01-15T09:30:00Z"
           response:
             body:
-              datetimeinstring: "2024-01-15T09:30:00Z"
+              datetimeInString: "2024-01-15T09:30:00Z"
 
     getAndReturnWithRequiredField:
       path: /get-and-return-with-required-field

--- a/test-definitions/fern/apis/exhaustive/definition/types/object.yml
+++ b/test-definitions/fern/apis/exhaustive/definition/types/object.yml
@@ -16,6 +16,7 @@ types:
       set: optional<set<string>>
       map: optional<map<integer, string>>
       bigint: optional<bigint>
+      datetimeinstring: optional<string>
 
   ObjectWithRequiredField:
     properties:

--- a/test-definitions/fern/apis/exhaustive/definition/types/object.yml
+++ b/test-definitions/fern/apis/exhaustive/definition/types/object.yml
@@ -16,7 +16,7 @@ types:
       set: optional<set<string>>
       map: optional<map<integer, string>>
       bigint: optional<bigint>
-      datetimeinstring: optional<string>
+      datetimeInString: optional<string>
 
   ObjectWithRequiredField:
     properties:


### PR DESCRIPTION
## Description
Occasionally, strings that were in fact DateTimes would be normalized by the wire test generator, but not in the snippet generator, leading to mismatches and failed wire tests; this normalizes those DateTimes in the snippet generator.

## Changes Made
Just to csharp-model.
