### PR TITLE
fix: preserve $ref keys in x-fern-examples as literal strings

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/ref-in-examples.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/ref-in-examples.json
@@ -1,0 +1,224 @@
+{
+  "title": "Test $ref in examples bug",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "createCustomAttributeDefinition",
+      "tags": [],
+      "sdkName": {
+        "groupName": [],
+        "methodName": "create"
+      },
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "CreateRequest",
+      "request": {
+        "schema": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "createRequestCustomAttributeDefinition",
+              "key": "custom_attribute_definition",
+              "schema": {
+                "generatedName": "CreateRequestCustomAttributeDefinition",
+                "value": {
+                  "allOf": [],
+                  "properties": [
+                    {
+                      "conflict": {},
+                      "generatedName": "createRequestCustomAttributeDefinitionKey",
+                      "key": "key",
+                      "schema": {
+                        "generatedName": "CreateRequestCustomAttributeDefinitionKey",
+                        "value": {
+                          "schema": {
+                            "type": "string"
+                          },
+                          "generatedName": "CreateRequestCustomAttributeDefinitionKey",
+                          "groupName": [],
+                          "type": "primitive"
+                        },
+                        "groupName": [],
+                        "type": "optional"
+                      },
+                      "audiences": []
+                    },
+                    {
+                      "conflict": {},
+                      "generatedName": "createRequestCustomAttributeDefinitionName",
+                      "key": "name",
+                      "schema": {
+                        "generatedName": "CreateRequestCustomAttributeDefinitionName",
+                        "value": {
+                          "schema": {
+                            "type": "string"
+                          },
+                          "generatedName": "CreateRequestCustomAttributeDefinitionName",
+                          "groupName": [],
+                          "type": "primitive"
+                        },
+                        "groupName": [],
+                        "type": "optional"
+                      },
+                      "audiences": []
+                    },
+                    {
+                      "conflict": {},
+                      "generatedName": "createRequestCustomAttributeDefinitionSchema",
+                      "key": "schema",
+                      "schema": {
+                        "generatedName": "CreateRequestCustomAttributeDefinitionSchema",
+                        "value": {
+                          "key": {
+                            "schema": {
+                              "type": "string"
+                            },
+                            "generatedName": "CreateRequestCustomAttributeDefinitionSchemaKey",
+                            "groupName": [],
+                            "type": "primitive"
+                          },
+                          "value": {
+                            "generatedName": "CreateRequestCustomAttributeDefinitionSchemaValue",
+                            "type": "unknown"
+                          },
+                          "generatedName": "CreateRequestCustomAttributeDefinitionSchema",
+                          "groupName": [],
+                          "type": "map"
+                        },
+                        "groupName": [],
+                        "type": "optional"
+                      },
+                      "audiences": []
+                    }
+                  ],
+                  "allOfPropertyConflicts": [],
+                  "generatedName": "CreateRequestCustomAttributeDefinition",
+                  "groupName": [],
+                  "additionalProperties": false,
+                  "source": {
+                    "file": "../openapi.yml",
+                    "type": "openapi"
+                  },
+                  "type": "object"
+                },
+                "groupName": [],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "CreateRequest",
+          "groupName": [],
+          "additionalProperties": false,
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Success",
+        "schema": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "createResponseId",
+              "key": "id",
+              "schema": {
+                "generatedName": "CreateResponseId",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "CreateResponseId",
+                  "groupName": [],
+                  "type": "primitive"
+                },
+                "groupName": [],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "CreateResponse",
+          "groupName": [],
+          "additionalProperties": false,
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/v2/customers/custom-attribute-definitions",
+      "examples": [
+        {
+          "value": {
+            "request": {
+              "custom_attribute_definition": {
+                "key": "favoriteShow",
+                "name": "Favorite Show",
+                "schema": {
+                  "$ref": "https://developer-production-s3.s3.amazonaws.com/schema.json#type"
+                }
+              }
+            }
+          },
+          "type": "unknown"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [
+    {
+      "header": "Square-Version",
+      "optional": true
+    }
+  ],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/ref-in-examples.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/ref-in-examples.json
@@ -1,0 +1,154 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "create": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "custom_attribute_definition": {
+                      "key": "favoriteShow",
+                      "name": "Favorite Show",
+                      "schema": {
+                        "$ref": "https://developer-production-s3.s3.amazonaws.com/schema.json#type",
+                      },
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/v2/customers/custom-attribute-definitions",
+              "request": {
+                "body": {
+                  "properties": {
+                    "custom_attribute_definition": "optional<CreateRequestCustomAttributeDefinition>",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "CreateRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "CreateResponse",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "CreateRequestCustomAttributeDefinition": {
+            "docs": undefined,
+            "inline": true,
+            "properties": {
+              "key": "optional<string>",
+              "name": "optional<string>",
+              "schema": "optional<map<string, unknown>>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "CreateResponse": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "id": "optional<string>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  CreateRequestCustomAttributeDefinition:
+    properties:
+      key: optional<string>
+      name: optional<string>
+      schema: optional<map<string, unknown>>
+    source:
+      openapi: ../openapi.yml
+    inline: true
+  CreateResponse:
+    properties:
+      id: optional<string>
+    source:
+      openapi: ../openapi.yml
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    create:
+      path: /v2/customers/custom-attribute-definitions
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      request:
+        name: CreateRequest
+        body:
+          properties:
+            custom_attribute_definition: optional<CreateRequestCustomAttributeDefinition>
+        content-type: application/json
+      response:
+        docs: Success
+        type: CreateResponse
+        status-code: 200
+      examples:
+        - request:
+            custom_attribute_definition:
+              key: favoriteShow
+              name: Favorite Show
+              schema:
+                $ref: >-
+                  https://developer-production-s3.s3.amazonaws.com/schema.json#type
+  source:
+    openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Test $ref in examples bug",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "headers": {
+        "Square-Version": {
+          "env": undefined,
+          "name": undefined,
+          "type": "optional<string>",
+        },
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Test $ref in examples bug
+headers:
+  Square-Version:
+    type: optional<string>
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ref-in-examples/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ref-in-examples/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "test",
+  "version": "0.0.0"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ref-in-examples/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ref-in-examples/fern/generators.yml
@@ -1,0 +1,4 @@
+api:
+  specs:
+    - openapi: ../openapi.yml
+      overrides: ../overrides.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ref-in-examples/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ref-in-examples/openapi.yml
@@ -1,0 +1,37 @@
+openapi: 3.1.0
+info:
+  title: Test $ref in examples bug
+  version: 1.0.0
+x-fern-global-headers:
+  - header: Square-Version
+    optional: true
+paths:
+  /v2/customers/custom-attribute-definitions:
+    post:
+      operationId: createCustomAttributeDefinition
+      x-fern-sdk-method-name: create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                custom_attribute_definition:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    schema:
+                      type: object
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ref-in-examples/overrides.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/ref-in-examples/overrides.yml
@@ -1,0 +1,10 @@
+paths:
+  /v2/customers/custom-attribute-definitions:
+    post:
+      x-fern-examples:
+      - request:
+          custom_attribute_definition:
+            key: "favoriteShow"
+            name: "Favorite Show"
+            schema:
+              $ref: https://developer-production-s3.s3.amazonaws.com/schema.json#type

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.52.1
+  changelogEntry:
+    - summary: |
+        Fix `$ref` keys in `x-fern-examples` being incorrectly resolved as JSON Schema references. When example data in OpenAPI overrides contains `$ref` keys (as literal string values, not schema references), they are now preserved as-is instead of being processed by the bundler. This also fixes a bug where `$ref` in example data could corrupt `x-fern-global-headers` optional flags.
+      type: fix
+  createdAt: "2026-01-29"
+  irVersion: 63
+
 - version: 3.52.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Reported by user

Fixes a bug where `$ref` keys in `x-fern-examples` (example data, not schema references) were being incorrectly resolved by Redocly's bundler, which could corrupt other parts of the OpenAPI document including the `optional: true` flag on `x-fern-global-headers`.

**Link to Devin run:** https://app.devin.ai/sessions/c58fa720f39e4fe3ab7a2468b8faaed0
**Requested by:** @Ryan-Amirthan

## Changes Made

- Added `escapeRefsInExamples` and `unescapeRefsInExamples` helper functions in `loadOpenAPI.ts` that temporarily replace `$ref` keys with a sentinel value (`__fern_literal_ref__`) within example data contexts before parsing
- The escape/unescape is applied around the `parseOpenAPI` call when overrides or overlays are present
- Example contexts are identified using the existing `OPENAPI_EXAMPLES_KEYS` constant (examples, example, x-fern-examples, and Redocly code sample keys)
- Added test fixture `ref-in-examples` that reproduces the bug scenario with global headers and $ref in example data
- Updated CLI versions.yml with changelog entry (v3.52.1)

## Testing

- [x] Unit tests added (openapi-ir-to-fern-tests fixture)
- [x] Lint checks pass (`pnpm check`)
- [x] Test snapshot confirms:
  - `$ref` is preserved in example data (not resolved)
  - Global header `Square-Version` correctly shows `optional: true`

## Human Review Checklist

- [ ] Verify the escape/unescape traversal correctly identifies all example context keys
- [ ] Verify sentinel value `__fern_literal_ref__` is unlikely to conflict with real user data
- [ ] Consider if there are edge cases with deeply nested $ref in examples
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/11904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
