### PR TITLE
feat(php): switch to fernapi/php-seed image for wire tests

### DIFF
--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -146,7 +146,7 @@ fixtures:
             analyze: echo skip
             hello: echo hello
 scripts:
-  - image: composer:2.7.9
+  - image: fernapi/php-seed
     commands:
       build:
         # Retry composer install up to 3 times to handle intermittent network failures
@@ -167,9 +167,6 @@ allowedFailures:
   # Generating a union called "Exception" makes our references to Exception throws be escaped incorrectly
   - examples:no-custom-config
   - examples:readme-config
-  # Wire tests require Docker-in-Docker support (fernapi/php-seed image)
-  # TODO: Remove after php-seed image is built and seed.yml is updated to use it
-  - exhaustive:wire-tests
   - trace
   - circular-references
   - circular-references-advanced


### PR DESCRIPTION
## Description

Refs: #11778
Requested by @jsklan

Link to Devin run: https://app.devin.ai/sessions/4204d1a51d914df48ba3664351fb9577

This is the follow-up PR to #11778. Now that the `fernapi/php-seed` Docker image has been built and pushed to DockerHub, this PR switches the PHP seed tests to use it and removes `exhaustive:wire-tests` from the allowed failures list.

## Changes Made

- Changed scripts image from `composer:2.7.9` to `fernapi/php-seed` (which includes Docker-in-Docker support for running WireMock containers)
- Removed `exhaustive:wire-tests` from `allowedFailures` since it should now pass with the new image

## Testing

- [x] Verified `fernapi/php-seed:latest` image exists on DockerHub
- [ ] CI will validate that `exhaustive:wire-tests` passes with the new image

## Human Review Checklist

- [ ] Watch CI to confirm `exhaustive:wire-tests` passes (if it fails, we may need to investigate the php-seed image)