### PR TITLE
fix(cli): normalize path separators to forward slashes on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
 
   generate-docs-test-windows:
     environment: Fern Dev
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' }}
+    if: github.repository == 'fern-api/fern'
     runs-on: windows-latest
     steps:
       - name: Checkout repo

--- a/packages/commons/fs-utils/src/dirname.ts
+++ b/packages/commons/fs-utils/src/dirname.ts
@@ -1,10 +1,12 @@
 import path from "path";
 
 import { AbsoluteFilePath } from "./AbsoluteFilePath";
+import { convertToOsPath } from "./osPathConverter";
 import { RelativeFilePath } from "./RelativeFilePath";
 
 export function dirname(filepath: RelativeFilePath): RelativeFilePath;
 export function dirname(filepath: AbsoluteFilePath): AbsoluteFilePath;
 export function dirname(filepath: string): string {
-    return path.dirname(filepath);
+    // Normalize output to use forward slashes for cross-platform consistency
+    return convertToOsPath(path.dirname(filepath));
 }

--- a/packages/commons/fs-utils/src/join.ts
+++ b/packages/commons/fs-utils/src/join.ts
@@ -1,11 +1,13 @@
 import path from "path";
 
 import { AbsoluteFilePath } from "./AbsoluteFilePath";
+import { convertToOsPath } from "./osPathConverter";
 import { RelativeFilePath } from "./RelativeFilePath";
 
 export function join(first: RelativeFilePath, ...parts: RelativeFilePath[]): RelativeFilePath;
 export function join(first: AbsoluteFilePath, ...parts: RelativeFilePath[]): AbsoluteFilePath;
 export function join(...parts: RelativeFilePath[]): RelativeFilePath;
 export function join(...parts: string[]): string {
-    return path.join(...parts);
+    // Normalize output to use forward slashes for cross-platform consistency
+    return convertToOsPath(path.join(...parts));
 }

--- a/packages/commons/fs-utils/src/resolve.ts
+++ b/packages/commons/fs-utils/src/resolve.ts
@@ -5,5 +5,6 @@ import { convertToOsPath } from "./osPathConverter";
 
 export function resolve(first: AbsoluteFilePath, ...rest: string[]): AbsoluteFilePath;
 export function resolve(...paths: string[]): string {
-    return path.resolve(...paths.map(convertToOsPath));
+    // Normalize both inputs and output to use forward slashes for cross-platform consistency
+    return convertToOsPath(path.resolve(...paths.map(convertToOsPath)));
 }

--- a/windows/fern/docs/assets/images/test-image.svg
+++ b/windows/fern/docs/assets/images/test-image.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#4A90E2"/><text x="50" y="55" text-anchor="middle" fill="white" font-size="14">Test</text></svg>

--- a/windows/fern/docs/pages/intro.mdx
+++ b/windows/fern/docs/pages/intro.mdx
@@ -4,6 +4,14 @@ slug: intro
 
 Welcome to Pied Piper's Enterprise API Platform Documentation. This comprehensive documentation portal provides detailed technical specifications and implementation guides for our enterprise-grade APIs and webhook integrations across our complete product portfolio.
 
+## Test Image
+
+This image tests that paths are correctly resolved on Windows:
+
+![Test Image](/docs/assets/images/test-image.svg)
+
+<img src="/docs/assets/images/test-image.svg" alt="Test Image HTML" />
+
 Our robust API ecosystem enables seamless enterprise system integration, offering programmatic access to our full suite of business solutions. We maintain a continuous development cycle, regularly enhancing our API capabilities to meet evolving enterprise requirements and industry standards.
 
 For enterprise architects and development teams utilizing API development tools such as Postman, we provide our complete API specification in OpenAPI format:


### PR DESCRIPTION
## Description

Refs: https://buildwithfern.slack.com/archives/C09MPC09FUL/p1769461601587929

Fixes an issue where `fern generate --docs` on Windows machines produces image paths with Windows absolute paths (e.g., `C:\Users\devon\...`) that appear in generated HTML/markdown, causing images to fail to load in both local dev and deploy previews.

## Changes Made

- Modified `dirname()`, `join()`, and `resolve()` functions in `@fern-api/fs-utils` to normalize their output to use forward slashes
- This ensures cross-platform consistency since Node.js path functions return backslashes on Windows
- Enabled `generate-docs-test-windows` CI job to run on PRs (previously only ran on main branch)
- Added test image to Windows fixture to verify image path resolution with both markdown and HTML img tag syntax

The fix applies `convertToOsPath()` (which converts `\` to `/`) to the output of these path manipulation functions, matching the existing behavior of `AbsoluteFilePath.of()` and `RelativeFilePath.of()`.

## Testing

- [x] Existing unit tests pass (10 tests in fs-utils, 147 tests in docs-markdown-utils)
- [x] Windows CI job (`generate-docs-test-windows`) will now run on this PR to validate the fix
- [ ] Manual testing on Windows machine (not available in dev environment)

## Human Review Checklist

- [ ] Verify the Windows CI job passes (this will confirm the fix works on Windows)
- [ ] Consider if there are other path functions that might need similar treatment
- [ ] Confirm forward slashes work correctly on Windows (they should - Node.js accepts them)

---

Link to Devin run: https://app.devin.ai/sessions/e3e7f08157a04186931595d467a1e519
Requested by: @thesandlord (Sandeep Dinesh)