### PR TITLE
fix(python): run poetry lock instead of install after generation

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.54.1
+  changelogEntry:
+    - summary: |
+        Switch from `poetry install` to `poetry lock` after SDK generation. This performs dependency
+        resolution and saves the lockfile without installing packages, which avoids failures when
+        transitive dependencies require custom build tools.
+      type: fix
+  createdAt: "2026-01-29"
+  irVersion: 62
+
 - version: 4.54.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -189,11 +189,11 @@ class AbstractGenerator(ABC):
             publisher.run_ruff_check_fix("/fern/output", cwd="/")
             publisher.run_ruff_format("/fern/output", cwd="/")
         elif output_mode_union.type == "github":
-            publisher.run_poetry_install()
+            publisher.run_poetry_lock()
             publisher.run_ruff_check_fix()
             publisher.run_ruff_format()
         elif output_mode_union.type == "publish":
-            publisher.run_poetry_install()
+            publisher.run_poetry_lock()
             publisher.run_ruff_check_fix()
             publisher.run_ruff_format()
             publisher.publish_package(publish_config=output_mode_union)

--- a/generators/python/src/fern_python/cli/publisher.py
+++ b/generators/python/src/fern_python/cli/publisher.py
@@ -25,7 +25,7 @@ class Publisher:
 
     def run_ruff_check_fix(self, path: Optional[str] = None, *, cwd: Optional[str] = None) -> None:
         if self._should_fix:
-            command = ["poetry", "run", "ruff", "check", "--fix", "--no-cache", "--ignore", "E741"]
+            command = ["ruff", "check", "--fix", "--no-cache", "--ignore", "E741"]
             if path is not None:
                 command.append(path)
             self._run_command(
@@ -36,7 +36,7 @@ class Publisher:
 
     def run_ruff_format(self, path: Optional[str] = None, *, cwd: Optional[str] = None) -> None:
         if self._should_format:
-            command = ["poetry", "run", "ruff", "format", "--no-cache"]
+            command = ["ruff", "format", "--no-cache"]
             if path is not None:
                 command.append(path)
             self._run_command(
@@ -45,10 +45,10 @@ class Publisher:
                 cwd=cwd,
             )
 
-    def run_poetry_install(self) -> None:
+    def run_poetry_lock(self) -> None:
         self._run_command(
-            command=["poetry", "install"],
-            safe_command="poetry install",
+            command=["poetry", "lock"],
+            safe_command="poetry lock",
         )
 
     def publish_package(


### PR DESCRIPTION
Fix: Runs `poetry lock`, instead of `poetry install` after SDK generation. Thus, we avoid downloading the packages, and compiling any transitive dependencies that it may have.
Fixes FER-8437