### PR TITLE
feat(cli): Update 'v2' sub-command to 'beta'

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -206,7 +206,7 @@ async function tryRunCli(cliContext: CliContext) {
     addWriteDocsDefinitionCommand(cli, cliContext);
     addWriteTranslationCommand(cli, cliContext);
     addExportCommand(cli, cliContext);
-    addV2Command(cli, cliContext);
+    addBetaCommand(cli, cliContext);
 
     // CLI V2 Sanctioned Commands
     addGetOrganizationCommand(cli, cliContext);
@@ -1821,9 +1821,9 @@ function addExportCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
     );
 }
 
-function addV2Command(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
+function addBetaCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
     cli.command(
-        "v2",
+        "beta",
         false, // Hidden from --help while in-development.
         (yargs) =>
             yargs.help(false).version(false).strict(false).parserConfiguration({

--- a/packages/cli/ete-tests/src/tests/v2/v2.test.ts
+++ b/packages/cli/ete-tests/src/tests/v2/v2.test.ts
@@ -23,13 +23,13 @@ sdks:
 
 const INVALID_FERN_YML = `org: 12345`;
 
-describe("fern v2", () => {
+describe("fern beta", () => {
     it("fern check (success)", async () => {
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
         await writeFile(join(tmpDir.path, "fern.yml"), VALID_FERN_YML);
 
-        const { stdout } = await runFernCli(["v2", "check"], {
+        const { stdout } = await runFernCli(["beta", "check"], {
             cwd: directory
         });
         expect(stdout).to.be.empty;
@@ -40,7 +40,7 @@ describe("fern v2", () => {
         const directory = AbsoluteFilePath.of(tmpDir.path);
         await writeFile(join(tmpDir.path, "fern.yml"), INVALID_FERN_YML);
 
-        const { stdout, stderr, exitCode } = await runFernCli(["v2", "check"], {
+        const { stdout, stderr, exitCode } = await runFernCli(["beta", "check"], {
             cwd: directory,
             reject: false
         });


### PR DESCRIPTION
## Description

This updates the hidden `v2` sub-command to be called `beta` -- this will be more clear for users that onboard to the new CLI commands before it goes live.

```sh
$ fern beta --help
fern <command>

Commands:
  fern auth <command>  Authenticate fern
  fern check           Validate your API, docs, and SDK configuration
  fern sdk <command>   Configure and generate SDKs

Options:
  --help       Show help                                               [boolean]
  --version    Show version number                                     [boolean]
  --log-level  Set log level
          [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
```

## Changes Made
- Update `v2` sub-command to `beta`.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
