### PR TITLE
feat(python): add status_code property to HttpResponse

### DIFF
--- a/generators/python/core_utilities/shared/http_response.py
+++ b/generators/python/core_utilities/shared/http_response.py
@@ -7,7 +7,7 @@ T = TypeVar("T")
 
 
 class BaseHttpResponse:
-    """Minimalist HTTP response wrapper that exposes response headers."""
+    """Minimalist HTTP response wrapper that exposes response headers and status code."""
 
     _response: httpx.Response
 
@@ -17,6 +17,10 @@ class BaseHttpResponse:
     @property
     def headers(self) -> Dict[str, str]:
         return dict(self._response.headers)
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status_code
 
 
 class HttpResponse(Generic[T], BaseHttpResponse):

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.53.2
+  changelogEntry:
+    - summary: |
+        Add `status_code` property to `HttpResponse` and `AsyncHttpResponse` classes.
+        This allows users to access the HTTP status code when using `with_raw_response`.
+      type: feat
+  createdAt: "2026-01-29"
+  irVersion: 62
+
 - version: 4.53.1
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
-- version: 4.53.2
+- version: 4.54.0
   changelogEntry:
     - summary: |
         Add `status_code` property to `HttpResponse` and `AsyncHttpResponse` classes.

--- a/generators/python/src/fern_python/generator_cli/readme_snippet_builder.py
+++ b/generators/python/src/fern_python/generator_cli/readme_snippet_builder.py
@@ -259,6 +259,7 @@ client.{endpoint.endpoint_package_path}{endpoint.method_name}({"..., " if has_pa
                     )
                 )
                 writer.write_line("print(response.headers)  # access the response headers")
+                writer.write_line("print(response.status_code)  # access the response status code")
                 writer.write_line("print(response.data)  # access the underlying object")
 
             if pagination_endpoint_id and (
@@ -311,7 +312,8 @@ client.{endpoint.endpoint_package_path}{endpoint.method_name}({"..., " if has_pa
                             )
                         ],
                         body=[
-                            AST.Expression("print(response.headers)  # access the response headers\n"),
+                            AST.Expression("print(response.headers)  # access the response headers"),
+                            AST.Expression("print(response.status_code)  # access the response status code\n"),
                             AST.ForStatement(
                                 target="chunk",
                                 iterable="response.data",

--- a/seed/python-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/python-sdk/exhaustive/no-custom-config/README.md
@@ -101,6 +101,7 @@ response = client.endpoints.container.with_raw_response.get_and_return_list_of_p
     ...
 )
 print(response.headers)  # access the response headers
+print(response.status_code)  # access the response status code
 print(response.data)  # access the underlying object
 ```
 

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_response.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_response.py
@@ -9,7 +9,7 @@ T = TypeVar("T")
 
 
 class BaseHttpResponse:
-    """Minimalist HTTP response wrapper that exposes response headers."""
+    """Minimalist HTTP response wrapper that exposes response headers and status code."""
 
     _response: httpx.Response
 
@@ -19,6 +19,10 @@ class BaseHttpResponse:
     @property
     def headers(self) -> Dict[str, str]:
         return dict(self._response.headers)
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status_code
 
 
 class HttpResponse(Generic[T], BaseHttpResponse):


### PR DESCRIPTION
## Description

Refs: User request from @iamnamananand996

Adds `status_code` property to `HttpResponse` and `AsyncHttpResponse` classes, allowing users to access the HTTP status code when using `with_raw_response`.

Previously, users could only access `headers` and `data` from raw responses. The status code was only accessible via the private `_response` attribute.

Link to Devin run: https://app.devin.ai/sessions/59e691c655aa4655b2ab3f8534e71dd7

## Changes Made

- Added `status_code` property to `BaseHttpResponse` class (inherited by both `HttpResponse` and `AsyncHttpResponse`)
- Updated docstring to reflect the new capability
- Added version 4.54.0 changelog entry (minor version bump for feat change)
- [x] Updated README.md generator to include `status_code` in the "Access Raw Response Data" snippets (both regular and streaming examples)
- [x] Updated seed fixture (`exhaustive/no-custom-config`) with generated changes

## Testing

- [ ] Unit tests added/updated
- [x] Pre-commit hooks pass
- [x] Seed fixture `exhaustive:no-custom-config` ran successfully and verified:
  - `status_code` property correctly generated in `http_response.py`
  - README snippet includes `print(response.status_code)  # access the response status code`

## Human Review Checklist

- [x] Verify the property correctly returns the HTTP status code when using `with_raw_response`
- [x] Confirm version bump to 4.54.0 is appropriate for this feature addition
- [x] Verify the generated README snippets look correct with the new `status_code` line