### PR TITLE
feat(php): add support for deep object query parameters

### DIFF
--- a/generators/php/base/src/asIs/Client/RawClientTest.Template.php
+++ b/generators/php/base/src/asIs/Client/RawClientTest.Template.php
@@ -667,4 +667,79 @@ class RawClientTest extends TestCase
         $this->assertGreaterThanOrEqual(60000, $delay);
         $this->assertLessThanOrEqual(72000, $delay);
     }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testDeepObjectQueryParameters(): void
+    {
+        $this->mockHandler->append(new Response(200));
+
+        $request = new JsonApiRequest(
+            $this->baseUrl,
+            '/test',
+            HttpMethod::GET,
+            [],
+            ['filter' => ['name' => 'john', 'age' => 30]]
+        );
+
+        $this->rawClient->sendRequest($request);
+
+        $lastRequest = $this->mockHandler->getLastRequest();
+        assert($lastRequest instanceof RequestInterface);
+        $this->assertEquals(
+            'https://api.example.com/test?filter%5Bname%5D=john&filter%5Bage%5D=30',
+            (string)$lastRequest->getUri()
+        );
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testDeeplyNestedObjectQueryParameters(): void
+    {
+        $this->mockHandler->append(new Response(200));
+
+        $request = new JsonApiRequest(
+            $this->baseUrl,
+            '/test',
+            HttpMethod::GET,
+            [],
+            ['filter' => ['user' => ['name' => 'john', 'role' => 'admin'], 'status' => 'active']]
+        );
+
+        $this->rawClient->sendRequest($request);
+
+        $lastRequest = $this->mockHandler->getLastRequest();
+        assert($lastRequest instanceof RequestInterface);
+        $this->assertEquals(
+            'https://api.example.com/test?filter%5Buser%5D%5Bname%5D=john&filter%5Buser%5D%5Brole%5D=admin&filter%5Bstatus%5D=active',
+            (string)$lastRequest->getUri()
+        );
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testArrayOfObjectsQueryParameters(): void
+    {
+        $this->mockHandler->append(new Response(200));
+
+        $request = new JsonApiRequest(
+            $this->baseUrl,
+            '/test',
+            HttpMethod::GET,
+            [],
+            ['objects' => [['key' => 'hello', 'value' => 'world'], ['key' => 'foo', 'value' => 'bar']]]
+        );
+
+        $this->rawClient->sendRequest($request);
+
+        $lastRequest = $this->mockHandler->getLastRequest();
+        assert($lastRequest instanceof RequestInterface);
+        $this->assertEquals(
+            'https://api.example.com/test?objects%5Bkey%5D=hello&objects%5Bvalue%5D=world&objects%5Bkey%5D=foo&objects%5Bvalue%5D=bar',
+            (string)$lastRequest->getUri()
+        );
+    }
 }

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.26.0
+  changelogEntry:
+    - summary: |
+        Add support for deep object query parameters. Nested objects in query parameters are now encoded using bracket notation (e.g., `filter[user][name]=john&filter[user][age]=30`). This matches the OpenAPI 3.0 deepObject serialization style and is consistent with Python, Java, and C# generators.
+      type: feat
+  createdAt: "2026-01-26"
+  irVersion: 62
+
 - version: 1.25.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Requested by @iamnamananand996

Adds support for deep object query parameters in the PHP SDK generator. Nested objects in query parameters are now encoded using bracket notation (e.g., `filter[user][name]=john&filter[user][age]=30`), matching the OpenAPI 3.0 deepObject serialization style.

This brings PHP in line with Python, Java, and C# generators which already support this feature.

Link to Devin run: https://app.devin.ai/sessions/64b3914c128f4cfa957eaab189b9c426

## Changes Made

- Added `flattenQueryParams()` method to `RawClient.Template.php` that recursively flattens nested arrays into query parameter format with bracket notation
- Modified `encodeQuery()` to use the new flattening method
- Added 3 unit tests covering:
  - Simple deep object query parameters (`filter[name]=john`)
  - Deeply nested objects (`filter[user][name]=john`)
  - Arrays of objects (`objects[key]=hello&objects[value]=world`)
- Updated versions.yml with version 1.26.0 changelog entry
- [ ] Updated README.md generator (if applicable) - N/A

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed (verified with mock server that encoding produces correct OpenAPI deepObject format)

## Updates Since Last Revision

- Merged main branch to resolve merge conflict in versions.yml (incorporated v1.25.4 fix for wire tests)

## Human Review Checklist

- [ ] Verify `flattenQueryParams` correctly distinguishes between associative arrays (objects) and sequential arrays (lists) using `isSequential()`
- [ ] Confirm empty array handling is correct (empty arrays treated as sequential, resulting in no query params)
- [ ] Verify test assertions match expected OpenAPI deepObject serialization format (brackets URL-encoded as `%5B` and `%5D`)