### PR TITLE
chore(ruby): add versions.yml entry for publish workflow fix

### DIFF
--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc85
+  changelogEntry:
+    - summary: |
+        Fix detached HEAD error in publish workflow. When triggered by a tag push, the workflow
+        enters detached HEAD state, causing `rubygems/release-gem@v1` (which runs `rake release`)
+        to fail when pushing to a non-existent branch. Replaced with manual build/push steps using
+        `rubygems/configure-rubygems-credentials@v1.0.0` for OIDC auth, `bundle exec rake build`,
+        and `gem push pkg/*.gem`. Also replaced `bundler-cache: true` with explicit `bundle install`
+        for more reliable dependency installation.
+      type: fix
+  createdAt: "2026-01-28"
+  irVersion: 61
+
 - version: 1.0.0-rc84
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Adds the missing versions.yml changelog entry for the publish workflow fix that was merged in PR #11878. The fix replaced `rubygems/release-gem@v1` with manual build/push steps to resolve a detached HEAD error when publishing gems.

## Changes Made

- Added versions.yml entry (1.0.0-rc85) documenting the publish workflow fix
- [x] Updated README.md generator (if applicable) - N/A, changelog only

## Testing

- [x] Unit tests added/updated - N/A, changelog entry only
- [x] Manual testing completed - N/A, changelog entry only

## Human Review Checklist

- [ ] Verify changelog entry accurately describes the fix from PR #11878
- [ ] Verify version number 1.0.0-rc85 is correct (follows 1.0.0-rc84)

---

> ✨ Generated by [Devin](https://devin.ai/) - requested by naman.anand@buildwithfern.com (@iamnamananand996)
> 🔗 [Devin session](https://app.devin.ai/sessions/2a15b1d981ce49bfb229648812a49c04)