### PR TITLE
fix(typescript): Fix variable alias collision when path param and header have same camelCase name

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/request-parameter/RequestWrapperParameter.ts
+++ b/generators/typescript/sdk/client-class-generator/src/request-parameter/RequestWrapperParameter.ts
@@ -223,7 +223,10 @@ export class RequestWrapperParameter extends AbstractRequestParameter {
     private getDefaultVariableNameForNonBodyProperty(
         nonBodyProperty: RequestWrapperNonBodyProperty
     ): DefaultNonBodyKeyName {
-        return nonBodyProperty.safeName as DefaultNonBodyKeyName;
+        // Use propertyName as the key instead of safeName to avoid collisions
+        // when different parameters have the same safeName (e.g., a path parameter
+        // named "contact_id" and a header named "X-Contact-ID" both have safeName "contactId")
+        return nonBodyProperty.propertyName as DefaultNonBodyKeyName;
     }
 
     private getAliasForNonBodyProperty(nonBodyProperty: RequestWrapperNonBodyProperty): string {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.45.2
+  changelogEntry:
+    - summary: |
+        Fix variable alias collision when a path parameter and header have the same camelCase name.
+        Previously, when an endpoint had both a path parameter (e.g., `contact_id`) and a header
+        (e.g., `X-Contact-ID`) that resolve to the same camelCase name (`contactId`), the generated
+        code would use the wrong variable for the URL path. This was caused by the alias lookup map
+        using `safeName` as the key, which could collide. Now the map uses `propertyName` as the key,
+        which is unique for each parameter.
+      type: fix
+  createdAt: "2026-01-28"
+  irVersion: 63
+
 - version: 3.45.1
   changelogEntry:
     - summary: Remove check if body is `null` or `undefined`. If `null`, it is valid JSON `null`, and if `undefined`, it handles correctly to not have a body.


### PR DESCRIPTION
## Description

Refs: https://app.devin.ai/sessions/351f23e829b14844bc080cac8669b297
Requested by: @fern-support

Fixes a bug where the TypeScript SDK generator would use the wrong variable for URL path parameters when an endpoint has both a path parameter and a header that resolve to the same camelCase name.

## Changes Made

- Changed `getDefaultVariableNameForNonBodyProperty` in `RequestWrapperParameter.ts` to use `propertyName` instead of `safeName` as the lookup key for variable aliases
- Added version 3.45.2 changelog entry

### Root Cause

When destructuring request parameters, the generator creates a map (`nonBodyKeyAliases`) to track variable aliases. For example:
```typescript
const { contact_id: contactId, client_id: clientId, "X-Contact-ID": contactId_ } = request;
```

The map was keyed by `safeName` (the camelCase variable name). When a path parameter `contact_id` and header `X-Contact-ID` both have `safeName: "contactId"`, the header's entry would overwrite the path parameter's entry. Later, when building the URL, the code would look up the alias for the path parameter and incorrectly get `contactId_` (the header's alias) instead of `contactId`.

The fix uses `propertyName` (e.g., `"contact_id"` vs `"X-Contact-ID"`) as the key, which is unique for each parameter.

## Testing

- [x] Verified the code compiles successfully
- [ ] No unit tests exist for this specific scenario - the fix was verified through code analysis
- [ ] Manual testing: The bug was discovered in the `fern-demo/ebury-ts-sdk` repo where wire tests were failing

## Human Review Checklist

- [ ] Verify that `propertyName` is unique across all parameter types (path, query, header) in all scenarios
- [ ] Consider whether a unit test should be added for this edge case