### PR TITLE
fix(python): avoid parsing binary websocket messages as JSON

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.51.3
+  changelogEntry:
+    - summary: |
+        Fix WebSocket methods and iterators to avoid parsing binary messages as JSON.
+      type: fix
+  createdAt: "2026-01-27"
+  irVersion: 62
 
 - version: 4.51.2
   changelogEntry:

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/empty/empty_realtime/socket_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/empty/empty_realtime/socket_client.py
@@ -24,7 +24,10 @@ class AsyncEmptyRealtimeSocketClient(EventEmitterMixin):
 
     async def __aiter__(self):
         async for message in self._websocket:
-            yield parse_obj_as(EmptyRealtimeSocketClientResponse, json.loads(message))  # type: ignore
+            if isinstance(message, bytes):
+                yield message
+            else:
+                yield parse_obj_as(EmptyRealtimeSocketClientResponse, json.loads(message))  # type: ignore
 
     async def start_listening(self):
         """
@@ -39,8 +42,11 @@ class AsyncEmptyRealtimeSocketClient(EventEmitterMixin):
         await self._emit_async(EventType.OPEN, None)
         try:
             async for raw_message in self._websocket:
-                json_data = json.loads(raw_message)
-                parsed = parse_obj_as(EmptyRealtimeSocketClientResponse, json_data)  # type: ignore
+                if isinstance(raw_message, bytes):
+                    parsed = raw_message
+                else:
+                    json_data = json.loads(raw_message)
+                    parsed = parse_obj_as(EmptyRealtimeSocketClientResponse, json_data)  # type: ignore
                 await self._emit_async(EventType.MESSAGE, parsed)
         except (websockets.WebSocketException, JSONDecodeError) as exc:
             await self._emit_async(EventType.ERROR, exc)
@@ -52,6 +58,8 @@ class AsyncEmptyRealtimeSocketClient(EventEmitterMixin):
         Receive a message from the websocket connection.
         """
         data = await self._websocket.recv()
+        if isinstance(data, bytes):
+            return data  # type: ignore
         json_data = json.loads(data)
         return parse_obj_as(EmptyRealtimeSocketClientResponse, json_data)  # type: ignore
 
@@ -77,7 +85,10 @@ class EmptyRealtimeSocketClient(EventEmitterMixin):
 
     def __iter__(self):
         for message in self._websocket:
-            yield parse_obj_as(EmptyRealtimeSocketClientResponse, json.loads(message))  # type: ignore
+            if isinstance(message, bytes):
+                yield message
+            else:
+                yield parse_obj_as(EmptyRealtimeSocketClientResponse, json.loads(message))  # type: ignore
 
     def start_listening(self):
         """
@@ -92,8 +103,11 @@ class EmptyRealtimeSocketClient(EventEmitterMixin):
         self._emit(EventType.OPEN, None)
         try:
             for raw_message in self._websocket:
-                json_data = json.loads(raw_message)
-                parsed = parse_obj_as(EmptyRealtimeSocketClientResponse, json_data)  # type: ignore
+                if isinstance(raw_message, bytes):
+                    parsed = raw_message
+                else:
+                    json_data = json.loads(raw_message)
+                    parsed = parse_obj_as(EmptyRealtimeSocketClientResponse, json_data)  # type: ignore
                 self._emit(EventType.MESSAGE, parsed)
         except (websockets.WebSocketException, JSONDecodeError) as exc:
             self._emit(EventType.ERROR, exc)
@@ -105,6 +119,8 @@ class EmptyRealtimeSocketClient(EventEmitterMixin):
         Receive a message from the websocket connection.
         """
         data = self._websocket.recv()
+        if isinstance(data, bytes):
+            return data  # type: ignore
         json_data = json.loads(data)
         return parse_obj_as(EmptyRealtimeSocketClientResponse, json_data)  # type: ignore
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/socket_client.py
@@ -31,7 +31,10 @@ class AsyncRealtimeSocketClient(EventEmitterMixin):
 
     async def __aiter__(self):
         async for message in self._websocket:
-            yield parse_obj_as(RealtimeSocketClientResponse, json.loads(message))  # type: ignore
+            if isinstance(message, bytes):
+                yield message
+            else:
+                yield parse_obj_as(RealtimeSocketClientResponse, json.loads(message))  # type: ignore
 
     async def start_listening(self):
         """
@@ -46,8 +49,11 @@ class AsyncRealtimeSocketClient(EventEmitterMixin):
         await self._emit_async(EventType.OPEN, None)
         try:
             async for raw_message in self._websocket:
-                json_data = json.loads(raw_message)
-                parsed = parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
+                if isinstance(raw_message, bytes):
+                    parsed = raw_message
+                else:
+                    json_data = json.loads(raw_message)
+                    parsed = parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
                 await self._emit_async(EventType.MESSAGE, parsed)
         except (websockets.WebSocketException, JSONDecodeError) as exc:
             await self._emit_async(EventType.ERROR, exc)
@@ -80,6 +86,8 @@ class AsyncRealtimeSocketClient(EventEmitterMixin):
         Receive a message from the websocket connection.
         """
         data = await self._websocket.recv()
+        if isinstance(data, bytes):
+            return data  # type: ignore
         json_data = json.loads(data)
         return parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
 
@@ -105,7 +113,10 @@ class RealtimeSocketClient(EventEmitterMixin):
 
     def __iter__(self):
         for message in self._websocket:
-            yield parse_obj_as(RealtimeSocketClientResponse, json.loads(message))  # type: ignore
+            if isinstance(message, bytes):
+                yield message
+            else:
+                yield parse_obj_as(RealtimeSocketClientResponse, json.loads(message))  # type: ignore
 
     def start_listening(self):
         """
@@ -120,8 +131,11 @@ class RealtimeSocketClient(EventEmitterMixin):
         self._emit(EventType.OPEN, None)
         try:
             for raw_message in self._websocket:
-                json_data = json.loads(raw_message)
-                parsed = parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
+                if isinstance(raw_message, bytes):
+                    parsed = raw_message
+                else:
+                    json_data = json.loads(raw_message)
+                    parsed = parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
                 self._emit(EventType.MESSAGE, parsed)
         except (websockets.WebSocketException, JSONDecodeError) as exc:
             self._emit(EventType.ERROR, exc)
@@ -154,6 +168,8 @@ class RealtimeSocketClient(EventEmitterMixin):
         Receive a message from the websocket connection.
         """
         data = self._websocket.recv()
+        if isinstance(data, bytes):
+            return data  # type: ignore
         json_data = json.loads(data)
         return parse_obj_as(RealtimeSocketClientResponse, json_data)  # type: ignore
 


### PR DESCRIPTION
## Description
Various parts of socket clients would throw parsing errors if they received binary messages as input; this PR returns those messages early instead of trying to parse them as JSON.
```py
async def __aiter__(self):
        async for message in self._websocket:
            if isinstance(message, bytes):  # NEW
                yield message  # NEW
            else:
                yield parse_obj_as(V1SocketClientResponse, json.loads(message))  # type: ignore
```

## Changes Made
Just to the websocket part of the Python generator.

## Testing
Changes reflect on the `websocket` fixture.
- [X] Unit tests added/updated
- [X] Manual testing completed
