### PR TITLE
feat(internal): Tag 'latest' for all generator images

### DIFF
--- a/packages/seed/src/commands/publish/publishGenerator.ts
+++ b/packages/seed/src/commands/publish/publishGenerator.ts
@@ -93,12 +93,16 @@ async function buildAndPushContainerImage(
         input: dockerHubPassword
     });
 
-    const aliases = [containerConfig.image, ...(containerConfig.aliases ?? [])].map((alias) => `${alias}:${version}`);
-    const tagArgs = aliases.map((imageTag) => ["-t", imageTag]).flat();
-    context.logger.debug(`Pushing container image ${aliases[0]} using docker...`);
-    if (aliases.length > 1) {
-        context.logger.debug(`Also tagging with aliases: ${aliases.slice(1).join(", ")}`);
+    const images = [containerConfig.image, ...(containerConfig.aliases ?? [])];
+    const versionTags = images.map((image) => `${image}:${version}`);
+    const latestTags = images.map((image) => `${image}:latest`);
+    const allTags = [...versionTags, ...latestTags];
+    const tagArgs = allTags.map((imageTag) => ["-t", imageTag]).flat();
+    context.logger.debug(`Pushing container images ${allTags[0]} using docker...`);
+    if (images.length > 1) {
+        context.logger.debug(`Also tagging with aliases: ${images.slice(1).join(", ")}`);
     }
+    context.logger.debug(`Also tagging as latest: ${latestTags.join(", ")}`);
     const standardBuildOptions = [
         "build",
         "--push",


### PR DESCRIPTION
## Description

This updates our generator publish job to update the `:latest` tag every time we release a new generator version. This will allow users to always use the latest version of a generator without explicitly setting it. This feature is largely meant for new users onboarding to the platform -- enterprise users are expected to use an explicit `version` tag for reproducibility.

For example, we plan to support the following configuration:

```yaml
# fern.yml
org: acme
sdks:
  targets:
    # Both the 'language' and 'version' are inferred, so all
    # the user needs to do is configure an output path.
    typescript:
      output:
        path: ./sdks/typescript-sdk
```

## Changes Made
- Update the `seed` publish command to support updating the `:latest` tag when we publish the image to DockerHub.

## Testing
This will be tested when the next generator version is released.
