### PR TITLE
feat(php): add Docker-in-Docker support for PHP seed tests

### DIFF
--- a/.github/workflows/seed-dockers.yml
+++ b/.github/workflows/seed-dockers.yml
@@ -29,8 +29,12 @@ on:
         description: Rebuild C# seed container
         type: boolean
         default: false
+      php:
+        description: Rebuild PHP seed container
+        type: boolean
+        default: false
 
-# Cancel previous workflows on previous push
+# Cancel previous workflowson previous push
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -46,6 +50,7 @@ jobs:
       java: ${{ steps.set-output.outputs.java }}
       python: ${{ steps.set-output.outputs.python }}
       csharp: ${{ steps.set-output.outputs.csharp }}
+      php: ${{ steps.set-output.outputs.php }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,6 +80,12 @@ jobs:
         with:
           files: docker/seed/Dockerfile.csharp
 
+      - name: Check for php changes
+        id: php
+        uses: ./.github/actions/check-for-changed-files
+        with:
+          files: docker/seed/Dockerfile.php
+
       - name: Check for workflow changes
         id: workflow
         uses: ./.github/actions/check-for-changed-files
@@ -91,12 +102,14 @@ jobs:
               echo "java=true" >> $GITHUB_OUTPUT
               echo "python=true" >> $GITHUB_OUTPUT
               echo "csharp=true" >> $GITHUB_OUTPUT
+              echo "php=true" >> $GITHUB_OUTPUT
               echo "Manual run: rebuilding all images"
             else
               echo "ts=${{ inputs.ts }}" >> $GITHUB_OUTPUT
               echo "java=${{ inputs.java }}" >> $GITHUB_OUTPUT
               echo "python=${{ inputs.python }}" >> $GITHUB_OUTPUT
               echo "csharp=${{ inputs.csharp }}" >> $GITHUB_OUTPUT
+              echo "php=${{ inputs.php }}" >> $GITHUB_OUTPUT
               echo "Manual run: selected images set from inputs"
             fi
           else
@@ -106,12 +119,14 @@ jobs:
               echo "java=true" >> $GITHUB_OUTPUT
               echo "python=true" >> $GITHUB_OUTPUT
               echo "csharp=true" >> $GITHUB_OUTPUT
+              echo "php=true" >> $GITHUB_OUTPUT
               echo "Workflow changed, rebuilding all images"
             else
               echo "ts=${{ steps.ts.outputs.any_changed }}" >> $GITHUB_OUTPUT
               echo "java=${{ steps.java.outputs.any_changed }}" >> $GITHUB_OUTPUT
               echo "python=${{ steps.python.outputs.any_changed }}" >> $GITHUB_OUTPUT
               echo "csharp=${{ steps.csharp.outputs.any_changed }}" >> $GITHUB_OUTPUT
+              echo "php=${{ steps.php.outputs.any_changed }}" >> $GITHUB_OUTPUT
               echo "Set outputs based on individual file changes"
             fi
           fi
@@ -322,9 +337,58 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  build-php:
+    if: ${{ needs.changes.outputs.php == 'true' }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        arch: [amd64, arm64]
+        exclude:
+          - runner: ubuntu-latest
+            arch: arm64
+          - runner: ubuntu-24.04-arm
+            arch: amd64
+    runs-on: ${{ matrix.runner }}
+    needs: [changes, generate-sha]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: fernapi/php-seed
+          tags: |
+            type=raw,value=${{ needs.generate-sha.outputs.sha }}-${{ matrix.arch }}
+            type=raw,value=latest-${{ matrix.arch }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: fernapi
+          password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/seed/Dockerfile.php
+          platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   merge-manifests:
-    if: ${{ !cancelled() && (needs.changes.outputs.ts == 'true' || needs.changes.outputs.java == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.csharp == 'true') }}
-    needs: [changes, build-ts, build-java, build-python, build-csharp, generate-sha]
+    if: ${{ !cancelled() && (needs.changes.outputs.ts == 'true' || needs.changes.outputs.java == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.csharp == 'true' || needs.changes.outputs.php == 'true') }}
+    needs: [changes, build-ts, build-java, build-python, build-csharp, build-php, generate-sha]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
@@ -351,6 +415,9 @@ jobs:
           fi
           if [[ "${{ needs.changes.outputs.csharp }}" == "true" ]]; then
             packages+="csharp "
+          fi
+          if [[ "${{ needs.changes.outputs.php }}" == "true" ]]; then
+            packages+="php "
           fi
           echo "packages=${packages% }" >> $GITHUB_OUTPUT
           echo "Building manifests for: ${packages% }"

--- a/.github/workflows/seed-dockers.yml
+++ b/.github/workflows/seed-dockers.yml
@@ -34,7 +34,7 @@ on:
         type: boolean
         default: false
 
-# Cancel previous workflowson previous push
+# Cancel previous workflows on previous push
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -1,0 +1,34 @@
+FROM docker:28.4.0-dind-alpine3.22
+
+# Install PHP, Composer, and required extensions
+RUN apk add --no-cache \
+    php83 \
+    php83-phar \
+    php83-mbstring \
+    php83-openssl \
+    php83-curl \
+    php83-json \
+    php83-dom \
+    php83-xml \
+    php83-xmlwriter \
+    php83-tokenizer \
+    php83-ctype \
+    php83-iconv \
+    php83-simplexml \
+    php83-fileinfo \
+    composer \
+    bash \
+    git
+
+# Create symlink for php command
+RUN ln -sf /usr/bin/php83 /usr/bin/php
+
+# Create entrypoint script to start dockerd and execute commands
+RUN echo '#!/bin/sh' > /entrypoint.sh && \
+    echo 'dockerd &' >> /entrypoint.sh && \
+    echo 'sleep 3' >> /entrypoint.sh && \
+    echo 'exec "$@"' >> /entrypoint.sh && \
+    chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["tail", "-f", "/dev/null"]

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -146,7 +146,7 @@ fixtures:
             analyze: echo skip
             hello: echo hello
 scripts:
-  - image: fernapi/php-seed
+  - image: composer:2.7.9
     commands:
       build:
         # Retry composer install up to 3 times to handle intermittent network failures
@@ -167,6 +167,9 @@ allowedFailures:
   # Generating a union called "Exception" makes our references to Exception throws be escaped incorrectly
   - examples:no-custom-config
   - examples:readme-config
+  # Wire tests require Docker-in-Docker support (fernapi/php-seed image)
+  # TODO: Remove after php-seed image is built and seed.yml is updated to use it
+  - exhaustive:wire-tests
   - trace
   - circular-references
   - circular-references-advanced

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -146,7 +146,7 @@ fixtures:
             analyze: echo skip
             hello: echo hello
 scripts:
-  - image: composer:2.7.9
+  - image: fernapi/php-seed
     commands:
       build:
         # Retry composer install up to 3 times to handle intermittent network failures
@@ -167,10 +167,6 @@ allowedFailures:
   # Generating a union called "Exception" makes our references to Exception throws be escaped incorrectly
   - examples:no-custom-config
   - examples:readme-config
-  # Enums don't support the fromJson method yet.
-  - exhaustive
-  # Wire tests have a bug where tests extend TestCase instead of WireMockTestCase
-  - exhaustive:wire-tests
   - trace
   - circular-references
   - circular-references-advanced


### PR DESCRIPTION
## Description

Refs: Requested by @jsklan

Link to Devin run: https://app.devin.ai/sessions/4c95ff73acf348cc9bbb44ca9203ebe3

This PR adds the infrastructure for Docker-in-Docker support for PHP seed tests. The wire tests require Docker to run WireMock containers, which isn't available in the `composer:2.7.9` image.

**Note: This is Step 1 of a two-step process:**
1. **This PR**: Add the Dockerfile and workflow to build `fernapi/php-seed` image. Keep using `composer:2.7.9` for now.
2. **Follow-up PR**: After the image is built and pushed to Docker Hub, switch `seed.yml` to use `fernapi/php-seed` and remove `exhaustive:wire-tests` from allowedFailures.

## Changes Made

- Added `docker/seed/Dockerfile.php` - A Docker-in-Docker image based on `docker:28.4.0-dind-alpine3.22` with PHP 8.3, Composer, and required extensions (following the pattern of `Dockerfile.python`)
- Updated `.github/workflows/seed-dockers.yml` to build and push the `fernapi/php-seed` image for both amd64 and arm64 architectures
- Updated `seed/php-sdk/seed.yml`:
  - Removed `exhaustive` from allowedFailures (it passes with current setup)
  - Kept `exhaustive:wire-tests` in allowedFailures with TODO comment (requires php-seed image)

## Updates Since Last Revision

- Fixed typo in seed-dockers.yml comment ("workflowson" → "workflows on")

## Testing

- [x] Built the Docker image locally and verified it works
- [x] Ran `node --enable-source-maps packages/seed/dist/cli.cjs test --generator php-sdk --fixture exhaustive` - `exhaustive:no-custom-config` passes, `exhaustive:wire-tests` requires the php-seed image

## Human Review Checklist

- [ ] Verify the two-step approach is acceptable (image must be built before it can be used in CI)
- [ ] Verify the Dockerfile.php follows the correct pattern (compare with Dockerfile.python)
- [ ] After merge, manually trigger the seed-dockers workflow or wait for next push to main to build the php-seed image