### PR TITLE
fix(cli): use OVERRIDE_FDR_ORIGIN for air-gap detection in self-hosted environments

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.51.3
+  changelogEntry:
+    - summary: |
+        Fix air-gap detection to use `OVERRIDE_FDR_ORIGIN` when set. In self-hosted environments, the air-gap detection now correctly checks the local FDR server (e.g., `http://localhost:8080/health`) instead of the external registry. Also improved debug logging for all air-gap checks to show the URL being tested and the result.
+      type: fix
+  createdAt: "2026-01-27"
+  irVersion: 63
+
 - version: 3.51.2
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -79,8 +79,14 @@ export async function publishDocs({
     excludeApis?: boolean;
     targetAudiences?: string[];
 }): Promise<void> {
-    const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
-    const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
+    const fdrOrigin =
+        process.env.OVERRIDE_FDR_ORIGIN ?? process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
+    const airGapCheckUrl = `${fdrOrigin}/health`;
+    context.logger.debug(`Checking air-gapped mode against FDR: ${airGapCheckUrl}`);
+    const isAirGapped = await detectAirGappedMode(airGapCheckUrl, context.logger);
+    context.logger.debug(
+        `Air-gap detection result for FDR (${airGapCheckUrl}): ${isAirGapped ? "air-gapped" : "connected"}`
+    );
     if (isAirGapped) {
         context.logger.debug("Detected air-gapped environment - skipping external FDR service calls");
     }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -54,8 +54,14 @@ export async function runRemoteGenerationForGenerator({
 }): Promise<RemoteTaskHandler.Response | undefined> {
     const fdr = createFdrService({ token: token.value });
 
-    const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
-    const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, interactiveTaskContext.logger);
+    const fdrOrigin =
+        process.env.OVERRIDE_FDR_ORIGIN ?? process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
+    const airGapCheckUrl = `${fdrOrigin}/health`;
+    interactiveTaskContext.logger.debug(`Checking air-gapped mode against FDR: ${airGapCheckUrl}`);
+    const isAirGapped = await detectAirGappedMode(airGapCheckUrl, interactiveTaskContext.logger);
+    interactiveTaskContext.logger.debug(
+        `Air-gap detection result for FDR (${airGapCheckUrl}): ${isAirGapped ? "air-gapped" : "connected"}`
+    );
 
     const packageName = generatorsYml.getPackageName({ generatorInvocation });
 

--- a/packages/cli/register/src/ai-example-enhancer/lambdaClient.ts
+++ b/packages/cli/register/src/ai-example-enhancer/lambdaClient.ts
@@ -62,25 +62,31 @@ export class LambdaExampleEnhancer {
             return this.venusAirGappedResult;
         }
 
-        this.context.logger.debug(`Checking Venus connectivity at ${this.venusOrigin}/health`);
+        const venusHealthUrl = `${this.venusOrigin}/health`;
+        this.context.logger.debug(`Checking air-gapped mode against Venus: ${venusHealthUrl}`);
 
         try {
-            await fetch(`${this.venusOrigin}/health`, {
+            await fetch(venusHealthUrl, {
                 method: "GET",
                 signal: AbortSignal.timeout(5000) // 5 second timeout
             });
             this.venusAirGappedResult = false;
-            this.context.logger.debug("Venus connectivity check succeeded");
+            this.context.logger.debug(`Air-gap detection result for Venus (${venusHealthUrl}): connected`);
             return false;
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             if (isNetworkError(errorMessage)) {
                 this.venusAirGappedResult = true;
-                this.context.logger.debug(`Venus connectivity check failed - air-gapped mode: ${errorMessage}`);
+                this.context.logger.debug(
+                    `Air-gap detection result for Venus (${venusHealthUrl}): air-gapped (${errorMessage})`
+                );
                 return true;
             }
             // Non-network error - assume not air-gapped
             this.venusAirGappedResult = false;
+            this.context.logger.debug(
+                `Air-gap detection result for Venus (${venusHealthUrl}): connected (non-network error)`
+            );
             return false;
         }
     }

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
@@ -46,7 +46,7 @@ export async function detectAirGappedMode(url: string, logger: Logger, timeoutMs
 }
 
 async function performAirGapDetection(url: string, logger: Logger, timeoutMs: number): Promise<boolean> {
-    logger.debug(`Detecting air-gapped mode by checking connectivity to ${url}`);
+    logger.debug(`Checking air-gapped mode: ${url} (timeout: ${timeoutMs}ms)`);
 
     try {
         await fetch(url, {
@@ -55,16 +55,17 @@ async function performAirGapDetection(url: string, logger: Logger, timeoutMs: nu
         });
 
         airGapDetectionResult = false;
-        logger.debug("Network check succeeded - not in air-gapped mode");
+        logger.debug(`Air-gap detection result (${url}): connected`);
         return false;
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         if (isNetworkError(errorMessage)) {
             airGapDetectionResult = true;
-            logger.debug(`Network check failed - entering air-gapped mode: ${errorMessage}`);
+            logger.debug(`Air-gap detection result (${url}): air-gapped (${errorMessage})`);
             return true;
         }
         airGapDetectionResult = false;
+        logger.debug(`Air-gap detection result (${url}): connected (non-network error: ${errorMessage})`);
         return false;
     }
 }


### PR DESCRIPTION
## Description

Refs: Slack thread from @thesandlord about `fern generate --docs` stalling in air-gapped environments

Link to Devin run: https://app.devin.ai/sessions/dcec6a094378444b94e7253cc9c06cf4
Requested by: Sandeep Dinesh (@thesandlord)

In self-hosted environments, the air-gap detection was checking connectivity to `https://registry.buildwithfern.com/health` (from `DEFAULT_FDR_ORIGIN`) instead of the local FDR server at `http://localhost:8080/health` (from `OVERRIDE_FDR_ORIGIN`). This caused the CLI to incorrectly detect air-gapped mode even when the local FDR server was reachable.

The FDR client already respects `OVERRIDE_FDR_ORIGIN`, but the air-gap detection did not.

## Changes Made

- Updated `publishDocs.ts` and `runRemoteGenerationForGenerator.ts` to use `OVERRIDE_FDR_ORIGIN ?? DEFAULT_FDR_ORIGIN` for air-gap detection, matching the FDR client behavior
- Improved debug logging for all air-gap checks to show:
  - The URL being tested
  - The timeout value
  - The result (connected/air-gapped) with error details when applicable
- Added changelog entry for version 3.51.3

## Testing

- [ ] Manual testing in air-gapped environment (requires self-hosted deployment)
- [x] Lint checks pass

## Human Review Checklist

- [ ] Verify the environment variable precedence (`OVERRIDE_FDR_ORIGIN ?? DEFAULT_FDR_ORIGIN ?? fallback`) is correct
- [ ] Confirm no other files need this fix (searched for `DEFAULT_FDR_ORIGIN` usage in air-gap detection)