### PR TITLE
fix(cli): bump versions.yml for broken-links validation fix

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.51.1
+  changelogEntry:
+    - summary: |
+        Fix `fern docs dev --broken-links` failing with "Failed to load API Definition" error for valid API configurations. The broken links validator now properly handles OpenAPI-only workspaces.
+      type: fix
+  createdAt: "2026-01-26"
+  irVersion: 63
+
 - version: 3.51.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Bumps CLI versions.yml to document and release the fix from #11772.

**Link to Devin run:** https://app.devin.ai/sessions/3b253c3becd648c8b5db1b8b8667a199
**Requested by:** Sandeep Dinesh (@thesandlord)

## Changes Made

- Added version 3.51.1 changelog entry documenting the fix for `fern docs dev --broken-links` failing with "Failed to load API Definition" error for valid API configurations

## Testing

- [ ] N/A - changelog entry only

## Human Review Checklist

- [ ] Verify the changelog description accurately reflects the fix in #11772
- [ ] Confirm version bump (3.51.0 → 3.51.1) is appropriate for a bug fix