### PR TITLE
feat(ruby): implement HTTP status code-based retry with exponential backoff

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
@@ -77,7 +77,7 @@ module <%= gem_namespace %>
         end
 
         # Calculates the delay before the next retry attempt using exponential backoff with jitter.
-        # Respects Retry-After and X-RateLimit-Reset headers if present.
+        # Respects Retry-After header if present.
         # @param response [Net::HTTPResponse] The HTTP response.
         # @param attempt [Integer] The current retry attempt (0-indexed).
         # @return [Float] The delay in seconds before the next retry.
@@ -89,13 +89,6 @@ module <%= gem_namespace %>
             return [delay, MAX_RETRY_DELAY].min if delay&.positive?
           end
 
-          # Check for X-RateLimit-Reset header (Unix timestamp)
-          rate_limit_reset = response["X-RateLimit-Reset"]
-          if rate_limit_reset
-            reset_time = rate_limit_reset.to_i
-            delay = reset_time - Time.now.to_i
-            return add_jitter([delay, MAX_RETRY_DELAY].min) if delay.positive?
-          end
 
           # Exponential backoff with jitter: base_delay * 2^attempt
           base_delay = INITIAL_RETRY_DELAY * (2**attempt)

--- a/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
@@ -5,6 +5,15 @@ module <%= gem_namespace %>
     module Http
       # @api private
       class RawClient
+        # Default HTTP status codes that trigger a retry
+        RETRYABLE_STATUSES = [408, 429, 500, 502, 503, 504, 521, 522, 524].freeze
+        # Initial delay between retries in seconds
+        INITIAL_RETRY_DELAY = 0.5
+        # Maximum delay between retries in seconds
+        MAX_RETRY_DELAY = 60.0
+        # Jitter factor for randomizing retry delays (20%)
+        JITTER_FACTOR = 0.2
+
         # @return [String] The base URL for requests
         attr_reader :base_url
 
@@ -27,21 +36,96 @@ module <%= gem_namespace %>
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          attempt = 0
+          response = nil
 
-          http_request = build_http_request(
-            url:,
-            method: request.method,
-            headers: request.encode_headers,
-            body: request.encode_body
-          )
+          loop do
+            http_request = build_http_request(
+              url:,
+              method: request.method,
+              headers: request.encode_headers,
+              body: request.encode_body
+            )
 
-          conn = connect(url)
-          conn.open_timeout = @timeout
-          conn.read_timeout = @timeout
-          conn.write_timeout = @timeout
-          conn.continue_timeout = @timeout
+            conn = connect(url)
+            conn.open_timeout = @timeout
+            conn.read_timeout = @timeout
+            conn.write_timeout = @timeout
+            conn.continue_timeout = @timeout
 
-          conn.request(http_request)
+            response = conn.request(http_request)
+
+            break unless should_retry?(response, attempt)
+
+            delay = retry_delay(response, attempt)
+            sleep(delay)
+            attempt += 1
+          end
+
+          response
+        end
+
+        # Determines if a request should be retried based on the response status code.
+        # @param response [Net::HTTPResponse] The HTTP response.
+        # @param attempt [Integer] The current retry attempt (0-indexed).
+        # @return [Boolean] Whether the request should be retried.
+        def should_retry?(response, attempt)
+          return false if attempt >= @max_retries
+
+          status = response.code.to_i
+          RETRYABLE_STATUSES.include?(status)
+        end
+
+        # Calculates the delay before the next retry attempt using exponential backoff with jitter.
+        # Respects Retry-After and X-RateLimit-Reset headers if present.
+        # @param response [Net::HTTPResponse] The HTTP response.
+        # @param attempt [Integer] The current retry attempt (0-indexed).
+        # @return [Float] The delay in seconds before the next retry.
+        def retry_delay(response, attempt)
+          # Check for Retry-After header (can be seconds or HTTP date)
+          retry_after = response["Retry-After"]
+          if retry_after
+            delay = parse_retry_after(retry_after)
+            return [delay, MAX_RETRY_DELAY].min if delay&.positive?
+          end
+
+          # Check for X-RateLimit-Reset header (Unix timestamp)
+          rate_limit_reset = response["X-RateLimit-Reset"]
+          if rate_limit_reset
+            reset_time = rate_limit_reset.to_i
+            delay = reset_time - Time.now.to_i
+            return add_jitter([delay, MAX_RETRY_DELAY].min) if delay.positive?
+          end
+
+          # Exponential backoff with jitter: base_delay * 2^attempt
+          base_delay = INITIAL_RETRY_DELAY * (2**attempt)
+          add_jitter([base_delay, MAX_RETRY_DELAY].min)
+        end
+
+        # Parses the Retry-After header value.
+        # @param value [String] The Retry-After header value (seconds or HTTP date).
+        # @return [Float, nil] The delay in seconds, or nil if parsing fails.
+        def parse_retry_after(value)
+          # Try parsing as integer (seconds)
+          seconds = Integer(value, exception: false)
+          return seconds.to_f if seconds
+
+          # Try parsing as HTTP date
+          begin
+            retry_time = Time.httpdate(value)
+            delay = retry_time - Time.now
+            delay.positive? ? delay : nil
+          rescue ArgumentError
+            nil
+          end
+        end
+
+        # Adds random jitter to a delay value.
+        # @param delay [Float] The base delay in seconds.
+        # @return [Float] The delay with jitter applied.
+        def add_jitter(delay)
+          jitter = delay * JITTER_FACTOR * (rand - 0.5) * 2
+          [delay + jitter, 0].max
         end
 
         # @param request [<%= gem_namespace %>::Internal::Http::BaseRequest] The HTTP request.
@@ -104,7 +188,9 @@ module <%= gem_namespace %>
 
           http = Net::HTTP.new(url.host, port)
           http.use_ssl = is_https
-          http.max_retries = @max_retries
+          # Note: We handle retries at the application level with HTTP status code awareness,
+          # so we set max_retries to 0 to disable Net::HTTP's built-in network-level retries.
+          http.max_retries = 0
           http
         end
 
@@ -115,4 +201,4 @@ module <%= gem_namespace %>
       end
     end
   end
-end                                                                
+end                                                                                                                                                                                                                                                                

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -5,8 +5,8 @@
     - summary: |
         Implement HTTP status code-based retry logic with exponential backoff. The SDK now automatically
         retries requests that fail with retryable HTTP status codes (408, 429, 500, 502, 503, 504, 521,
-        522, 524) using exponential backoff with jitter. The retry logic respects Retry-After and
-        X-RateLimit-Reset headers when present. This addresses the feature gap where the SDK previously
+        522, 524) using exponential backoff with jitter. The retry logic respects Retry-After
+        headers when present. This addresses the feature gap where the SDK previously
         only used Net::HTTP's network-level retries, which don't handle HTTP status codes like 429
         (Too Many Requests). The max_retries parameter now controls application-level retries with
         proper backoff, enabling compliance with rate-limiting requirements like Square App Marketplace.

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,19 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc82
+  changelogEntry:
+    - summary: |
+        Implement HTTP status code-based retry logic with exponential backoff. The SDK now automatically
+        retries requests that fail with retryable HTTP status codes (408, 429, 500, 502, 503, 504, 521,
+        522, 524) using exponential backoff with jitter. The retry logic respects Retry-After and
+        X-RateLimit-Reset headers when present. This addresses the feature gap where the SDK previously
+        only used Net::HTTP's network-level retries, which don't handle HTTP status codes like 429
+        (Too Many Requests). The max_retries parameter now controls application-level retries with
+        proper backoff, enabling compliance with rate-limiting requirements like Square App Marketplace.
+      type: feat
+  createdAt: "2026-01-27"
+  irVersion: 61
+
 - version: 1.0.0-rc81
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: User-reported issue requesting exponential backoff retry logic for HTTP status codes (specifically 429 rate limit errors) to meet Square App Marketplace listing requirements.

Link to Devin run: https://app.devin.ai/sessions/5d7e9bfc387248cc89098c2b349cea6b
Requested by: @jsklan

This PR implements application-level retry logic with exponential backoff in the Ruby v2 SDK generator's RawClient, addressing a feature gap where the SDK previously only used Net::HTTP's network-level retries (which don't handle HTTP status codes like 429).

**Update**: Removed support for the non-standard X-RateLimit-Reset header as it has inconsistent unit implementations across different APIs, making it unreliable for retry timing.

## Changes Made

- Added retry loop in `RawClient.send` method that retries on specific HTTP status codes
- Implemented exponential backoff with 20% jitter to prevent thundering herd
- Added support for `Retry-After` header (both seconds and HTTP date formats)
- ~~Added support for `X-RateLimit-Reset` header (Unix timestamp)~~ **Removed - non-standard header with inconsistent implementations**
- Retryable status codes: `[408, 429, 500, 502, 503, 504, 521, 522, 524]` (matches legacy SDK)
- Constants: `INITIAL_RETRY_DELAY = 0.5s`, `MAX_RETRY_DELAY = 60s`, `JITTER_FACTOR = 0.2`
- Disabled Net::HTTP's built-in `max_retries` (set to 0) since we now handle retries at application level
- Updated `versions.yml` with changelog entry for v1.0.0-rc82 (updated to reflect X-RateLimit-Reset removal)

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [x] Project compiles successfully
- [ ] Unit tests added/updated (not added - Ruby v2 generator seed tests are in allowedFailures)
- [x] Manual code review of retry logic
- [x] Verified retry behavior with only standard Retry-After header support

## Human Review Checklist

- [ ] Verify retry status codes match requirements (legacy SDK compatibility)
- [ ] Review decision to disable `Net::HTTP.max_retries` - this means network-level failures (connection timeouts) won't be retried by Net::HTTP anymore, only by our application-level logic which checks HTTP status codes
- [ ] Verify jitter calculation produces expected range (±20% of delay)
- [ ] Consider if the `Retry-After` header parsing handles edge cases correctly
- [ ] Confirm removal of X-RateLimit-Reset header is appropriate (non-standard, inconsistent units)