### PR TITLE
fix(csharp): Only apply datetime reformatter to datetime types

### DIFF
--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -1,4 +1,4 @@
-import { ast, text, WithGeneration } from "@fern-api/csharp-codegen";
+import { ast, WithGeneration } from "@fern-api/csharp-codegen";
 import {
     ExampleEndpointCall,
     ExampleRequestBody,
@@ -58,12 +58,7 @@ export class MockEndpointGenerator extends WithGeneration {
                     const filteredRequestJson = this.filterReadOnlyPropertiesFromExample(example.request, endpoint);
 
                     writer.writeLine(`const string requestJson${suffix} = """`);
-                    writer.writeLine(
-                        JSON.stringify(filteredRequestJson, text.normalizeDates, 2).replace(
-                            /"\\{1,2}\$ref"/g,
-                            '"$ref\"'
-                        )
-                    );
+                    writer.writeLine(JSON.stringify(filteredRequestJson, null, 2).replace(/"\\{1,2}\$ref"/g, '"$ref"'));
                     writer.writeTextStatement('"""');
                 }
                 writer.newLine();
@@ -72,10 +67,7 @@ export class MockEndpointGenerator extends WithGeneration {
                     if (responseBodyType === "json") {
                         writer.writeLine(`const string mockResponse${suffix} = """`);
                         writer.writeLine(
-                            JSON.stringify(jsonExampleResponse, text.normalizeDates, 2).replace(
-                                /"\\{1,2}\$ref"/g,
-                                '"$ref\"'
-                            )
+                            JSON.stringify(jsonExampleResponse, null, 2).replace(/"\\{1,2}\$ref"/g, '"$ref"')
                         );
                         writer.writeTextStatement('"""');
                     } else if (responseBodyType === "text") {
@@ -443,6 +435,13 @@ export class MockEndpointGenerator extends WithGeneration {
 
         switch (shape.type) {
             case "primitive":
+                // Normalize datetime values to ISO 8601 format with milliseconds
+                // This ensures the expected JSON matches what the SDK serializes for DateTime types
+                if (shape.primitive.type === "datetime") {
+                    return new Date(shape.primitive.datetime).toISOString();
+                }
+                return exampleTypeRef.jsonExample;
+
             case "unknown":
                 return exampleTypeRef.jsonExample;
 

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -427,8 +427,13 @@ export class MockEndpointGenerator extends WithGeneration {
     }
 
     /**
-     * Filters read-only properties from an example type reference.
-     * Recursively handles containers (optional, list, map, etc.) and named types.
+     * Processes an example type reference for mock server tests.
+     *
+     * This function:
+     * - Filters out read-only properties from objects
+     * - Normalizes datetime primitives to ISO 8601 format with milliseconds (.000Z)
+     *   to match what the SDK serializes for DateTime types
+     * - Recursively handles containers (optional, list, map, etc.) and named types
      */
     private filterExampleTypeReference(exampleTypeRef: ExampleTypeReference): unknown {
         const shape = exampleTypeRef.shape;

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.19.5
+  changelogEntry:
+    - summary: |
+        Fix wire test issue for examples that contained string fields that looked like datetimes.
+      type: fix
+  createdAt: "2026-01-28"
+  irVersion: 62
+
 - version: 2.19.4
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -108,6 +108,11 @@ async function createJob({
         publishMetadata: generatorInvocation.publishMetadata
     };
 
+    // DEBUG: Log the create job payload
+    context.logger.info("=== DEBUG: Create Job Payload ===");
+    context.logger.info(`Output Mode: ${JSON.stringify(generatorInvocation.outputMode, null, 2)}`);
+    context.logger.info("=================================");
+
     const createResponse = await remoteGenerationService.remoteGen.createJobV3({
         apiName: workspace.definition.rootApiFile.contents.name,
         version,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -108,11 +108,6 @@ async function createJob({
         publishMetadata: generatorInvocation.publishMetadata
     };
 
-    // DEBUG: Log the create job payload
-    context.logger.info("=== DEBUG: Create Job Payload ===");
-    context.logger.info(`Output Mode: ${JSON.stringify(generatorInvocation.outputMode, null, 2)}`);
-    context.logger.info("=================================");
-
     const createResponse = await remoteGenerationService.remoteGen.createJobV3({
         apiName: workspace.definition.rootApiFile.contents.name,
         version,


### PR DESCRIPTION
This was also formatting strings floating around that looked like datetimes, causing mismatches