### PR TITLE
fix(cli): Fix AsyncAPI JSON detection in no-non-component-refs validation rule

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.51.3
+  changelogEntry:
+    - summary: |
+        Fix `fern check` incorrectly reporting "Invalid OpenAPI reference" errors for AsyncAPI JSON files. The validation rule now detects both YAML format (`asyncapi:`) and JSON format (`"asyncapi":`) when skipping AsyncAPI files.
+      type: fix
+  createdAt: "2026-01-28"
+  irVersion: 63
+
 - version: 3.51.2
   changelogEntry:
     - summary: |

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/__test__/no-non-component-refs.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/__test__/no-non-component-refs.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RuleContext } from "../../../Rule";
+import { NoNonComponentRefsRule } from "../no-non-component-refs";
+
+describe("NoNonComponentRefsRule", () => {
+    it("should be defined and have correct name", () => {
+        expect(NoNonComponentRefsRule).toBeDefined();
+        expect(NoNonComponentRefsRule.name).toBe("no-non-component-refs");
+        expect(NoNonComponentRefsRule.create).toBeDefined();
+    });
+
+    it("should create a rule visitor with file method", async () => {
+        const mockContext = {
+            ossWorkspaces: [],
+            logger: {
+                disable: vi.fn(),
+                enable: vi.fn(),
+                trace: vi.fn(),
+                debug: vi.fn(),
+                info: vi.fn(),
+                warn: vi.fn(),
+                error: vi.fn(),
+                log: vi.fn()
+            },
+            workspace: {
+                absoluteFilePath: "/test/path"
+            }
+        } as unknown as RuleContext;
+
+        const ruleVisitor = await NoNonComponentRefsRule.create(mockContext);
+        expect(ruleVisitor).toBeDefined();
+        expect(ruleVisitor.file).toBeDefined();
+        expect(typeof ruleVisitor.file).toBe("function");
+    });
+
+    describe("AsyncAPI detection", () => {
+        it("should detect AsyncAPI files in YAML format (asyncapi:)", () => {
+            const yamlContent = `asyncapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0`;
+            expect(yamlContent.includes("asyncapi:")).toBe(true);
+        });
+
+        it("should detect AsyncAPI files in JSON format (\"asyncapi\":)", () => {
+            const jsonContent = `{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  }
+}`;
+            // This is the fix - JSON format should also be detected
+            const isAsyncAPI = jsonContent.includes("asyncapi:") || jsonContent.includes('"asyncapi":');
+            expect(isAsyncAPI).toBe(true);
+        });
+
+        it("should not detect regular OpenAPI files as AsyncAPI", () => {
+            const openapiContent = `{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  }
+}`;
+            const isAsyncAPI = openapiContent.includes("asyncapi:") || openapiContent.includes('"asyncapi":');
+            expect(isAsyncAPI).toBe(false);
+        });
+    });
+});

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/__test__/no-non-component-refs.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/__test__/no-non-component-refs.test.ts
@@ -43,7 +43,7 @@ info:
             expect(yamlContent.includes("asyncapi:")).toBe(true);
         });
 
-        it("should detect AsyncAPI files in JSON format (\"asyncapi\":)", () => {
+        it('should detect AsyncAPI files in JSON format ("asyncapi":)', () => {
             const jsonContent = `{
   "asyncapi": "3.0.0",
   "info": {

--- a/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-non-component-refs/no-non-component-refs.ts
@@ -38,7 +38,9 @@ export const NoNonComponentRefsRule: Rule = {
                                     }
 
                                     // Skip AsyncAPI files - they have different reference patterns than OpenAPI
-                                    const isAsyncAPI = contents.includes("asyncapi:");
+                                    // Check for both YAML format (asyncapi:) and JSON format ("asyncapi":)
+                                    const isAsyncAPI =
+                                        contents.includes("asyncapi:") || contents.includes('"asyncapi":');
                                     if (isAsyncAPI) {
                                         continue; // Skip AsyncAPI files
                                     }


### PR DESCRIPTION
## Description

Fixes `fern check` incorrectly reporting "Invalid OpenAPI reference" errors for AsyncAPI files in JSON format.

## Changes Made

- Updated the `no-non-component-refs` validation rule to detect AsyncAPI files in both YAML format (`asyncapi:`) and JSON format (`"asyncapi":`)
- Added version 3.51.3 to CLI versions.yml

## Problem

The validation rule was checking `contents.includes("asyncapi:")` to skip AsyncAPI files, but this only matches YAML format. JSON-formatted AsyncAPI files have `"asyncapi":` (with quotes), so they were incorrectly processed as OpenAPI files and failed validation with errors like:

```
Reference "#/channels/~1api~1v1~1asr" points to a non-component location...
```

## Human Review Checklist

- [ ] Verify the string matching logic correctly identifies JSON AsyncAPI files
- [ ] Consider edge cases where an OpenAPI file might contain the string `"asyncapi":` (unlikely but worth noting)

## Testing

- [ ] Manual testing completed - verified fix resolves the 18 AsyncAPI reference errors in smallest-ai-fern-config

---

Devin session: https://app.devin.ai/sessions/74a0166bb92c4c7a8ef3fda132a50f80
Requested by: @fern-support