### PR TITLE
fix(php): start/stop mock server once for all wire tests instead of per class

### DIFF
--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -558,6 +558,11 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
     }
 
     public getRawAsIsFiles(): string[] {
+        // When wire tests are enabled, we generate a custom phpunit.xml with the wire test bootstrap
+        // so we exclude the default phpunit.xml here
+        if (this.customConfig.enableWireTests) {
+            return [AsIsFiles.GitIgnore, AsIsFiles.PhpStanNeon];
+        }
         return [AsIsFiles.GitIgnore, AsIsFiles.PhpStanNeon, AsIsFiles.PhpUnitXml];
     }
 

--- a/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -225,23 +225,24 @@ register_shutdown_function(function () use ($dockerComposeFile) {
     }
 
     /**
-     * Generates a phpunit.wire.xml file specifically for wire tests
-     * that uses the bootstrap file.
+     * Generates a phpunit.xml file that uses the wire bootstrap.
+     * This overrides the default phpunit.xml so that `composer test` works correctly.
      */
     private generateWireTestPhpunitXml(): void {
         const phpunitContent = this.buildWireTestPhpunitXmlContent();
-        this.context.project.addRawFiles(new File("phpunit.wire.xml", RelativeFilePath.of(""), phpunitContent));
-        this.context.logger.debug("Generated phpunit.wire.xml for wire tests");
+        this.context.project.addRawFiles(new File("phpunit.xml", RelativeFilePath.of(""), phpunitContent));
+        this.context.logger.debug("Generated phpunit.xml with wire test bootstrap");
     }
 
     /**
-     * Builds the content for the phpunit.wire.xml file
+     * Builds the content for the phpunit.xml file with wire test bootstrap.
+     * This runs all tests (including wire tests) with WireMock started.
      */
     private buildWireTestPhpunitXmlContent(): string {
         return `<phpunit bootstrap="tests/Wire/bootstrap.php">
     <testsuites>
-        <testsuite name="Wire Test Suite">
-            <directory suffix="Test.php">tests/Wire</directory>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -25,6 +25,8 @@ export class WireTestSetupGenerator {
         this.generateWireMockConfigFile();
         this.generateDockerComposeFile();
         this.generateWireMockTestCaseFile();
+        this.generateWireTestBootstrapFile();
+        this.generateWireTestPhpunitXml();
     }
 
     public static getWiremockConfigContent(ir: IntermediateRepresentation) {
@@ -102,44 +104,11 @@ use PHPUnit\\Framework\\TestCase;
 /**
  * Base test case for WireMock-based wire tests.
  *
- * This class manages the WireMock container lifecycle for integration tests.
+ * The WireMock container lifecycle is managed by the bootstrap file (tests/Wire/bootstrap.php)
+ * which starts the container once before all tests and stops it after all tests complete.
  */
 abstract class WireMockTestCase extends TestCase
 {
-    protected static string $dockerComposeFile;
-
-    public static function setUpBeforeClass(): void
-    {
-        $testDir = __DIR__;
-        $projectRoot = \\dirname($testDir, 2);
-        $wiremockDir = $projectRoot . '/wiremock';
-        self::$dockerComposeFile = $wiremockDir . '/docker-compose.test.yml';
-
-        echo "\\nStarting WireMock container...\\n";
-        $cmd = sprintf(
-            'docker compose -f %s up -d --wait 2>&1',
-            escapeshellarg(self::$dockerComposeFile)
-        );
-        exec($cmd, $output, $exitCode);
-        if ($exitCode !== 0) {
-            throw new \\RuntimeException("Failed to start WireMock: " . implode("\\n", $output));
-        }
-        echo "WireMock container is ready\\n";
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (!isset(self::$dockerComposeFile)) {
-            return;
-        }
-        echo "\\nStopping WireMock container...\\n";
-        $cmd = sprintf(
-            'docker compose -f %s down -v 2>&1',
-            escapeshellarg(self::$dockerComposeFile)
-        );
-        exec($cmd);
-    }
-
     /**
      * Verifies the number of requests made to WireMock filtered by test ID for concurrency safety.
      *
@@ -198,6 +167,84 @@ abstract class WireMockTestCase extends TestCase
         );
     }
 }
+`;
+    }
+
+    /**
+     * Generates a bootstrap file that starts WireMock once before all tests
+     * and registers a shutdown function to stop it after all tests complete.
+     */
+    private generateWireTestBootstrapFile(): void {
+        const bootstrapContent = this.buildWireTestBootstrapContent();
+        this.context.project.addRawFiles(
+            new File("bootstrap.php", RelativeFilePath.of("tests/Wire"), bootstrapContent)
+        );
+        this.context.logger.debug("Generated bootstrap.php for WireMock container lifecycle management");
+    }
+
+    /**
+     * Builds the content for the bootstrap.php file
+     */
+    private buildWireTestBootstrapContent(): string {
+        return `<?php
+
+/**
+ * Bootstrap file for wire tests.
+ *
+ * This file is loaded once before any tests run and manages the WireMock
+ * container lifecycle - starting it once at the beginning and stopping it
+ * after all tests complete.
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$projectRoot = \\dirname(__DIR__, 2);
+$dockerComposeFile = $projectRoot . '/wiremock/docker-compose.test.yml';
+
+echo "\\nStarting WireMock container...\\n";
+$cmd = sprintf(
+    'docker compose -f %s up -d --wait 2>&1',
+    escapeshellarg($dockerComposeFile)
+);
+exec($cmd, $output, $exitCode);
+if ($exitCode !== 0) {
+    throw new \\RuntimeException("Failed to start WireMock: " . implode("\\n", $output));
+}
+echo "WireMock container is ready\\n";
+
+// Register shutdown function to stop the container after all tests complete
+register_shutdown_function(function () use ($dockerComposeFile) {
+    echo "\\nStopping WireMock container...\\n";
+    $cmd = sprintf(
+        'docker compose -f %s down -v 2>&1',
+        escapeshellarg($dockerComposeFile)
+    );
+    exec($cmd);
+});
+`;
+    }
+
+    /**
+     * Generates a phpunit.wire.xml file specifically for wire tests
+     * that uses the bootstrap file.
+     */
+    private generateWireTestPhpunitXml(): void {
+        const phpunitContent = this.buildWireTestPhpunitXmlContent();
+        this.context.project.addRawFiles(new File("phpunit.wire.xml", RelativeFilePath.of(""), phpunitContent));
+        this.context.logger.debug("Generated phpunit.wire.xml for wire tests");
+    }
+
+    /**
+     * Builds the content for the phpunit.wire.xml file
+     */
+    private buildWireTestPhpunitXmlContent(): string {
+        return `<phpunit bootstrap="tests/Wire/bootstrap.php">
+    <testsuites>
+        <testsuite name="Wire Test Suite">
+            <directory suffix="Test.php">tests/Wire</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
 `;
     }
 }

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.25.4
+  changelogEntry:
+    - summary: |
+        Fix wire tests to start and stop the mock server once for all tests instead of per test class. Previously, each test class would start and stop the WireMock container in setUpBeforeClass/tearDownAfterClass, causing the container to restart multiple times. Now uses a PHPUnit bootstrap file to manage the container lifecycle once for the entire test suite.
+      type: fix
+  createdAt: "2026-01-26"
+  irVersion: 62
+
 - version: 1.25.3
   changelogEntry:
     - summary: |

--- a/seed/php-sdk/exhaustive/wire-tests/phpunit.xml
+++ b/seed/php-sdk/exhaustive/wire-tests/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="vendor/autoload.php">
+<phpunit bootstrap="tests/Wire/bootstrap.php">
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">tests</directory>

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/WireMockTestCase.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/WireMockTestCase.php
@@ -8,44 +8,11 @@ use PHPUnit\Framework\TestCase;
 /**
  * Base test case for WireMock-based wire tests.
  *
- * This class manages the WireMock container lifecycle for integration tests.
+ * The WireMock container lifecycle is managed by the bootstrap file (tests/Wire/bootstrap.php)
+ * which starts the container once before all tests and stops it after all tests complete.
  */
 abstract class WireMockTestCase extends TestCase
 {
-    protected static string $dockerComposeFile;
-
-    public static function setUpBeforeClass(): void
-    {
-        $testDir = __DIR__;
-        $projectRoot = \dirname($testDir, 2);
-        $wiremockDir = $projectRoot . '/wiremock';
-        self::$dockerComposeFile = $wiremockDir . '/docker-compose.test.yml';
-
-        echo "\nStarting WireMock container...\n";
-        $cmd = sprintf(
-            'docker compose -f %s up -d --wait 2>&1',
-            escapeshellarg(self::$dockerComposeFile)
-        );
-        exec($cmd, $output, $exitCode);
-        if ($exitCode !== 0) {
-            throw new \RuntimeException("Failed to start WireMock: " . implode("\n", $output));
-        }
-        echo "WireMock container is ready\n";
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        if (!isset(self::$dockerComposeFile)) {
-            return;
-        }
-        echo "\nStopping WireMock container...\n";
-        $cmd = sprintf(
-            'docker compose -f %s down -v 2>&1',
-            escapeshellarg(self::$dockerComposeFile)
-        );
-        exec($cmd);
-    }
-
     /**
      * Verifies the number of requests made to WireMock filtered by test ID for concurrency safety.
      *

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/bootstrap.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/bootstrap.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Bootstrap file for wire tests.
+ *
+ * This file is loaded once before any tests run and manages the WireMock
+ * container lifecycle - starting it once at the beginning and stopping it
+ * after all tests complete.
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$projectRoot = \dirname(__DIR__, 2);
+$dockerComposeFile = $projectRoot . '/wiremock/docker-compose.test.yml';
+
+echo "\nStarting WireMock container...\n";
+$cmd = sprintf(
+    'docker compose -f %s up -d --wait 2>&1',
+    escapeshellarg($dockerComposeFile)
+);
+exec($cmd, $output, $exitCode);
+if ($exitCode !== 0) {
+    throw new \RuntimeException("Failed to start WireMock: " . implode("\n", $output));
+}
+echo "WireMock container is ready\n";
+
+// Register shutdown function to stop the container after all tests complete
+register_shutdown_function(function () use ($dockerComposeFile) {
+    echo "\nStopping WireMock container...\n";
+    $cmd = sprintf(
+        'docker compose -f %s down -v 2>&1',
+        escapeshellarg($dockerComposeFile)
+    );
+    exec($cmd);
+});


### PR DESCRIPTION
## Description

Refs: Requested by @iamnamananand996

Fixes PHP wire tests to start and stop the WireMock container once for the entire test suite instead of once per test class.

**Problem:** The `WireMockTestCase` base class had `setUpBeforeClass()` and `tearDownAfterClass()` methods that started/stopped the WireMock container. Since PHPUnit calls these methods once per test class (not once for the entire suite), the container was being restarted for each test file (e.g., 14 times for the exhaustive fixture).

**Solution:** Use PHPUnit's bootstrap mechanism to manage the container lifecycle:
- Generate a `bootstrap.php` file that starts WireMock once before any tests run
- Use `register_shutdown_function` to stop the container after all tests complete
- Override the default `phpunit.xml` to use this bootstrap, so `composer test` works correctly

## Changes Made
- Removed `setUpBeforeClass()` and `tearDownAfterClass()` from generated `WireMockTestCase.php`
- Added `generateWireTestBootstrapFile()` to create `tests/Wire/bootstrap.php`
- Added `generateWireTestPhpunitXml()` to create `phpunit.xml` with bootstrap config
- Modified `SdkGeneratorContext.getRawAsIsFiles()` to exclude default `phpunit.xml` when wire tests are enabled (prevents file conflict)
- Updated versions.yml with changelog entry for v1.25.4
- Regenerated seed tests for `exhaustive:wire-tests` fixture

## Testing
- [x] Seed tests regenerated and generated files verified
- [x] `phpunit.xml` correctly points to `tests/Wire/bootstrap.php`
- [x] `bootstrap.php` starts WireMock and uses `register_shutdown_function` for cleanup
- [ ] Manual testing with Docker environment (wire tests are in allowed failures due to Docker-in-Docker limitation in CI)

## Human Review Checklist
- [x] Verify the conditional exclusion of default `phpunit.xml` doesn't affect non-wire-test PHP SDKs
- [x] Confirm `register_shutdown_function` approach is appropriate for PHPUnit's execution flow
- [x] Check that `composer test` will work correctly in environments with Docker available

Link to Devin run: https://app.devin.ai/sessions/cf784df00a9044d9b4eef291d11e3ace