### PR TITLE
fix(csharp): fix missing `[Optional]` or `[Nullable]` attributes in certain cases

### DIFF
--- a/generators/csharp/model/src/generateFields.ts
+++ b/generators/csharp/model/src/generateFields.ts
@@ -89,12 +89,18 @@ export function generateField(
         property,
         className,
         context,
-        jsonProperty = true
+        jsonProperty = true,
+        initializerOverride,
+        useRequiredOverride
     }: {
         property: FernIr.ObjectProperty | FernIr.InlinedRequestBodyProperty;
         className: string;
         context: ModelGeneratorContext;
         jsonProperty?: boolean;
+        /** Override the default initializer (e.g., for default values) */
+        initializerOverride?: ast.CodeBlock;
+        /** Override whether the field should be required */
+        useRequiredOverride?: boolean;
     }
 ): ast.Field {
     const fieldType = context.csharpTypeMapper.convert({ reference: property.valueType });
@@ -155,6 +161,14 @@ export function generateField(
         };
         initializer = undefined;
         useRequired = false;
+    }
+
+    // Apply overrides if provided
+    if (initializerOverride !== undefined) {
+        initializer = initializerOverride;
+    }
+    if (useRequiredOverride !== undefined) {
+        useRequired = useRequiredOverride;
     }
 
     return cls.addField({

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.19.4
+  changelogEntry:
+    - summary: |
+        Fix missing `[Optional]` and/or `Nullable` attributes on generated properties with defaults.
+      type: fix
+  createdAt: "2026-01-28"
+  irVersion: 62
+
 - version: 2.19.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Occasionally (when there was a default set), the code path would miss generating `[Optional]` and `[Nullable]` attributes, which are important for serialization; this PR fixes that.

## Changes Made
Runs all field generation through the same generateField() function, just with overrides set.

## Testing
Tested on Auth0 spec, shouldn't change existing fixtures.
- [X] Unit tests added/updated
- [X] Manual testing completed
