### PR TITLE
feat(rust): add support for deep object query parameters

### DIFF
--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.18.0
+  changelogEntry:
+    - summary: |
+        Add support for deep object query parameters. Nested objects are now encoded using bracket
+        notation (e.g., filter[name]=john&filter[age]=30). Arrays are serialized in exploded format
+        (e.g., tags=a&tags=b), and arrays of objects are flattened with the array key as prefix.
+      type: feat
+  createdAt: "2026-01-26"
+  irVersion: 62
+
 - version: 0.17.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Related to PHP implementation in #11765

Adds deep object query parameter encoding support to the Rust SDK generator. This enables nested objects to be serialized using bracket notation (e.g., `filter[name]=john&filter[age]=30`) following the OpenAPI 3.0 deepObject serialization style.

Link to Devin run: https://app.devin.ai/sessions/64b3914c128f4cfa957eaab189b9c426
Requested by: @iamnamananand996

## Changes Made

- Added `serialize_deep_object<T>` method to `QueryBuilder` for encoding nested objects with bracket notation
- Added `serialize_deep_object_array<T>` method for handling arrays of nested objects
- Added `flatten_json_value` helper function that recursively flattens JSON values into query parameter format
- Added `json_value_to_string` helper for converting JSON primitives to strings
- Added comprehensive unit tests covering:
  - Simple nested objects
  - Deeply nested objects
  - Arrays (exploded format)
  - Arrays of objects
  - Mixed nested objects with arrays
  - None/null value handling

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify `flatten_json_value` correctly handles recursive object/array structures
- [ ] Confirm the bracket notation format matches OpenAPI deepObject serialization spec
- [ ] Note: This PR adds the capability to QueryBuilder but does not update the generator to automatically use these methods - that would be a follow-up change