### PR TITLE
feat(ruby): add support for deep object query parameters

### DIFF
--- a/generators/ruby/sdk/src/AbstractionUtilities.ts
+++ b/generators/ruby/sdk/src/AbstractionUtilities.ts
@@ -48,6 +48,7 @@ import { ArtifactRegistry } from "./utils/ArtifactRegistry";
 import { EndpointGenerator } from "./utils/EndpointGenerator";
 import { FileUploadUtility } from "./utils/FileUploadUtility";
 import { HeadersGenerator } from "./utils/HeadersGenerator";
+import { QueryParamsUtility } from "./utils/QueryParamsUtility";
 import { IdempotencyRequestOptions } from "./utils/IdempotencyRequestOptionsClass";
 import { OauthFunction, OauthTokenProvider } from "./utils/oauth/OauthTokenProvider";
 import { RequestOptions } from "./utils/RequestOptionsClass";
@@ -76,6 +77,7 @@ export function generateEndpoints(
     generatedClasses: Map<TypeId, Class_>,
     flattenedProperties: Map<TypeId, ObjectProperty[]>,
     fileUploadUtility: FileUploadUtility,
+    queryParamsUtility: QueryParamsUtility,
     packagePath: string[],
     packageClassReference: ClassReference | undefined,
     artifactRegistry: ArtifactRegistry | undefined
@@ -107,7 +109,8 @@ export function generateEndpoints(
                 crf,
                 eg,
                 generatedClasses,
-                fileUploadUtility
+                fileUploadUtility,
+                queryParamsUtility
             );
 
             const shouldOverwriteUrl = endpoint.baseUrl !== undefined;
@@ -194,6 +197,7 @@ export function generateRootPackage(
     generatedClasses: Map<TypeId, Class_>,
     flattenedProperties: Map<TypeId, ObjectProperty[]>,
     fileUploadUtility: FileUploadUtility,
+    queryParamsUtility: QueryParamsUtility,
     typeExporterLocation: string,
     headersGenerator: HeadersGenerator,
     retriesProperty: Property,
@@ -331,6 +335,7 @@ export function generateRootPackage(
                   generatedClasses,
                   flattenedProperties,
                   fileUploadUtility,
+                  queryParamsUtility,
                   [],
                   classReference,
                   artifactRegistry
@@ -415,6 +420,7 @@ export function generateRootPackage(
                   generatedClasses,
                   flattenedProperties,
                   fileUploadUtility,
+                  queryParamsUtility,
                   [],
                   undefined,
                   undefined
@@ -568,6 +574,7 @@ export function generateService(
     generatedClasses: Map<TypeId, Class_>,
     flattenedProperties: Map<TypeId, ObjectProperty[]>,
     fileUploadUtility: FileUploadUtility,
+    queryParamsUtility: QueryParamsUtility,
     locationGenerator: LocationGenerator,
     packagePath: string[],
     artifactRegistry: ArtifactRegistry
@@ -609,6 +616,7 @@ export function generateService(
             generatedClasses,
             flattenedProperties,
             fileUploadUtility,
+            queryParamsUtility,
             packagePath,
             syncClientClassReference,
             artifactRegistry
@@ -638,6 +646,7 @@ export function generateService(
             generatedClasses,
             flattenedProperties,
             fileUploadUtility,
+            queryParamsUtility,
             packagePath,
             undefined,
             undefined

--- a/generators/ruby/sdk/src/ClientsGenerator.ts
+++ b/generators/ruby/sdk/src/ClientsGenerator.ts
@@ -40,6 +40,7 @@ import {
 import { ArtifactRegistry } from "./utils/ArtifactRegistry";
 import { FileUploadUtility } from "./utils/FileUploadUtility";
 import { HeadersGenerator } from "./utils/HeadersGenerator";
+import { QueryParamsUtility } from "./utils/QueryParamsUtility";
 import { IdempotencyRequestOptions } from "./utils/IdempotencyRequestOptionsClass";
 import { AccessToken } from "./utils/oauth/AccessToken";
 import { OauthTokenProvider } from "./utils/oauth/OauthTokenProvider";
@@ -262,6 +263,18 @@ export class ClientsGenerator {
             );
         }
 
+        const queryParamsUtilityClass = new QueryParamsUtility(this.clientName);
+        const queryParamsUtilityModule = Module_.wrapInModules({
+            locationGenerator: this.locationGenerator,
+            child: queryParamsUtilityClass
+        });
+        clientFiles.push(
+            new GeneratedRubyFile({
+                rootNode: queryParamsUtilityModule,
+                fullPath: "core/query_params_utils"
+            })
+        );
+
         const subpackageClassReferences = new Map<SubpackageId, ClientClassPair>();
         const locationGenerator = this.locationGenerator;
         // 1. Generate service files, these are the classes that query the endpoints
@@ -304,6 +317,7 @@ export class ClientsGenerator {
                 generatedClasses,
                 flattenedProperties,
                 fileUtilityClass,
+                queryParamsUtilityClass,
                 locationGenerator,
                 subpackagePaths.get(packageId) ?? [],
                 artifactRegistry
@@ -495,6 +509,7 @@ export class ClientsGenerator {
                 this.generatedClasses,
                 this.flattenedProperties,
                 fileUtilityClass,
+                queryParamsUtilityClass,
                 typeExporterLocation,
                 headersGenerator,
                 retriesProperty,

--- a/generators/ruby/sdk/src/utils/QueryParamsUtility.ts
+++ b/generators/ruby/sdk/src/utils/QueryParamsUtility.ts
@@ -1,11 +1,13 @@
 import {
     Class_,
     ClassReference,
+    Expression,
     Function_,
     GenericClassReference,
     HashReference,
     Import,
-    Parameter
+    Parameter,
+    StringClassReference
 } from "@fern-api/ruby-codegen";
 
 export class QueryParamsUtility extends Class_ {
@@ -14,7 +16,7 @@ export class QueryParamsUtility extends Class_ {
     constructor(clientName: string) {
         const hashParam = new Parameter({
             name: "hash",
-            type: HashReference,
+            type: new HashReference({ keyType: StringClassReference, valueType: GenericClassReference }),
             documentation: "The hash to flatten for query parameters."
         });
         const prefixParam = new Parameter({
@@ -24,6 +26,13 @@ export class QueryParamsUtility extends Class_ {
             documentation: "The prefix for nested keys (used in recursion)."
         });
 
+        // Helper function to create raw Ruby code lines as Expression nodes
+        const rawLine = (code: string): Expression =>
+            new Expression({
+                rightSide: code,
+                isAssignment: false
+            });
+
         // The flatten_query_params method flattens nested hashes using bracket notation
         // For example: {filter: {name: "john", age: 30}} becomes {"filter[name]" => "john", "filter[age]" => 30}
         // Arrays are kept as-is for exploded format: {tags: ["a", "b"]} stays as {"tags" => ["a", "b"]}
@@ -31,27 +40,29 @@ export class QueryParamsUtility extends Class_ {
             name: "flatten_query_params",
             isStatic: true,
             functionBody: [
-                "result = {}",
-                "hash.each do |key, value|",
-                '  full_key = prefix.nil? ? key.to_s : "#{prefix}[#{key}]"',
-                "  if value.is_a?(Hash)",
-                "    result.merge!(flatten_query_params(value, full_key))",
-                "  elsif value.is_a?(Array)",
-                "    value.each do |item|",
-                "      if item.is_a?(Hash)",
-                "        result.merge!(flatten_query_params(item, full_key)) { |_k, old, new_val| [*old, *new_val].flatten }",
-                "      else",
-                "        (result[full_key] ||= []) << item",
-                "      end",
-                "    end",
-                "  else",
-                "    result[full_key] = value",
-                "  end",
-                "end",
-                "result"
+                rawLine("result = {}"),
+                rawLine("hash.each do |key, value|"),
+                rawLine('  full_key = prefix.nil? ? key.to_s : "#{prefix}[#{key}]"'),
+                rawLine("  if value.is_a?(Hash)"),
+                rawLine("    result.merge!(flatten_query_params(value, full_key))"),
+                rawLine("  elsif value.is_a?(Array)"),
+                rawLine("    value.each do |item|"),
+                rawLine("      if item.is_a?(Hash)"),
+                rawLine(
+                    "        result.merge!(flatten_query_params(item, full_key)) { |_k, old, new_val| [*old, *new_val].flatten }"
+                ),
+                rawLine("      else"),
+                rawLine("        (result[full_key] ||= []) << item"),
+                rawLine("      end"),
+                rawLine("    end"),
+                rawLine("  else"),
+                rawLine("    result[full_key] = value"),
+                rawLine("  end"),
+                rawLine("end"),
+                rawLine("result")
             ],
             parameters: [hashParam, prefixParam],
-            returnValue: HashReference
+            returnValue: new HashReference({ keyType: StringClassReference, valueType: GenericClassReference })
         });
 
         super({

--- a/generators/ruby/sdk/src/utils/QueryParamsUtility.ts
+++ b/generators/ruby/sdk/src/utils/QueryParamsUtility.ts
@@ -1,0 +1,71 @@
+import {
+    Class_,
+    ClassReference,
+    Function_,
+    GenericClassReference,
+    HashReference,
+    Import,
+    Parameter
+} from "@fern-api/ruby-codegen";
+
+export class QueryParamsUtility extends Class_ {
+    public flattenQueryParams: Function_;
+
+    constructor(clientName: string) {
+        const hashParam = new Parameter({
+            name: "hash",
+            type: HashReference,
+            documentation: "The hash to flatten for query parameters."
+        });
+        const prefixParam = new Parameter({
+            name: "prefix",
+            type: GenericClassReference,
+            isOptional: true,
+            documentation: "The prefix for nested keys (used in recursion)."
+        });
+
+        // The flatten_query_params method flattens nested hashes using bracket notation
+        // For example: {filter: {name: "john", age: 30}} becomes {"filter[name]" => "john", "filter[age]" => 30}
+        // Arrays are kept as-is for exploded format: {tags: ["a", "b"]} stays as {"tags" => ["a", "b"]}
+        const flattenQueryParams = new Function_({
+            name: "flatten_query_params",
+            isStatic: true,
+            functionBody: [
+                "result = {}",
+                "hash.each do |key, value|",
+                '  full_key = prefix.nil? ? key.to_s : "#{prefix}[#{key}]"',
+                "  if value.is_a?(Hash)",
+                "    result.merge!(flatten_query_params(value, full_key))",
+                "  elsif value.is_a?(Array)",
+                "    value.each do |item|",
+                "      if item.is_a?(Hash)",
+                "        result.merge!(flatten_query_params(item, full_key)) { |_k, old, new_val| [*old, *new_val].flatten }",
+                "      else",
+                "        (result[full_key] ||= []) << item",
+                "      end",
+                "    end",
+                "  else",
+                "    result[full_key] = value",
+                "  end",
+                "end",
+                "result"
+            ],
+            parameters: [hashParam, prefixParam],
+            returnValue: HashReference
+        });
+
+        super({
+            classReference: new ClassReference({
+                name: "QueryParamsUtils",
+                import_: new Import({ from: "core/query_params_utils", isExternal: false }),
+                moduleBreadcrumbs: [clientName]
+            }),
+            includeInitializer: false,
+            properties: [],
+            documentation: "Utility class for encoding query parameters with deep object support.",
+            functions: [flattenQueryParams]
+        });
+
+        this.flattenQueryParams = flattenQueryParams;
+    }
+}

--- a/generators/ruby/sdk/versions.yml
+++ b/generators/ruby/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 0.8.4
+  createdAt: "2026-01-26"
+  changelogEntry:
+    - type: feat
+      summary: >-
+        Add support for deep object query parameters. Nested objects are now
+        encoded using bracket notation (e.g., filter[name]=john&filter[age]=30).
+  irVersion: 39
+
 - version: 0.8.3
   createdAt: "2025-11-19"
   changelogEntry:


### PR DESCRIPTION
## Description

Refs: https://app.devin.ai/sessions/64b3914c128f4cfa957eaab189b9c426
Requested by: @iamnamananand996

Adds support for deep object query parameters to the Ruby SDK generator, following the same pattern as the PHP implementation. Nested objects are now encoded using bracket notation (e.g., `filter[name]=john&filter[age]=30`).

## Changes Made

- Added new `QueryParamsUtility` class that generates a Ruby utility with `flatten_query_params` method
- Modified `EndpointGenerator` to wrap query parameters with the flatten call before passing to Faraday
- Updated `AbstractionUtilities` and `ClientsGenerator` to thread the utility through the generation pipeline
- Added changelog entry for version 0.8.4

The generated Ruby utility handles:
- Simple nested objects: `{filter: {name: "john"}}` → `filter[name]=john`
- Deeply nested objects: `{filter: {user: {name: "john"}}}` → `filter[user][name]=john`
- Arrays (exploded format): `{tags: ["a", "b"]}` → `tags=a&tags=b`
- Arrays of objects: `{objects: [{key: "val"}]}` → `objects[key]=val`

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed (lint checks pass, TypeScript compiles)
- [x] CI checks passing

## Human Review Checklist

- [ ] Verify the Ruby code strings in `QueryParamsUtility.ts` (lines 42-62) are syntactically correct Ruby
- [ ] Verify the array of objects merge logic `{ |_k, old, new_val| [*old, *new_val].flatten }` handles edge cases correctly
- [ ] Confirm all `generateEndpoints` call sites have been updated with the new `queryParamsUtility` parameter
- [ ] Consider whether seed tests should be run to verify generated SDK output