### PR TITLE
fix(java): add endpointId option to resolve snippet collisions

### DIFF
--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
@@ -17,7 +17,7 @@ export abstract class AbstractDynamicSnippetsGenerator<
         request: FernIr.dynamic.EndpointSnippetRequest,
         options: Options = {}
     ): Promise<FernIr.dynamic.EndpointSnippetResponse> {
-        const endpoints = this.context.resolveEndpointLocationOrThrow(request.endpoint);
+        const endpoints = this.resolveEndpoints({ request, options });
         if (endpoints.length === 0) {
             throw new Error(`No endpoints found that match "${request.endpoint.method} ${request.endpoint.path}"`);
         }
@@ -47,7 +47,7 @@ export abstract class AbstractDynamicSnippetsGenerator<
         request: FernIr.dynamic.EndpointSnippetRequest,
         options: Options = {}
     ): Promise<AbstractAstNode> {
-        const endpoints = this.context.resolveEndpointLocationOrThrow(request.endpoint);
+        const endpoints = this.resolveEndpoints({ request, options });
         if (endpoints.length === 0) {
             throw new Error(`No endpoints found that match "${request.endpoint.method} ${request.endpoint.path}"`);
         }
@@ -74,7 +74,7 @@ export abstract class AbstractDynamicSnippetsGenerator<
         request: FernIr.dynamic.EndpointSnippetRequest,
         options: Options = {}
     ): FernIr.dynamic.EndpointSnippetResponse {
-        const endpoints = this.context.resolveEndpointLocationOrThrow(request.endpoint);
+        const endpoints = this.resolveEndpoints({ request, options });
         if (endpoints.length === 0) {
             throw new Error(`No endpoints found that match "${request.endpoint.method} ${request.endpoint.path}"`);
         }
@@ -98,5 +98,27 @@ export abstract class AbstractDynamicSnippetsGenerator<
             }
         }
         return result.getResponseOrThrow({ endpoint: request.endpoint });
+    }
+
+    /**
+     * Resolves endpoints based on the request and options.
+     * If an endpointId is specified in options, returns only that specific endpoint.
+     * Otherwise, resolves all endpoints matching the endpoint location (method + path).
+     */
+    private resolveEndpoints({
+        request,
+        options
+    }: {
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options: Options;
+    }): FernIr.dynamic.Endpoint[] {
+        if (options.endpointId != null) {
+            const endpoint = this.context.resolveEndpointById(options.endpointId);
+            if (endpoint == null) {
+                throw new Error(`No endpoint found with ID "${options.endpointId}"`);
+            }
+            return [endpoint];
+        }
+        return this.context.resolveEndpointLocationOrThrow(request.endpoint);
     }
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/Options.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/Options.ts
@@ -24,4 +24,9 @@ export interface Options {
     // Skip client instantiation in the generated snippet. Useful for wire tests
     // where the client is already instantiated in the test setup.
     skipClientInstantiation?: boolean;
+
+    // Optional endpoint ID to generate a snippet for a specific endpoint.
+    // This is useful when multiple endpoints have the same HTTP method and path
+    // across different namespaces, and we need to generate a snippet for a specific one.
+    endpointId?: string;
 }

--- a/generators/java-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
+++ b/generators/java-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
@@ -1,7 +1,6 @@
 import {
     AbstractAstNode,
     AbstractDynamicSnippetsGenerator,
-    AbstractFormatter,
     FernGeneratorExec,
     Options
 } from "@fern-api/browser-compatible-base-generator";
@@ -13,8 +12,6 @@ export class DynamicSnippetsGenerator extends AbstractDynamicSnippetsGenerator<
     DynamicSnippetsGeneratorContext,
     EndpointSnippetGenerator
 > {
-    private formatter: AbstractFormatter | undefined;
-
     constructor({
         ir,
         config,

--- a/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
@@ -449,7 +449,11 @@ export class SdkWireTestGenerator {
 
             try {
                 dynamicIr.endpoints[endpoint.id] = correctedDynamicEndpoint;
-                const snippet = await this.generateSnippetForExample(firstDynamicExample, dynamicSnippetsGenerator, endpoint.id);
+                const snippet = await this.generateSnippetForExample(
+                    firstDynamicExample,
+                    dynamicSnippetsGenerator,
+                    endpoint.id
+                );
                 this.context.logger.debug(`Service correction succeeded for endpoint ${endpoint.id}`);
                 return snippet;
             } catch (error) {

--- a/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
@@ -336,10 +336,13 @@ export class SdkWireTestGenerator {
 
     private async generateSnippetForExample(
         example: dynamic.EndpointExample,
-        dynamicSnippetsGenerator: DynamicSnippetsGenerator
+        dynamicSnippetsGenerator: DynamicSnippetsGenerator,
+        endpointId: string
     ): Promise<string> {
         const snippetRequest = convertDynamicEndpointSnippetRequest(example);
-        const response = await dynamicSnippetsGenerator.generate(snippetRequest);
+        // Pass endpointId to avoid path collision issues when multiple namespaces
+        // have endpoints with the same HTTP method and path pattern
+        const response = await dynamicSnippetsGenerator.generate(snippetRequest, { endpointId });
         if (!response.snippet) {
             throw new Error("No snippet generated for example");
         }
@@ -446,7 +449,7 @@ export class SdkWireTestGenerator {
 
             try {
                 dynamicIr.endpoints[endpoint.id] = correctedDynamicEndpoint;
-                const snippet = await this.generateSnippetForExample(firstDynamicExample, dynamicSnippetsGenerator);
+                const snippet = await this.generateSnippetForExample(firstDynamicExample, dynamicSnippetsGenerator, endpoint.id);
                 this.context.logger.debug(`Service correction succeeded for endpoint ${endpoint.id}`);
                 return snippet;
             } catch (error) {
@@ -464,7 +467,7 @@ export class SdkWireTestGenerator {
                 }
             }
         } else {
-            return await this.generateSnippetForExample(firstDynamicExample, dynamicSnippetsGenerator);
+            return await this.generateSnippetForExample(firstDynamicExample, dynamicSnippetsGenerator, endpoint.id);
         }
     }
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.34.6
+  changelogEntry:
+    - summary: |
+        Fix wire test generation importing types from the wrong package when multiple services have
+        endpoints with the same HTTP method and path. The generator now uses endpoint IDs to resolve
+        the correct endpoint instead of relying solely on method and path matching.
+      type: fix
+  createdAt: "2026-01-29"
+  irVersion: 63
+
 - version: 3.34.5
   changelogEntry:
     - summary: |

--- a/generators/python-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
@@ -1,7 +1,8 @@
 import {
     AbstractAstNode,
     AbstractDynamicSnippetsGenerator,
-    FernGeneratorExec
+    FernGeneratorExec,
+    Options
 } from "@fern-api/browser-compatible-base-generator";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { python } from "@fern-api/python-ast";
@@ -23,26 +24,43 @@ export class DynamicSnippetsGenerator extends AbstractDynamicSnippetsGenerator<
     }
 
     public async generate(
-        request: FernIr.dynamic.EndpointSnippetRequest
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options: Options = {}
     ): Promise<FernIr.dynamic.EndpointSnippetResponse> {
-        return super.generate(request);
+        return super.generate(request, options);
     }
 
-    public generateSync(request: FernIr.dynamic.EndpointSnippetRequest): FernIr.dynamic.EndpointSnippetResponse {
-        return super.generateSync(request);
+    public generateSync(
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options: Options = {}
+    ): FernIr.dynamic.EndpointSnippetResponse {
+        return super.generateSync(request, options);
     }
 
-    public async generateSnippetAst(request: FernIr.dynamic.EndpointSnippetRequest): Promise<AbstractAstNode> {
-        return super.generateSnippetAst(request);
+    public async generateSnippetAst(
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options: Options = {}
+    ): Promise<AbstractAstNode> {
+        return super.generateSnippetAst(request, options);
     }
 
     /**
      * Generates just the method call AST without the client instantiation.
      * This is useful for wire tests where the client is created separately
      * with test-specific configuration.
+     *
+     * @param request - The snippet request
+     * @param options - Optional options, including endpointId to resolve a specific endpoint
+     *                  when multiple endpoints share the same HTTP method and path
      */
-    public generateMethodCallSnippetAst(request: FernIr.dynamic.EndpointSnippetRequest): python.AstNode {
-        const endpoints = this.context.resolveEndpointLocationOrThrow(request.endpoint);
+    public generateMethodCallSnippetAst({
+        request,
+        options = {}
+    }: {
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): python.AstNode {
+        const endpoints = this.resolveEndpointsForMethodCall({ request, options });
         if (endpoints.length === 0) {
             throw new Error(`No endpoints found that match "${request.endpoint.method} ${request.endpoint.path}"`);
         }
@@ -64,22 +82,21 @@ export class DynamicSnippetsGenerator extends AbstractDynamicSnippetsGenerator<
         );
     }
 
-    /**
-     * Generates just the method call AST without the client instantiation, using the endpoint ID directly.
-     * This is useful for wire tests where the client is created separately with test-specific configuration,
-     * and when there are multiple endpoints with the same HTTP method and path pattern across different namespaces.
-     */
-    public generateMethodCallSnippetAstById({
-        endpointId,
-        request
+    private resolveEndpointsForMethodCall({
+        request,
+        options
     }: {
-        endpointId: FernIr.dynamic.EndpointId;
         request: FernIr.dynamic.EndpointSnippetRequest;
-    }): python.AstNode {
-        const endpoint = this.context.resolveEndpointByIdOrThrow(endpointId);
-        const context = this.context.clone() as DynamicSnippetsGeneratorContext;
-        const snippetGenerator = this.createSnippetGenerator(context);
-        return snippetGenerator.generateMethodCallSnippetAst({ endpoint, request });
+        options: Options;
+    }): FernIr.dynamic.Endpoint[] {
+        if (options.endpointId != null) {
+            const endpoint = this.context.resolveEndpointById(options.endpointId);
+            if (endpoint == null) {
+                throw new Error(`No endpoint found with ID "${options.endpointId}"`);
+            }
+            return [endpoint];
+        }
+        return this.context.resolveEndpointLocationOrThrow(request.endpoint);
     }
 
     protected createSnippetGenerator(context: DynamicSnippetsGeneratorContext): EndpointSnippetGenerator {

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -532,11 +532,11 @@ export class WireTestGenerator {
             this.addPlaceholderFileUploadFields({ endpoint, snippetRequest });
 
             // Generate just the method call AST using DynamicSnippetsGenerator
-            // Use the endpoint ID directly to avoid path collision issues when multiple
+            // Pass endpointId to avoid path collision issues when multiple
             // namespaces have endpoints with the same HTTP method and path pattern
-            return this.snippetGenerator.generateMethodCallSnippetAstById({
-                endpointId: endpoint.id,
-                request: snippetRequest
+            return this.snippetGenerator.generateMethodCallSnippetAst({
+                request: snippetRequest,
+                options: { endpointId: endpoint.id }
             });
         } catch (error) {
             // Fallback: log error and generate a placeholder


### PR DESCRIPTION
Fixes dynamic snippet resolution when multiple endpoints share the same path and verb.

Previously, this was implemented directly on the python DSG. This PR pulls this up to the parent class in a back-compat way (optional property on the `Options` type).

🤖 Generated with [Claude Code](https://claude.ai/code)