### PR TITLE
fix(cli): fix broken-links validation failing for valid API configurations

### DIFF
--- a/packages/cli/cli/src/commands/validate/validateDocsBrokenLinks.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsBrokenLinks.ts
@@ -23,13 +23,14 @@ export async function validateDocsBrokenLinks({
 
     await cliContext.runTaskForWorkspace(docsWorkspace, async (context) => {
         const startTime = performance.now();
-        const fernWorkspaces = await Promise.all(
-            project.apiWorkspaces.map(async (workspace) => {
-                return workspace.toFernWorkspace({ context });
-            })
-        );
         const ossWorkspaces = await filterOssWorkspaces(project);
-        const violations = await validateDocsWorkspace(docsWorkspace, context, fernWorkspaces, ossWorkspaces, true);
+        const violations = await validateDocsWorkspace(
+            docsWorkspace,
+            context,
+            project.apiWorkspaces,
+            ossWorkspaces,
+            true
+        );
 
         const elapsedMillis = performance.now() - startTime;
         logViolations({

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -1212,21 +1212,15 @@ export class DocsDefinitionResolver {
         const snippetsConfig = convertDocsSnippetsConfigToFdr(item.snippetsConfiguration);
 
         let ir: IntermediateRepresentation | undefined = undefined;
-        const workspace = await this.getFernWorkspaceForApiSection(item).toFernWorkspace(
-            { context: this.taskContext },
-            {
-                enableUniqueErrorsPerEndpoint: true,
-                detectGlobalHeaders: false,
-                objectQueryParameters: true,
-                preserveSchemaIds: true
-            }
-        );
+        let workspace: FernWorkspace | undefined = undefined;
+        let openapiWorkspace: OSSWorkspace | undefined = undefined;
+        let openapiError: unknown = undefined;
         const openapiParserV3 = this.parsedDocsConfig.experimental?.openapiParserV3;
         const useV3Parser = openapiParserV3 == null || openapiParserV3;
         // The v3 parser is enabled on default. We attempt to load the OpenAPI workspace and generate an IR directly.
         if (useV3Parser) {
             try {
-                const openapiWorkspace = this.getOpenApiWorkspaceForApiSection(item);
+                openapiWorkspace = this.getOpenApiWorkspaceForApiSection(item);
                 ir = await openapiWorkspace.getIntermediateRepresentation({
                     context: this.taskContext,
                     audiences: item.audiences,
@@ -1235,7 +1229,7 @@ export class DocsDefinitionResolver {
                     logWarnings: false
                 });
             } catch (error) {
-                // noop
+                openapiError = error;
             }
         }
 
@@ -1243,8 +1237,8 @@ export class DocsDefinitionResolver {
         let openApiTags: Record<string, { id: string; description: string | undefined }> | undefined;
         if (item.tagDescriptionPages && useV3Parser) {
             try {
-                const openapiWorkspace = this.getOpenApiWorkspaceForApiSection(item);
-                const openApiIr = await openapiWorkspace.getOpenAPIIr({
+                const workspaceForTags = openapiWorkspace ?? this.getOpenApiWorkspaceForApiSection(item);
+                const openApiIr = await workspaceForTags.getOpenAPIIr({
                     context: this.taskContext,
                     loadAiExamples: true
                 });
@@ -1269,6 +1263,18 @@ export class DocsDefinitionResolver {
         }
         // This case runs if either the V3 parser is not enabled, or if we failed to load the OpenAPI workspace
         if (ir == null) {
+            if (this.apiWorkspaces.length === 0 && openapiError != null) {
+                throw openapiError;
+            }
+            workspace = await this.getFernWorkspaceForApiSection(item).toFernWorkspace(
+                { context: this.taskContext },
+                {
+                    enableUniqueErrorsPerEndpoint: true,
+                    detectGlobalHeaders: false,
+                    objectQueryParameters: true,
+                    preserveSchemaIds: true
+                }
+            );
             ir = generateIntermediateRepresentation({
                 workspace,
                 audiences: item.audiences,
@@ -1304,7 +1310,7 @@ export class DocsDefinitionResolver {
         // Use item.apiName (from api-name in docs.yml) if explicitly set,
         // otherwise fall back to the workspace's folder name for FDR registration.
         // This allows users to reference APIs by folder name in docs components like <Schema api="latest" />
-        const apiNameForRegistration = item.apiName ?? workspace.workspaceName;
+        const apiNameForRegistration = item.apiName ?? workspace?.workspaceName ?? openapiWorkspace?.workspaceName;
 
         const apiDefinitionId = await this.registerApi({
             ir,


### PR DESCRIPTION
## Description

Fixes `fern docs dev --broken-links` failing with "Failed to load API Definition" error for valid API configurations.

**Link to Devin run:** https://app.devin.ai/sessions/84a67e2dc3d843e397b39ffa76b9ecd8
**Requested by:** Sandeep Dinesh (@thesandlord)

## Changes Made

- Fixed `validateDocsBrokenLinks` to pass `project.apiWorkspaces` directly instead of converting them to `FernWorkspace[]` first
- Updated `DocsDefinitionResolver` to defer `toFernWorkspace()` conversion until actually needed
- Added support for OpenAPI-only workspaces in broken-link validation by properly handling cases where no Fern API workspaces exist
- Fixed `apiNameForRegistration` to fall back to `openapiWorkspace.workspaceName` when using OpenAPI-only workspaces

**Root cause:** The broken links validator was calling `toFernWorkspace()` on all API workspaces before passing them to `validateDocsWorkspace`. The `DocsDefinitionResolver` then tried to look up workspaces by name, but this lookup was failing because the conversion was unnecessary and potentially losing workspace metadata.

## Testing

- [ ] Manual testing completed
- [ ] Unit tests added/updated

## Human Review Checklist

- [ ] Verify the error handling logic: `openapiError` is only re-thrown when `this.apiWorkspaces.length === 0` - confirm this is the intended behavior
- [ ] Confirm that `workspace` being potentially `undefined` (when using OpenAPI-only workspaces) doesn't cause issues in downstream code that may reference it
- [ ] Check that the `apiNameForRegistration` fallback chain (`item.apiName ?? workspace?.workspaceName ?? openapiWorkspace?.workspaceName`) works correctly for all cases