### PR TITLE
fix(ruby): fix request body serialization for endpoints with path/query params

### DIFF
--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc83
+  changelogEntry:
+    - summary: |
+        Fix request body serialization bug where path/query/header parameters were incorrectly
+        serialized as nil values in the request body. For endpoints with inlined request bodies
+        that also have path, query, or header parameters, the wrapper type (which includes all
+        endpoint parameters) was being created with only body properties, causing non-body fields
+        to be nil and serialized as null in the JSON body. The fix uses a serialize-then-split
+        pattern: serialize ALL params through the wrapper type first, then remove non-body params
+        from the serialized result. This ensures proper type conversion while keeping non-body
+        params out of the request body.
+      type: fix
+  createdAt: "2026-01-28"
+  irVersion: 61
+
 - version: 1.0.0-rc82
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: User-reported bug analysis document

Fixes a bug in the Ruby v2 SDK generator where path/query/header parameters were incorrectly serialized as nil values in the request body, causing API errors like `EXPECTED_STRING` for fields that shouldn't be in the body at all.

## Changes Made

- Modified `WrappedEndpointRequest.ts` to use a "serialize-then-split" pattern for inlined request bodies
- Added `getNonBodyParameterWireNames()` method to collect wire names of all non-body parameters (path, query, headers)
- Updated `versions.yml` with changelog entry for version 1.0.0-rc83

**Before (buggy):**
```ruby
path_param_names = %i[group_id]
body_params = params.except(*path_param_names)  # Remove path params from input
body_bag = body_params.slice(*body_prop_names)
WrapperType.new(body_bag).to_h  # BUG: group_id is nil, serialized as null
```

**After (fixed):**
```ruby
request_data = WrapperType.new(params).to_h  # Serialize ALL params
non_body_param_names = ["group_id"]
body = request_data.except(*non_body_param_names)  # Remove non-body params from result
```

## Testing

- [x] TypeScript compilation passes
- [x] Lint checks pass (`pnpm run check`)
- [ ] Seed tests have IR version mismatches (expected failures per seed.yml)

## Human Review Checklist

- [ ] Verify `getNonBodyParameterWireNames()` correctly uses `originalName` for path params and `wireValue` for query/header params
- [ ] Confirm the generated Ruby code pattern correctly excludes non-body params from the serialized body
- [ ] Check edge case: endpoints with only headers (no path/query params) are handled correctly

---

Link to Devin run: https://app.devin.ai/sessions/8bff9635002a44a8b74b774fb0d2a092
Requested by: @jsklan