### PR TITLE
feat(cli): Add better line wrapping

### DIFF
--- a/packages/cli/cli-v2/build-utils.mjs
+++ b/packages/cli/cli-v2/build-utils.mjs
@@ -116,4 +116,9 @@ export async function buildCli(config) {
 
     // Run npm pkg fix to format and fix the package.json
     await execAsync("npm pkg fix");
+
+    // Install runtime dependencies if any
+    if (Object.keys(dependencies).length > 0) {
+        await execAsync("pnpm install --ignore-workspace");
+    }
 }

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -13,9 +13,11 @@ export async function runCliV2(argv?: string[]): Promise<void> {
 }
 
 function createCliV2(argv?: string[]): Argv<GlobalArgs> {
+    const terminalWidth = process.stdout.columns ?? 80;
     const cli: Argv<GlobalArgs> = yargs(argv ?? hideBin(process.argv))
         .scriptName("fern")
         .version(Version)
+        .wrap(Math.min(120, terminalWidth))
         .option("log-level", {
             type: "string",
             description: "Set log level",

--- a/packages/cli/cli-v2/src/config/FileFinder.ts
+++ b/packages/cli/cli-v2/src/config/FileFinder.ts
@@ -27,10 +27,16 @@ export class FileFinder {
      * @returns The absolute path to the file if found, undefined otherwise.
      * @throws Error if the file is not found.
      */
-    public async findOrThrow(filename: string): Promise<AbsoluteFilePath> {
-        const filepath = await this.find(filename);
+    public async findOrThrow({
+        filename,
+        remediationMessage
+    }: {
+        filename: string;
+        remediationMessage?: string;
+    }): Promise<AbsoluteFilePath> {
+        const filepath = await this.find({ filename });
         if (filepath == null) {
-            throw new Error(`File ${filename} not found in any parent directory from ${this.from}`);
+            throw new Error(`${filename} file not found in any parent directory from ${this.from}`);
         }
         return filepath;
     }
@@ -42,7 +48,7 @@ export class FileFinder {
      * @param filename - The name of the file to find (e.g., "fern.yml")
      * @returns The absolute path to the file if found, undefined otherwise.
      */
-    public async find(filename: string): Promise<AbsoluteFilePath | undefined> {
+    public async find({ filename }: { filename: string }): Promise<AbsoluteFilePath | undefined> {
         const filepath = await findUp(filename, { cwd: this.from, type: "file" });
         if (filepath == null) {
             return undefined;

--- a/packages/cli/cli-v2/src/config/fern-yml/FernYmlSchemaLoader.ts
+++ b/packages/cli/cli-v2/src/config/fern-yml/FernYmlSchemaLoader.ts
@@ -36,7 +36,10 @@ export class FernYmlSchemaLoader {
      * @throws Error if fern.yml is not found.
      */
     public async load(): Promise<FernYmlSchemaLoader.Result> {
-        const absoluteFilePath = await this.finder.findOrThrow(FILENAME);
+        const absoluteFilePath = await this.finder.find({ filename: FILENAME });
+        if (absoluteFilePath == null) {
+            throw new Error(`${FILENAME} file not found in any parent directory; did you forget to run \`fern init\`?`);
+        }
         return await this.loader.load({
             absoluteFilePath,
             schema: FernYmlSchema

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -1,4 +1,5 @@
 import { LogLevel } from "@fern-api/logger";
+import chalk from "chalk";
 import { CliError } from "../errors/CliError";
 import { ValidationError } from "../errors/ValidationError";
 import { Context } from "./Context";
@@ -42,27 +43,27 @@ function createContext(options: GlobalArgs): Context {
 function handleError(context: Context, error: unknown): void {
     if (error instanceof ValidationError) {
         for (const issue of error.issues) {
-            context.stderr.info(issue.toString());
+            process.stderr.write(`${chalk.red(issue.toString())}\n`);
         }
         return;
     }
 
     if (error instanceof CliError) {
         if (error.message.length > 0) {
-            context.stderr.error(error.message);
+            process.stderr.write(`${chalk.red(error.message)}\n`);
         }
         return;
     }
 
     if (error instanceof Error) {
-        context.stderr.error(error.message);
-        if (error.stack != null) {
-            context.stderr.debug(error.stack);
+        process.stderr.write(`${chalk.red(error.message)}\n`);
+        if (error.stack != null && context.logLevel === LogLevel.Debug) {
+            process.stderr.write(`${chalk.dim(error.stack)}\n`);
         }
         return;
     }
 
-    context.stderr.error(String(error));
+    process.stderr.write(`${chalk.red(String(error))}\n`);
 }
 
 function parseLogLevel(level: string): LogLevel {

--- a/packages/cli/cli-v2/src/ui/TaskGroup.ts
+++ b/packages/cli/cli-v2/src/ui/TaskGroup.ts
@@ -222,7 +222,7 @@ export class TaskGroup {
             }
             case "error": {
                 const duration = this.formatTaskDuration(task);
-                const errorLines = this.formatMultilineError(task.error);
+                const errorLines = this.formatMultilineText(task.error, chalk.red.bind(chalk));
                 return `${chalk.red("x")} ${name}${duration}${logLines}${errorLines}`;
             }
             case "skipped":
@@ -234,6 +234,8 @@ export class TaskGroup {
 
     private static readonly MAX_DISPLAYED_LOGS_TTY = 10;
 
+    private static readonly URL_PATTERN = /https?:\/\//i;
+
     private formatTaskLogs(logs: TaskLog[] | undefined): string {
         if (logs == null || logs.length === 0) {
             return "";
@@ -242,31 +244,33 @@ export class TaskGroup {
         // In TTY mode (interactive), limit logs to avoid overwhelming the display.
         // In CI/non-TTY mode, show all logs since the console can handle scrolling.
         const shouldLimit = this.context.isTTY;
-        const logsToShow =
-            shouldLimit && logs.length > TaskGroup.MAX_DISPLAYED_LOGS_TTY
-                ? logs.slice(-TaskGroup.MAX_DISPLAYED_LOGS_TTY)
-                : logs;
-        const hiddenCount = logs.length - logsToShow.length;
 
-        // Get max message length for TTY mode to prevent line wrapping
-        const maxMessageLength = shouldLimit ? this.getMaxLogMessageLength() : Infinity;
+        // Filter out debug logs containing URLs in TTY mode - they cause rendering
+        // issues in IDE terminals. These logs are still written to the log file.
+        const filteredLogs = shouldLimit
+            ? logs.filter((log) => log.level !== "debug" || !TaskGroup.URL_PATTERN.test(log.message))
+            : logs;
+
+        const logsToShow =
+            shouldLimit && filteredLogs.length > TaskGroup.MAX_DISPLAYED_LOGS_TTY
+                ? filteredLogs.slice(-TaskGroup.MAX_DISPLAYED_LOGS_TTY)
+                : filteredLogs;
+        const hiddenCount = logs.length - logsToShow.length;
 
         const formattedLogs = logsToShow
             .map((log) => {
-                const message = shouldLimit ? this.truncateMessage(log.message, maxMessageLength) : log.message;
                 switch (log.level) {
                     case "debug": {
+                        // For debug logs, we want to truncate the message to prevent line wrapping in TTY mode.
+                        const maxMessageLength = shouldLimit ? this.getMaxLogMessageLength() : Infinity;
+                        const message = shouldLimit ? this.truncateMessage(log.message, maxMessageLength) : log.message;
                         const icon = chalk.dim("•");
                         return `\n    ${icon} ${chalk.dim(message)}`;
                     }
-                    case "warn": {
-                        const icon = chalk.yellow("⚠");
-                        return `\n    ${icon} ${chalk.yellow(message)}`;
-                    }
-                    case "error": {
-                        const icon = chalk.red("✗");
-                        return `\n    ${icon} ${chalk.red(message)}`;
-                    }
+                    case "warn":
+                        return this.formatMultilineText(log.message, chalk.yellow.bind(chalk), chalk.yellow("⚠"));
+                    case "error":
+                        return this.formatMultilineText(log.message, chalk.red.bind(chalk), chalk.red("✗"));
                     default:
                         assertNever(log.level);
                 }
@@ -308,13 +312,19 @@ export class TaskGroup {
         return "";
     }
 
-    private formatMultilineError(error: string | undefined): string {
-        if (error == null) {
+    private formatMultilineText(text: string | undefined, colorFn: (text: string) => string, icon?: string): string {
+        if (text == null) {
             return "";
         }
-        // Split error into lines and format each with proper indentation.
-        const lines = error.split("\n").filter((line) => line.trim().length > 0);
-        return lines.map((line) => `\n    ${chalk.red(line)}`).join("");
+        // Split text into lines and format each with proper indentation.
+        const lines = text.split("\n").filter((line) => line.trim().length > 0);
+        if (icon != null) {
+            const [first, ...rest] = lines;
+            const firstLine = `\n    ${icon} ${colorFn(first ?? "")}`;
+            const restLines = rest.map((line) => `\n      ${colorFn(line)}`).join("");
+            return firstLine + restLines;
+        }
+        return lines.map((line) => `\n    ${colorFn(line)}`).join("");
     }
 
     private formatDuration(ms: number): string {


### PR DESCRIPTION
## Description

This configures `yargs` so that the `--help` text is better displayed in the terminal, and updates errors to be correctly wrapped under each group.


Now users will see a structure like the following (which adapts to their terminal window size):
```sh
$ fern-v2 sdk generate --help
fern generate [options]

Generate SDKs configured in fern.yml

Options:
  --help              Show help                                                                                [boolean]
  --log-level         Set log level               [string] [choices: "debug", "info", "warn", "error"] [default: "info"]
  --target            The SDK target to generate                                                                [string]
  --group             The SDK group to generate                                                                 [string]
  --audiences         Filter the target API(s) with the given audiences                                          [array]
  --local             Run the generator locally in a container                                [boolean] [default: false]
  --container-engine  Choose the container engine to use for local generation              [choices: "docker", "podman"]
  --keep-container    Prevent auto-deletion of any containers used for local generation       [boolean] [default: false]
  --preview           Generate a preview of the generated SDK in a local preview directory    [boolean] [default: false]
  --output            Output directory for preview mode (requires --preview)                                    [string]
  --force             Ignore prompts to confirm generation                                    [boolean] [default: false]
  --version           The version to use for the generated packages (e.g. 1.0.0)                                [string]
```

```sh
$ fern-v2 sdk generate --container-engine podman --local

◆ Generating SDKs
  org: amckinney

┌─
│ x typescript 34ms
│     ✗ Cannot generate because output location is not local-file-system
│ x go 264ms
│     ✗ Generation failed: Container runtime 'podman' is not installed or not found on PATH.
│       Seed tests default to Podman. Install podman: https://podman.io/docs/installation
│       Error details: No output
└─

✕ Failed to generate SDKs in 265ms

Logs written to: /Users/alex/code/demo/.fern/logs/2026-01-29T15-47-26-345Z.log
```

There's still some work we need to do on the debug log output because it messes up VSCode and Cursor terminals, but we'll come back to that in a larger overhaul of the `TtyAwareLogger` and `TaskGroup` output structure.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
