### PR TITLE
feat(python): dynamic ci python version and pypi classifiers

### DIFF
--- a/generators/python/fastapi/Dockerfile
+++ b/generators/python/fastapi/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.11.13 AS base
 ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 ENV _TYPER_STANDARD_TRACEBACK=1
 
+# Keep in sync with the poetry-core version in pyproject.toml
 RUN pip3 install poetry==1.8.5
 RUN poetry config virtualenvs.create false
 

--- a/generators/python/poetry.lock
+++ b/generators/python/poetry.lock
@@ -597,6 +597,18 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "poetry-core"
+version = "2.3.0"
+description = "Poetry PEP 517 Build Backend"
+optional = false
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "poetry_core-2.3.0-py3-none-any.whl", hash = "sha256:fc42f3854e346e4b96fb2b38d29e6873ec2ed25fbd7b8f1afba06613a966eaef"},
+    {file = "poetry_core-2.3.0.tar.gz", hash = "sha256:f6da8f021fe380d8c9716085f4dcc5d26a5120a2452e077196333892af5de307"},
+]
+
+[[package]]
 name = "pre-commit"
 version = "2.21.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -1192,4 +1204,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "107f2aa22d8c46dc36ce995aac36014eb0ac24f6d493abfaebd7cf9b42d9c791"
+content-hash = "015ab806e30c9a32868aff08471a05291007c88dd9ba716df2027ec5a4dec48f"

--- a/generators/python/poetry.lock
+++ b/generators/python/poetry.lock
@@ -598,14 +598,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "poetry-core"
-version = "2.3.0"
+version = "1.9.1"
 description = "Poetry PEP 517 Build Backend"
 optional = false
-python-versions = "<4.0,>=3.10"
+python-versions = "<4.0,>=3.8"
 groups = ["main"]
 files = [
-    {file = "poetry_core-2.3.0-py3-none-any.whl", hash = "sha256:fc42f3854e346e4b96fb2b38d29e6873ec2ed25fbd7b8f1afba06613a966eaef"},
-    {file = "poetry_core-2.3.0.tar.gz", hash = "sha256:f6da8f021fe380d8c9716085f4dcc5d26a5120a2452e077196333892af5de307"},
+    {file = "poetry_core-1.9.1-py3-none-any.whl", hash = "sha256:6f45dd3598e0de8d9b0367360253d4c5d4d0110c8f5c71120a14f0e0f116c1a0"},
+    {file = "poetry_core-1.9.1.tar.gz", hash = "sha256:7a2d49214bf58b4f17f99d6891d947a9836c9899a67a5069f52d7b67217f61b8"},
 ]
 
 [[package]]
@@ -1204,4 +1204,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "015ab806e30c9a32868aff08471a05291007c88dd9ba716df2027ec5a4dec48f"
+content-hash = "044e00f33a1022b2b05a91e0d6f6ad8e6f0aa83e04a9cfad1fa1cc7c900e6af0"

--- a/generators/python/pydantic/Dockerfile
+++ b/generators/python/pydantic/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.11.13 AS base
 ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 ENV _TYPER_STANDARD_TRACEBACK=1
 
+# Keep in sync with the poetry-core version in pyproject.toml
 RUN pip3 install poetry==1.8.5
 RUN poetry config virtualenvs.create false
 

--- a/generators/python/pyproject.toml
+++ b/generators/python/pyproject.toml
@@ -16,6 +16,7 @@ fern-fern-generator-cli-sdk = { version = "^0.1.1", source = "fern-prod" }
 fern_fern_ir_v60 = "62.6.0"
 black = "^25.1.0"
 isort = "^6.0.1"
+poetry-core = "^2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"

--- a/generators/python/pyproject.toml
+++ b/generators/python/pyproject.toml
@@ -16,7 +16,11 @@ fern-fern-generator-cli-sdk = { version = "^0.1.1", source = "fern-prod" }
 fern_fern_ir_v60 = "62.6.0"
 black = "^25.1.0"
 isort = "^6.0.1"
-poetry-core = "^2.0.0"
+# NOTE: poetry-core must stay at ^1.9.0 because the Dockerfile uses `virtualenvs.create false`,
+# which installs dependencies into the same environment as Poetry itself. Using poetry-core 2.x
+# would overwrite Poetry 1.8.5's internal poetry-core and cause "'ProjectPackage' object has no
+# attribute 'readme_content'" errors during `poetry install`.
+poetry-core = "^1.9.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -23,6 +23,7 @@ ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 ENV _TYPER_STANDARD_TRACEBACK=1
 ENV HTTPX_LOG_LEVEL=trace
 
+# Keep in sync with the poetry-core version in pyproject.toml
 RUN pip3 install poetry==1.8.5
 RUN poetry config virtualenvs.create false
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.54.2
+  changelogEntry:
+    - summary: |
+        Generate CI workflow Python versions and PyPI trove classifiers dynamically based on the
+        `pyproject_python_version` constraint.
+      type: fix
+  createdAt: "2026-01-29"
+  irVersion: 62
+
 - version: 4.54.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/codegen/pypi_classifier_creator.py
+++ b/generators/python/src/fern_python/codegen/pypi_classifier_creator.py
@@ -1,0 +1,91 @@
+"""Creates PyPI trove classifier metadata for pyproject.toml."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, cast
+
+from fern_python.version import get_matching_python_versions
+
+from fern.generator_exec import BasicLicense, LicenseConfig, LicenseId
+
+
+class PyPIClassifierMetadataGenerator:
+    """Generates PyPI trove classifier metadata for pyproject.toml."""
+
+    # Static classifiers that appear before Python version classifiers
+    CLASSIFIERS_PREFIX: List[str] = ["Intended Audience :: Developers"]
+
+    # Static classifiers that appear after Python version classifiers
+    CLASSIFIERS_SUFFIX: List[str] = [
+        "Operating System :: OS Independent",
+        "Operating System :: POSIX",
+        "Operating System :: MacOS",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Microsoft :: Windows",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Typing :: Typed",
+    ]
+
+    # Base Python classifiers (before version-specific ones)
+    PYTHON_BASE_CLASSIFIERS: List[str] = [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+    ]
+
+    # Mapping from LicenseId to PyPI classifier string
+    LICENSE_CLASSIFIERS: Dict[LicenseId, str] = {
+        LicenseId.MIT: "License :: OSI Approved :: MIT License",
+        LicenseId.APACHE_2: "License :: OSI Approved :: Apache Software License",
+    }
+
+    @staticmethod
+    def create_classifiers(
+        python_version: str,
+        license_: Optional[LicenseConfig] = None,
+    ) -> List[str]:
+        """
+        Generate the complete list of PyPI classifiers for pyproject.toml.
+
+        Args:
+            python_version: A version constraint string like "^3.8", ">=3.9", etc.
+            license_: Optional license configuration.
+
+        Returns:
+            A complete list of classifier strings.
+        """
+        classifiers: List[str] = [
+            *PyPIClassifierMetadataGenerator.CLASSIFIERS_PREFIX,
+            *PyPIClassifierMetadataGenerator._create_python_programming_language_classifiers(python_version),
+            *PyPIClassifierMetadataGenerator.CLASSIFIERS_SUFFIX,
+        ]
+
+        license_classifier = PyPIClassifierMetadataGenerator._get_license_classifier(license_)
+        if license_classifier is not None:
+            classifiers.append(license_classifier)
+
+        return classifiers
+
+    @staticmethod
+    def _create_python_programming_language_classifiers(python_version_constraint: str) -> List[str]:
+        """Generate Python version classifier strings."""
+        versions = get_matching_python_versions(python_version_constraint)
+
+        classifiers: List[str] = list(PyPIClassifierMetadataGenerator.PYTHON_BASE_CLASSIFIERS)
+
+        for py_version in versions:
+            classifiers.append(f"Programming Language :: Python :: {py_version.spec.to_string()}")
+
+        return classifiers
+
+    @staticmethod
+    def _get_license_classifier(license_: Optional[LicenseConfig]) -> Optional[str]:
+        """Get the license classifier string if applicable."""
+        if license_ is None:
+            return None
+
+        license_union = license_.get_as_union()
+        if license_union.type != "basic":
+            return None
+
+        license_id = cast(BasicLicense, license_union).id
+        return PyPIClassifierMetadataGenerator.LICENSE_CLASSIFIERS.get(license_id)

--- a/generators/python/src/fern_python/version/__init__.py
+++ b/generators/python/src/fern_python/version/__init__.py
@@ -1,0 +1,15 @@
+from fern_python.version.ci_python_version import GithubCIPythonVersionResolver
+from fern_python.version.python_version import (
+    PythonVersion,
+    PythonVersionSpec,
+    get_matching_python_versions,
+    get_minimum_compatible_version,
+)
+
+__all__ = [
+    "GithubCIPythonVersionResolver",
+    "PythonVersion",
+    "PythonVersionSpec",
+    "get_matching_python_versions",
+    "get_minimum_compatible_version",
+]

--- a/generators/python/src/fern_python/version/ci_python_version.py
+++ b/generators/python/src/fern_python/version/ci_python_version.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from typing import ClassVar, Set
+
+from fern_python.version.python_version import PythonVersion, get_matching_python_versions
+
+logger = logging.getLogger(__name__)
+
+
+class GithubCIPythonVersionResolver:
+    # https://github.com/actions/python-versions/blob/main/versions-manifest.json
+    # The manifest above declares stable versions of Python supported in the setup-python action.
+    SUPPORTED_VERSIONS: ClassVar[Set[PythonVersion]] = {
+        PythonVersion.PY3_8,
+        PythonVersion.PY3_9,
+        PythonVersion.PY3_10,
+        PythonVersion.PY3_11,
+        PythonVersion.PY3_12,
+        PythonVersion.PY3_13,
+        PythonVersion.PY3_14,
+    }
+
+    DEFAULT_VERSION: ClassVar[PythonVersion] = PythonVersion.PY3_9
+
+    @staticmethod
+    def resolve(python_version_constraint: str) -> PythonVersion:
+        matching_versions = get_matching_python_versions(python_version_constraint)
+
+        ci_compatible_versions = list(GithubCIPythonVersionResolver.SUPPORTED_VERSIONS.intersection(matching_versions))
+
+        if not ci_compatible_versions:
+            logger.error(
+                f"No CI-supported Python versions satisfy constraint '{python_version_constraint}'. "
+                f"Supported versions are: {', '.join(v.spec.to_string() for v in sorted(GithubCIPythonVersionResolver.SUPPORTED_VERSIONS, key=lambda x: x.spec))}. "
+                f"Defaulting to {GithubCIPythonVersionResolver.DEFAULT_VERSION.spec.to_string()}."
+            )
+            return GithubCIPythonVersionResolver.DEFAULT_VERSION
+
+        if GithubCIPythonVersionResolver.DEFAULT_VERSION in ci_compatible_versions:
+            return GithubCIPythonVersionResolver.DEFAULT_VERSION
+
+        return min(ci_compatible_versions, key=lambda v: v.spec)

--- a/generators/python/src/fern_python/version/python_version.py
+++ b/generators/python/src/fern_python/version/python_version.py
@@ -1,0 +1,89 @@
+"""Utilities for Python version constraint parsing.
+
+Uses poetry-core to parse version constraints (^, ~, >=, etc.) and determine
+which Python versions satisfy them.
+
+This module is used for:
+- Generating PyPI classifier metadata (Programming Language :: Python :: X.Y)
+- Determining the minimum Python version for CI workflows
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from poetry.core.constraints.version import Version, parse_constraint
+
+
+@dataclass(frozen=True, order=True)
+class PythonVersionSpec:
+    """Represents a Python major.minor version."""
+
+    major: int
+    minor: int
+
+    def to_string(self) -> str:
+        return f"{self.major}.{self.minor}"
+
+    def to_poetry_version(self) -> Version:
+        return Version.parse(self.to_string())
+
+
+class PythonVersion(Enum):
+    """
+    All known Python versions.
+    Update this enum as new Python versions are released.
+    """
+
+    PY3_8 = PythonVersionSpec(3, 8)
+    PY3_9 = PythonVersionSpec(3, 9)
+    PY3_10 = PythonVersionSpec(3, 10)
+    PY3_11 = PythonVersionSpec(3, 11)
+    PY3_12 = PythonVersionSpec(3, 12)
+    PY3_13 = PythonVersionSpec(3, 13)
+    PY3_14 = PythonVersionSpec(3, 14)
+    PY3_15 = PythonVersionSpec(3, 15)
+
+    @property
+    def spec(self) -> PythonVersionSpec:
+        return self.value
+
+    @classmethod
+    def all(cls) -> list[PythonVersion]:
+        """Returns all Python versions in order."""
+        return list(cls)
+
+
+def get_matching_python_versions(python_version_constraint: str) -> list[PythonVersion]:
+    """
+    Given a Python version constraint string (Poetry or PEP 440 format),
+    return the list of Python versions that satisfy the constraint.
+
+    Args:
+        python_version_constraint: A version constraint string like "^3.8", ">=3.9", "~3.10", etc.
+
+    Returns:
+        A list of PythonVersion enum members that satisfy the constraint.
+
+    Examples:
+        >>> get_matching_python_versions("^3.8")
+        [PY3_8, PY3_9, PY3_10, ...]
+
+        >>> get_matching_python_versions("^3.10")
+        [PY3_10, PY3_11, PY3_12, ...]
+
+        >>> get_matching_python_versions(">=3.9,<3.12")
+        [PY3_9, PY3_10, PY3_11]
+    """
+    constraint = parse_constraint(python_version_constraint)
+
+    return [py_version for py_version in PythonVersion if constraint.allows(py_version.spec.to_poetry_version())]
+
+
+def get_minimum_compatible_version(python_version_constraint: str) -> Optional[PythonVersion]:
+    matching_versions = get_matching_python_versions(python_version_constraint)
+    if not matching_versions:
+        return None
+    return matching_versions[0]

--- a/generators/python/tests/codegen/test_github_ci_python_version.py
+++ b/generators/python/tests/codegen/test_github_ci_python_version.py
@@ -1,0 +1,15 @@
+"""Tests for GithubCIPythonVersionResolver."""
+
+from fern_python.version import GithubCIPythonVersionResolver, PythonVersion
+
+
+class TestGithubCIPythonVersionResolver:
+    def test_resolve_default_constraint_returns_3_9(self) -> None:
+        """Default pyproject_python_version (^3.8) should resolve to 3.9 for CI."""
+        default_python_version_constraint = "^3.8"
+        result = GithubCIPythonVersionResolver.resolve(default_python_version_constraint)
+        assert result == PythonVersion.PY3_9
+
+    def test_resolve_uses_minimum_when_3_9_not_in_intersection(self) -> None:
+        result = GithubCIPythonVersionResolver.resolve("^3.10")
+        assert result == PythonVersion.PY3_10

--- a/generators/python/tests/codegen/test_pypi_classifier_creator.py
+++ b/generators/python/tests/codegen/test_pypi_classifier_creator.py
@@ -1,0 +1,114 @@
+"""Tests for pypi_classifier_creator module."""
+
+from typing import List, Optional
+
+from fern_python.codegen.pypi_classifier_creator import PyPIClassifierMetadataGenerator
+from fern_python.version import PythonVersion
+
+from fern.generator_exec import BasicLicense, LicenseConfig, LicenseId
+
+
+def create_license_config(license_id: LicenseId) -> LicenseConfig:
+    """Create a LicenseConfig for testing."""
+    return LicenseConfig.factory.basic(BasicLicense(id=license_id))
+
+
+def build_expected_classifiers(
+    versions: List[PythonVersion],
+    license_id: Optional[LicenseId] = None,
+) -> List[str]:
+    """Build expected classifier list using the class constants."""
+    python_classifiers = list(PyPIClassifierMetadataGenerator.PYTHON_BASE_CLASSIFIERS)
+    for v in versions:
+        python_classifiers.append(f"Programming Language :: Python :: {v.spec.to_string()}")
+
+    classifiers = (
+        list(PyPIClassifierMetadataGenerator.CLASSIFIERS_PREFIX)
+        + python_classifiers
+        + list(PyPIClassifierMetadataGenerator.CLASSIFIERS_SUFFIX)
+    )
+
+    if license_id is not None:
+        license_classifier = PyPIClassifierMetadataGenerator.LICENSE_CLASSIFIERS.get(license_id)
+        if license_classifier is not None:
+            classifiers.append(license_classifier)
+
+    return classifiers
+
+
+class TestCreateClassifiers:
+    """Tests for PyPIClassifierMetadataGenerator.create_classifiers."""
+
+    def test_generates_classifiers_for_version_constraint(self) -> None:
+        """Test that classifiers are generated correctly for a version constraint."""
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers(">=3.9,<3.12")
+
+        expected = build_expected_classifiers(
+            [
+                PythonVersion.PY3_9,
+                PythonVersion.PY3_10,
+                PythonVersion.PY3_11,
+            ]
+        )
+        assert classifiers == expected
+
+    def test_generates_classifiers_for_all_versions(self) -> None:
+        """Test that ^3.8 includes all versions."""
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers("^3.8")
+
+        expected = build_expected_classifiers(PythonVersion.all())
+        assert classifiers == expected
+
+    def test_no_license_classifier_when_none(self) -> None:
+        """Test no license classifier when license is None."""
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers("~3.10", None)
+
+        # Should not contain any license classifier
+        license_classifiers = [c for c in classifiers if c.startswith("License ::")]
+        assert len(license_classifiers) == 0
+
+
+class TestLicenseClassifiers:
+    """Tests for license classifier generation."""
+
+    def test_mit_license(self) -> None:
+        """Test MIT license classifier is appended."""
+        license_config = create_license_config(LicenseId.MIT)
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers("~3.10", license_config)
+
+        assert classifiers[-1] == PyPIClassifierMetadataGenerator.LICENSE_CLASSIFIERS[LicenseId.MIT]
+
+    def test_apache_2_license(self) -> None:
+        """Test Apache-2 license classifier is appended."""
+        license_config = create_license_config(LicenseId.APACHE_2)
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers("~3.10", license_config)
+
+        assert classifiers[-1] == PyPIClassifierMetadataGenerator.LICENSE_CLASSIFIERS[LicenseId.APACHE_2]
+
+    def test_license_with_version_constraint(self) -> None:
+        """Test full output with license and version constraint."""
+        license_config = create_license_config(LicenseId.MIT)
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers(">=3.9,<3.12", license_config)
+
+        expected = build_expected_classifiers(
+            [PythonVersion.PY3_9, PythonVersion.PY3_10, PythonVersion.PY3_11],
+            license_id=LicenseId.MIT,
+        )
+        assert classifiers == expected
+
+
+class TestClassifierIntegrity:
+    """Tests for classifier format validity."""
+
+    def test_no_duplicates(self) -> None:
+        """Test that there are no duplicate classifiers."""
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers("^3.8")
+
+        assert len(classifiers) == len(set(classifiers))
+
+    def test_valid_format(self) -> None:
+        """Test that all classifiers contain the :: separator."""
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers("^3.8")
+
+        for c in classifiers:
+            assert " :: " in c, f"Invalid classifier format: {c}"

--- a/generators/python/tests/codegen/test_pyproject_toml.py
+++ b/generators/python/tests/codegen/test_pyproject_toml.py
@@ -1,0 +1,153 @@
+"""Tests for pyproject_toml module."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fern_python.codegen.pyproject_toml import (
+    PyProjectToml,
+    PyProjectTomlPackageConfig,
+)
+from fern_python.codegen.pypi_classifier_creator import PyPIClassifierMetadataGenerator
+from poetry.core.factory import Factory
+
+
+class TestPoetryBlock:
+    """Tests for PyProjectToml.PoetryBlock."""
+
+    def _create_block(
+        self,
+        classifiers: list[str],
+        version: str,
+    ) -> PyProjectToml.PoetryBlock:
+        """Helper to create a PoetryBlock for testing."""
+        return PyProjectToml.PoetryBlock(
+            name="test-package",
+            version=version,
+            package=PyProjectTomlPackageConfig(include="test_package", _from="src"),
+            classifiers=classifiers,
+            pypi_metadata=None,
+            github_output_mode=None,
+            license_=None,
+        )
+
+    def test_classifiers_reflect_version_constraint(self) -> None:
+        """Test that classifiers correctly reflect the version constraint."""
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers(">=3.9,<3.12")
+        block = PyProjectToml.PoetryBlock(
+            name="test",
+            version="1.0.0",
+            package=PyProjectTomlPackageConfig(include="test"),
+            classifiers=classifiers,
+            pypi_metadata=None,
+            github_output_mode=None,
+            license_=None,
+        )
+        output = block.to_string()
+
+        # Should include only 3.9, 3.10, 3.11
+        assert "Programming Language :: Python :: 3.9" in output
+        assert "Programming Language :: Python :: 3.10" in output
+        assert "Programming Language :: Python :: 3.11" in output
+        # Should NOT include versions outside range
+        assert "Programming Language :: Python :: 3.8" not in output
+        assert "Programming Language :: Python :: 3.12" not in output
+        assert "Programming Language :: Python :: 3.13" not in output
+        assert "Programming Language :: Python :: 3.14" not in output
+        assert "Programming Language :: Python :: 3.15" not in output
+
+    def test_to_string_contains_required_fields(self) -> None:
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers(">=3.9,<3.12")
+        version = "1.0.0"
+        block = self._create_block(classifiers=classifiers, version=version)
+        output = block.to_string()
+
+        assert "[tool.poetry]" in output
+        assert 'name = "test-package"' in output
+        assert f'version = "{version}"' in output
+        assert 'readme = "README.md"' in output
+        assert 'description = "' in output
+        assert "classifiers = " in output
+        assert 'include = "test_package"' in output
+        assert 'from = "src"' in output
+
+
+class TestDependenciesBlock:
+    """Tests for PyProjectToml.DependenciesBlock."""
+
+    def test_to_string_structure(self) -> None:
+        """Test that output has correct structure."""
+        python_version = "^3.10"
+        block = PyProjectToml.DependenciesBlock(
+            dependencies=set(),
+            dev_dependencies=set(),
+            python_version=python_version,
+            enable_wire_tests=False,
+        )
+        output = block.to_string()
+
+        assert "[tool.poetry.dependencies]" in output
+        assert f'python = "{python_version}"' in output
+        assert "[tool.poetry.group.dev.dependencies]" in output
+
+
+class TestBuildSystemBlock:
+    """Tests for PyProjectToml.BuildSystemBlock."""
+
+    def test_to_string_structure(self) -> None:
+        """Test that output has correct build-system structure."""
+        block = PyProjectToml.BuildSystemBlock()
+        output = block.to_string()
+
+        assert "[build-system]" in output
+        assert 'requires = ["poetry-core"]' in output
+        assert 'build-backend = "poetry.core.masonry.api"' in output
+
+
+class TestPoetryCoreValidation:
+    """Validate generated pyproject.toml using poetry-core."""
+
+    def test_generated_toml_is_valid_poetry_project(self) -> None:
+        """Test that generated TOML can be parsed by poetry-core Factory."""
+        # Build a complete pyproject.toml from all blocks
+        python_version = "^3.10"
+        classifiers = PyPIClassifierMetadataGenerator.create_classifiers(python_version)
+
+        poetry_block = PyProjectToml.PoetryBlock(
+            name="test-package",
+            version="1.0.0",
+            package=PyProjectTomlPackageConfig(include="test_package", _from="src"),
+            classifiers=classifiers,
+            pypi_metadata=None,
+            github_output_mode=None,
+            license_=None,
+        )
+
+        deps_block = PyProjectToml.DependenciesBlock(
+            dependencies=set(),
+            dev_dependencies=set(),
+            python_version=python_version,
+            enable_wire_tests=False,
+        )
+
+        build_block = PyProjectToml.BuildSystemBlock()
+
+        # Combine all blocks
+        toml_content = poetry_block.to_string() + deps_block.to_string() + build_block.to_string()
+
+        # Write to temp file and validate with poetry-core
+        with tempfile.TemporaryDirectory() as tmpdir:
+            toml_path = Path(tmpdir) / "pyproject.toml"
+            toml_path.write_text(toml_content)
+
+            # Create a dummy src/test_package directory structure
+            package_dir = Path(tmpdir) / "src" / "test_package"
+            package_dir.mkdir(parents=True)
+            (package_dir / "__init__.py").write_text("")
+
+            # Factory.create_poetry will raise if the TOML is invalid
+            poetry = Factory().create_poetry(Path(tmpdir))
+
+            assert poetry.package.name == "test-package"
+            assert str(poetry.package.version) == "1.0.0"

--- a/generators/python/tests/codegen/test_python_version_utils.py
+++ b/generators/python/tests/codegen/test_python_version_utils.py
@@ -1,0 +1,107 @@
+import pytest
+
+from fern_python.version import (
+    PythonVersion,
+    get_matching_python_versions,
+    get_minimum_compatible_version,
+)
+
+
+class TestPythonVersionSpec:
+    """Tests for PythonVersionSpec dataclass."""
+
+    def test_ordering_3_10_greater_than_3_9(self) -> None:
+        """Critical: 3.10 must be greater than 3.9 (not lexicographic string comparison)."""
+        assert PythonVersion.PY3_10.spec > PythonVersion.PY3_9.spec
+        assert PythonVersion.PY3_9.spec < PythonVersion.PY3_10.spec
+
+        # Verify sorting works correctly
+        versions = [PythonVersion.PY3_10.spec, PythonVersion.PY3_9.spec]
+        assert sorted(versions) == [PythonVersion.PY3_9.spec, PythonVersion.PY3_10.spec]
+
+    def test_to_string(self) -> None:
+        """Test version string generation."""
+        assert PythonVersion.PY3_8.spec.to_string() == "3.8"
+        assert PythonVersion.PY3_10.spec.to_string() == "3.10"
+
+    def test_frozen(self) -> None:
+        """Test that PythonVersionSpec is immutable."""
+        with pytest.raises(AttributeError):
+            PythonVersion.PY3_10.spec.major = 4  # type: ignore
+
+
+class TestPythonVersion:
+    """Tests for PythonVersion enum."""
+
+    def test_all_versions(self) -> None:
+        all_versions = PythonVersion.all()
+        version_strings = [v.spec.to_string() for v in all_versions]
+
+        assert version_strings == ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        assert [v.spec for v in all_versions] == sorted([v.spec for v in all_versions])
+
+
+class TestGetMatchingPythonVersions:
+    """Tests for get_matching_python_versions function."""
+
+    def test_caret_constraint(self) -> None:
+        versions = get_matching_python_versions("^3.10")
+        assert versions == [
+            PythonVersion.PY3_10,
+            PythonVersion.PY3_11,
+            PythonVersion.PY3_12,
+            PythonVersion.PY3_13,
+            PythonVersion.PY3_14,
+            PythonVersion.PY3_15,
+        ]
+
+    def test_tilde_constraint(self) -> None:
+        versions = get_matching_python_versions("~3.10")
+        assert versions == [PythonVersion.PY3_10]
+
+    def test_range_constraint(self) -> None:
+        versions = get_matching_python_versions(">=3.9,<3.12")
+
+        assert versions == [
+            PythonVersion.PY3_9,
+            PythonVersion.PY3_10,
+            PythonVersion.PY3_11,
+        ]
+
+    def test_exact_version(self) -> None:
+        versions = get_matching_python_versions("==3.10")
+
+        assert versions == [PythonVersion.PY3_10]
+
+    def test_wildcard_matches_all(self) -> None:
+        versions = get_matching_python_versions("*")
+
+        assert versions == PythonVersion.all()
+
+    def test_impossible_constraint_returns_empty(self) -> None:
+        versions = get_matching_python_versions("^3.99")
+        assert versions == []
+
+
+class TestGetMinimumCompatibleVersion:
+    """Tests for get_minimum_compatible_version function."""
+
+    def test_caret_3_8_returns_3_8(self) -> None:
+        """Test ^3.8 returns 3.8 as minimum."""
+        min_version = get_minimum_compatible_version("^3.8")
+        assert min_version == PythonVersion.PY3_8
+
+    def test_caret_3_10_returns_3_10(self) -> None:
+        """Test ^3.10 returns 3.10 as minimum."""
+        min_version = get_minimum_compatible_version("^3.10")
+        assert min_version == PythonVersion.PY3_10
+
+    def test_range_returns_lower_bound(self) -> None:
+        """Test range constraint returns lower bound."""
+        min_version = get_minimum_compatible_version(">=3.9,<3.12")
+        assert min_version == PythonVersion.PY3_9
+
+    def test_impossible_constraint_returns_none(self) -> None:
+        """Test impossible constraint returns None."""
+        min_version = get_minimum_compatible_version("^3.99")
+        assert min_version is None


### PR DESCRIPTION
Python SDK: Dynamic Python Version Support

Problem: Generated SDKs had hardcoded Python versions in CI workflows and PyPI classifiers, causing mismatches when users specified custom pyproject_python_version constraints.
Solution: CI Python versions and PyPI trove classifiers are now dynamically derived from the pyproject_python_version constraint.

Tested with multiple constraints (>=3.9,<3.14, >=3.10,<3.14, >=3.11,<3.14, >=3.12,<3.14) — everything works correctly. Also verified Poetry 1.5.1+ compatibility with Python 3.9-3.13.