### PR TITLE
fix(cli): fix URL name extraction for hyphenated subdomains

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
@@ -231,15 +231,18 @@ function extractApiNameFromUrl(url: string): string {
         const commonTerms = new Set(["api", "www", "service", "services", "example", "com", "org", "net", "io"]);
 
         for (const part of parts) {
-            const cleanPart = part.split("-")[0]; // Handle cases like "payments-service"
+            // Try the prefix before hyphen (e.g., "payments" from "payments-service")
+            const prefix = part.split("-")[0];
+            // Use prefix if it's meaningful, otherwise use the full part
+            const cleanPart = prefix && prefix.length > 2 ? prefix : part;
             if (cleanPart && !commonTerms.has(cleanPart.toLowerCase()) && cleanPart.length > 2) {
                 return cleanPart.toLowerCase();
             }
         }
 
-        // Fallback: use first part of hostname
-        const firstPart = parts[0]?.split("-")[0];
-        return firstPart ? firstPart.toLowerCase() : "api";
+        // Fallback: use first part of hostname (full, not split)
+        const firstPart = parts[0];
+        return firstPart && firstPart.length > 0 ? firstPart.toLowerCase() : "api";
     } catch {
         // If URL parsing fails, extract from string pattern
         const match = url.match(/https?:\/\/([^./-]+)/);

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.49.7
+  changelogEntry:
+    - summary: |
+        Fix `group-multi-api-environments` URL name extraction for hyphenated subdomains (e.g., `ip-messaging.twilio.com` now extracts as `ip-messaging` instead of colliding with other URLs).
+      type: fix
+  createdAt: "2026-01-23"
+  irVersion: 63
+
 - version: 3.49.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Summary

Fix `group-multi-api-environments` URL name extraction for hyphenated subdomains.

When the hyphen-split prefix is too short (e.g., "ip" from "ip-messaging"), use the full subdomain instead. This prevents collisions like:
- `api.twilio.com` → `twilio`
- `ip-messaging.twilio.com` → `twilio` (was colliding, now correctly extracts as `ip-messaging`)

## Test plan

- [x] Existing tests pass (253 tests)
- [ ] Manual verification with Twilio config

🤖 Generated with [Claude Code](https://claude.ai/claude-code)