### PR TITLE
fix(python): only add pydantic-core dependency for explicit v2 mode

### DIFF
--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -74,7 +74,7 @@ def parse_obj_as(type_: Type[T], object_: Any) -> T:
 
 def to_jsonable_with_fallback(obj: Any, fallback_serializer: Callable[[Any], Any]) -> Any:
     if IS_PYDANTIC_V2:
-        from pydantic_core import to_jsonable_python
+        from pydantic_core import to_jsonable_python  # type: ignore[import-not-found]
 
         return to_jsonable_python(obj, fallback=fallback_serializer)
     return fallback_serializer(obj)
@@ -351,7 +351,7 @@ def _get_field_default(field: PydanticField) -> Any:
     except:
         value = field.default
     if IS_PYDANTIC_V2:
-        from pydantic_core import PydanticUndefined
+        from pydantic_core import PydanticUndefined  # type: ignore[import-not-found]
 
         if value == PydanticUndefined:
             return None

--- a/generators/python/core_utilities/shared/unchecked_base_model.py
+++ b/generators/python/core_utilities/shared/unchecked_base_model.py
@@ -18,7 +18,11 @@ from .pydantic_utilities import (
     parse_obj_as,
 )
 from .serialization import get_field_to_alias_mapping
-from pydantic_core import PydanticUndefined
+
+if IS_PYDANTIC_V2:
+    from pydantic_core import PydanticUndefined  # type: ignore[import-not-found]
+else:
+    PydanticUndefined = None  # type: ignore[misc, assignment]
 
 
 class UnionMetadata:
@@ -366,7 +370,7 @@ def _get_field_default(field: PydanticField) -> typing.Any:
     except:
         value = field.default
     if IS_PYDANTIC_V2:
-        from pydantic_core import PydanticUndefined
+        from pydantic_core import PydanticUndefined  # type: ignore[import-not-found]
 
         if value == PydanticUndefined:
             return None

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -42,7 +42,7 @@ def parse_obj_as(type_: Type[T], object_: Any) -> T:
 
 def to_jsonable_with_fallback(obj: Any, fallback_serializer: Callable[[Any], Any]) -> Any:
     if IS_PYDANTIC_V2:
-        from pydantic_core import to_jsonable_python
+        from pydantic_core import to_jsonable_python  # type: ignore[import-not-found]
 
         return to_jsonable_python(obj, fallback=fallback_serializer)
     return fallback_serializer(obj)
@@ -220,7 +220,7 @@ def _get_field_default(field: PydanticField) -> Any:
     except:
         value = field.default
     if IS_PYDANTIC_V2:
-        from pydantic_core import PydanticUndefined
+        from pydantic_core import PydanticUndefined  # type: ignore[import-not-found]
 
         if value == PydanticUndefined:
             return None

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
 
+- version: 4.50.1
+  changelogEntry:
+    - summary: |
+        Fix pydantic-core dependency to only be added for explicit v2 mode. Previously, pydantic-core
+        was unconditionally added as a dependency, which broke compatibility for users wanting to use
+        Pydantic v1. Now pydantic-core is only added when the pydantic version is explicitly set to v2.
+        For "both" mode, pydantic-core is a transitive dependency of pydantic>=2.0 and doesn't need to
+        be explicitly listed.
+      type: fix
+  createdAt: "2026-01-26"
+  irVersion: 62
+
 - version: 4.50.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/core_utilities/core_utilities.py
@@ -83,7 +83,12 @@ class CoreUtilities:
             }
             | (set() if is_v1_on_v2 else {"IS_PYDANTIC_V2"}),
         )
-        project.add_dependency(PYDANTIC_CORE_DEPENDENCY)
+        # Only add pydantic-core for explicit v2 mode
+        # For "both" mode, it's a transitive dependency of pydantic>=2.0
+        # For v1 mode, it doesn't exist
+        # For v1_on_v2 mode, we use pydantic.v1 compatibility layer
+        if self._pydantic_compatibility == PydanticVersionCompatibility.V2:
+            project.add_dependency(PYDANTIC_CORE_DEPENDENCY)
 
         self._copy_file_to_project(
             project=project,

--- a/generators/python/src/fern_python/generators/fastapi/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/fastapi/core_utilities/core_utilities.py
@@ -193,7 +193,12 @@ class CoreUtilities:
             exports={"FieldMetadata", "convert_and_respect_annotation_metadata"},
         )
 
-        project.add_dependency(PYDANTIC_CORE_DEPENDENCY)
+        # Only add pydantic-core for explicit v2 mode
+        # For "both" mode, it's a transitive dependency of pydantic>=2.0
+        # For v1 mode, it doesn't exist
+        # For v1_on_v2 mode, we use pydantic.v1 compatibility layer
+        if self._pydantic_compatibility == PydanticVersionCompatibility.V2:
+            project.add_dependency(PYDANTIC_CORE_DEPENDENCY)
         self._copy_security_to_project(project=project)
         self._copy_exceptions_to_project(project=project)
 

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -187,7 +187,12 @@ class CoreUtilities:
             if not self._exclude_types_from_init_exports
             else set(),
         )
-        project.add_dependency(PYDANTIC_CORE_DEPENDENCY)
+        # Only add pydantic-core for explicit v2 mode
+        # For "both" mode, it's a transitive dependency of pydantic>=2.0
+        # For v1 mode, it doesn't exist
+        # For v1_on_v2 mode, we use pydantic.v1 compatibility layer
+        if self._version == PydanticVersionCompatibility.V2:
+            project.add_dependency(PYDANTIC_CORE_DEPENDENCY)
 
         self._copy_file_to_project(
             project=project,


### PR DESCRIPTION
## Description

Fixes a bug where `pydantic-core` was unconditionally added as a dependency to all generated Python SDKs, breaking compatibility for users who want to use Pydantic v1.

**Link to Devin run:** https://app.devin.ai/sessions/28614b85508c4423a875ee8848ab1fca
**Requested by:** @jsklan

## Changes Made

- Modified the SDK, Pydantic model, and FastAPI generators to only add `pydantic-core` as a dependency when the Pydantic version is explicitly set to `v2`
- For "both" mode, `pydantic-core` is a transitive dependency of `pydantic>=2.0` and doesn't need to be explicitly listed
- For v1 mode, `pydantic-core` doesn't exist
- For v1_on_v2 mode, we use the `pydantic.v1` compatibility layer
- Added version 4.50.1 changelog entry

## Updates since last revision

Fixed mypy type-checking errors that occurred because mypy tries to resolve imports at type-checking time even when they're inside runtime conditionals:
- Added `# type: ignore[import-not-found]` comments to all `pydantic_core` imports in the core utilities
- Made the top-level `PydanticUndefined` import in `unchecked_base_model.py` conditional with a `None` fallback for non-v2 mode

## Testing

- [x] Pre-commit hooks pass
- [x] Seed tests pass in CI

## Human Review Checklist

- [ ] Verify the conditional check uses the correct variable name in each file (`self._version` in SDK vs `self._pydantic_compatibility` in others)
- [ ] Confirm the `PydanticUndefined = None` fallback in `unchecked_base_model.py` is safe (it's only used inside `if IS_PYDANTIC_V2:` blocks)
- [ ] Verify seed tests pass for Python SDK fixtures with different Pydantic version configurations