### PR TITLE
fix(csharp): top-level client uses interface types for subclients

### DIFF
--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -149,7 +149,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                     access: ast.Access.Public,
                     get: true,
                     origin: subpackage,
-                    type: this.context.getSubpackageClassReference(subpackage)
+                    type: this.context.getSubpackageInterfaceReference(subpackage)
                 });
             }
         }

--- a/generators/csharp/sdk/src/root-client/RootClientInterfaceGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientInterfaceGenerator.ts
@@ -27,14 +27,12 @@ export class RootClientInterfaceGenerator extends FileGenerator<CSharpFile, SdkG
 
         for (const subpackage of this.getSubpackages()) {
             if (this.context.subPackageHasEndpointsRecursively(subpackage)) {
-                // Use concrete class reference (not interface) to match the implementing class's property type
-                // C# requires exact type match when implementing interface properties
                 interface_.addField({
                     name: subpackage.name.pascalCase.safeName,
                     enclosingType: interface_,
                     access: ast.Access.Public,
                     get: true,
-                    type: this.context.getSubpackageClassReference(subpackage)
+                    type: this.context.getSubpackageInterfaceReference(subpackage)
                 });
             }
         }

--- a/generators/csharp/sdk/src/subpackage-client/SubPackageClientGenerator.ts
+++ b/generators/csharp/sdk/src/subpackage-client/SubPackageClientGenerator.ts
@@ -103,7 +103,7 @@ export class SubPackageClientGenerator extends FileGenerator<CSharpFile, SdkGene
                     origin: subpackage,
                     access: ast.Access.Public,
                     get: true,
-                    type: this.context.getSubpackageClassReference(subpackage)
+                    type: this.context.getSubpackageInterfaceReference(subpackage)
                 });
             }
         }

--- a/generators/csharp/sdk/src/subpackage-client/SubPackageClientInterfaceGenerator.ts
+++ b/generators/csharp/sdk/src/subpackage-client/SubPackageClientInterfaceGenerator.ts
@@ -37,14 +37,12 @@ export class SubPackageClientInterfaceGenerator extends FileGenerator<CSharpFile
 
         for (const childSubpackage of this.getSubpackages()) {
             if (this.context.subPackageHasEndpointsRecursively(childSubpackage)) {
-                // Use concrete class reference (not interface) to match the implementing class's property type
-                // C# requires exact type match when implementing interface properties
                 interface_.addField({
                     name: childSubpackage.name.pascalCase.safeName,
                     enclosingType: interface_,
                     access: ast.Access.Public,
                     get: true,
-                    type: this.context.getSubpackageClassReference(childSubpackage)
+                    type: this.context.getSubpackageInterfaceReference(childSubpackage)
                 });
             }
         }

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.19.7
+  changelogEntry:
+    - summary: |
+        The top-level client now uses the interface types for sub-clients instead of concrete types.
+      type: fix
+  createdAt: "2026-01-29"
+  irVersion: 62
+
 - version: 2.19.6
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -2,7 +2,7 @@
 - version: 2.19.7
   changelogEntry:
     - summary: |
-        The top-level client now uses the interface types for sub-clients instead of concrete types.
+        Top-level clients now use interface types for sub-clients instead of concrete types.
       type: fix
   createdAt: "2026-01-29"
   irVersion: 62

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/ISeedAcceptClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/ISeedAcceptClient.cs
@@ -2,5 +2,5 @@ namespace SeedAccept;
 
 public partial interface ISeedAcceptClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/SeedAcceptClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/SeedAcceptClient.cs
@@ -37,5 +37,5 @@ public partial class SeedAcceptClient : ISeedAcceptClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/ISeedAnyAuthClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/ISeedAnyAuthClient.cs
@@ -2,6 +2,6 @@ namespace SeedAnyAuth;
 
 public partial interface ISeedAnyAuthClient
 {
-    public AuthClient Auth { get; }
-    public UserClient User { get; }
+    public IAuthClient Auth { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuthClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuthClient.cs
@@ -85,9 +85,9 @@ public partial class SeedAnyAuthClient : ISeedAnyAuthClient
         User = new UserClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 
     private static string GetFromEnvironmentOrThrow(string env, string message)
     {

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/ISeedApiWideBasePathClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/ISeedApiWideBasePathClient.cs
@@ -2,5 +2,5 @@ namespace SeedApiWideBasePath;
 
 public partial interface ISeedApiWideBasePathClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePathClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePathClient.cs
@@ -29,5 +29,5 @@ public partial class SeedApiWideBasePathClient : ISeedApiWideBasePathClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/FolderAClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/FolderAClient.cs
@@ -12,5 +12,5 @@ public partial class FolderAClient : IFolderAClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/IFolderAClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderA/IFolderAClient.cs
@@ -2,5 +2,5 @@ namespace SeedAudiences.FolderA;
 
 public partial interface IFolderAClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/FolderDClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/FolderDClient.cs
@@ -12,5 +12,5 @@ public partial class FolderDClient : IFolderDClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/IFolderDClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/FolderD/IFolderDClient.cs
@@ -2,5 +2,5 @@ namespace SeedAudiences.FolderD;
 
 public partial interface IFolderDClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/ISeedAudiencesClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/ISeedAudiencesClient.cs
@@ -5,7 +5,7 @@ namespace SeedAudiences;
 
 public partial interface ISeedAudiencesClient
 {
-    public FolderAClient FolderA { get; }
-    public FolderDClient FolderD { get; }
-    public FooClient Foo { get; }
+    public IFolderAClient FolderA { get; }
+    public IFolderDClient FolderD { get; }
+    public IFooClient Foo { get; }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/SeedAudiencesClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/SeedAudiencesClient.cs
@@ -33,9 +33,9 @@ public partial class SeedAudiencesClient : ISeedAudiencesClient
         Foo = new FooClient(_client);
     }
 
-    public FolderAClient FolderA { get; }
+    public IFolderAClient FolderA { get; }
 
-    public FolderDClient FolderD { get; }
+    public IFolderDClient FolderD { get; }
 
-    public FooClient Foo { get; }
+    public IFooClient Foo { get; }
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/ISeedBasicAuthEnvironmentVariablesClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/ISeedBasicAuthEnvironmentVariablesClient.cs
@@ -2,5 +2,5 @@ namespace SeedBasicAuthEnvironmentVariables;
 
 public partial interface ISeedBasicAuthEnvironmentVariablesClient
 {
-    public BasicAuthClient BasicAuth { get; }
+    public IBasicAuthClient BasicAuth { get; }
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariablesClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariablesClient.cs
@@ -42,7 +42,7 @@ public partial class SeedBasicAuthEnvironmentVariablesClient
         BasicAuth = new BasicAuthClient(_client);
     }
 
-    public BasicAuthClient BasicAuth { get; }
+    public IBasicAuthClient BasicAuth { get; }
 
     private static string GetFromEnvironmentOrThrow(string env, string message)
     {

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/ISeedBasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/ISeedBasicAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedBasicAuth;
 
 public partial interface ISeedBasicAuthClient
 {
-    public BasicAuthClient BasicAuth { get; }
+    public IBasicAuthClient BasicAuth { get; }
 }

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/SeedBasicAuthClient.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth/SeedBasicAuthClient.cs
@@ -33,5 +33,5 @@ public partial class SeedBasicAuthClient : ISeedBasicAuthClient
         BasicAuth = new BasicAuthClient(_client);
     }
 
-    public BasicAuthClient BasicAuth { get; }
+    public IBasicAuthClient BasicAuth { get; }
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/ISeedBearerTokenEnvironmentVariableClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/ISeedBearerTokenEnvironmentVariableClient.cs
@@ -2,5 +2,5 @@ namespace SeedBearerTokenEnvironmentVariable;
 
 public partial interface ISeedBearerTokenEnvironmentVariableClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariableClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariableClient.cs
@@ -53,7 +53,7 @@ public partial class SeedBearerTokenEnvironmentVariableClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 
     private static string GetFromEnvironmentOrThrow(string env, string message)
     {

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/ISeedBytesDownloadClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/ISeedBytesDownloadClient.cs
@@ -2,5 +2,5 @@ namespace SeedBytesDownload;
 
 public partial interface ISeedBytesDownloadClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/SeedBytesDownloadClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/SeedBytesDownloadClient.cs
@@ -29,5 +29,5 @@ public partial class SeedBytesDownloadClient : ISeedBytesDownloadClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/ISeedBytesUploadClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/ISeedBytesUploadClient.cs
@@ -2,5 +2,5 @@ namespace SeedBytesUpload;
 
 public partial interface ISeedBytesUploadClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/SeedBytesUploadClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/SeedBytesUploadClient.cs
@@ -29,5 +29,5 @@ public partial class SeedBytesUploadClient : ISeedBytesUploadClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/ISeedClientSideParamsClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/ISeedClientSideParamsClient.cs
@@ -2,5 +2,5 @@ namespace SeedClientSideParams;
 
 public partial interface ISeedClientSideParamsClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/SeedClientSideParamsClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/SeedClientSideParamsClient.cs
@@ -37,5 +37,5 @@ public partial class SeedClientSideParamsClient : ISeedClientSideParamsClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/ISeedContentTypesClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/ISeedContentTypesClient.cs
@@ -2,5 +2,5 @@ namespace SeedContentTypes;
 
 public partial interface ISeedContentTypesClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/SeedContentTypesClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/SeedContentTypesClient.cs
@@ -29,5 +29,5 @@ public partial class SeedContentTypesClient : ISeedContentTypesClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/FolderAClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/FolderAClient.cs
@@ -12,5 +12,5 @@ public partial class FolderAClient : IFolderAClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/IFolderAClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderA/IFolderAClient.cs
@@ -2,5 +2,5 @@ namespace SeedCrossPackageTypeNames.FolderA;
 
 public partial interface IFolderAClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/FolderDClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/FolderDClient.cs
@@ -12,5 +12,5 @@ public partial class FolderDClient : IFolderDClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/IFolderDClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/FolderD/IFolderDClient.cs
@@ -2,5 +2,5 @@ namespace SeedCrossPackageTypeNames.FolderD;
 
 public partial interface IFolderDClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/ISeedCrossPackageTypeNamesClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/ISeedCrossPackageTypeNamesClient.cs
@@ -5,7 +5,7 @@ namespace SeedCrossPackageTypeNames;
 
 public partial interface ISeedCrossPackageTypeNamesClient
 {
-    public FolderAClient FolderA { get; }
-    public FolderDClient FolderD { get; }
-    public FooClient Foo { get; }
+    public IFolderAClient FolderA { get; }
+    public IFolderDClient FolderD { get; }
+    public IFooClient Foo { get; }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNamesClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNamesClient.cs
@@ -33,9 +33,9 @@ public partial class SeedCrossPackageTypeNamesClient : ISeedCrossPackageTypeName
         Foo = new FooClient(_client);
     }
 
-    public FolderAClient FolderA { get; }
+    public IFolderAClient FolderA { get; }
 
-    public FolderDClient FolderD { get; }
+    public IFolderDClient FolderD { get; }
 
-    public FooClient Foo { get; }
+    public IFooClient Foo { get; }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public DataserviceClient Dataservice { get; }
+    public IDataserviceClient Dataservice { get; }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApiClient.cs
@@ -41,5 +41,5 @@ public partial class SeedApiClient : ISeedApiClient
         }
     }
 
-    public DataserviceClient Dataservice { get; }
+    public IDataserviceClient Dataservice { get; }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public DataserviceClient Dataservice { get; }
+    public IDataserviceClient Dataservice { get; }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApiClient.cs
@@ -29,5 +29,5 @@ public partial class SeedApiClient : ISeedApiClient
         Dataservice = new DataserviceClient(_client);
     }
 
-    public DataserviceClient Dataservice { get; }
+    public IDataserviceClient Dataservice { get; }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public DataserviceClient Dataservice { get; }
+    public IDataserviceClient Dataservice { get; }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApiClient.cs
@@ -29,5 +29,5 @@ public partial class SeedApiClient : ISeedApiClient
         Dataservice = new DataserviceClient(_client);
     }
 
-    public DataserviceClient Dataservice { get; }
+    public IDataserviceClient Dataservice { get; }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public DataserviceClient Dataservice { get; }
+    public IDataserviceClient Dataservice { get; }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApiClient.cs
@@ -29,5 +29,5 @@ public partial class SeedApiClient : ISeedApiClient
         Dataservice = new DataserviceClient(_client);
     }
 
-    public DataserviceClient Dataservice { get; }
+    public IDataserviceClient Dataservice { get; }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/ISeedCsharpNamespaceCollisionClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/ISeedCsharpNamespaceCollisionClient.cs
@@ -4,7 +4,7 @@ namespace SeedCsharpNamespaceCollision;
 
 public partial interface ISeedCsharpNamespaceCollisionClient
 {
-    public SystemClient System { get; }
+    public ISystemClient System { get; }
     WithRawResponseTask<User> CreateUserAsync(
         User request,
         RequestOptions? options = null,

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollisionClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollisionClient.cs
@@ -31,7 +31,7 @@ public partial class SeedCsharpNamespaceCollisionClient : ISeedCsharpNamespaceCo
         System = new SystemClient(_client);
     }
 
-    public SystemClient System { get; }
+    public ISystemClient System { get; }
 
     private async Task<WithRawResponse<User>> CreateUserAsyncCore(
         User request,

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/ISeedCsharpNamespaceConflictClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/ISeedCsharpNamespaceConflictClient.cs
@@ -2,5 +2,5 @@ namespace SeedCsharpNamespaceConflict;
 
 public partial interface ISeedCsharpNamespaceConflictClient
 {
-    public TasktestClient Tasktest { get; }
+    public ITasktestClient Tasktest { get; }
 }

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/SeedCsharpNamespaceConflictClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/SeedCsharpNamespaceConflictClient.cs
@@ -29,5 +29,5 @@ public partial class SeedCsharpNamespaceConflictClient : ISeedCsharpNamespaceCon
         Tasktest = new TasktestClient(_client);
     }
 
-    public TasktestClient Tasktest { get; }
+    public ITasktestClient Tasktest { get; }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/ISeedEndpointSecurityAuthClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/ISeedEndpointSecurityAuthClient.cs
@@ -2,6 +2,6 @@ namespace SeedEndpointSecurityAuth;
 
 public partial interface ISeedEndpointSecurityAuthClient
 {
-    public AuthClient Auth { get; }
-    public UserClient User { get; }
+    public IAuthClient Auth { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuthClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuthClient.cs
@@ -85,9 +85,9 @@ public partial class SeedEndpointSecurityAuthClient : ISeedEndpointSecurityAuthC
         User = new UserClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 
     private static string GetFromEnvironmentOrThrow(string env, string message)
     {

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/ISeedEnumClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/ISeedEnumClient.cs
@@ -2,9 +2,9 @@ namespace SeedEnum;
 
 public partial interface ISeedEnumClient
 {
-    public HeadersClient Headers { get; }
-    public InlinedRequestClient InlinedRequest { get; }
-    public MultipartFormClient MultipartForm { get; }
-    public PathParamClient PathParam { get; }
-    public QueryParamClient QueryParam { get; }
+    public IHeadersClient Headers { get; }
+    public IInlinedRequestClient InlinedRequest { get; }
+    public IMultipartFormClient MultipartForm { get; }
+    public IPathParamClient PathParam { get; }
+    public IQueryParamClient QueryParam { get; }
 }

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/SeedEnumClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/SeedEnumClient.cs
@@ -33,13 +33,13 @@ public partial class SeedEnumClient : ISeedEnumClient
         QueryParam = new QueryParamClient(_client);
     }
 
-    public HeadersClient Headers { get; }
+    public IHeadersClient Headers { get; }
 
-    public InlinedRequestClient InlinedRequest { get; }
+    public IInlinedRequestClient InlinedRequest { get; }
 
-    public MultipartFormClient MultipartForm { get; }
+    public IMultipartFormClient MultipartForm { get; }
 
-    public PathParamClient PathParam { get; }
+    public IPathParamClient PathParam { get; }
 
-    public QueryParamClient QueryParam { get; }
+    public IQueryParamClient QueryParam { get; }
 }

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/ISeedEnumClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/ISeedEnumClient.cs
@@ -2,9 +2,9 @@ namespace SeedEnum;
 
 public partial interface ISeedEnumClient
 {
-    public HeadersClient Headers { get; }
-    public InlinedRequestClient InlinedRequest { get; }
-    public MultipartFormClient MultipartForm { get; }
-    public PathParamClient PathParam { get; }
-    public QueryParamClient QueryParam { get; }
+    public IHeadersClient Headers { get; }
+    public IInlinedRequestClient InlinedRequest { get; }
+    public IMultipartFormClient MultipartForm { get; }
+    public IPathParamClient PathParam { get; }
+    public IQueryParamClient QueryParam { get; }
 }

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/SeedEnumClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/SeedEnumClient.cs
@@ -33,13 +33,13 @@ public partial class SeedEnumClient : ISeedEnumClient
         QueryParam = new QueryParamClient(_client);
     }
 
-    public HeadersClient Headers { get; }
+    public IHeadersClient Headers { get; }
 
-    public InlinedRequestClient InlinedRequest { get; }
+    public IInlinedRequestClient InlinedRequest { get; }
 
-    public MultipartFormClient MultipartForm { get; }
+    public IMultipartFormClient MultipartForm { get; }
 
-    public PathParamClient PathParam { get; }
+    public IPathParamClient PathParam { get; }
 
-    public QueryParamClient QueryParam { get; }
+    public IQueryParamClient QueryParam { get; }
 }

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/ISeedErrorPropertyClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/ISeedErrorPropertyClient.cs
@@ -2,5 +2,5 @@ namespace SeedErrorProperty;
 
 public partial interface ISeedErrorPropertyClient
 {
-    public PropertyBasedErrorClient PropertyBasedError { get; }
+    public IPropertyBasedErrorClient PropertyBasedError { get; }
 }

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/SeedErrorPropertyClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/SeedErrorPropertyClient.cs
@@ -29,5 +29,5 @@ public partial class SeedErrorPropertyClient : ISeedErrorPropertyClient
         PropertyBasedError = new PropertyBasedErrorClient(_client);
     }
 
-    public PropertyBasedErrorClient PropertyBasedError { get; }
+    public IPropertyBasedErrorClient PropertyBasedError { get; }
 }

--- a/seed/csharp-sdk/errors/src/SeedErrors/ISeedErrorsClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/ISeedErrorsClient.cs
@@ -2,5 +2,5 @@ namespace SeedErrors;
 
 public partial interface ISeedErrorsClient
 {
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/errors/src/SeedErrors/SeedErrorsClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/SeedErrorsClient.cs
@@ -29,5 +29,5 @@ public partial class SeedErrorsClient : ISeedErrorsClient
         Simple = new SimpleClient(_client);
     }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/FileClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/FileClient.cs
@@ -14,7 +14,7 @@ public partial class FileClient : IFileClient
         Service = new ServiceClient(_client);
     }
 
-    public NotificationClient Notification { get; }
+    public INotificationClient Notification { get; }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/IFileClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/IFileClient.cs
@@ -4,6 +4,6 @@ namespace SeedExamples.File_;
 
 public partial interface IFileClient
 {
-    public NotificationClient Notification { get; }
-    public ServiceClient Service { get; }
+    public INotificationClient Notification { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/INotificationClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/INotificationClient.cs
@@ -2,5 +2,5 @@ namespace SeedExamples.File_.Notification;
 
 public partial interface INotificationClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/NotificationClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/File/Notification/NotificationClient.cs
@@ -12,5 +12,5 @@ public partial class NotificationClient : INotificationClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/HealthClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/HealthClient.cs
@@ -12,5 +12,5 @@ public partial class HealthClient : IHealthClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/IHealthClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Health/IHealthClient.cs
@@ -2,5 +2,5 @@ namespace SeedExamples.Health;
 
 public partial interface IHealthClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/ISeedExamplesClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/ISeedExamplesClient.cs
@@ -6,9 +6,9 @@ namespace SeedExamples;
 
 public partial interface ISeedExamplesClient
 {
-    public FileClient File { get; }
-    public HealthClient Health { get; }
-    public ServiceClient Service { get; }
+    public IFileClient File { get; }
+    public IHealthClient Health { get; }
+    public IServiceClient Service { get; }
     WithRawResponseTask<string> EchoAsync(
         string request,
         RequestOptions? options = null,

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamplesClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamplesClient.cs
@@ -43,11 +43,11 @@ public partial class SeedExamplesClient : ISeedExamplesClient
         Service = new ServiceClient(_client);
     }
 
-    public FileClient File { get; }
+    public IFileClient File { get; }
 
-    public HealthClient Health { get; }
+    public IHealthClient Health { get; }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 
     private async Task<WithRawResponse<string>> EchoAsyncCore(
         string request,

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/FileClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/FileClient.cs
@@ -14,7 +14,7 @@ public partial class FileClient : IFileClient
         Service = new ServiceClient(_client);
     }
 
-    public NotificationClient Notification { get; }
+    public INotificationClient Notification { get; }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/IFileClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/IFileClient.cs
@@ -4,6 +4,6 @@ namespace SeedExamples.File_;
 
 public partial interface IFileClient
 {
-    public NotificationClient Notification { get; }
-    public ServiceClient Service { get; }
+    public INotificationClient Notification { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/INotificationClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/INotificationClient.cs
@@ -2,5 +2,5 @@ namespace SeedExamples.File_.Notification;
 
 public partial interface INotificationClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/NotificationClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/File/Notification/NotificationClient.cs
@@ -12,5 +12,5 @@ public partial class NotificationClient : INotificationClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/HealthClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/HealthClient.cs
@@ -12,5 +12,5 @@ public partial class HealthClient : IHealthClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/IHealthClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Health/IHealthClient.cs
@@ -2,5 +2,5 @@ namespace SeedExamples.Health;
 
 public partial interface IHealthClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/ISeedExamplesClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/ISeedExamplesClient.cs
@@ -6,9 +6,9 @@ namespace SeedExamples;
 
 public partial interface ISeedExamplesClient
 {
-    public FileClient File { get; }
-    public HealthClient Health { get; }
-    public ServiceClient Service { get; }
+    public IFileClient File { get; }
+    public IHealthClient Health { get; }
+    public IServiceClient Service { get; }
     WithRawResponseTask<string> EchoAsync(
         string request,
         RequestOptions? options = null,

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamplesClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamplesClient.cs
@@ -43,11 +43,11 @@ public partial class SeedExamplesClient : ISeedExamplesClient
         Service = new ServiceClient(_client);
     }
 
-    public FileClient File { get; }
+    public IFileClient File { get; }
 
-    public HealthClient Health { get; }
+    public IHealthClient Health { get; }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 
     private async Task<WithRawResponse<string>> EchoAsyncCore(
         string request,

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -1,10 +1,13 @@
 using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints.Container;
 using SeedExhaustive.Endpoints.ContentType;
+using SeedExhaustive.Endpoints.Enum;
 using SeedExhaustive.Endpoints.HttpMethods;
+using SeedExhaustive.Endpoints.Object;
 using SeedExhaustive.Endpoints.Params;
 using SeedExhaustive.Endpoints.Primitive;
 using SeedExhaustive.Endpoints.Put;
+using SeedExhaustive.Endpoints.Union;
 using SeedExhaustive.Endpoints.Urls;
 
 namespace SeedExhaustive.Endpoints;
@@ -28,23 +31,23 @@ public partial class EndpointsClient : IEndpointsClient
         Urls = new UrlsClient(_client);
     }
 
-    public ContainerClient Container { get; }
+    public IContainerClient Container { get; }
 
-    public ContentTypeClient ContentType { get; }
+    public IContentTypeClient ContentType { get; }
 
-    public SeedExhaustive.Endpoints.Enum.EnumClient Enum { get; }
+    public IEnumClient Enum { get; }
 
-    public HttpMethodsClient HttpMethods { get; }
+    public IHttpMethodsClient HttpMethods { get; }
 
-    public SeedExhaustive.Endpoints.Object.ObjectClient Object { get; }
+    public IObjectClient Object { get; }
 
-    public ParamsClient Params { get; }
+    public IParamsClient Params { get; }
 
-    public PrimitiveClient Primitive { get; }
+    public IPrimitiveClient Primitive { get; }
 
-    public PutClient Put { get; }
+    public IPutClient Put { get; }
 
-    public SeedExhaustive.Endpoints.Union.UnionClient Union { get; }
+    public IUnionClient Union { get; }
 
-    public UrlsClient Urls { get; }
+    public IUrlsClient Urls { get; }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/IEndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/IEndpointsClient.cs
@@ -1,23 +1,26 @@
 using SeedExhaustive.Endpoints.Container;
 using SeedExhaustive.Endpoints.ContentType;
+using SeedExhaustive.Endpoints.Enum;
 using SeedExhaustive.Endpoints.HttpMethods;
+using SeedExhaustive.Endpoints.Object;
 using SeedExhaustive.Endpoints.Params;
 using SeedExhaustive.Endpoints.Primitive;
 using SeedExhaustive.Endpoints.Put;
+using SeedExhaustive.Endpoints.Union;
 using SeedExhaustive.Endpoints.Urls;
 
 namespace SeedExhaustive.Endpoints;
 
 public partial interface IEndpointsClient
 {
-    public ContainerClient Container { get; }
-    public ContentTypeClient ContentType { get; }
-    public SeedExhaustive.Endpoints.Enum.EnumClient Enum { get; }
-    public HttpMethodsClient HttpMethods { get; }
-    public SeedExhaustive.Endpoints.Object.ObjectClient Object { get; }
-    public ParamsClient Params { get; }
-    public PrimitiveClient Primitive { get; }
-    public PutClient Put { get; }
-    public SeedExhaustive.Endpoints.Union.UnionClient Union { get; }
-    public UrlsClient Urls { get; }
+    public IContainerClient Container { get; }
+    public IContentTypeClient ContentType { get; }
+    public IEnumClient Enum { get; }
+    public IHttpMethodsClient HttpMethods { get; }
+    public IObjectClient Object { get; }
+    public IParamsClient Params { get; }
+    public IPrimitiveClient Primitive { get; }
+    public IPutClient Put { get; }
+    public IUnionClient Union { get; }
+    public IUrlsClient Urls { get; }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/ISeedExhaustiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/ISeedExhaustiveClient.cs
@@ -8,9 +8,9 @@ namespace SeedExhaustive;
 
 public partial interface ISeedExhaustiveClient
 {
-    public EndpointsClient Endpoints { get; }
-    public InlinedRequestsClient InlinedRequests { get; }
-    public NoAuthClient NoAuth { get; }
-    public NoReqBodyClient NoReqBody { get; }
-    public ReqWithHeadersClient ReqWithHeaders { get; }
+    public IEndpointsClient Endpoints { get; }
+    public IInlinedRequestsClient InlinedRequests { get; }
+    public INoAuthClient NoAuth { get; }
+    public INoReqBodyClient NoReqBody { get; }
+    public IReqWithHeadersClient ReqWithHeaders { get; }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/SeedExhaustiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/SeedExhaustiveClient.cs
@@ -46,13 +46,13 @@ public partial class SeedExhaustiveClient : ISeedExhaustiveClient
         ReqWithHeaders = new ReqWithHeadersClient(_client);
     }
 
-    public EndpointsClient Endpoints { get; }
+    public IEndpointsClient Endpoints { get; }
 
-    public InlinedRequestsClient InlinedRequests { get; }
+    public IInlinedRequestsClient InlinedRequests { get; }
 
-    public NoAuthClient NoAuth { get; }
+    public INoAuthClient NoAuth { get; }
 
-    public NoReqBodyClient NoReqBody { get; }
+    public INoReqBodyClient NoReqBody { get; }
 
-    public ReqWithHeadersClient ReqWithHeaders { get; }
+    public IReqWithHeadersClient ReqWithHeaders { get; }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -29,23 +29,23 @@ public partial class EndpointsClient : IEndpointsClient
         }
     }
 
-    public ContainerClient Container { get; }
+    public IContainerClient Container { get; }
 
-    public ContentTypeClient ContentType { get; }
+    public IContentTypeClient ContentType { get; }
 
-    public EnumClient Enum { get; }
+    public IEnumClient Enum { get; }
 
-    public HttpMethodsClient HttpMethods { get; }
+    public IHttpMethodsClient HttpMethods { get; }
 
-    public ObjectClient Object { get; }
+    public IObjectClient Object { get; }
 
-    public ParamsClient Params { get; }
+    public IParamsClient Params { get; }
 
-    public PrimitiveClient Primitive { get; }
+    public IPrimitiveClient Primitive { get; }
 
-    public PutClient Put { get; }
+    public IPutClient Put { get; }
 
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 
-    public UrlsClient Urls { get; }
+    public IUrlsClient Urls { get; }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/IEndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/IEndpointsClient.cs
@@ -2,14 +2,14 @@ namespace SeedExhaustive.Endpoints;
 
 public partial interface IEndpointsClient
 {
-    public ContainerClient Container { get; }
-    public ContentTypeClient ContentType { get; }
-    public EnumClient Enum { get; }
-    public HttpMethodsClient HttpMethods { get; }
-    public ObjectClient Object { get; }
-    public ParamsClient Params { get; }
-    public PrimitiveClient Primitive { get; }
-    public PutClient Put { get; }
-    public UnionClient Union { get; }
-    public UrlsClient Urls { get; }
+    public IContainerClient Container { get; }
+    public IContentTypeClient ContentType { get; }
+    public IEnumClient Enum { get; }
+    public IHttpMethodsClient HttpMethods { get; }
+    public IObjectClient Object { get; }
+    public IParamsClient Params { get; }
+    public IPrimitiveClient Primitive { get; }
+    public IPutClient Put { get; }
+    public IUnionClient Union { get; }
+    public IUrlsClient Urls { get; }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/ISeedExhaustiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/ISeedExhaustiveClient.cs
@@ -4,9 +4,9 @@ namespace SeedExhaustive;
 
 public partial interface ISeedExhaustiveClient
 {
-    public EndpointsClient Endpoints { get; }
-    public InlinedRequestsClient InlinedRequests { get; }
-    public NoAuthClient NoAuth { get; }
-    public NoReqBodyClient NoReqBody { get; }
-    public ReqWithHeadersClient ReqWithHeaders { get; }
+    public IEndpointsClient Endpoints { get; }
+    public IInlinedRequestsClient InlinedRequests { get; }
+    public INoAuthClient NoAuth { get; }
+    public INoReqBodyClient NoReqBody { get; }
+    public IReqWithHeadersClient ReqWithHeaders { get; }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/SeedExhaustiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/SeedExhaustiveClient.cs
@@ -54,13 +54,13 @@ public partial class SeedExhaustiveClient : ISeedExhaustiveClient
         }
     }
 
-    public EndpointsClient Endpoints { get; }
+    public IEndpointsClient Endpoints { get; }
 
-    public InlinedRequestsClient InlinedRequests { get; }
+    public IInlinedRequestsClient InlinedRequests { get; }
 
-    public NoAuthClient NoAuth { get; }
+    public INoAuthClient NoAuth { get; }
 
-    public NoReqBodyClient NoReqBody { get; }
+    public INoReqBodyClient NoReqBody { get; }
 
-    public ReqWithHeadersClient ReqWithHeaders { get; }
+    public IReqWithHeadersClient ReqWithHeaders { get; }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -21,23 +21,23 @@ public partial class EndpointsClient : IEndpointsClient
         Urls = new UrlsClient(_client);
     }
 
-    public ContainerClient Container { get; }
+    public IContainerClient Container { get; }
 
-    public ContentTypeClient ContentType { get; }
+    public IContentTypeClient ContentType { get; }
 
-    public EnumClient Enum { get; }
+    public IEnumClient Enum { get; }
 
-    public HttpMethodsClient HttpMethods { get; }
+    public IHttpMethodsClient HttpMethods { get; }
 
-    public ObjectClient Object { get; }
+    public IObjectClient Object { get; }
 
-    public ParamsClient Params { get; }
+    public IParamsClient Params { get; }
 
-    public PrimitiveClient Primitive { get; }
+    public IPrimitiveClient Primitive { get; }
 
-    public PutClient Put { get; }
+    public IPutClient Put { get; }
 
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 
-    public UrlsClient Urls { get; }
+    public IUrlsClient Urls { get; }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/IEndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/IEndpointsClient.cs
@@ -2,14 +2,14 @@ namespace SeedExhaustive.Endpoints;
 
 public partial interface IEndpointsClient
 {
-    public ContainerClient Container { get; }
-    public ContentTypeClient ContentType { get; }
-    public EnumClient Enum { get; }
-    public HttpMethodsClient HttpMethods { get; }
-    public ObjectClient Object { get; }
-    public ParamsClient Params { get; }
-    public PrimitiveClient Primitive { get; }
-    public PutClient Put { get; }
-    public UnionClient Union { get; }
-    public UrlsClient Urls { get; }
+    public IContainerClient Container { get; }
+    public IContentTypeClient ContentType { get; }
+    public IEnumClient Enum { get; }
+    public IHttpMethodsClient HttpMethods { get; }
+    public IObjectClient Object { get; }
+    public IParamsClient Params { get; }
+    public IPrimitiveClient Primitive { get; }
+    public IPutClient Put { get; }
+    public IUnionClient Union { get; }
+    public IUrlsClient Urls { get; }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/ISeedExhaustiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/ISeedExhaustiveClient.cs
@@ -4,9 +4,9 @@ namespace SeedExhaustive;
 
 public partial interface ISeedExhaustiveClient
 {
-    public EndpointsClient Endpoints { get; }
-    public InlinedRequestsClient InlinedRequests { get; }
-    public NoAuthClient NoAuth { get; }
-    public NoReqBodyClient NoReqBody { get; }
-    public ReqWithHeadersClient ReqWithHeaders { get; }
+    public IEndpointsClient Endpoints { get; }
+    public IInlinedRequestsClient InlinedRequests { get; }
+    public INoAuthClient NoAuth { get; }
+    public INoReqBodyClient NoReqBody { get; }
+    public IReqWithHeadersClient ReqWithHeaders { get; }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/SeedExhaustiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/SeedExhaustiveClient.cs
@@ -42,13 +42,13 @@ public partial class SeedExhaustiveClient : ISeedExhaustiveClient
         ReqWithHeaders = new ReqWithHeadersClient(_client);
     }
 
-    public EndpointsClient Endpoints { get; }
+    public IEndpointsClient Endpoints { get; }
 
-    public InlinedRequestsClient InlinedRequests { get; }
+    public IInlinedRequestsClient InlinedRequests { get; }
 
-    public NoAuthClient NoAuth { get; }
+    public INoAuthClient NoAuth { get; }
 
-    public NoReqBodyClient NoReqBody { get; }
+    public INoReqBodyClient NoReqBody { get; }
 
-    public ReqWithHeadersClient ReqWithHeaders { get; }
+    public IReqWithHeadersClient ReqWithHeaders { get; }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/EndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/EndpointsClient.cs
@@ -21,23 +21,23 @@ public partial class EndpointsClient : IEndpointsClient
         Urls = new UrlsClient(_client);
     }
 
-    public ContainerClient Container { get; }
+    public IContainerClient Container { get; }
 
-    public ContentTypeClient ContentType { get; }
+    public IContentTypeClient ContentType { get; }
 
-    public EnumClient Enum { get; }
+    public IEnumClient Enum { get; }
 
-    public HttpMethodsClient HttpMethods { get; }
+    public IHttpMethodsClient HttpMethods { get; }
 
-    public ObjectClient Object { get; }
+    public IObjectClient Object { get; }
 
-    public ParamsClient Params { get; }
+    public IParamsClient Params { get; }
 
-    public PrimitiveClient Primitive { get; }
+    public IPrimitiveClient Primitive { get; }
 
-    public PutClient Put { get; }
+    public IPutClient Put { get; }
 
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 
-    public UrlsClient Urls { get; }
+    public IUrlsClient Urls { get; }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/IEndpointsClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/IEndpointsClient.cs
@@ -2,14 +2,14 @@ namespace SeedExhaustive.Endpoints;
 
 public partial interface IEndpointsClient
 {
-    public ContainerClient Container { get; }
-    public ContentTypeClient ContentType { get; }
-    public EnumClient Enum { get; }
-    public HttpMethodsClient HttpMethods { get; }
-    public ObjectClient Object { get; }
-    public ParamsClient Params { get; }
-    public PrimitiveClient Primitive { get; }
-    public PutClient Put { get; }
-    public UnionClient Union { get; }
-    public UrlsClient Urls { get; }
+    public IContainerClient Container { get; }
+    public IContentTypeClient ContentType { get; }
+    public IEnumClient Enum { get; }
+    public IHttpMethodsClient HttpMethods { get; }
+    public IObjectClient Object { get; }
+    public IParamsClient Params { get; }
+    public IPrimitiveClient Primitive { get; }
+    public IPutClient Put { get; }
+    public IUnionClient Union { get; }
+    public IUrlsClient Urls { get; }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/ISeedExhaustiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/ISeedExhaustiveClient.cs
@@ -4,9 +4,9 @@ namespace SeedExhaustive;
 
 public partial interface ISeedExhaustiveClient
 {
-    public EndpointsClient Endpoints { get; }
-    public InlinedRequestsClient InlinedRequests { get; }
-    public NoAuthClient NoAuth { get; }
-    public NoReqBodyClient NoReqBody { get; }
-    public ReqWithHeadersClient ReqWithHeaders { get; }
+    public IEndpointsClient Endpoints { get; }
+    public IInlinedRequestsClient InlinedRequests { get; }
+    public INoAuthClient NoAuth { get; }
+    public INoReqBodyClient NoReqBody { get; }
+    public IReqWithHeadersClient ReqWithHeaders { get; }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/SeedExhaustiveClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/SeedExhaustiveClient.cs
@@ -42,13 +42,13 @@ public partial class SeedExhaustiveClient : ISeedExhaustiveClient
         ReqWithHeaders = new ReqWithHeadersClient(_client);
     }
 
-    public EndpointsClient Endpoints { get; }
+    public IEndpointsClient Endpoints { get; }
 
-    public InlinedRequestsClient InlinedRequests { get; }
+    public IInlinedRequestsClient InlinedRequests { get; }
 
-    public NoAuthClient NoAuth { get; }
+    public INoAuthClient NoAuth { get; }
 
-    public NoReqBodyClient NoReqBody { get; }
+    public INoReqBodyClient NoReqBody { get; }
 
-    public ReqWithHeadersClient ReqWithHeaders { get; }
+    public IReqWithHeadersClient ReqWithHeaders { get; }
 }

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/ISeedExtraPropertiesClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/ISeedExtraPropertiesClient.cs
@@ -2,5 +2,5 @@ namespace SeedExtraProperties;
 
 public partial interface ISeedExtraPropertiesClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/SeedExtraPropertiesClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/SeedExtraPropertiesClient.cs
@@ -29,5 +29,5 @@ public partial class SeedExtraPropertiesClient : ISeedExtraPropertiesClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/ISeedFileDownloadClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/ISeedFileDownloadClient.cs
@@ -2,5 +2,5 @@ namespace SeedFileDownload;
 
 public partial interface ISeedFileDownloadClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/SeedFileDownloadClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/SeedFileDownloadClient.cs
@@ -29,5 +29,5 @@ public partial class SeedFileDownloadClient : ISeedFileDownloadClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public FileUploadExampleClient FileUploadExample { get; }
+    public IFileUploadExampleClient FileUploadExample { get; }
 }

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/SeedApiClient.cs
@@ -29,5 +29,5 @@ public partial class SeedApiClient : ISeedApiClient
         FileUploadExample = new FileUploadExampleClient(_client);
     }
 
-    public FileUploadExampleClient FileUploadExample { get; }
+    public IFileUploadExampleClient FileUploadExample { get; }
 }

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/ISeedFileUploadClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/ISeedFileUploadClient.cs
@@ -2,5 +2,5 @@ namespace SeedFileUpload;
 
 public partial interface ISeedFileUploadClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/SeedFileUploadClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/SeedFileUploadClient.cs
@@ -29,5 +29,5 @@ public partial class SeedFileUploadClient : ISeedFileUploadClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/folders/src/SeedApi/A/AClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/AClient.cs
@@ -15,7 +15,7 @@ public partial class AClient : IAClient
         C = new CClient(_client);
     }
 
-    public BClient B { get; }
+    public IBClient B { get; }
 
-    public CClient C { get; }
+    public ICClient C { get; }
 }

--- a/seed/csharp-sdk/folders/src/SeedApi/A/IAClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/A/IAClient.cs
@@ -5,6 +5,6 @@ namespace SeedApi.A;
 
 public partial interface IAClient
 {
-    public BClient B { get; }
-    public CClient C { get; }
+    public IBClient B { get; }
+    public ICClient C { get; }
 }

--- a/seed/csharp-sdk/folders/src/SeedApi/Folder/FolderClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Folder/FolderClient.cs
@@ -13,7 +13,7 @@ public partial class FolderClient : IFolderClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 
     /// <example><code>
     /// await client.Folder.FooAsync();

--- a/seed/csharp-sdk/folders/src/SeedApi/Folder/IFolderClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Folder/IFolderClient.cs
@@ -4,6 +4,6 @@ namespace SeedApi.Folder;
 
 public partial interface IFolderClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
     Task FooAsync(RequestOptions? options = null, CancellationToken cancellationToken = default);
 }

--- a/seed/csharp-sdk/folders/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/ISeedApiClient.cs
@@ -5,7 +5,7 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public AClient A { get; }
-    public FolderClient Folder { get; }
+    public IAClient A { get; }
+    public IFolderClient Folder { get; }
     Task FooAsync(RequestOptions? options = null, CancellationToken cancellationToken = default);
 }

--- a/seed/csharp-sdk/folders/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/SeedApiClient.cs
@@ -32,9 +32,9 @@ public partial class SeedApiClient : ISeedApiClient
         Folder = new FolderClient(_client);
     }
 
-    public AClient A { get; }
+    public IAClient A { get; }
 
-    public FolderClient Folder { get; }
+    public IFolderClient Folder { get; }
 
     /// <example><code>
     /// await client.FooAsync();

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/ISeedHeaderTokenEnvironmentVariableClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/ISeedHeaderTokenEnvironmentVariableClient.cs
@@ -2,5 +2,5 @@ namespace SeedHeaderTokenEnvironmentVariable;
 
 public partial interface ISeedHeaderTokenEnvironmentVariableClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariableClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariableClient.cs
@@ -48,7 +48,7 @@ public partial class SeedHeaderTokenEnvironmentVariableClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 
     private static string GetFromEnvironmentOrThrow(string env, string message)
     {

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/ISeedHeaderTokenClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/ISeedHeaderTokenClient.cs
@@ -2,5 +2,5 @@ namespace SeedHeaderToken;
 
 public partial interface ISeedHeaderTokenClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/SeedHeaderTokenClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/SeedHeaderTokenClient.cs
@@ -43,5 +43,5 @@ public partial class SeedHeaderTokenClient : ISeedHeaderTokenClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/ISeedHttpHeadClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/ISeedHttpHeadClient.cs
@@ -2,5 +2,5 @@ namespace SeedHttpHead;
 
 public partial interface ISeedHttpHeadClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/SeedHttpHeadClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/SeedHttpHeadClient.cs
@@ -29,5 +29,5 @@ public partial class SeedHttpHeadClient : ISeedHttpHeadClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/ISeedIdempotencyHeadersClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/ISeedIdempotencyHeadersClient.cs
@@ -2,5 +2,5 @@ namespace SeedIdempotencyHeaders;
 
 public partial interface ISeedIdempotencyHeadersClient
 {
-    public PaymentClient Payment { get; }
+    public IPaymentClient Payment { get; }
 }

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeadersClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeadersClient.cs
@@ -37,5 +37,5 @@ public partial class SeedIdempotencyHeadersClient : ISeedIdempotencyHeadersClien
         Payment = new PaymentClient(_client);
     }
 
-    public PaymentClient Payment { get; }
+    public IPaymentClient Payment { get; }
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/SeedApiClient.cs
@@ -37,5 +37,5 @@ public partial class SeedApiClient : ISeedApiClient
         Imdb = new ImdbClient(_client);
     }
 
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/BaseClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/BaseClient.cs
@@ -37,5 +37,5 @@ public partial class BaseClient : IBaseClient
         Imdb = new ImdbClient(_client);
     }
 
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/IBaseClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/IBaseClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface IBaseClient
 {
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/SeedApiClient.cs
@@ -37,5 +37,5 @@ public partial class SeedApiClient : ISeedApiClient
         Imdb = new ImdbClient(_client);
     }
 
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/SeedApiClient.cs
@@ -49,5 +49,5 @@ public partial class SeedApiClient : ISeedApiClient
         }
     }
 
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/SeedApiClient.cs
@@ -37,5 +37,5 @@ public partial class SeedApiClient : ISeedApiClient
         Imdb = new ImdbClient(_client);
     }
 
-    public ImdbClient Imdb { get; }
+    public IImdbClient Imdb { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/ISeedInferredAuthExplicitClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/ISeedInferredAuthExplicitClient.cs
@@ -5,8 +5,8 @@ namespace SeedInferredAuthExplicit;
 
 public partial interface ISeedInferredAuthExplicitClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthExplicit.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthExplicit.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicitClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicitClient.cs
@@ -54,11 +54,11 @@ public partial class SeedInferredAuthExplicitClient : ISeedInferredAuthExplicitC
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/ISeedInferredAuthImplicitApiKeyClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/ISeedInferredAuthImplicitApiKeyClient.cs
@@ -5,8 +5,8 @@ namespace SeedInferredAuthImplicitApiKey;
 
 public partial interface ISeedInferredAuthImplicitApiKeyClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthImplicitApiKey.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthImplicitApiKey.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKeyClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKeyClient.cs
@@ -45,11 +45,11 @@ public partial class SeedInferredAuthImplicitApiKeyClient : ISeedInferredAuthImp
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/ISeedInferredAuthImplicitNoExpiryClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/ISeedInferredAuthImplicitNoExpiryClient.cs
@@ -5,8 +5,8 @@ namespace SeedInferredAuthImplicitNoExpiry;
 
 public partial interface ISeedInferredAuthImplicitNoExpiryClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthImplicitNoExpiry.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthImplicitNoExpiry.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiryClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiryClient.cs
@@ -55,11 +55,11 @@ public partial class SeedInferredAuthImplicitNoExpiryClient
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/ISeedInferredAuthImplicitClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/ISeedInferredAuthImplicitClient.cs
@@ -5,8 +5,8 @@ namespace SeedInferredAuthImplicit;
 
 public partial interface ISeedInferredAuthImplicitClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthImplicit.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthImplicit.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicitClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicitClient.cs
@@ -52,11 +52,11 @@ public partial class SeedInferredAuthImplicitClient : ISeedInferredAuthImplicitC
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/ISeedInferredAuthImplicitClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/ISeedInferredAuthImplicitClient.cs
@@ -5,8 +5,8 @@ namespace SeedInferredAuthImplicit;
 
 public partial interface ISeedInferredAuthImplicitClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthImplicit.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedInferredAuthImplicit.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicitClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicitClient.cs
@@ -54,11 +54,11 @@ public partial class SeedInferredAuthImplicitClient : ISeedInferredAuthImplicitC
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/ISeedLiteralClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/ISeedLiteralClient.cs
@@ -2,9 +2,9 @@ namespace SeedLiteral;
 
 public partial interface ISeedLiteralClient
 {
-    public HeadersClient Headers { get; }
-    public InlinedClient Inlined { get; }
-    public PathClient Path { get; }
-    public QueryClient Query { get; }
-    public ReferenceClient Reference { get; }
+    public IHeadersClient Headers { get; }
+    public IInlinedClient Inlined { get; }
+    public IPathClient Path { get; }
+    public IQueryClient Query { get; }
+    public IReferenceClient Reference { get; }
 }

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/SeedLiteralClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/SeedLiteralClient.cs
@@ -53,13 +53,13 @@ public partial class SeedLiteralClient : ISeedLiteralClient
         Reference = new ReferenceClient(_client);
     }
 
-    public HeadersClient Headers { get; }
+    public IHeadersClient Headers { get; }
 
-    public InlinedClient Inlined { get; }
+    public IInlinedClient Inlined { get; }
 
-    public PathClient Path { get; }
+    public IPathClient Path { get; }
 
-    public QueryClient Query { get; }
+    public IQueryClient Query { get; }
 
-    public ReferenceClient Reference { get; }
+    public IReferenceClient Reference { get; }
 }

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/ISeedLiteralClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/ISeedLiteralClient.cs
@@ -2,9 +2,9 @@ namespace SeedLiteral;
 
 public partial interface ISeedLiteralClient
 {
-    public HeadersClient Headers { get; }
-    public InlinedClient Inlined { get; }
-    public PathClient Path { get; }
-    public QueryClient Query { get; }
-    public ReferenceClient Reference { get; }
+    public IHeadersClient Headers { get; }
+    public IInlinedClient Inlined { get; }
+    public IPathClient Path { get; }
+    public IQueryClient Query { get; }
+    public IReferenceClient Reference { get; }
 }

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/SeedLiteralClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/SeedLiteralClient.cs
@@ -53,13 +53,13 @@ public partial class SeedLiteralClient : ISeedLiteralClient
         Reference = new ReferenceClient(_client);
     }
 
-    public HeadersClient Headers { get; }
+    public IHeadersClient Headers { get; }
 
-    public InlinedClient Inlined { get; }
+    public IInlinedClient Inlined { get; }
 
-    public PathClient Path { get; }
+    public IPathClient Path { get; }
 
-    public QueryClient Query { get; }
+    public IQueryClient Query { get; }
 
-    public ReferenceClient Reference { get; }
+    public IReferenceClient Reference { get; }
 }

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/ISeedMixedCaseClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/ISeedMixedCaseClient.cs
@@ -2,5 +2,5 @@ namespace SeedMixedCase;
 
 public partial interface ISeedMixedCaseClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/SeedMixedCaseClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/SeedMixedCaseClient.cs
@@ -29,5 +29,5 @@ public partial class SeedMixedCaseClient : ISeedMixedCaseClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/ISeedMixedFileDirectoryClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/ISeedMixedFileDirectoryClient.cs
@@ -2,6 +2,6 @@ namespace SeedMixedFileDirectory;
 
 public partial interface ISeedMixedFileDirectoryClient
 {
-    public OrganizationClient Organization { get; }
-    public UserClient User { get; }
+    public IOrganizationClient Organization { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectoryClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectoryClient.cs
@@ -30,7 +30,7 @@ public partial class SeedMixedFileDirectoryClient : ISeedMixedFileDirectoryClien
         User = new UserClient(_client);
     }
 
-    public OrganizationClient Organization { get; }
+    public IOrganizationClient Organization { get; }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/EventsClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/EventsClient.cs
@@ -15,7 +15,7 @@ public partial class EventsClient : IEventsClient
         Metadata = new MetadataClient(_client);
     }
 
-    public MetadataClient Metadata { get; }
+    public IMetadataClient Metadata { get; }
 
     private async Task<WithRawResponse<IEnumerable<Event>>> ListEventsAsyncCore(
         ListUserEventsRequest request,

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/IEventsClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/Events/IEventsClient.cs
@@ -5,7 +5,7 @@ namespace SeedMixedFileDirectory.User_;
 
 public partial interface IEventsClient
 {
-    public MetadataClient Metadata { get; }
+    public IMetadataClient Metadata { get; }
 
     /// <summary>
     /// List all user events.

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/IUserClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/IUserClient.cs
@@ -4,7 +4,7 @@ namespace SeedMixedFileDirectory;
 
 public partial interface IUserClient
 {
-    public EventsClient Events { get; }
+    public IEventsClient Events { get; }
 
     /// <summary>
     /// List all users.

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/UserClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/User/UserClient.cs
@@ -14,7 +14,7 @@ public partial class UserClient : IUserClient
         Events = new EventsClient(_client);
     }
 
-    public EventsClient Events { get; }
+    public IEventsClient Events { get; }
 
     private async Task<WithRawResponse<IEnumerable<User>>> ListAsyncCore(
         ListUsersRequest request,

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/ISeedMultiLineDocsClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/ISeedMultiLineDocsClient.cs
@@ -2,5 +2,5 @@ namespace SeedMultiLineDocs;
 
 public partial interface ISeedMultiLineDocsClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocsClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocsClient.cs
@@ -29,5 +29,5 @@ public partial class SeedMultiLineDocsClient : ISeedMultiLineDocsClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/ISeedMultiUrlEnvironmentNoDefaultClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/ISeedMultiUrlEnvironmentNoDefaultClient.cs
@@ -2,6 +2,6 @@ namespace SeedMultiUrlEnvironmentNoDefault;
 
 public partial interface ISeedMultiUrlEnvironmentNoDefaultClient
 {
-    public Ec2Client Ec2 { get; }
-    public S3Client S3 { get; }
+    public IEc2Client Ec2 { get; }
+    public IS3Client S3 { get; }
 }

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefaultClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefaultClient.cs
@@ -42,7 +42,7 @@ public partial class SeedMultiUrlEnvironmentNoDefaultClient
         S3 = new S3Client(_client);
     }
 
-    public Ec2Client Ec2 { get; }
+    public IEc2Client Ec2 { get; }
 
-    public S3Client S3 { get; }
+    public IS3Client S3 { get; }
 }

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/ISeedMultiUrlEnvironmentClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/ISeedMultiUrlEnvironmentClient.cs
@@ -2,6 +2,6 @@ namespace SeedMultiUrlEnvironment;
 
 public partial interface ISeedMultiUrlEnvironmentClient
 {
-    public Ec2Client Ec2 { get; }
-    public S3Client S3 { get; }
+    public IEc2Client Ec2 { get; }
+    public IS3Client S3 { get; }
 }

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironmentClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironmentClient.cs
@@ -38,7 +38,7 @@ public partial class SeedMultiUrlEnvironmentClient : ISeedMultiUrlEnvironmentCli
         S3 = new S3Client(_client);
     }
 
-    public Ec2Client Ec2 { get; }
+    public IEc2Client Ec2 { get; }
 
-    public S3Client S3 { get; }
+    public IS3Client S3 { get; }
 }

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/ISeedMultiUrlEnvironmentClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/ISeedMultiUrlEnvironmentClient.cs
@@ -2,6 +2,6 @@ namespace SeedMultiUrlEnvironment;
 
 public partial interface ISeedMultiUrlEnvironmentClient
 {
-    public Ec2Client Ec2 { get; }
-    public S3Client S3 { get; }
+    public IEc2Client Ec2 { get; }
+    public IS3Client S3 { get; }
 }

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironmentClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironmentClient.cs
@@ -38,7 +38,7 @@ public partial class SeedMultiUrlEnvironmentClient : ISeedMultiUrlEnvironmentCli
         S3 = new S3Client(_client);
     }
 
-    public Ec2Client Ec2 { get; }
+    public IEc2Client Ec2 { get; }
 
-    public S3Client S3 { get; }
+    public IS3Client S3 { get; }
 }

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/ISeedNoEnvironmentClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/ISeedNoEnvironmentClient.cs
@@ -2,5 +2,5 @@ namespace SeedNoEnvironment;
 
 public partial interface ISeedNoEnvironmentClient
 {
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/SeedNoEnvironmentClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/SeedNoEnvironmentClient.cs
@@ -37,5 +37,5 @@ public partial class SeedNoEnvironmentClient : ISeedNoEnvironmentClient
         Dummy = new DummyClient(_client);
     }
 
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/ISeedNoRetriesClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/ISeedNoRetriesClient.cs
@@ -2,5 +2,5 @@ namespace SeedNoRetries;
 
 public partial interface ISeedNoRetriesClient
 {
-    public RetriesClient Retries { get; }
+    public IRetriesClient Retries { get; }
 }

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/SeedNoRetriesClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/SeedNoRetriesClient.cs
@@ -29,5 +29,5 @@ public partial class SeedNoRetriesClient : ISeedNoRetriesClient
         Retries = new RetriesClient(_client);
     }
 
-    public RetriesClient Retries { get; }
+    public IRetriesClient Retries { get; }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/ISeedNullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/ISeedNullableOptionalClient.cs
@@ -2,5 +2,5 @@ namespace SeedNullableOptional;
 
 public partial interface ISeedNullableOptionalClient
 {
-    public NullableOptionalClient NullableOptional { get; }
+    public INullableOptionalClient NullableOptional { get; }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/SeedNullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/SeedNullableOptionalClient.cs
@@ -29,5 +29,5 @@ public partial class SeedNullableOptionalClient : ISeedNullableOptionalClient
         NullableOptional = new NullableOptionalClient(_client);
     }
 
-    public NullableOptionalClient NullableOptional { get; }
+    public INullableOptionalClient NullableOptional { get; }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/ISeedNullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/ISeedNullableOptionalClient.cs
@@ -2,5 +2,5 @@ namespace SeedNullableOptional;
 
 public partial interface ISeedNullableOptionalClient
 {
-    public NullableOptionalClient NullableOptional { get; }
+    public INullableOptionalClient NullableOptional { get; }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/SeedNullableOptionalClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/SeedNullableOptionalClient.cs
@@ -29,5 +29,5 @@ public partial class SeedNullableOptionalClient : ISeedNullableOptionalClient
         NullableOptional = new NullableOptionalClient(_client);
     }
 
-    public NullableOptionalClient NullableOptional { get; }
+    public INullableOptionalClient NullableOptional { get; }
 }

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/ISeedApiClient.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/ISeedApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedApi;
 
 public partial interface ISeedApiClient
 {
-    public TestGroupClient TestGroup { get; }
+    public ITestGroupClient TestGroup { get; }
 }

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/SeedApiClient.cs
@@ -29,5 +29,5 @@ public partial class SeedApiClient : ISeedApiClient
         TestGroup = new TestGroupClient(_client);
     }
 
-    public TestGroupClient TestGroup { get; }
+    public ITestGroupClient TestGroup { get; }
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/ISeedNullableClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/ISeedNullableClient.cs
@@ -2,5 +2,5 @@ namespace SeedNullable;
 
 public partial interface ISeedNullableClient
 {
-    public NullableClient Nullable { get; }
+    public INullableClient Nullable { get; }
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/SeedNullableClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/SeedNullableClient.cs
@@ -29,5 +29,5 @@ public partial class SeedNullableClient : ISeedNullableClient
         Nullable = new NullableClient(_client);
     }
 
-    public NullableClient Nullable { get; }
+    public INullableClient Nullable { get; }
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/ISeedNullableClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/ISeedNullableClient.cs
@@ -2,5 +2,5 @@ namespace SeedNullable;
 
 public partial interface ISeedNullableClient
 {
-    public NullableClient Nullable { get; }
+    public INullableClient Nullable { get; }
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/SeedNullableClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/SeedNullableClient.cs
@@ -29,5 +29,5 @@ public partial class SeedNullableClient : ISeedNullableClient
         Nullable = new NullableClient(_client);
     }
 
-    public NullableClient Nullable { get; }
+    public INullableClient Nullable { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/ISeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/ISeedOauthClientCredentialsClient.cs
@@ -5,8 +5,8 @@ namespace SeedOauthClientCredentials;
 
 public partial interface ISeedOauthClientCredentialsClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
@@ -48,11 +48,11 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/ISeedOauthClientCredentialsDefaultClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/ISeedOauthClientCredentialsDefaultClient.cs
@@ -5,8 +5,8 @@ namespace SeedOauthClientCredentialsDefault;
 
 public partial interface ISeedOauthClientCredentialsDefaultClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentialsDefault.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentialsDefault.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefaultClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefaultClient.cs
@@ -49,11 +49,11 @@ public partial class SeedOauthClientCredentialsDefaultClient
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/ISeedOauthClientCredentialsEnvironmentVariablesClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/ISeedOauthClientCredentialsEnvironmentVariablesClient.cs
@@ -5,8 +5,8 @@ namespace SeedOauthClientCredentialsEnvironmentVariables;
 
 public partial interface ISeedOauthClientCredentialsEnvironmentVariablesClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentialsEnvironmentVariables.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariablesClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariablesClient.cs
@@ -57,13 +57,13 @@ public partial class SeedOauthClientCredentialsEnvironmentVariablesClient
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 
     private static string GetFromEnvironmentOrThrow(string env, string message)
     {

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/ISeedOauthClientCredentialsMandatoryAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/ISeedOauthClientCredentialsMandatoryAuthClient.cs
@@ -4,7 +4,7 @@ namespace SeedOauthClientCredentialsMandatoryAuth;
 
 public partial interface ISeedOauthClientCredentialsMandatoryAuthClient
 {
-    public AuthClient Auth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentialsMandatoryAuth.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuthClient.cs
@@ -47,9 +47,9 @@ public partial class SeedOauthClientCredentialsMandatoryAuthClient
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/ISeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/ISeedOauthClientCredentialsClient.cs
@@ -6,8 +6,8 @@ namespace SeedOauthClientCredentials;
 
 public partial interface ISeedOauthClientCredentialsClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
@@ -49,11 +49,11 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/ISeedOauthClientCredentialsReferenceClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/ISeedOauthClientCredentialsReferenceClient.cs
@@ -2,6 +2,6 @@ namespace SeedOauthClientCredentialsReference;
 
 public partial interface ISeedOauthClientCredentialsReferenceClient
 {
-    public AuthClient Auth { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReferenceClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReferenceClient.cs
@@ -45,7 +45,7 @@ public partial class SeedOauthClientCredentialsReferenceClient
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/ISeedOauthClientCredentialsWithVariablesClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/ISeedOauthClientCredentialsWithVariablesClient.cs
@@ -5,9 +5,9 @@ namespace SeedOauthClientCredentialsWithVariables;
 
 public partial interface ISeedOauthClientCredentialsWithVariablesClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public ServiceClient Service { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public IServiceClient Service { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentialsWithVariables.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentialsWithVariables.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariablesClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariablesClient.cs
@@ -50,13 +50,13 @@ public partial class SeedOauthClientCredentialsWithVariablesClient
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/ISeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/ISeedOauthClientCredentialsClient.cs
@@ -5,8 +5,8 @@ namespace SeedOauthClientCredentials;
 
 public partial interface ISeedOauthClientCredentialsClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Nested/NestedClient.cs
@@ -20,5 +20,5 @@ public partial class NestedClient : INestedClient
         }
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
@@ -20,5 +20,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         }
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
@@ -60,11 +60,11 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
         }
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/ISeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/ISeedOauthClientCredentialsClient.cs
@@ -5,8 +5,8 @@ namespace SeedOauthClientCredentials;
 
 public partial interface ISeedOauthClientCredentialsClient
 {
-    public AuthClient Auth { get; }
-    public NestedNoAuthClient NestedNoAuth { get; }
-    public NestedClient Nested { get; }
-    public SimpleClient Simple { get; }
+    public IAuthClient Auth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
+    public INestedClient Nested { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/INestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/INestedClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentials.Nested;
 
 public partial interface INestedClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/NestedClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Nested/NestedClient.cs
@@ -12,5 +12,5 @@ public partial class NestedClient : INestedClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/INestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/INestedNoAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedOauthClientCredentials.NestedNoAuth;
 
 public partial interface INestedNoAuthClient
 {
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/NestedNoAuth/NestedNoAuthClient.cs
@@ -12,5 +12,5 @@ public partial class NestedNoAuthClient : INestedNoAuthClient
         Api = new ApiClient(_client);
     }
 
-    public ApiClient Api { get; }
+    public IApiClient Api { get; }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
@@ -48,11 +48,11 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
         Simple = new SimpleClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 
-    public NestedNoAuthClient NestedNoAuth { get; }
+    public INestedNoAuthClient NestedNoAuth { get; }
 
-    public NestedClient Nested { get; }
+    public INestedClient Nested { get; }
 
-    public SimpleClient Simple { get; }
+    public ISimpleClient Simple { get; }
 }

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/ISeedObjectsWithImportsClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/ISeedObjectsWithImportsClient.cs
@@ -2,5 +2,5 @@ namespace SeedObjectsWithImports;
 
 public partial interface ISeedObjectsWithImportsClient
 {
-    public OptionalClient Optional { get; }
+    public IOptionalClient Optional { get; }
 }

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/SeedObjectsWithImportsClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/SeedObjectsWithImportsClient.cs
@@ -29,5 +29,5 @@ public partial class SeedObjectsWithImportsClient : ISeedObjectsWithImportsClien
         Optional = new OptionalClient(_client);
     }
 
-    public OptionalClient Optional { get; }
+    public IOptionalClient Optional { get; }
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/ISeedObjectsWithImportsClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/ISeedObjectsWithImportsClient.cs
@@ -2,5 +2,5 @@ namespace SeedObjectsWithImports;
 
 public partial interface ISeedObjectsWithImportsClient
 {
-    public OptionalClient Optional { get; }
+    public IOptionalClient Optional { get; }
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/SeedObjectsWithImportsClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/SeedObjectsWithImportsClient.cs
@@ -29,5 +29,5 @@ public partial class SeedObjectsWithImportsClient : ISeedObjectsWithImportsClien
         Optional = new OptionalClient(_client);
     }
 
-    public OptionalClient Optional { get; }
+    public IOptionalClient Optional { get; }
 }

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/ISeedPackageYmlClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/ISeedPackageYmlClient.cs
@@ -2,7 +2,7 @@ namespace SeedPackageYml;
 
 public partial interface ISeedPackageYmlClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
     WithRawResponseTask<string> EchoAsync(
         string id,
         EchoRequest request,

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYmlClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYmlClient.cs
@@ -30,7 +30,7 @@ public partial class SeedPackageYmlClient : ISeedPackageYmlClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 
     private async Task<WithRawResponse<string>> EchoAsyncCore(
         string id,

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/ISeedPaginationClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/ISeedPaginationClient.cs
@@ -2,5 +2,5 @@ namespace SeedPagination;
 
 public partial interface ISeedPaginationClient
 {
-    public UsersClient Users { get; }
+    public IUsersClient Users { get; }
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/SeedPaginationClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/SeedPaginationClient.cs
@@ -37,5 +37,5 @@ public partial class SeedPaginationClient : ISeedPaginationClient
         Users = new UsersClient(_client);
     }
 
-    public UsersClient Users { get; }
+    public IUsersClient Users { get; }
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/ISeedPaginationClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/ISeedPaginationClient.cs
@@ -4,7 +4,7 @@ namespace SeedPagination;
 
 public partial interface ISeedPaginationClient
 {
-    public ComplexClient Complex { get; }
-    public InlineUsersClient InlineUsers { get; }
-    public UsersClient Users { get; }
+    public IComplexClient Complex { get; }
+    public IInlineUsersClient InlineUsers { get; }
+    public IUsersClient Users { get; }
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/IInlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/IInlineUsersClient.cs
@@ -2,5 +2,5 @@ namespace SeedPagination.InlineUsers;
 
 public partial interface IInlineUsersClient
 {
-    public InlineUsersClient_ InlineUsers { get; }
+    public IInlineUsersClient_ InlineUsers { get; }
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsersClient.cs
@@ -20,5 +20,5 @@ public partial class InlineUsersClient : IInlineUsersClient
         }
     }
 
-    public InlineUsersClient_ InlineUsers { get; }
+    public IInlineUsersClient_ InlineUsers { get; }
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/SeedPaginationClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/SeedPaginationClient.cs
@@ -52,9 +52,9 @@ public partial class SeedPaginationClient : ISeedPaginationClient
         }
     }
 
-    public ComplexClient Complex { get; }
+    public IComplexClient Complex { get; }
 
-    public InlineUsersClient InlineUsers { get; }
+    public IInlineUsersClient InlineUsers { get; }
 
-    public UsersClient Users { get; }
+    public IUsersClient Users { get; }
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/ISeedPaginationClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/ISeedPaginationClient.cs
@@ -4,7 +4,7 @@ namespace SeedPagination;
 
 public partial interface ISeedPaginationClient
 {
-    public ComplexClient Complex { get; }
-    public InlineUsersClient InlineUsers { get; }
-    public UsersClient Users { get; }
+    public IComplexClient Complex { get; }
+    public IInlineUsersClient InlineUsers { get; }
+    public IUsersClient Users { get; }
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/IInlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/IInlineUsersClient.cs
@@ -2,5 +2,5 @@ namespace SeedPagination.InlineUsers;
 
 public partial interface IInlineUsersClient
 {
-    public InlineUsersClient_ InlineUsers { get; }
+    public IInlineUsersClient_ InlineUsers { get; }
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsersClient.cs
@@ -12,5 +12,5 @@ public partial class InlineUsersClient : IInlineUsersClient
         InlineUsers = new InlineUsersClient_(_client);
     }
 
-    public InlineUsersClient_ InlineUsers { get; }
+    public IInlineUsersClient_ InlineUsers { get; }
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/SeedPaginationClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/SeedPaginationClient.cs
@@ -40,9 +40,9 @@ public partial class SeedPaginationClient : ISeedPaginationClient
         Users = new UsersClient(_client);
     }
 
-    public ComplexClient Complex { get; }
+    public IComplexClient Complex { get; }
 
-    public InlineUsersClient InlineUsers { get; }
+    public IInlineUsersClient InlineUsers { get; }
 
-    public UsersClient Users { get; }
+    public IUsersClient Users { get; }
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/ISeedPaginationClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/ISeedPaginationClient.cs
@@ -4,7 +4,7 @@ namespace SeedPagination;
 
 public partial interface ISeedPaginationClient
 {
-    public ComplexClient Complex { get; }
-    public InlineUsersClient InlineUsers { get; }
-    public UsersClient Users { get; }
+    public IComplexClient Complex { get; }
+    public IInlineUsersClient InlineUsers { get; }
+    public IUsersClient Users { get; }
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/IInlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/IInlineUsersClient.cs
@@ -2,5 +2,5 @@ namespace SeedPagination.InlineUsers;
 
 public partial interface IInlineUsersClient
 {
-    public InlineUsersClient_ InlineUsers { get; }
+    public IInlineUsersClient_ InlineUsers { get; }
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsersClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsersClient.cs
@@ -12,5 +12,5 @@ public partial class InlineUsersClient : IInlineUsersClient
         InlineUsers = new InlineUsersClient_(_client);
     }
 
-    public InlineUsersClient_ InlineUsers { get; }
+    public IInlineUsersClient_ InlineUsers { get; }
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/SeedPaginationClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/SeedPaginationClient.cs
@@ -40,9 +40,9 @@ public partial class SeedPaginationClient : ISeedPaginationClient
         Users = new UsersClient(_client);
     }
 
-    public ComplexClient Complex { get; }
+    public IComplexClient Complex { get; }
 
-    public InlineUsersClient InlineUsers { get; }
+    public IInlineUsersClient InlineUsers { get; }
 
-    public UsersClient Users { get; }
+    public IUsersClient Users { get; }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/ISeedPathParametersClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/ISeedPathParametersClient.cs
@@ -2,6 +2,6 @@ namespace SeedPathParameters;
 
 public partial interface ISeedPathParametersClient
 {
-    public OrganizationsClient Organizations { get; }
-    public UserClient User { get; }
+    public IOrganizationsClient Organizations { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/SeedPathParametersClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/SeedPathParametersClient.cs
@@ -30,7 +30,7 @@ public partial class SeedPathParametersClient : ISeedPathParametersClient
         User = new UserClient(_client);
     }
 
-    public OrganizationsClient Organizations { get; }
+    public IOrganizationsClient Organizations { get; }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/ISeedPathParametersClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/ISeedPathParametersClient.cs
@@ -2,6 +2,6 @@ namespace SeedPathParameters;
 
 public partial interface ISeedPathParametersClient
 {
-    public OrganizationsClient Organizations { get; }
-    public UserClient User { get; }
+    public IOrganizationsClient Organizations { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/SeedPathParametersClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/SeedPathParametersClient.cs
@@ -30,7 +30,7 @@ public partial class SeedPathParametersClient : ISeedPathParametersClient
         User = new UserClient(_client);
     }
 
-    public OrganizationsClient Organizations { get; }
+    public IOrganizationsClient Organizations { get; }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/ISeedPlainTextClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/ISeedPlainTextClient.cs
@@ -2,5 +2,5 @@ namespace SeedPlainText;
 
 public partial interface ISeedPlainTextClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/SeedPlainTextClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/SeedPlainTextClient.cs
@@ -29,5 +29,5 @@ public partial class SeedPlainTextClient : ISeedPlainTextClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/ISeedPublicObjectClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/ISeedPublicObjectClient.cs
@@ -2,5 +2,5 @@ namespace SeedPublicObject;
 
 public partial interface ISeedPublicObjectClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/SeedPublicObjectClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/SeedPublicObjectClient.cs
@@ -29,5 +29,5 @@ public partial class SeedPublicObjectClient : ISeedPublicObjectClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/ISeedQueryParametersClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/ISeedQueryParametersClient.cs
@@ -2,5 +2,5 @@ namespace SeedQueryParameters;
 
 public partial interface ISeedQueryParametersClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/SeedQueryParametersClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/SeedQueryParametersClient.cs
@@ -29,5 +29,5 @@ public partial class SeedQueryParametersClient : ISeedQueryParametersClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/ISeedRequestParametersClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/ISeedRequestParametersClient.cs
@@ -2,5 +2,5 @@ namespace SeedRequestParameters;
 
 public partial interface ISeedRequestParametersClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/SeedRequestParametersClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/SeedRequestParametersClient.cs
@@ -29,5 +29,5 @@ public partial class SeedRequestParametersClient : ISeedRequestParametersClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/ISeedRequestParametersClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/ISeedRequestParametersClient.cs
@@ -2,5 +2,5 @@ namespace SeedRequestParameters;
 
 public partial interface ISeedRequestParametersClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParametersClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParametersClient.cs
@@ -29,5 +29,5 @@ public partial class SeedRequestParametersClient : ISeedRequestParametersClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/ISeedNurseryApiClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/ISeedNurseryApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedNurseryApi;
 
 public partial interface ISeedNurseryApiClient
 {
-    public PackageClient Package { get; }
+    public IPackageClient Package { get; }
 }

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/SeedNurseryApiClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/SeedNurseryApiClient.cs
@@ -29,5 +29,5 @@ public partial class SeedNurseryApiClient : ISeedNurseryApiClient
         Package = new PackageClient(_client);
     }
 
-    public PackageClient Package { get; }
+    public IPackageClient Package { get; }
 }

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/ISeedResponsePropertyClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/ISeedResponsePropertyClient.cs
@@ -2,5 +2,5 @@ namespace SeedResponseProperty;
 
 public partial interface ISeedResponsePropertyClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/SeedResponsePropertyClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/SeedResponsePropertyClient.cs
@@ -29,5 +29,5 @@ public partial class SeedResponsePropertyClient : ISeedResponsePropertyClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/ISeedServerSentEventsClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/ISeedServerSentEventsClient.cs
@@ -2,5 +2,5 @@ namespace SeedServerSentEvents;
 
 public partial interface ISeedServerSentEventsClient
 {
-    public CompletionsClient Completions { get; }
+    public ICompletionsClient Completions { get; }
 }

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEventsClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEventsClient.cs
@@ -29,5 +29,5 @@ public partial class SeedServerSentEventsClient : ISeedServerSentEventsClient
         Completions = new CompletionsClient(_client);
     }
 
-    public CompletionsClient Completions { get; }
+    public ICompletionsClient Completions { get; }
 }

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/ISeedServerSentEventsClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/ISeedServerSentEventsClient.cs
@@ -2,5 +2,5 @@ namespace SeedServerSentEvents;
 
 public partial interface ISeedServerSentEventsClient
 {
-    public CompletionsClient Completions { get; }
+    public ICompletionsClient Completions { get; }
 }

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEventsClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEventsClient.cs
@@ -29,5 +29,5 @@ public partial class SeedServerSentEventsClient : ISeedServerSentEventsClient
         Completions = new CompletionsClient(_client);
     }
 
-    public CompletionsClient Completions { get; }
+    public ICompletionsClient Completions { get; }
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/ISeedSimpleApiClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/ISeedSimpleApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedSimpleApi;
 
 public partial interface ISeedSimpleApiClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/SeedSimpleApiClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/SeedSimpleApiClient.cs
@@ -37,5 +37,5 @@ public partial class SeedSimpleApiClient : ISeedSimpleApiClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/ISeedSimpleApiClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/ISeedSimpleApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedSimpleApi;
 
 public partial interface ISeedSimpleApiClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/SeedSimpleApiClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/SeedSimpleApiClient.cs
@@ -37,5 +37,5 @@ public partial class SeedSimpleApiClient : ISeedSimpleApiClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/ISeedSimpleApiClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/ISeedSimpleApiClient.cs
@@ -2,5 +2,5 @@ namespace SeedSimpleApi;
 
 public partial interface ISeedSimpleApiClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/SeedSimpleApiClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/SeedSimpleApiClient.cs
@@ -37,5 +37,5 @@ public partial class SeedSimpleApiClient : ISeedSimpleApiClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/ISeedSingleUrlEnvironmentDefaultClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/ISeedSingleUrlEnvironmentDefaultClient.cs
@@ -2,5 +2,5 @@ namespace SeedSingleUrlEnvironmentDefault;
 
 public partial interface ISeedSingleUrlEnvironmentDefaultClient
 {
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefaultClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefaultClient.cs
@@ -40,5 +40,5 @@ public partial class SeedSingleUrlEnvironmentDefaultClient : ISeedSingleUrlEnvir
         Dummy = new DummyClient(_client);
     }
 
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/ISeedSingleUrlEnvironmentNoDefaultClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/ISeedSingleUrlEnvironmentNoDefaultClient.cs
@@ -2,5 +2,5 @@ namespace SeedSingleUrlEnvironmentNoDefault;
 
 public partial interface ISeedSingleUrlEnvironmentNoDefaultClient
 {
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefaultClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefaultClient.cs
@@ -41,5 +41,5 @@ public partial class SeedSingleUrlEnvironmentNoDefaultClient
         Dummy = new DummyClient(_client);
     }
 
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/ISeedStreamingClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/ISeedStreamingClient.cs
@@ -2,5 +2,5 @@ namespace SeedStreaming;
 
 public partial interface ISeedStreamingClient
 {
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/SeedStreamingClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/SeedStreamingClient.cs
@@ -29,5 +29,5 @@ public partial class SeedStreamingClient : ISeedStreamingClient
         Dummy = new DummyClient(_client);
     }
 
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/streaming/src/SeedStreaming/ISeedStreamingClient.cs
+++ b/seed/csharp-sdk/streaming/src/SeedStreaming/ISeedStreamingClient.cs
@@ -2,5 +2,5 @@ namespace SeedStreaming;
 
 public partial interface ISeedStreamingClient
 {
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/streaming/src/SeedStreaming/SeedStreamingClient.cs
+++ b/seed/csharp-sdk/streaming/src/SeedStreaming/SeedStreamingClient.cs
@@ -29,5 +29,5 @@ public partial class SeedStreamingClient : ISeedStreamingClient
         Dummy = new DummyClient(_client);
     }
 
-    public DummyClient Dummy { get; }
+    public IDummyClient Dummy { get; }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/ISeedUndiscriminatedUnionsClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/ISeedUndiscriminatedUnionsClient.cs
@@ -2,5 +2,5 @@ namespace SeedUndiscriminatedUnions;
 
 public partial interface ISeedUndiscriminatedUnionsClient
 {
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnionsClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnionsClient.cs
@@ -29,5 +29,5 @@ public partial class SeedUndiscriminatedUnionsClient : ISeedUndiscriminatedUnion
         Union = new UnionClient(_client);
     }
 
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/ISeedUndiscriminatedUnionsClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/ISeedUndiscriminatedUnionsClient.cs
@@ -2,5 +2,5 @@ namespace SeedUndiscriminatedUnions;
 
 public partial interface ISeedUndiscriminatedUnionsClient
 {
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnionsClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnionsClient.cs
@@ -29,5 +29,5 @@ public partial class SeedUndiscriminatedUnionsClient : ISeedUndiscriminatedUnion
         Union = new UnionClient(_client);
     }
 
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/ISeedUnionsClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/ISeedUnionsClient.cs
@@ -2,7 +2,7 @@ namespace SeedUnions;
 
 public partial interface ISeedUnionsClient
 {
-    public BigunionClient Bigunion { get; }
-    public TypesClient Types { get; }
-    public UnionClient Union { get; }
+    public IBigunionClient Bigunion { get; }
+    public ITypesClient Types { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/SeedUnionsClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/SeedUnionsClient.cs
@@ -31,9 +31,9 @@ public partial class SeedUnionsClient : ISeedUnionsClient
         Union = new UnionClient(_client);
     }
 
-    public BigunionClient Bigunion { get; }
+    public IBigunionClient Bigunion { get; }
 
-    public TypesClient Types { get; }
+    public ITypesClient Types { get; }
 
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/ISeedUnionsClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/ISeedUnionsClient.cs
@@ -2,6 +2,6 @@ namespace SeedUnions;
 
 public partial interface ISeedUnionsClient
 {
-    public BigunionClient Bigunion { get; }
-    public UnionClient Union { get; }
+    public IBigunionClient Bigunion { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/SeedUnionsClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/SeedUnionsClient.cs
@@ -30,7 +30,7 @@ public partial class SeedUnionsClient : ISeedUnionsClient
         Union = new UnionClient(_client);
     }
 
-    public BigunionClient Bigunion { get; }
+    public IBigunionClient Bigunion { get; }
 
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/ISeedUnionsClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/ISeedUnionsClient.cs
@@ -2,6 +2,6 @@ namespace SeedUnions;
 
 public partial interface ISeedUnionsClient
 {
-    public BigunionClient Bigunion { get; }
-    public UnionClient Union { get; }
+    public IBigunionClient Bigunion { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/SeedUnionsClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/SeedUnionsClient.cs
@@ -30,7 +30,7 @@ public partial class SeedUnionsClient : ISeedUnionsClient
         Union = new UnionClient(_client);
     }
 
-    public BigunionClient Bigunion { get; }
+    public IBigunionClient Bigunion { get; }
 
-    public UnionClient Union { get; }
+    public IUnionClient Union { get; }
 }

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/ISeedUnknownAsAnyClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/ISeedUnknownAsAnyClient.cs
@@ -2,5 +2,5 @@ namespace SeedUnknownAsAny;
 
 public partial interface ISeedUnknownAsAnyClient
 {
-    public UnknownClient Unknown { get; }
+    public IUnknownClient Unknown { get; }
 }

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/SeedUnknownAsAnyClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/SeedUnknownAsAnyClient.cs
@@ -29,5 +29,5 @@ public partial class SeedUnknownAsAnyClient : ISeedUnknownAsAnyClient
         Unknown = new UnknownClient(_client);
     }
 
-    public UnknownClient Unknown { get; }
+    public IUnknownClient Unknown { get; }
 }

--- a/seed/csharp-sdk/variables/src/SeedVariables/ISeedVariablesClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/ISeedVariablesClient.cs
@@ -2,5 +2,5 @@ namespace SeedVariables;
 
 public partial interface ISeedVariablesClient
 {
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/variables/src/SeedVariables/SeedVariablesClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/SeedVariablesClient.cs
@@ -29,5 +29,5 @@ public partial class SeedVariablesClient : ISeedVariablesClient
         Service = new ServiceClient(_client);
     }
 
-    public ServiceClient Service { get; }
+    public IServiceClient Service { get; }
 }

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/ISeedVersionClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/ISeedVersionClient.cs
@@ -2,5 +2,5 @@ namespace SeedVersion;
 
 public partial interface ISeedVersionClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/SeedVersionClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/SeedVersionClient.cs
@@ -29,5 +29,5 @@ public partial class SeedVersionClient : ISeedVersionClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/version/src/SeedVersion/ISeedVersionClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/ISeedVersionClient.cs
@@ -2,5 +2,5 @@ namespace SeedVersion;
 
 public partial interface ISeedVersionClient
 {
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/version/src/SeedVersion/SeedVersionClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/SeedVersionClient.cs
@@ -29,5 +29,5 @@ public partial class SeedVersionClient : ISeedVersionClient
         User = new UserClient(_client);
     }
 
-    public UserClient User { get; }
+    public IUserClient User { get; }
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/ISeedWebsocketAuthClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/ISeedWebsocketAuthClient.cs
@@ -2,5 +2,5 @@ namespace SeedWebsocketAuth;
 
 public partial interface ISeedWebsocketAuthClient
 {
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuthClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuthClient.cs
@@ -49,5 +49,5 @@ public partial class SeedWebsocketAuthClient : ISeedWebsocketAuthClient
         Auth = new AuthClient(_client);
     }
 
-    public AuthClient Auth { get; }
+    public IAuthClient Auth { get; }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/ISeedWebsocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/ISeedWebsocketClient.cs
@@ -4,5 +4,5 @@ namespace SeedWebsocket;
 
 public partial interface ISeedWebsocketClient
 {
-    public EmptyClient Empty { get; }
+    public IEmptyClient Empty { get; }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocketClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocketClient.cs
@@ -30,7 +30,7 @@ public partial class SeedWebsocketClient : ISeedWebsocketClient
         Empty = new EmptyClient(_client);
     }
 
-    public EmptyClient Empty { get; }
+    public IEmptyClient Empty { get; }
 
     public RealtimeApi CreateRealtimeApi(RealtimeApi.Options options)
     {


### PR DESCRIPTION
## Description
Instead of the top-level client using concrete types,
```csharp
public ActionsClient Actions { get; }

public BrandingClient Branding { get; }

public ClientGrantsClient ClientGrants { get; }
```
it should use the interface types:
```csharp
public IActionsClient Actions { get; }

public IBrandingClient Branding { get; }

public IClientGrantsClient ClientGrants { get; }
```

## Testing
Regenerating seed now!
- [X] Unit tests added/updated
- [X] Manual testing completed
