### PR TITLE
fix(csharp): wire tests use JSON element comparison

### DIFF
--- a/generators/csharp/base/src/AsIs.ts
+++ b/generators/csharp/base/src/AsIs.ts
@@ -93,6 +93,7 @@ export const AsIsFiles = {
         },
         Utils: {
             AdditionalPropertiesComparer: "test/Utils/AdditionalPropertiesComparer.Template.cs",
+            JsonAssert: "test/Utils/JsonAssert.Template.cs",
             JsonElementComparer: "test/Utils/JsonElementComparer.Template.cs",
             NUnitExtensions: "test/Utils/NUnitExtensions.Template.cs",
             OneOfComparer: "test/Utils/OneOfComparer.Template.cs",

--- a/generators/csharp/base/src/asIs/test/Utils/JsonAssert.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Utils/JsonAssert.Template.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using <%= namespaces.core%>;
+
+namespace <%= namespace%>;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/generators/csharp/codegen/src/context/generation-info.ts
+++ b/generators/csharp/codegen/src/context/generation-info.ts
@@ -629,6 +629,12 @@ export class Generation {
                 origin: this.model.staticExplicit("JsonUtils"),
                 namespace: this.namespaces.core
             }),
+        /** Test assertion helper for JSON comparison */
+        JsonAssert: () =>
+            this.csharp.classReference({
+                origin: this.model.staticExplicit("JsonAssert"),
+                namespace: this.namespaces.testUtils
+            }),
         /** Factory for creating custom pagination instances */
         CustomPagerFactory: () =>
             this.csharp.classReference({

--- a/generators/csharp/model/src/undiscriminated-union/UndiscriminatedUnionGenerator.ts
+++ b/generators/csharp/model/src/undiscriminated-union/UndiscriminatedUnionGenerator.ts
@@ -785,7 +785,7 @@ export class UndiscriminatedUnionGenerator extends FileGenerator<CSharpFile, Mod
         converterClass.addMethod({
             access: ast.Access.Public,
             override: true,
-            return_: unionReference.asOptional(),
+            return_: unionReference,
             name: "ReadAsPropertyName",
             parameters: [
                 this.csharp.parameter({

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -45,10 +45,11 @@ export class MockEndpointGenerator extends WithGeneration {
                     if (example.response.type !== "ok" || example.response.value.type !== "body") {
                         throw new Error("Unexpected error response type");
                     }
-                    // Filter the response body to normalize datetime values to ISO 8601 format
                     const responseValue = example.response.value.value;
                     jsonExampleResponse =
-                        responseValue != null ? this.filterExampleTypeReference(responseValue) : undefined;
+                        responseValue != null
+                            ? this.filterExampleTypeReference(responseValue, { filterWriteOnly: true })
+                            : undefined;
                 }
                 const responseBodyType = endpoint.response?.body?.type;
                 // whether or not we support this response type in this generator; the example json may
@@ -420,11 +421,15 @@ export class MockEndpointGenerator extends WithGeneration {
     }
 
     /**
-     * Filters read-only properties from an example type reference.
+     * Filters properties from an example type reference.
      * Recursively handles containers (optional, list, map, etc.) and named types.
      * Also normalizes datetime/date values to ISO 8601 format for wire test matching.
+     * @param filterWriteOnly - If true, filters write-only properties (for responses). If false, filters read-only (for requests).
      */
-    private filterExampleTypeReference(exampleTypeRef: ExampleTypeReference): unknown {
+    private filterExampleTypeReference(
+        exampleTypeRef: ExampleTypeReference,
+        options: { filterWriteOnly?: boolean } = {}
+    ): unknown {
         const shape = exampleTypeRef.shape;
 
         switch (shape.type) {
@@ -448,15 +453,15 @@ export class MockEndpointGenerator extends WithGeneration {
                 if (shape.container.type === "literal") {
                     return exampleTypeRef.jsonExample;
                 }
-                return this.filterContainerExample(shape.container);
+                return this.filterContainerExample(shape.container, options);
 
             case "named":
-                return this.filterNamedExample(shape);
+                return this.filterNamedExample(shape, options);
         }
     }
 
     /**
-     * Filters read-only properties from a container example (optional, list, map, etc.).
+     * Filters properties from a container example (optional, list, map, etc.).
      */
     private filterContainerExample(
         container:
@@ -465,26 +470,27 @@ export class MockEndpointGenerator extends WithGeneration {
             | { type: "optional"; optional: ExampleTypeReference | undefined }
             | { type: "nullable"; nullable: ExampleTypeReference | undefined }
             | { type: "map"; map: Array<{ key: ExampleTypeReference; value: ExampleTypeReference }> }
-            | { type: "literal"; literal: unknown }
+            | { type: "literal"; literal: unknown },
+        options: { filterWriteOnly?: boolean } = {}
     ): unknown {
         switch (container.type) {
             case "list":
-                return container.list.map((item) => this.filterExampleTypeReference(item));
+                return container.list.map((item) => this.filterExampleTypeReference(item, options));
 
             case "set":
-                return container.set.map((item) => this.filterExampleTypeReference(item));
+                return container.set.map((item) => this.filterExampleTypeReference(item, options));
 
             case "optional":
                 if (container.optional == null) {
                     return null;
                 }
-                return this.filterExampleTypeReference(container.optional);
+                return this.filterExampleTypeReference(container.optional, options);
 
             case "nullable":
                 if (container.nullable == null) {
                     return null;
                 }
-                return this.filterExampleTypeReference(container.nullable);
+                return this.filterExampleTypeReference(container.nullable, options);
 
             case "map": {
                 const mapResult: Record<string, unknown> = {};
@@ -492,7 +498,7 @@ export class MockEndpointGenerator extends WithGeneration {
                     const key = entry.key.jsonExample;
                     // JSON object keys are always strings, but the example might have numeric keys
                     if (typeof key === "string" || typeof key === "number") {
-                        mapResult[String(key)] = this.filterExampleTypeReference(entry.value);
+                        mapResult[String(key)] = this.filterExampleTypeReference(entry.value, options);
                     }
                 }
                 return mapResult;
@@ -521,59 +527,70 @@ export class MockEndpointGenerator extends WithGeneration {
     }
 
     /**
-     * Filters read-only properties from a named type example.
+     * Filters properties from a named type example.
      */
-    private filterNamedExample(namedShape: {
-        type: "named";
-        typeName: { typeId: TypeId };
-        shape:
-            | { type: "object"; properties: Array<{ name: { wireValue: string }; value: ExampleTypeReference }> }
-            | { type: "union"; discriminant: { wireValue: string }; singleUnionType: unknown }
-            | { type: "enum"; value: { wireValue: string } }
-            | { type: "alias"; value: ExampleTypeReference }
-            | { type: "undiscriminatedUnion"; index: number; singleUnionType: ExampleTypeReference };
-    }): unknown {
+    private filterNamedExample(
+        namedShape: {
+            type: "named";
+            typeName: { typeId: TypeId };
+            shape:
+                | { type: "object"; properties: Array<{ name: { wireValue: string }; value: ExampleTypeReference }> }
+                | { type: "union"; discriminant: { wireValue: string }; singleUnionType: unknown }
+                | { type: "enum"; value: { wireValue: string } }
+                | { type: "alias"; value: ExampleTypeReference }
+                | { type: "undiscriminatedUnion"; index: number; singleUnionType: ExampleTypeReference };
+        },
+        options: { filterWriteOnly?: boolean } = {}
+    ): unknown {
         const typeId = namedShape.typeName.typeId;
         const innerShape = namedShape.shape;
 
         switch (innerShape.type) {
             case "object":
-                return this.filterObjectExample(typeId, innerShape.properties);
+                return this.filterObjectExample(typeId, innerShape.properties, options);
 
             case "alias":
-                return this.filterExampleTypeReference(innerShape.value);
+                return this.filterExampleTypeReference(innerShape.value, options);
 
             case "enum":
                 return innerShape.value.wireValue;
 
             case "union":
                 // For unions, we need to handle the discriminant and the union value
-                return this.filterUnionExample(innerShape);
+                return this.filterUnionExample(innerShape, options);
 
             case "undiscriminatedUnion":
-                return this.filterExampleTypeReference(innerShape.singleUnionType);
+                return this.filterExampleTypeReference(innerShape.singleUnionType, options);
         }
     }
 
     /**
-     * Filters read-only properties from an object example.
+     * Filters properties from an object example.
      * Also omits null values for properties that are optional-but-not-nullable,
      * since the SDK won't serialize those nulls.
+     * @param filterWriteOnly - If true, filters both write-only and read-only properties (for responses).
+     *                          Write-only are not deserialized, read-only are not serialized when comparing.
+     *                          If false, filters only read-only (for requests).
      */
     private filterObjectExample(
         typeId: TypeId,
-        properties: Array<{ name: { wireValue: string }; value: ExampleTypeReference }>
+        properties: Array<{ name: { wireValue: string }; value: ExampleTypeReference }>,
+        options: { filterWriteOnly?: boolean } = {}
     ): Record<string, unknown> {
         const typeDeclaration = this.context.model.dereferenceType(typeId).typeDeclaration;
         const readOnlyNames = this.getReadOnlyPropertyNamesForType(typeDeclaration);
+        const writeOnlyNames = options.filterWriteOnly
+            ? this.getWriteOnlyPropertyNamesForType(typeDeclaration)
+            : new Set<string>();
+        const propertiesToFilter = new Set([...readOnlyNames, ...writeOnlyNames]);
         const nullableNames = this.getNullablePropertyNamesForType(typeDeclaration);
 
         const result: Record<string, unknown> = {};
         for (const prop of properties) {
-            if (readOnlyNames.has(prop.name.wireValue)) {
+            if (propertiesToFilter.has(prop.name.wireValue)) {
                 continue;
             }
-            const filteredValue = this.filterExampleTypeReference(prop.value);
+            const filteredValue = this.filterExampleTypeReference(prop.value, options);
 
             // Omit null values for properties that are optional-but-not-nullable
             // since the SDK won't serialize those nulls (JsonIgnoreCondition.WhenWritingNull)
@@ -586,9 +603,12 @@ export class MockEndpointGenerator extends WithGeneration {
     }
 
     /**
-     * Filters read-only properties from a union example.
+     * Filters properties from a union example.
      */
-    private filterUnionExample(unionShape: { discriminant: { wireValue: string }; singleUnionType: unknown }): unknown {
+    private filterUnionExample(
+        unionShape: { discriminant: { wireValue: string }; singleUnionType: unknown },
+        options: { filterWriteOnly?: boolean } = {}
+    ): unknown {
         // Union examples have a complex structure - for now, return the JSON example
         // and rely on the SDK's serialization to handle read-only properties
         const singleUnionType = unionShape.singleUnionType as {
@@ -610,12 +630,13 @@ export class MockEndpointGenerator extends WithGeneration {
         if (singleUnionType.shape.type === "samePropertiesAsObject") {
             const filteredProps = this.filterObjectExample(
                 singleUnionType.shape.typeId,
-                singleUnionType.shape.object.properties
+                singleUnionType.shape.object.properties,
+                options
             );
             Object.assign(result, filteredProps);
         } else if (singleUnionType.shape.type === "singleProperty") {
             // Single property unions have a nested value
-            const filteredValue = this.filterExampleTypeReference(singleUnionType.shape.typeReference);
+            const filteredValue = this.filterExampleTypeReference(singleUnionType.shape.typeReference, options);
             // The property name for single property unions is typically the variant name
             // but we need to check the union definition for the actual wire name
             Object.assign(result, filteredValue);
@@ -656,6 +677,40 @@ export class MockEndpointGenerator extends WithGeneration {
         }
 
         return readOnlyNames;
+    }
+
+    /**
+     * Gets the set of write-only property wire names for a type declaration.
+     */
+    private getWriteOnlyPropertyNamesForType(typeDeclaration: {
+        shape: {
+            type: string;
+            properties?: Array<{ name: { wireValue: string }; propertyAccess?: string }>;
+            extendedProperties?: Array<{ name: { wireValue: string }; propertyAccess?: string }>;
+        };
+    }): Set<string> {
+        const writeOnlyNames = new Set<string>();
+        const shape = typeDeclaration.shape;
+
+        if (shape.type !== "object" || !shape.properties) {
+            return writeOnlyNames;
+        }
+
+        for (const prop of shape.properties) {
+            if (prop.propertyAccess === ObjectPropertyAccess.WriteOnly) {
+                writeOnlyNames.add(prop.name.wireValue);
+            }
+        }
+
+        if (shape.extendedProperties) {
+            for (const prop of shape.extendedProperties) {
+                if (prop.propertyAccess === ObjectPropertyAccess.WriteOnly) {
+                    writeOnlyNames.add(prop.name.wireValue);
+                }
+            }
+        }
+
+        return writeOnlyNames;
     }
 
     /**

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -5,7 +5,8 @@ import {
     ExampleTypeReference,
     HttpEndpoint,
     ObjectPropertyAccess,
-    TypeId
+    TypeId,
+    TypeReference
 } from "@fern-fern/ir-sdk/api";
 import { DefaultValueExtractor, ExtractedDefault } from "../../DefaultValueExtractor";
 import { getContentTypeFromRequestBody } from "../../endpoint/utils/getContentTypeFromRequestBody";
@@ -556,6 +557,8 @@ export class MockEndpointGenerator extends WithGeneration {
 
     /**
      * Filters read-only properties from an object example.
+     * Also omits null values for properties that are optional-but-not-nullable,
+     * since the SDK won't serialize those nulls.
      */
     private filterObjectExample(
         typeId: TypeId,
@@ -563,13 +566,21 @@ export class MockEndpointGenerator extends WithGeneration {
     ): Record<string, unknown> {
         const typeDeclaration = this.context.model.dereferenceType(typeId).typeDeclaration;
         const readOnlyNames = this.getReadOnlyPropertyNamesForType(typeDeclaration);
+        const nullableNames = this.getNullablePropertyNamesForType(typeDeclaration);
 
         const result: Record<string, unknown> = {};
         for (const prop of properties) {
             if (readOnlyNames.has(prop.name.wireValue)) {
                 continue;
             }
-            result[prop.name.wireValue] = this.filterExampleTypeReference(prop.value);
+            const filteredValue = this.filterExampleTypeReference(prop.value);
+
+            // Omit null values for properties that are optional-but-not-nullable
+            // since the SDK won't serialize those nulls (JsonIgnoreCondition.WhenWritingNull)
+            if (filteredValue === null && !nullableNames.has(prop.name.wireValue)) {
+                continue;
+            }
+            result[prop.name.wireValue] = filteredValue;
         }
         return result;
     }
@@ -645,6 +656,41 @@ export class MockEndpointGenerator extends WithGeneration {
         }
 
         return readOnlyNames;
+    }
+
+    /**
+     * Gets the set of nullable property wire names for a type declaration.
+     * A property is nullable if its type is a nullable container or optional<nullable<T>>.
+     */
+    private getNullablePropertyNamesForType(typeDeclaration: {
+        shape: {
+            type: string;
+            properties?: Array<{ name: { wireValue: string }; valueType: TypeReference }>;
+            extendedProperties?: Array<{ name: { wireValue: string }; valueType: TypeReference }>;
+        };
+    }): Set<string> {
+        const nullableNames = new Set<string>();
+        const shape = typeDeclaration.shape;
+
+        if (shape.type !== "object" || !shape.properties) {
+            return nullableNames;
+        }
+
+        for (const prop of shape.properties) {
+            if (this.context.isNullable(prop.valueType)) {
+                nullableNames.add(prop.name.wireValue);
+            }
+        }
+
+        if (shape.extendedProperties) {
+            for (const prop of shape.extendedProperties) {
+                if (this.context.isNullable(prop.valueType)) {
+                    nullableNames.add(prop.name.wireValue);
+                }
+            }
+        }
+
+        return nullableNames;
     }
 
     /**

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockServerTestGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockServerTestGenerator.ts
@@ -132,27 +132,15 @@ export class MockServerTestGenerator extends FileGenerator<CSharpFile, SdkGenera
                         writer.write("var response = ");
                         writer.writeNodeStatement(endpointSnippet);
                         if (responseBodyType === "json") {
-                            // Use JSON element comparison for reliable deep equality
-                            // This handles collections and union types correctly
-                            writer.write("var actualJson = ");
                             writer.writeNodeStatement(
                                 this.csharp.invokeMethod({
-                                    on: this.Types.JsonUtils,
-                                    method: "SerializeToElement",
-                                    arguments_: [this.csharp.codeblock("response")]
+                                    on: this.Types.JsonAssert,
+                                    method: "AreEqual",
+                                    arguments_: [
+                                        this.csharp.codeblock("response"),
+                                        this.csharp.codeblock("mockResponse")
+                                    ]
                                 })
-                            );
-                            writer.write("var expectedJson = ");
-                            writer.writeNodeStatement(
-                                this.csharp.invokeMethod({
-                                    on: this.Types.JsonUtils,
-                                    method: "Deserialize",
-                                    generics: [this.System.Text.Json.JsonElement],
-                                    arguments_: [this.csharp.codeblock("mockResponse")]
-                                })
-                            );
-                            writer.writeTextStatement(
-                                "Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer())"
                             );
                         } else if (responseBodyType === "text") {
                             writer.writeTextStatement("Assert.That(response, Is.EqualTo(mockResponse))");

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockServerTestGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockServerTestGenerator.ts
@@ -1,16 +1,9 @@
-import { assertNever } from "@fern-api/core-utils";
-import { CSharpFile, convertExampleTypeReferenceToTypeReference, FileGenerator } from "@fern-api/csharp-base";
-import { ast, is, Writer } from "@fern-api/csharp-codegen";
+import { CSharpFile, FileGenerator } from "@fern-api/csharp-base";
+import { ast, Writer } from "@fern-api/csharp-codegen";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 
 import { FernIr } from "@fern-fern/ir-sdk";
-import {
-    ExampleEndpointCall,
-    ExampleResponse,
-    ExampleTypeReference,
-    HttpEndpoint,
-    ServiceId
-} from "@fern-fern/ir-sdk/api";
+import { ExampleEndpointCall, ExampleTypeReference, HttpEndpoint, ServiceId } from "@fern-fern/ir-sdk/api";
 import { HttpEndpointGenerator } from "../../endpoint/http/HttpEndpointGenerator";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext";
 import { MockEndpointGenerator } from "./MockEndpointGenerator";
@@ -139,40 +132,28 @@ export class MockServerTestGenerator extends FileGenerator<CSharpFile, SdkGenera
                         writer.write("var response = ");
                         writer.writeNodeStatement(endpointSnippet);
                         if (responseBodyType === "json") {
-                            const responseType = this.getCsharpTypeFromResponse(example.response);
-                            const deserializeResponseNode = this.csharp.invokeMethod({
-                                on: this.Types.JsonUtils,
-                                method: "Deserialize",
-                                generics: [responseType],
-                                arguments_: [this.csharp.codeblock("mockResponse")]
-                            });
-                            const innerType = responseType.asNonOptional();
-                            if (is.OneOf.OneOf(innerType) || is.OneOf.OneOfBase(innerType)) {
-                                writer.writeLine(`Assert.That(
-                                response.Value,
-                                Is.EqualTo(`);
-                                writer.writeNode(deserializeResponseNode);
-                                writer.writeLine(".Value).UsingDefaults()");
-                            } else {
-                                if (
-                                    innerType.isCollection ||
-                                    is.Primitive.object(innerType) ||
-                                    is.ClassReference(innerType)
-                                ) {
-                                    writer.writeLine(`Assert.That(
-                                        response,
-                                        Is.EqualTo(`);
-                                    writer.writeNode(deserializeResponseNode);
-                                    writer.writeLine(").UsingDefaults()");
-                                } else {
-                                    writer.writeLine(`Assert.That(
-                                  response,
-                                  Is.EqualTo(`);
-                                    writer.writeNode(deserializeResponseNode);
-                                    writer.writeLine(")");
-                                }
-                            }
-                            writer.writeTextStatement(")");
+                            // Use JSON element comparison for reliable deep equality
+                            // This handles collections and union types correctly
+                            writer.write("var actualJson = ");
+                            writer.writeNodeStatement(
+                                this.csharp.invokeMethod({
+                                    on: this.Types.JsonUtils,
+                                    method: "SerializeToElement",
+                                    arguments_: [this.csharp.codeblock("response")]
+                                })
+                            );
+                            writer.write("var expectedJson = ");
+                            writer.writeNodeStatement(
+                                this.csharp.invokeMethod({
+                                    on: this.Types.JsonUtils,
+                                    method: "Deserialize",
+                                    generics: [this.System.Text.Json.JsonElement],
+                                    arguments_: [this.csharp.codeblock("mockResponse")]
+                                })
+                            );
+                            writer.writeTextStatement(
+                                "Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer())"
+                            );
                         } else if (responseBodyType === "text") {
                             writer.writeTextStatement("Assert.That(response, Is.EqualTo(mockResponse))");
                         }
@@ -272,33 +253,6 @@ export class MockServerTestGenerator extends FileGenerator<CSharpFile, SdkGenera
                     : undefined;
             case "unknown":
                 return undefined;
-        }
-    }
-
-    getCsharpTypeFromResponse(exampleResponse: ExampleResponse): ast.Type {
-        switch (exampleResponse.type) {
-            case "ok":
-                if (exampleResponse.value.type === "body") {
-                    if (exampleResponse.value.value) {
-                        const typeReference = convertExampleTypeReferenceToTypeReference(exampleResponse.value.value);
-                        const type = this.context.csharpTypeMapper.convert({
-                            reference: typeReference
-                        });
-                        return type;
-                    }
-                }
-                throw new Error("Internal error; could not convert example response to C# type");
-            case "error":
-                if (exampleResponse.body) {
-                    const typeReference = convertExampleTypeReferenceToTypeReference(exampleResponse.body);
-                    const type = this.context.csharpTypeMapper.convert({
-                        reference: typeReference
-                    });
-                    return type;
-                }
-                throw new Error("Internal error; could not convert example response to C# type");
-            default:
-                assertNever(exampleResponse);
         }
     }
 }

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.20.2
+  changelogEntry:
+    - summary: |
+        Wire test assertions now use JSON element comparison instead of object equality, resolving false failures when comparing collections inside undiscriminated union types.
+      type: fix
+    - summary: |
+        Fix mock response data generation to omit null values for optional-but-not-nullable properties, matching SDK serialization behavior.
+      type: fix
+    - summary: |
+        Fix nullability warning (CS8764) in undiscriminated union JsonConverter by using non-optional return type for ReadAsPropertyName method.
+      type: fix
+  createdAt: "2026-01-29"
+  irVersion: 62
+
 - version: 2.20.1
   changelogEntry:
     - summary: |

--- a/seed/csharp-model/accept-header/src/SeedAccept.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/accept-header/src/SeedAccept.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAccept.Core;
+
+namespace SeedAccept.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAliasExtends.Core;
+
+namespace SeedAliasExtends.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/alias/src/SeedAlias.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/alias/src/SeedAlias.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAlias.Core;
+
+namespace SeedAlias.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAnyAuth.Core;
+
+namespace SeedAnyAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApiWideBasePath.Core;
+
+namespace SeedApiWideBasePath.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/audiences/src/SeedAudiences.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/audiences/src/SeedAudiences.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAudiences.Core;
+
+namespace SeedAudiences.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBasicAuthEnvironmentVariables.Core;
+
+namespace SeedBasicAuthEnvironmentVariables.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBasicAuth.Core;
+
+namespace SeedBasicAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBearerTokenEnvironmentVariable.Core;
+
+namespace SeedBearerTokenEnvironmentVariable.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBytesDownload.Core;
+
+namespace SeedBytesDownload.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBytesUpload.Core;
+
+namespace SeedBytesUpload.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/circular-references/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/circular-references/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedClientSideParams.Core;
+
+namespace SeedClientSideParams.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/content-type/src/SeedContentTypes.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/content-type/src/SeedContentTypes.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedContentTypes.Core;
+
+namespace SeedContentTypes.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCrossPackageTypeNames.Core;
+
+namespace SeedCrossPackageTypeNames.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpNamespaceCollision.Core;
+
+namespace SeedCsharpNamespaceCollision.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpNamespaceConflict.Core;
+
+namespace SeedCsharpNamespaceConflict.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpReadonlyRequest.Core;
+
+namespace SeedCsharpReadonlyRequest.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpSystemCollision.Core;
+
+namespace SeedCsharpSystemCollision.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpXmlEntities.Core;
+
+namespace SeedCsharpXmlEntities.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedDollarStringExamples.Core;
+
+namespace SeedDollarStringExamples.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedEmptyClients.Core;
+
+namespace SeedEmptyClients.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedEndpointSecurityAuth.Core;
+
+namespace SeedEndpointSecurityAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedEnum.Core;
+
+namespace SeedEnum.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/enum/plain-enums/src/SeedEnum.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/enum/plain-enums/src/SeedEnum.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedEnum.Core;
+
+namespace SeedEnum.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/error-property/src/SeedErrorProperty.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedErrorProperty.Core;
+
+namespace SeedErrorProperty.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/errors/src/SeedErrors.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/errors/src/SeedErrors.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedErrors.Core;
+
+namespace SeedErrors.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/examples/src/SeedExamples.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/examples/src/SeedExamples.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExamples.Core;
+
+namespace SeedExamples.Test_.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExhaustive.Core;
+
+namespace SeedExhaustive.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/extends/src/SeedExtends.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/extends/src/SeedExtends.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExtends.Core;
+
+namespace SeedExtends.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExtraProperties.Core;
+
+namespace SeedExtraProperties.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/file-download/src/SeedFileDownload.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/file-download/src/SeedFileDownload.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedFileDownload.Core;
+
+namespace SeedFileDownload.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/file-upload/src/SeedFileUpload.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedFileUpload.Core;
+
+namespace SeedFileUpload.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/folders/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/folders/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedHeaderTokenEnvironmentVariable.Core;
+
+namespace SeedHeaderTokenEnvironmentVariable.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedHeaderToken.Core;
+
+namespace SeedHeaderToken.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/http-head/src/SeedHttpHead.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/http-head/src/SeedHttpHead.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedHttpHead.Core;
+
+namespace SeedHttpHead.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedIdempotencyHeaders.Core;
+
+namespace SeedIdempotencyHeaders.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/imdb/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/imdb/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthExplicit.Core;
+
+namespace SeedInferredAuthExplicit.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthImplicitApiKey.Core;
+
+namespace SeedInferredAuthImplicitApiKey.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthImplicitNoExpiry.Core;
+
+namespace SeedInferredAuthImplicitNoExpiry.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthImplicit.Core;
+
+namespace SeedInferredAuthImplicit.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthImplicit.Core;
+
+namespace SeedInferredAuthImplicit.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/license/src/SeedLicense.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/license/src/SeedLicense.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedLicense.Core;
+
+namespace SeedLicense.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/literal/src/SeedLiteral.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/literal/src/SeedLiteral.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedLiteral.Core;
+
+namespace SeedLiteral.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedLiteralsUnions.Core;
+
+namespace SeedLiteralsUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMixedCase.Core;
+
+namespace SeedMixedCase.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMixedFileDirectory.Core;
+
+namespace SeedMixedFileDirectory.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMultiLineDocs.Core;
+
+namespace SeedMultiLineDocs.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMultiUrlEnvironmentNoDefault.Core;
+
+namespace SeedMultiUrlEnvironmentNoDefault.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMultiUrlEnvironment.Core;
+
+namespace SeedMultiUrlEnvironment.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNoEnvironment.Core;
+
+namespace SeedNoEnvironment.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/no-retries/src/SeedNoRetries.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNoRetries.Core;
+
+namespace SeedNoRetries.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNullableOptional.Core;
+
+namespace SeedNullableOptional.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/nullable-request-body/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/nullable/src/SeedNullable.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/nullable/src/SeedNullable.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNullable.Core;
+
+namespace SeedNullable.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentials.Core;
+
+namespace SeedOauthClientCredentials.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsDefault.Core;
+
+namespace SeedOauthClientCredentialsDefault.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsEnvironmentVariables.Core;
+
+namespace SeedOauthClientCredentialsEnvironmentVariables.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsMandatoryAuth.Core;
+
+namespace SeedOauthClientCredentialsMandatoryAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentials.Core;
+
+namespace SeedOauthClientCredentials.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsReference.Core;
+
+namespace SeedOauthClientCredentialsReference.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsWithVariables.Core;
+
+namespace SeedOauthClientCredentialsWithVariables.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentials.Core;
+
+namespace SeedOauthClientCredentials.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/object/src/SeedObject.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/object/src/SeedObject.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedObject.Core;
+
+namespace SeedObject.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedObjectsWithImports.Core;
+
+namespace SeedObjectsWithImports.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedObjectsWithImports.Core;
+
+namespace SeedObjectsWithImports.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/package-yml/src/SeedPackageYml.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPackageYml.Core;
+
+namespace SeedPackageYml.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/pagination-custom/src/SeedPagination.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPagination.Core;
+
+namespace SeedPagination.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/pagination/src/SeedPagination.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/pagination/src/SeedPagination.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPagination.Core;
+
+namespace SeedPagination.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPathParameters.Core;
+
+namespace SeedPathParameters.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/plain-text/src/SeedPlainText.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/plain-text/src/SeedPlainText.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPlainText.Core;
+
+namespace SeedPlainText.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPropertyAccess.Core;
+
+namespace SeedPropertyAccess.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/public-object/src/SeedPublicObject.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/public-object/src/SeedPublicObject.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPublicObject.Core;
+
+namespace SeedPublicObject.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedQueryParameters.Core;
+
+namespace SeedQueryParameters.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedRequestParameters.Core;
+
+namespace SeedRequestParameters.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/required-nullable/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/required-nullable/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNurseryApi.Core;
+
+namespace SeedNurseryApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/response-property/src/SeedResponseProperty.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedResponseProperty.Core;
+
+namespace SeedResponseProperty.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedServerSentEvents.Core;
+
+namespace SeedServerSentEvents.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedServerSentEvents.Core;
+
+namespace SeedServerSentEvents.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedSimpleApi.Core;
+
+namespace SeedSimpleApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/simple-fhir/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/simple-fhir/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedSingleUrlEnvironmentDefault.Core;
+
+namespace SeedSingleUrlEnvironmentDefault.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedSingleUrlEnvironmentNoDefault.Core;
+
+namespace SeedSingleUrlEnvironmentNoDefault.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedStreaming.Core;
+
+namespace SeedStreaming.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/streaming/src/SeedStreaming.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/streaming/src/SeedStreaming.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedStreaming.Core;
+
+namespace SeedStreaming.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/trace/src/SeedTrace.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/trace/src/SeedTrace.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedTrace.Core;
+
+namespace SeedTrace.Test_.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUndiscriminatedUnionWithResponseProperty.Core;
+
+namespace SeedUndiscriminatedUnionWithResponseProperty.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUndiscriminatedUnions.Core;
+
+namespace SeedUndiscriminatedUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUnions.Core;
+
+namespace SeedUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/unions/src/SeedUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/unions/src/SeedUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUnions.Core;
+
+namespace SeedUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUnknownAsAny.Core;
+
+namespace SeedUnknownAsAny.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/url-form-encoded/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/validation/src/SeedValidation.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/validation/src/SeedValidation.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedValidation.Core;
+
+namespace SeedValidation.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/variables/src/SeedVariables.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/variables/src/SeedVariables.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedVariables.Core;
+
+namespace SeedVariables.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/version-no-default/src/SeedVersion.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/version-no-default/src/SeedVersion.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedVersion.Core;
+
+namespace SeedVersion.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/version/src/SeedVersion.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/version/src/SeedVersion.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedVersion.Core;
+
+namespace SeedVersion.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/webhook-audience/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/webhook-audience/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedWebsocketBearerAuth.Core;
+
+namespace SeedWebsocketBearerAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedWebsocketAuth.Core;
+
+namespace SeedWebsocketAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-model/websocket/src/SeedWebsocket.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-model/websocket/src/SeedWebsocket.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedWebsocket.Core;
+
+namespace SeedWebsocket.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/accept-header/src/SeedAccept.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAccept.Core;
+
+namespace SeedAccept.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAliasExtends.Core;
+
+namespace SeedAliasExtends.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/alias/src/SeedAlias.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAlias.Core;
+
+namespace SeedAlias.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Unit/MockServer/GetAdminsTest.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Unit/MockServer/GetAdminsTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedAnyAuth;
-using SeedAnyAuth.Core;
+using SeedAnyAuth.Test.Utils;
 
 namespace SeedAnyAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetAdminsTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetAdminsAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Unit/MockServer/GetTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedAnyAuth;
-using SeedAnyAuth.Core;
+using SeedAnyAuth.Test.Utils;
 
 namespace SeedAnyAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Unit/MockServer/GetTokenTest.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Unit/MockServer/GetTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedAnyAuth;
-using SeedAnyAuth.Core;
+using SeedAnyAuth.Test.Utils;
 
 namespace SeedAnyAuth.Test.Unit.MockServer;
 
@@ -51,9 +51,6 @@ public class GetTokenTest : BaseMockServerTest
                 GrantType = "client_credentials",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAnyAuth.Core;
+
+namespace SeedAnyAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApiWideBasePath.Core;
+
+namespace SeedApiWideBasePath.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Unit/MockServer/FindTest.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Unit/MockServer/FindTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedAudiences;
-using SeedAudiences.Core;
+using SeedAudiences.Test.Utils;
 
 namespace SeedAudiences.Test.Unit.MockServer;
 
@@ -47,9 +47,6 @@ public class FindTest : BaseMockServerTest
                 PrivateProperty = 1,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ImportingType>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Unit/MockServer/FolderA/GetDirectThreadTest.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Unit/MockServer/FolderA/GetDirectThreadTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedAudiences.Core;
 using SeedAudiences.FolderA;
 using SeedAudiences.Test.Unit.MockServer;
+using SeedAudiences.Test.Utils;
 
 namespace SeedAudiences.Test.Unit.MockServer.FolderA;
 
@@ -40,10 +40,6 @@ public class GetDirectThreadTest : BaseMockServerTest
         var response = await Client.FolderA.Service.GetDirectThreadAsync(
             new GetDirectThreadRequest { Ids = ["ids"], Tags = ["tags"] }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SeedAudiences.FolderA.Response>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Unit/MockServer/FolderD/GetDirectThreadTest.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Unit/MockServer/FolderD/GetDirectThreadTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedAudiences.Core;
 using SeedAudiences.Test.Unit.MockServer;
+using SeedAudiences.Test.Utils;
 
 namespace SeedAudiences.Test.Unit.MockServer.FolderD;
 
@@ -26,10 +26,6 @@ public class GetDirectThreadTest : BaseMockServerTest
             );
 
         var response = await Client.FolderD.Service.GetDirectThreadAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SeedAudiences.FolderD.Response>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedAudiences.Core;
+
+namespace SeedAudiences.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Unit/MockServer/GetWithBasicAuthTest.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Unit/MockServer/GetWithBasicAuthTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedBasicAuthEnvironmentVariables.Core;
+using SeedBasicAuthEnvironmentVariables.Test.Utils;
 
 namespace SeedBasicAuthEnvironmentVariables.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class GetWithBasicAuthTest : BaseMockServerTest
             );
 
         var response = await Client.BasicAuth.GetWithBasicAuthAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Unit/MockServer/PostWithBasicAuthTest.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Unit/MockServer/PostWithBasicAuthTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedBasicAuthEnvironmentVariables.Core;
+using SeedBasicAuthEnvironmentVariables.Test.Utils;
 
 namespace SeedBasicAuthEnvironmentVariables.Test.Unit.MockServer;
 
@@ -37,6 +37,6 @@ public class PostWithBasicAuthTest : BaseMockServerTest
         var response = await Client.BasicAuth.PostWithBasicAuthAsync(
             new Dictionary<object, object?>() { { "key", "value" } }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBasicAuthEnvironmentVariables.Core;
+
+namespace SeedBasicAuthEnvironmentVariables.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth.Test/Unit/MockServer/GetWithBasicAuthTest.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth.Test/Unit/MockServer/GetWithBasicAuthTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedBasicAuth.Core;
+using SeedBasicAuth.Test.Utils;
 
 namespace SeedBasicAuth.Test.Unit.MockServer;
 
@@ -23,7 +23,7 @@ public class GetWithBasicAuthTest : BaseMockServerTest
             );
 
         var response = await Client.BasicAuth.GetWithBasicAuthAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -43,6 +43,6 @@ public class GetWithBasicAuthTest : BaseMockServerTest
             );
 
         var response = await Client.BasicAuth.GetWithBasicAuthAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth.Test/Unit/MockServer/PostWithBasicAuthTest.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth.Test/Unit/MockServer/PostWithBasicAuthTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedBasicAuth.Core;
+using SeedBasicAuth.Test.Utils;
 
 namespace SeedBasicAuth.Test.Unit.MockServer;
 
@@ -37,7 +37,7 @@ public class PostWithBasicAuthTest : BaseMockServerTest
         var response = await Client.BasicAuth.PostWithBasicAuthAsync(
             new Dictionary<object, object?>() { { "key", "value" } }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -71,6 +71,6 @@ public class PostWithBasicAuthTest : BaseMockServerTest
         var response = await Client.BasicAuth.PostWithBasicAuthAsync(
             new Dictionary<object, object?>() { { "key", "value" } }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/basic-auth/src/SeedBasicAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/basic-auth/src/SeedBasicAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBasicAuth.Core;
+
+namespace SeedBasicAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/Unit/MockServer/GetWithBearerTokenTest.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/Unit/MockServer/GetWithBearerTokenTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedBearerTokenEnvironmentVariable.Core;
+using SeedBearerTokenEnvironmentVariable.Test.Utils;
 
 namespace SeedBearerTokenEnvironmentVariable.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class GetWithBearerTokenTest : BaseMockServerTest
             );
 
         var response = await Client.Service.GetWithBearerTokenAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBearerTokenEnvironmentVariable.Core;
+
+namespace SeedBearerTokenEnvironmentVariable.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBytesDownload.Core;
+
+namespace SeedBytesDownload.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedBytesUpload.Core;
+
+namespace SeedBytesUpload.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/circular-references/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -127,9 +127,6 @@ public class CreateUserTest : BaseMockServerTest
                 Connection = "connection",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/GetClientTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/GetClientTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -107,9 +107,6 @@ public class GetClientTest : BaseMockServerTest
             "clientId",
             new GetClientRequest { Fields = "fields", IncludeFields = true }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Client>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/GetConnectionTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/GetConnectionTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -57,9 +57,6 @@ public class GetConnectionTest : BaseMockServerTest
             "connectionId",
             new GetConnectionRequest { Fields = "fields" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Connection>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/GetResourceTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/GetResourceTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -44,9 +44,6 @@ public class GetResourceTest : BaseMockServerTest
             "resourceId",
             new GetResourceRequest { IncludeMetadata = true, Format = "json" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Resource>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/GetUserByIdTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/GetUserByIdTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -83,9 +83,6 @@ public class GetUserByIdTest : BaseMockServerTest
             "userId",
             new GetUserRequest { Fields = "fields", IncludeFields = true }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/ListClientsTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/ListClientsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -201,9 +201,6 @@ public class ListClientsTest : BaseMockServerTest
                 AppType = new List<string>() { "app_type", "app_type" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<PaginatedClientResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/ListConnectionsTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/ListConnectionsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -90,9 +90,6 @@ public class ListConnectionsTest : BaseMockServerTest
                 Fields = "fields",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<Connection>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/ListResourcesTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/ListResourcesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -71,9 +71,6 @@ public class ListResourcesTest : BaseMockServerTest
                 Search = "search",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<Resource>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/ListUsersTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/ListUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -157,9 +157,6 @@ public class ListUsersTest : BaseMockServerTest
                 Fields = "fields",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<PaginatedUserResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/SearchResourcesTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/SearchResourcesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -86,9 +86,6 @@ public class SearchResourcesTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SearchResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/UpdateUserTest.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Unit/MockServer/UpdateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedClientSideParams;
-using SeedClientSideParams.Core;
+using SeedClientSideParams.Test.Utils;
 
 namespace SeedClientSideParams.Test.Unit.MockServer;
 
@@ -128,9 +128,6 @@ public class UpdateUserTest : BaseMockServerTest
                 Blocked = true,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedClientSideParams.Core;
+
+namespace SeedClientSideParams.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedContentTypes.Core;
+
+namespace SeedContentTypes.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Unit/MockServer/FindTest.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Unit/MockServer/FindTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedCrossPackageTypeNames;
-using SeedCrossPackageTypeNames.Core;
+using SeedCrossPackageTypeNames.Test.Utils;
 
 namespace SeedCrossPackageTypeNames.Test.Unit.MockServer;
 
@@ -47,9 +47,6 @@ public class FindTest : BaseMockServerTest
                 PrivateProperty = 1,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ImportingType>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Unit/MockServer/FolderA/GetDirectThreadTest.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Unit/MockServer/FolderA/GetDirectThreadTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedCrossPackageTypeNames.Core;
 using SeedCrossPackageTypeNames.Test.Unit.MockServer;
+using SeedCrossPackageTypeNames.Test.Utils;
 
 namespace SeedCrossPackageTypeNames.Test.Unit.MockServer.FolderA;
 
@@ -30,12 +30,6 @@ public class GetDirectThreadTest : BaseMockServerTest
             );
 
         var response = await Client.FolderA.Service.GetDirectThreadAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<SeedCrossPackageTypeNames.FolderA.Response>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Unit/MockServer/FolderD/GetDirectThreadTest.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Unit/MockServer/FolderD/GetDirectThreadTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedCrossPackageTypeNames.Core;
 using SeedCrossPackageTypeNames.Test.Unit.MockServer;
+using SeedCrossPackageTypeNames.Test.Utils;
 
 namespace SeedCrossPackageTypeNames.Test.Unit.MockServer.FolderD;
 
@@ -30,12 +30,6 @@ public class GetDirectThreadTest : BaseMockServerTest
             );
 
         var response = await Client.FolderD.Service.GetDirectThreadAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<SeedCrossPackageTypeNames.FolderD.Response>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCrossPackageTypeNames.Core;
+
+namespace SeedCrossPackageTypeNames.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/Unit/MockServer/FooTest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/Unit/MockServer/FooTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -27,11 +27,7 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Dataservice.FooAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, object?>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -53,10 +49,6 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Dataservice.FooAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, object?>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/Unit/MockServer/FooTest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/Unit/MockServer/FooTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -27,11 +27,7 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Dataservice.FooAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, object?>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -53,10 +49,6 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Dataservice.FooAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, object?>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/Unit/MockServer/FooTest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/Unit/MockServer/FooTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -27,11 +27,7 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Dataservice.FooAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, object?>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -53,10 +49,6 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Dataservice.FooAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, object?>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/Unit/MockServer/FooTest.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/Unit/MockServer/FooTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -27,11 +27,7 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Dataservice.FooAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, object?>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -53,10 +49,6 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Dataservice.FooAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, object?>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Unit/MockServer/CreateTaskTest.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Unit/MockServer/CreateTaskTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedCsharpNamespaceCollision.Core;
+using SeedCsharpNamespaceCollision.Test.Utils;
 
 namespace SeedCsharpNamespaceCollision.Test.Unit.MockServer;
 
@@ -20,8 +20,7 @@ public class CreateTaskTest : BaseMockServerTest
         const string mockResponse = """
             {
               "name": "name",
-              "email": "email",
-              "password": "password"
+              "email": "email"
             }
             """;
 
@@ -49,9 +48,6 @@ public class CreateTaskTest : BaseMockServerTest
                 Password = "password",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Task>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedCsharpNamespaceCollision.Core;
+using SeedCsharpNamespaceCollision.Test.Utils;
 
 namespace SeedCsharpNamespaceCollision.Test.Unit.MockServer;
 
@@ -20,8 +20,7 @@ public class CreateUserTest : BaseMockServerTest
         const string mockResponse = """
             {
               "name": "name",
-              "email": "email",
-              "password": "password"
+              "email": "email"
             }
             """;
 
@@ -49,9 +48,6 @@ public class CreateUserTest : BaseMockServerTest
                 Password = "password",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Unit/MockServer/System/CreateTaskTest.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Unit/MockServer/System/CreateTaskTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedCsharpNamespaceCollision.Core;
+using SeedCsharpNamespaceCollision.Test.Utils;
 
 namespace SeedCsharpNamespaceCollision.Test.Unit.MockServer.System;
 
@@ -67,12 +67,6 @@ public class CreateTaskTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<SeedCsharpNamespaceCollision.System.Task>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Unit/MockServer/System/CreateUserTest.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Unit/MockServer/System/CreateUserTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedCsharpNamespaceCollision.Core;
+using SeedCsharpNamespaceCollision.Test.Utils;
 
 namespace SeedCsharpNamespaceCollision.Test.Unit.MockServer.System;
 
@@ -57,12 +57,6 @@ public class CreateUserTest : BaseMockServerTest
                 Country = "USA",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<SeedCsharpNamespaceCollision.System.User>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpNamespaceCollision.Core;
+
+namespace SeedCsharpNamespaceCollision.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpNamespaceConflict.Core;
+
+namespace SeedCsharpNamespaceConflict.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Unit/MockServer/BatchCreateTest.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Unit/MockServer/BatchCreateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedCsharpReadonlyRequest;
-using SeedCsharpReadonlyRequest.Core;
+using SeedCsharpReadonlyRequest.Test.Utils;
 
 namespace SeedCsharpReadonlyRequest.Test.Unit.MockServer;
 
@@ -65,10 +65,7 @@ public class BatchCreateTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<CreateVendorResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -129,9 +126,6 @@ public class BatchCreateTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<CreateVendorResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpReadonlyRequest.Core;
+
+namespace SeedCsharpReadonlyRequest.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Unit/MockServer/CreateTaskTest.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Unit/MockServer/CreateTaskTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedCsharpSystemCollision;
-using SeedCsharpSystemCollision.Core;
+using SeedCsharpSystemCollision.Test.Utils;
 
 namespace SeedCsharpSystemCollision.Test.Unit.MockServer;
 
@@ -68,10 +68,6 @@ public class CreateTaskTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SeedCsharpSystemCollision.Task>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedCsharpSystemCollision;
-using SeedCsharpSystemCollision.Core;
+using SeedCsharpSystemCollision.Test.Utils;
 
 namespace SeedCsharpSystemCollision.Test.Unit.MockServer;
 
@@ -58,9 +58,6 @@ public class CreateUserTest : BaseMockServerTest
                 Country = "USA",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpSystemCollision.Core;
+
+namespace SeedCsharpSystemCollision.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/Unit/MockServer/GetTimeZoneTest.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/Unit/MockServer/GetTimeZoneTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedCsharpXmlEntities;
-using SeedCsharpXmlEntities.Core;
+using SeedCsharpXmlEntities.Test.Utils;
 
 namespace SeedCsharpXmlEntities.Test.Unit.MockServer;
 
@@ -29,9 +28,6 @@ public class GetTimeZoneTest : BaseMockServerTest
             );
 
         var response = await Client.GetTimeZoneAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TimeZoneModel>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedCsharpXmlEntities.Core;
+
+namespace SeedCsharpXmlEntities.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedDollarStringExamples.Core;
+
+namespace SeedDollarStringExamples.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedEmptyClients.Core;
+
+namespace SeedEmptyClients.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetTokenTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedEndpointSecurityAuth;
-using SeedEndpointSecurityAuth.Core;
+using SeedEndpointSecurityAuth.Test.Utils;
 
 namespace SeedEndpointSecurityAuth.Test.Unit.MockServer;
 
@@ -51,9 +51,6 @@ public class GetTokenTest : BaseMockServerTest
                 GrantType = "client_credentials",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithAllAuthTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithAllAuthTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedEndpointSecurityAuth;
-using SeedEndpointSecurityAuth.Core;
+using SeedEndpointSecurityAuth.Test.Utils;
 
 namespace SeedEndpointSecurityAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetWithAllAuthTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetWithAllAuthAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithAnyAuthTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithAnyAuthTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedEndpointSecurityAuth;
-using SeedEndpointSecurityAuth.Core;
+using SeedEndpointSecurityAuth.Test.Utils;
 
 namespace SeedEndpointSecurityAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetWithAnyAuthTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetWithAnyAuthAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithApiKeyTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithApiKeyTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedEndpointSecurityAuth;
-using SeedEndpointSecurityAuth.Core;
+using SeedEndpointSecurityAuth.Test.Utils;
 
 namespace SeedEndpointSecurityAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetWithApiKeyTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetWithApiKeyAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithBasicTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithBasicTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedEndpointSecurityAuth;
-using SeedEndpointSecurityAuth.Core;
+using SeedEndpointSecurityAuth.Test.Utils;
 
 namespace SeedEndpointSecurityAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetWithBasicTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetWithBasicAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithBearerTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithBearerTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedEndpointSecurityAuth;
-using SeedEndpointSecurityAuth.Core;
+using SeedEndpointSecurityAuth.Test.Utils;
 
 namespace SeedEndpointSecurityAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetWithBearerTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetWithBearerAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithInferredAuthTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithInferredAuthTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedEndpointSecurityAuth;
-using SeedEndpointSecurityAuth.Core;
+using SeedEndpointSecurityAuth.Test.Utils;
 
 namespace SeedEndpointSecurityAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetWithInferredAuthTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetWithInferredAuthAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithOAuthTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/GetWithOAuthTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedEndpointSecurityAuth;
-using SeedEndpointSecurityAuth.Core;
+using SeedEndpointSecurityAuth.Test.Utils;
 
 namespace SeedEndpointSecurityAuth.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetWithOAuthTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetWithOAuthAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedEndpointSecurityAuth.Core;
+
+namespace SeedEndpointSecurityAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedEnum.Core;
+
+namespace SeedEnum.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedEnum.Core;
+
+namespace SeedEnum.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/Unit/MockServer/ThrowErrorTest.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/Unit/MockServer/ThrowErrorTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedErrorProperty.Core;
+using SeedErrorProperty.Test.Utils;
 
 namespace SeedErrorProperty.Test.Unit.MockServer;
 
@@ -28,6 +28,6 @@ public class ThrowErrorTest : BaseMockServerTest
             );
 
         var response = await Client.PropertyBasedError.ThrowErrorAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedErrorProperty.Core;
+
+namespace SeedErrorProperty.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/Unit/MockServer/FooTest.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/Unit/MockServer/FooTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedErrors;
-using SeedErrors.Core;
+using SeedErrors.Test.Utils;
 
 namespace SeedErrors.Test.Unit.MockServer;
 
@@ -38,9 +38,6 @@ public class FooTest : BaseMockServerTest
             );
 
         var response = await Client.Simple.FooAsync(new FooRequest { Bar = "bar" });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<FooResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/Unit/MockServer/FooWithExamplesTest.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/Unit/MockServer/FooWithExamplesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedErrors;
-using SeedErrors.Core;
+using SeedErrors.Test.Utils;
 
 namespace SeedErrors.Test.Unit.MockServer;
 
@@ -38,10 +38,7 @@ public class FooWithExamplesTest : BaseMockServerTest
             );
 
         var response = await Client.Simple.FooWithExamplesAsync(new FooRequest { Bar = "bar" });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<FooResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -75,9 +72,6 @@ public class FooWithExamplesTest : BaseMockServerTest
             );
 
         var response = await Client.Simple.FooWithExamplesAsync(new FooRequest { Bar = "hello" });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<FooResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/Unit/MockServer/FooWithoutEndpointErrorTest.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/Unit/MockServer/FooWithoutEndpointErrorTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedErrors;
-using SeedErrors.Core;
+using SeedErrors.Test.Utils;
 
 namespace SeedErrors.Test.Unit.MockServer;
 
@@ -40,9 +40,6 @@ public class FooWithoutEndpointErrorTest : BaseMockServerTest
         var response = await Client.Simple.FooWithoutEndpointErrorAsync(
             new FooRequest { Bar = "bar" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<FooResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedErrors.Core;
+
+namespace SeedErrors.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExamples.Core;
+
+namespace SeedExamples.Test_.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExamples.Core;
+
+namespace SeedExamples.Test_.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnListOfObjectsTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnListOfObjectsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Container;
@@ -55,10 +55,6 @@ public class GetAndReturnListOfObjectsTest : BaseMockServerTest
                 new ObjectWithRequiredField { String = "string" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<ObjectWithRequiredField>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnListOfPrimitivesTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnListOfPrimitivesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Container;
 
@@ -42,9 +42,6 @@ public class GetAndReturnListOfPrimitivesTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
             new List<string>() { "string", "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnMapOfPrimToObjectTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnMapOfPrimToObjectTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Container;
@@ -51,12 +51,6 @@ public class GetAndReturnMapOfPrimToObjectTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<Dictionary<string, ObjectWithRequiredField>>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnMapPrimToPrimTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnMapPrimToPrimTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Container;
 
@@ -40,10 +40,6 @@ public class GetAndReturnMapPrimToPrimTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnMapPrimToPrimAsync(
             new Dictionary<string, string>() { { "string", "string" } }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, string>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnOptionalTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnOptionalTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Container;
@@ -41,10 +41,6 @@ public class GetAndReturnOptionalTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnOptionalAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithRequiredField?>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnSetOfObjectsTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnSetOfObjectsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Container;
@@ -48,10 +48,6 @@ public class GetAndReturnSetOfObjectsTest : BaseMockServerTest
                 new ObjectWithRequiredField { String = "string" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<HashSet<ObjectWithRequiredField>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnSetOfPrimitivesTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Container/GetAndReturnSetOfPrimitivesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Container;
 
@@ -40,9 +40,6 @@ public class GetAndReturnSetOfPrimitivesTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnSetOfPrimitivesAsync(
             new HashSet<string>() { "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<HashSet<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Enum/GetAndReturnEnumTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Enum/GetAndReturnEnumTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Enum;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Enum;
@@ -35,9 +35,6 @@ public class GetAndReturnEnumTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Enum.GetAndReturnEnumAsync(WeatherReport.Sunny);
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<WeatherReport>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestDeleteTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestDeleteTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.HttpMethods;
 
@@ -26,6 +26,6 @@ public class TestDeleteTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.HttpMethods.TestDeleteAsync("id");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestGetTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestGetTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.HttpMethods;
 
@@ -26,6 +26,6 @@ public class TestGetTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.HttpMethods.TestGetAsync("id");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestPatchTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestPatchTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.HttpMethods;
@@ -100,9 +100,6 @@ public class TestPatchTest : BaseMockServerTest
                 Bigint = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestPostTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestPostTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.HttpMethods;
@@ -60,9 +60,6 @@ public class TestPostTest : BaseMockServerTest
         var response = await Client.Endpoints.HttpMethods.TestPostAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestPutTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/HttpMethods/TestPutTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.HttpMethods;
@@ -61,9 +61,6 @@ public class TestPutTest : BaseMockServerTest
             "id",
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnNestedWithOptionalFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnNestedWithOptionalFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Object;
@@ -109,10 +109,6 @@ public class GetAndReturnNestedWithOptionalFieldTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithOptionalField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnNestedWithRequiredFieldAsListTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnNestedWithRequiredFieldAsListTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Object;
@@ -163,10 +163,6 @@ public class GetAndReturnNestedWithRequiredFieldAsListTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithRequiredField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnNestedWithRequiredFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnNestedWithRequiredFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Object;
@@ -110,10 +110,6 @@ public class GetAndReturnNestedWithRequiredFieldTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithRequiredField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnWithDatetimeLikeStringTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnWithDatetimeLikeStringTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Object;
@@ -52,11 +52,7 @@ public class GetAndReturnWithDatetimeLikeStringTest : BaseMockServerTest
                 ),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithDatetimeLikeString>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -102,10 +98,6 @@ public class GetAndReturnWithDatetimeLikeStringTest : BaseMockServerTest
                 ),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithDatetimeLikeString>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnWithMapOfMapTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnWithMapOfMapTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Object;
@@ -58,9 +58,6 @@ public class GetAndReturnWithMapOfMapTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithMapOfMap>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnWithOptionalFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnWithOptionalFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Object;
@@ -99,9 +99,6 @@ public class GetAndReturnWithOptionalFieldTest : BaseMockServerTest
                 Bigint = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnWithRequiredFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Object/GetAndReturnWithRequiredFieldTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Object;
@@ -41,9 +41,6 @@ public class GetAndReturnWithRequiredFieldTest : BaseMockServerTest
         var response = await Client.Endpoints.Object.GetAndReturnWithRequiredFieldAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithRequiredField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Params/GetWithInlinePathTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Params/GetWithInlinePathTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints.Params;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Params;
 
@@ -29,6 +29,6 @@ public class GetWithInlinePathTest : BaseMockServerTest
         var response = await Client.Endpoints.Params.GetWithInlinePathAsync(
             new GetWithInlinePath { Param = "param" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Params/GetWithPathTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Params/GetWithPathTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Params;
 
@@ -26,6 +26,6 @@ public class GetWithPathTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Params.GetWithPathAsync("param");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Params/ModifyWithInlinePathTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Params/ModifyWithInlinePathTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints.Params;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Params;
 
@@ -37,6 +37,6 @@ public class ModifyWithInlinePathTest : BaseMockServerTest
         var response = await Client.Endpoints.Params.ModifyWithInlinePathAsync(
             new ModifyResourceAtInlinedPath { Param = "param", Body = "string" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Params/ModifyWithPathTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Params/ModifyWithPathTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Params;
 
@@ -34,6 +34,6 @@ public class ModifyWithPathTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Params.ModifyWithPathAsync("param", "string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnBase64Test.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnBase64Test.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -34,6 +34,6 @@ public class GetAndReturnBase64Test : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnBase64Async("SGVsbG8gd29ybGQh");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnBoolTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnBoolTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -34,6 +34,6 @@ public class GetAndReturnBoolTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnBoolAsync(true);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnDateTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnDateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -36,6 +36,6 @@ public class GetAndReturnDateTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnDateAsync(
             new DateOnly(2023, 1, 15)
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<DateOnly>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnDatetimeTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnDatetimeTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -37,6 +37,6 @@ public class GetAndReturnDatetimeTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnDatetimeAsync(
             DateTime.Parse("2024-01-15T09:30:00.000Z", null, DateTimeStyles.AdjustToUniversal)
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<DateTime>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnDoubleTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnDoubleTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -34,6 +34,6 @@ public class GetAndReturnDoubleTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnDoubleAsync(1.1);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<double>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnIntTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnIntTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -34,6 +34,6 @@ public class GetAndReturnIntTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnIntAsync(1);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<int>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnLongTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnLongTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -34,6 +34,6 @@ public class GetAndReturnLongTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnLongAsync(1000000);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<long>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnStringTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnStringTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -34,6 +34,6 @@ public class GetAndReturnStringTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnStringAsync("string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnUuidTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Primitive/GetAndReturnUuidTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Primitive;
 
@@ -36,6 +36,6 @@ public class GetAndReturnUuidTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnUuidAsync(
             "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Put/AddTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Put/AddTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints.Put;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Put;
 
@@ -40,9 +40,6 @@ public class AddTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Put.AddAsync(new PutRequest { Id = "id" });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<PutResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Union/GetAndReturnUnionTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Union/GetAndReturnUnionTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Union;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Union;
@@ -45,9 +45,6 @@ public class GetAndReturnUnionTest : BaseMockServerTest
         var response = await Client.Endpoints.Union.GetAndReturnUnionAsync(
             new Animal(new Animal.Dog(new Dog { Name = "name", LikesToWoof = true }))
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Animal>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Urls/NoEndingSlashTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Urls/NoEndingSlashTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Urls;
 
@@ -29,6 +29,6 @@ public class NoEndingSlashTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.NoEndingSlashAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Urls/WithEndingSlashTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Urls/WithEndingSlashTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Urls;
 
@@ -29,6 +29,6 @@ public class WithEndingSlashTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithEndingSlashAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Urls/WithMixedCaseTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Urls/WithMixedCaseTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Urls;
 
@@ -24,6 +24,6 @@ public class WithMixedCaseTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithMixedCaseAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Urls/WithUnderscoresTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/Urls/WithUnderscoresTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints.Urls;
 
@@ -29,6 +29,6 @@ public class WithUnderscoresTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithUnderscoresAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/InlinedRequests/PostWithObjectBodyandResponseTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/InlinedRequests/PostWithObjectBodyandResponseTest.cs
@@ -1,8 +1,8 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.InlinedRequests;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types.Object;
 
 namespace SeedExhaustive.Test.Unit.MockServer.InlinedRequests;
@@ -109,9 +109,6 @@ public class PostWithObjectBodyandResponseTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/NoAuth/PostWithNoAuthTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/NoAuth/PostWithNoAuthTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.NoAuth;
 
@@ -38,6 +38,6 @@ public class PostWithNoAuthTest : BaseMockServerTest
         var response = await Client.NoAuth.PostWithNoAuthAsync(
             new Dictionary<object, object?>() { { "key", "value" } }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/NoReqBody/GetWithNoRequestBodyTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/NoReqBody/GetWithNoRequestBodyTest.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
-using SeedExhaustive.Types.Object;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.NoReqBody;
 
@@ -46,9 +45,6 @@ public class GetWithNoRequestBodyTest : BaseMockServerTest
             );
 
         var response = await Client.NoReqBody.GetWithNoRequestBodyAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/NoReqBody/PostWithNoRequestBodyTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Unit/MockServer/NoReqBody/PostWithNoRequestBodyTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.NoReqBody;
 
@@ -24,6 +24,6 @@ public class PostWithNoRequestBodyTest : BaseMockServerTest
             );
 
         var response = await Client.NoReqBody.PostWithNoRequestBodyAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExhaustive.Core;
+
+namespace SeedExhaustive.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/AddTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/AddTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,9 +40,6 @@ public class AddTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Put.AddAsync(new PutRequest { Id = "id" });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<PutResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBase64Test.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBase64Test.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnBase64Test : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnBase64Async("SGVsbG8gd29ybGQh");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBoolTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBoolTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnBoolTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnBoolAsync(true);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDateTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -36,6 +36,6 @@ public class GetAndReturnDateTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnDateAsync(
             new DateOnly(2023, 1, 15)
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<DateOnly>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDatetimeTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDatetimeTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -37,6 +37,6 @@ public class GetAndReturnDatetimeTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnDatetimeAsync(
             DateTime.Parse("2024-01-15T09:30:00.000Z", null, DateTimeStyles.AdjustToUniversal)
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<DateTime>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDoubleTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDoubleTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnDoubleTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnDoubleAsync(1.1);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<double>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnEnumTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnEnumTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -35,9 +35,6 @@ public class GetAndReturnEnumTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Enum.GetAndReturnEnumAsync(WeatherReport.Sunny);
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<WeatherReport>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnIntTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnIntTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnIntTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnIntAsync(1);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<int>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfObjectsTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfObjectsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -55,10 +55,6 @@ public class GetAndReturnListOfObjectsTest : BaseMockServerTest
                 new ObjectWithRequiredField { String = "string" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<ObjectWithRequiredField>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfPrimitivesTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfPrimitivesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -42,9 +42,6 @@ public class GetAndReturnListOfPrimitivesTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
             new List<string>() { "string", "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnLongTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnLongTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnLongTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnLongAsync(1000000);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<long>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapOfPrimToObjectTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapOfPrimToObjectTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -51,12 +51,6 @@ public class GetAndReturnMapOfPrimToObjectTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<Dictionary<string, ObjectWithRequiredField>>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapPrimToPrimTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapPrimToPrimTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,10 +40,6 @@ public class GetAndReturnMapPrimToPrimTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnMapPrimToPrimAsync(
             new Dictionary<string, string>() { { "string", "string" } }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, string>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithOptionalFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithOptionalFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -109,10 +109,6 @@ public class GetAndReturnNestedWithOptionalFieldTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithOptionalField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldAsListTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldAsListTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -163,10 +163,6 @@ public class GetAndReturnNestedWithRequiredFieldAsListTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithRequiredField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -110,10 +110,6 @@ public class GetAndReturnNestedWithRequiredFieldTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithRequiredField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnOptionalTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnOptionalTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -41,10 +41,6 @@ public class GetAndReturnOptionalTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnOptionalAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithRequiredField?>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfObjectsTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfObjectsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -48,10 +48,6 @@ public class GetAndReturnSetOfObjectsTest : BaseMockServerTest
                 new ObjectWithRequiredField { String = "string" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<HashSet<ObjectWithRequiredField>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfPrimitivesTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfPrimitivesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,9 +40,6 @@ public class GetAndReturnSetOfPrimitivesTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnSetOfPrimitivesAsync(
             new HashSet<string>() { "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<HashSet<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnStringTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnStringTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnStringTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnStringAsync("string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUnionTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUnionTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -45,9 +45,6 @@ public class GetAndReturnUnionTest : BaseMockServerTest
         var response = await Client.Endpoints.Union.GetAndReturnUnionAsync(
             new Animal(new Animal.Dog(new Dog { Name = "name", LikesToWoof = true }))
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Animal>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUuidTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUuidTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -36,6 +36,6 @@ public class GetAndReturnUuidTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnUuidAsync(
             "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithDatetimeLikeStringTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithDatetimeLikeStringTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -52,11 +52,7 @@ public class GetAndReturnWithDatetimeLikeStringTest : BaseMockServerTest
                 ),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithDatetimeLikeString>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -102,10 +98,6 @@ public class GetAndReturnWithDatetimeLikeStringTest : BaseMockServerTest
                 ),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithDatetimeLikeString>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithMapOfMapTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithMapOfMapTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -58,9 +58,6 @@ public class GetAndReturnWithMapOfMapTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithMapOfMap>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithOptionalFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithOptionalFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -99,9 +99,6 @@ public class GetAndReturnWithOptionalFieldTest : BaseMockServerTest
                 Bigint = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithRequiredFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithRequiredFieldTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -41,9 +41,6 @@ public class GetAndReturnWithRequiredFieldTest : BaseMockServerTest
         var response = await Client.Endpoints.Object.GetAndReturnWithRequiredFieldAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithRequiredField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithInlinePathTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithInlinePathTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class GetWithInlinePathTest : BaseMockServerTest
         var response = await Client.Endpoints.Params.GetWithInlinePathAsync(
             new GetWithInlinePath { Param = "param" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithPathTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithPathTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class GetWithPathTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Params.GetWithPathAsync("param");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithInlinePathTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithInlinePathTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -37,6 +37,6 @@ public class ModifyWithInlinePathTest : BaseMockServerTest
         var response = await Client.Endpoints.Params.ModifyWithInlinePathAsync(
             new ModifyResourceAtInlinedPath { Param = "param", Body = "string" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithPathTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithPathTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class ModifyWithPathTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Params.ModifyWithPathAsync("param", "string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/NoEndingSlashTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/NoEndingSlashTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class NoEndingSlashTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.NoEndingSlashAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestDeleteTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestDeleteTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class TestDeleteTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.HttpMethods.TestDeleteAsync("id");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestGetTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestGetTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class TestGetTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.HttpMethods.TestGetAsync("id");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPatchTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPatchTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -100,9 +100,6 @@ public class TestPatchTest : BaseMockServerTest
                 Bigint = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPostTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPostTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -60,9 +60,6 @@ public class TestPostTest : BaseMockServerTest
         var response = await Client.Endpoints.HttpMethods.TestPostAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPutTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPutTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -61,9 +61,6 @@ public class TestPutTest : BaseMockServerTest
             "id",
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithEndingSlashTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithEndingSlashTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class WithEndingSlashTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithEndingSlashAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithMixedCaseTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithMixedCaseTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -24,6 +24,6 @@ public class WithMixedCaseTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithMixedCaseAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithUnderscoresTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithUnderscoresTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class WithUnderscoresTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithUnderscoresAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/GetWithNoRequestBodyTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/GetWithNoRequestBodyTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
-using SeedExhaustive.Types;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -45,9 +44,6 @@ public class GetWithNoRequestBodyTest : BaseMockServerTest
             );
 
         var response = await Client.NoReqBody.GetWithNoRequestBodyAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoAuthTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoAuthTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -37,6 +37,6 @@ public class PostWithNoAuthTest : BaseMockServerTest
         var response = await Client.NoAuth.PostWithNoAuthAsync(
             new Dictionary<object, object?>() { { "key", "value" } }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoRequestBodyTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoRequestBodyTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class PostWithNoRequestBodyTest : BaseMockServerTest
             );
 
         var response = await Client.NoReqBody.PostWithNoRequestBodyAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/PostWithObjectBodyandResponseTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Unit/MockServer/PostWithObjectBodyandResponseTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedExhaustive;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
@@ -108,9 +108,6 @@ public class PostWithObjectBodyandResponseTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExhaustive.Core;
+
+namespace SeedExhaustive.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/AddTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/AddTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,9 +40,6 @@ public class AddTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Put.AddAsync(new PutRequest { Id = "id" });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<PutResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBase64Test.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBase64Test.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnBase64Test : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnBase64Async("SGVsbG8gd29ybGQh");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBoolTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBoolTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnBoolTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnBoolAsync(true);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDateTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -36,6 +36,6 @@ public class GetAndReturnDateTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnDateAsync(
             new DateOnly(2023, 1, 15)
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<DateOnly>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDatetimeTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDatetimeTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -37,6 +37,6 @@ public class GetAndReturnDatetimeTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnDatetimeAsync(
             DateTime.Parse("2024-01-15T09:30:00.000Z", null, DateTimeStyles.AdjustToUniversal)
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<DateTime>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDoubleTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDoubleTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnDoubleTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnDoubleAsync(1.1);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<double>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnEnumTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnEnumTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -35,9 +35,6 @@ public class GetAndReturnEnumTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Enum.GetAndReturnEnumAsync(WeatherReport.Sunny);
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<WeatherReport>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnIntTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnIntTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnIntTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnIntAsync(1);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<int>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfObjectsTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfObjectsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -55,10 +55,6 @@ public class GetAndReturnListOfObjectsTest : BaseMockServerTest
                 new ObjectWithRequiredField { String = "string" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<ObjectWithRequiredField>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfPrimitivesTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfPrimitivesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -42,9 +42,6 @@ public class GetAndReturnListOfPrimitivesTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
             new List<string>() { "string", "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnLongTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnLongTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnLongTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnLongAsync(1000000);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<long>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapOfPrimToObjectTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapOfPrimToObjectTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -51,12 +51,6 @@ public class GetAndReturnMapOfPrimToObjectTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<Dictionary<string, ObjectWithRequiredField>>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapPrimToPrimTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapPrimToPrimTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,10 +40,6 @@ public class GetAndReturnMapPrimToPrimTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnMapPrimToPrimAsync(
             new Dictionary<string, string>() { { "string", "string" } }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, string>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithOptionalFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithOptionalFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -109,10 +109,6 @@ public class GetAndReturnNestedWithOptionalFieldTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithOptionalField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldAsListTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldAsListTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -163,10 +163,6 @@ public class GetAndReturnNestedWithRequiredFieldAsListTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithRequiredField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -110,10 +110,6 @@ public class GetAndReturnNestedWithRequiredFieldTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithRequiredField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnOptionalTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnOptionalTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -41,10 +41,6 @@ public class GetAndReturnOptionalTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnOptionalAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithRequiredField?>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfObjectsTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfObjectsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -48,10 +48,6 @@ public class GetAndReturnSetOfObjectsTest : BaseMockServerTest
                 new ObjectWithRequiredField { String = "string" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<HashSet<ObjectWithRequiredField>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfPrimitivesTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfPrimitivesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,9 +40,6 @@ public class GetAndReturnSetOfPrimitivesTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnSetOfPrimitivesAsync(
             new HashSet<string>() { "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<HashSet<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnStringTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnStringTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnStringTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnStringAsync("string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUnionTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUnionTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -45,9 +45,6 @@ public class GetAndReturnUnionTest : BaseMockServerTest
         var response = await Client.Endpoints.Union.GetAndReturnUnionAsync(
             new Animal(new Animal.Dog(new Dog { Name = "name", LikesToWoof = true }))
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Animal>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUuidTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUuidTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -36,6 +36,6 @@ public class GetAndReturnUuidTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnUuidAsync(
             "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithDatetimeLikeStringTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithDatetimeLikeStringTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -52,11 +52,7 @@ public class GetAndReturnWithDatetimeLikeStringTest : BaseMockServerTest
                 ),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithDatetimeLikeString>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -102,10 +98,6 @@ public class GetAndReturnWithDatetimeLikeStringTest : BaseMockServerTest
                 ),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithDatetimeLikeString>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithMapOfMapTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithMapOfMapTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -58,9 +58,6 @@ public class GetAndReturnWithMapOfMapTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithMapOfMap>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithOptionalFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithOptionalFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -99,9 +99,6 @@ public class GetAndReturnWithOptionalFieldTest : BaseMockServerTest
                 Bigint = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithRequiredFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithRequiredFieldTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -41,9 +41,6 @@ public class GetAndReturnWithRequiredFieldTest : BaseMockServerTest
         var response = await Client.Endpoints.Object.GetAndReturnWithRequiredFieldAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithRequiredField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithInlinePathTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithInlinePathTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class GetWithInlinePathTest : BaseMockServerTest
         var response = await Client.Endpoints.Params.GetWithInlinePathAsync(
             new GetWithInlinePath { Param = "param" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithPathTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithPathTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class GetWithPathTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Params.GetWithPathAsync("param");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithInlinePathTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithInlinePathTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -37,6 +37,6 @@ public class ModifyWithInlinePathTest : BaseMockServerTest
         var response = await Client.Endpoints.Params.ModifyWithInlinePathAsync(
             new ModifyResourceAtInlinedPath { Param = "param", Body = "string" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithPathTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithPathTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class ModifyWithPathTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Params.ModifyWithPathAsync("param", "string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/NoEndingSlashTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/NoEndingSlashTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class NoEndingSlashTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.NoEndingSlashAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestDeleteTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestDeleteTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class TestDeleteTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.HttpMethods.TestDeleteAsync("id");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestGetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestGetTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class TestGetTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.HttpMethods.TestGetAsync("id");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPatchTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPatchTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -100,9 +100,6 @@ public class TestPatchTest : BaseMockServerTest
                 Bigint = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPostTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPostTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -60,9 +60,6 @@ public class TestPostTest : BaseMockServerTest
         var response = await Client.Endpoints.HttpMethods.TestPostAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPutTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPutTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -61,9 +61,6 @@ public class TestPutTest : BaseMockServerTest
             "id",
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithEndingSlashTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithEndingSlashTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class WithEndingSlashTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithEndingSlashAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithMixedCaseTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithMixedCaseTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -24,6 +24,6 @@ public class WithMixedCaseTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithMixedCaseAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithUnderscoresTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithUnderscoresTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class WithUnderscoresTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithUnderscoresAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/GetWithNoRequestBodyTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/GetWithNoRequestBodyTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
-using SeedExhaustive.Types;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -45,9 +44,6 @@ public class GetWithNoRequestBodyTest : BaseMockServerTest
             );
 
         var response = await Client.NoReqBody.GetWithNoRequestBodyAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoAuthTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoAuthTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -37,6 +37,6 @@ public class PostWithNoAuthTest : BaseMockServerTest
         var response = await Client.NoAuth.PostWithNoAuthAsync(
             new Dictionary<object, object?>() { { "key", "value" } }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoRequestBodyTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoRequestBodyTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class PostWithNoRequestBodyTest : BaseMockServerTest
             );
 
         var response = await Client.NoReqBody.PostWithNoRequestBodyAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/PostWithObjectBodyandResponseTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Unit/MockServer/PostWithObjectBodyandResponseTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedExhaustive;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
@@ -108,9 +108,6 @@ public class PostWithObjectBodyandResponseTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExhaustive.Core;
+
+namespace SeedExhaustive.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/AddTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/AddTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,9 +40,6 @@ public class AddTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Put.AddAsync(new PutRequest { Id = "id" });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<PutResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBase64Test.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBase64Test.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnBase64Test : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnBase64Async("SGVsbG8gd29ybGQh");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBoolTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnBoolTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnBoolTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnBoolAsync(true);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDateTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -36,6 +36,6 @@ public class GetAndReturnDateTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnDateAsync(
             new DateOnly(2023, 1, 15)
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<DateOnly>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDatetimeTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDatetimeTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -37,6 +37,6 @@ public class GetAndReturnDatetimeTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnDatetimeAsync(
             DateTime.Parse("2024-01-15T09:30:00.000Z", null, DateTimeStyles.AdjustToUniversal)
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<DateTime>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDoubleTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnDoubleTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnDoubleTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnDoubleAsync(1.1);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<double>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnEnumTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnEnumTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -35,9 +35,6 @@ public class GetAndReturnEnumTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Enum.GetAndReturnEnumAsync(WeatherReport.Sunny);
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<WeatherReport>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnIntTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnIntTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnIntTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnIntAsync(1);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<int>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfObjectsTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfObjectsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -55,10 +55,6 @@ public class GetAndReturnListOfObjectsTest : BaseMockServerTest
                 new ObjectWithRequiredField { String = "string" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<ObjectWithRequiredField>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfPrimitivesTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnListOfPrimitivesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -42,9 +42,6 @@ public class GetAndReturnListOfPrimitivesTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
             new List<string>() { "string", "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnLongTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnLongTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnLongTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnLongAsync(1000000);
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<long>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapOfPrimToObjectTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapOfPrimToObjectTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -51,12 +51,6 @@ public class GetAndReturnMapOfPrimToObjectTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<Dictionary<string, ObjectWithRequiredField>>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapPrimToPrimTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnMapPrimToPrimTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,10 +40,6 @@ public class GetAndReturnMapPrimToPrimTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnMapPrimToPrimAsync(
             new Dictionary<string, string>() { { "string", "string" } }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<string, string>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithOptionalFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithOptionalFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -109,10 +109,6 @@ public class GetAndReturnNestedWithOptionalFieldTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithOptionalField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldAsListTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldAsListTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -163,10 +163,6 @@ public class GetAndReturnNestedWithRequiredFieldAsListTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithRequiredField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnNestedWithRequiredFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -110,10 +110,6 @@ public class GetAndReturnNestedWithRequiredFieldTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NestedObjectWithRequiredField>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnOptionalTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnOptionalTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -41,10 +41,6 @@ public class GetAndReturnOptionalTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnOptionalAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithRequiredField?>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfObjectsTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfObjectsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -48,10 +48,6 @@ public class GetAndReturnSetOfObjectsTest : BaseMockServerTest
                 new ObjectWithRequiredField { String = "string" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<HashSet<ObjectWithRequiredField>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfPrimitivesTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnSetOfPrimitivesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -40,9 +40,6 @@ public class GetAndReturnSetOfPrimitivesTest : BaseMockServerTest
         var response = await Client.Endpoints.Container.GetAndReturnSetOfPrimitivesAsync(
             new HashSet<string>() { "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<HashSet<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnStringTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnStringTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class GetAndReturnStringTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Primitive.GetAndReturnStringAsync("string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUnionTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUnionTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -45,9 +45,6 @@ public class GetAndReturnUnionTest : BaseMockServerTest
         var response = await Client.Endpoints.Union.GetAndReturnUnionAsync(
             new Animal(new Animal.Dog(new Dog { Name = "name", LikesToWoof = true }))
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Animal>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUuidTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnUuidTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -36,6 +36,6 @@ public class GetAndReturnUuidTest : BaseMockServerTest
         var response = await Client.Endpoints.Primitive.GetAndReturnUuidAsync(
             "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithDatetimeLikeStringTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithDatetimeLikeStringTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -52,11 +52,7 @@ public class GetAndReturnWithDatetimeLikeStringTest : BaseMockServerTest
                 ),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithDatetimeLikeString>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -102,10 +98,6 @@ public class GetAndReturnWithDatetimeLikeStringTest : BaseMockServerTest
                 ),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithDatetimeLikeString>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithMapOfMapTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithMapOfMapTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -58,9 +58,6 @@ public class GetAndReturnWithMapOfMapTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithMapOfMap>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithOptionalFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithOptionalFieldTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -99,9 +99,6 @@ public class GetAndReturnWithOptionalFieldTest : BaseMockServerTest
                 Bigint = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithRequiredFieldTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetAndReturnWithRequiredFieldTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -41,9 +41,6 @@ public class GetAndReturnWithRequiredFieldTest : BaseMockServerTest
         var response = await Client.Endpoints.Object.GetAndReturnWithRequiredFieldAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithRequiredField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithInlinePathTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithInlinePathTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class GetWithInlinePathTest : BaseMockServerTest
         var response = await Client.Endpoints.Params.GetWithInlinePathAsync(
             new GetWithInlinePath { Param = "param" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithPathTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/GetWithPathTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class GetWithPathTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Params.GetWithPathAsync("param");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithInlinePathTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithInlinePathTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Endpoints;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -37,6 +37,6 @@ public class ModifyWithInlinePathTest : BaseMockServerTest
         var response = await Client.Endpoints.Params.ModifyWithInlinePathAsync(
             new ModifyResourceAtInlinedPath { Param = "param", Body = "string" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithPathTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/ModifyWithPathTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -34,6 +34,6 @@ public class ModifyWithPathTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Params.ModifyWithPathAsync("param", "string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/NoEndingSlashTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/NoEndingSlashTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class NoEndingSlashTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.NoEndingSlashAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestDeleteTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestDeleteTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class TestDeleteTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.HttpMethods.TestDeleteAsync("id");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestGetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestGetTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -26,6 +26,6 @@ public class TestGetTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.HttpMethods.TestGetAsync("id");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPatchTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPatchTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -100,9 +100,6 @@ public class TestPatchTest : BaseMockServerTest
                 Bigint = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPostTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPostTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -60,9 +60,6 @@ public class TestPostTest : BaseMockServerTest
         var response = await Client.Endpoints.HttpMethods.TestPostAsync(
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPutTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/TestPutTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
@@ -61,9 +61,6 @@ public class TestPutTest : BaseMockServerTest
             "id",
             new ObjectWithRequiredField { String = "string" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithEndingSlashTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithEndingSlashTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class WithEndingSlashTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithEndingSlashAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithMixedCaseTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithMixedCaseTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -24,6 +24,6 @@ public class WithMixedCaseTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithMixedCaseAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithUnderscoresTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/Endpoints/WithUnderscoresTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
 using SeedExhaustive.Test.Unit.MockServer;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer.Endpoints;
 
@@ -29,6 +29,6 @@ public class WithUnderscoresTest : BaseMockServerTest
             );
 
         var response = await Client.Endpoints.Urls.WithUnderscoresAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/GetWithNoRequestBodyTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/GetWithNoRequestBodyTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
-using SeedExhaustive.Types;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -45,9 +44,6 @@ public class GetWithNoRequestBodyTest : BaseMockServerTest
             );
 
         var response = await Client.NoReqBody.GetWithNoRequestBodyAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoAuthTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoAuthTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -37,6 +37,6 @@ public class PostWithNoAuthTest : BaseMockServerTest
         var response = await Client.NoAuth.PostWithNoAuthAsync(
             new Dictionary<object, object?>() { { "key", "value" } }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoRequestBodyTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/PostWithNoRequestBodyTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class PostWithNoRequestBodyTest : BaseMockServerTest
             );
 
         var response = await Client.NoReqBody.PostWithNoRequestBodyAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/PostWithObjectBodyandResponseTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Unit/MockServer/PostWithObjectBodyandResponseTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedExhaustive;
-using SeedExhaustive.Core;
+using SeedExhaustive.Test.Utils;
 using SeedExhaustive.Types;
 
 namespace SeedExhaustive.Test.Unit.MockServer;
@@ -108,9 +108,6 @@ public class PostWithObjectBodyandResponseTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ObjectWithOptionalField>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExhaustive.Core;
+
+namespace SeedExhaustive.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/extends/src/SeedExtends.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExtends.Core;
+
+namespace SeedExtends.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedExtraProperties;
-using SeedExtraProperties.Core;
+using SeedExtraProperties.Test.Utils;
 
 namespace SeedExtraProperties.Test.Unit.MockServer;
 
@@ -47,10 +47,7 @@ public class CreateUserTest : BaseMockServerTest
                 Name = "name",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -100,9 +97,6 @@ public class CreateUserTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedExtraProperties.Core;
+
+namespace SeedExtraProperties.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedFileDownload.Core;
+
+namespace SeedFileDownload.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedFileUpload.Core;
+
+namespace SeedFileUpload.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/folders/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Unit/MockServer/GetWithBearerTokenTest.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Unit/MockServer/GetWithBearerTokenTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedHeaderTokenEnvironmentVariable.Core;
+using SeedHeaderTokenEnvironmentVariable.Test.Utils;
 
 namespace SeedHeaderTokenEnvironmentVariable.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class GetWithBearerTokenTest : BaseMockServerTest
             );
 
         var response = await Client.Service.GetWithBearerTokenAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedHeaderTokenEnvironmentVariable.Core;
+
+namespace SeedHeaderTokenEnvironmentVariable.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/Unit/MockServer/GetWithBearerTokenTest.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/Unit/MockServer/GetWithBearerTokenTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedHeaderToken.Core;
+using SeedHeaderToken.Test.Utils;
 
 namespace SeedHeaderToken.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class GetWithBearerTokenTest : BaseMockServerTest
             );
 
         var response = await Client.Service.GetWithBearerTokenAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedHeaderToken.Core;
+
+namespace SeedHeaderToken.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/Unit/MockServer/ListTest.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/Unit/MockServer/ListTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedHttpHead;
-using SeedHttpHead.Core;
+using SeedHttpHead.Test.Utils;
 
 namespace SeedHttpHead.Test.Unit.MockServer;
 
@@ -45,9 +45,6 @@ public class ListTest : BaseMockServerTest
             );
 
         var response = await Client.User.ListAsync(new ListUsersRequest { Limit = 1 });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedHttpHead.Core;
+
+namespace SeedHttpHead.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Unit/MockServer/CreateTest.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Unit/MockServer/CreateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedIdempotencyHeaders;
-using SeedIdempotencyHeaders.Core;
+using SeedIdempotencyHeaders.Test.Utils;
 
 namespace SeedIdempotencyHeaders.Test.Unit.MockServer;
 
@@ -39,6 +39,6 @@ public class CreateTest : BaseMockServerTest
         var response = await Client.Payment.CreateAsync(
             new CreatePaymentRequest { Amount = 1, Currency = Currency.Usd }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedIdempotencyHeaders.Core;
+
+namespace SeedIdempotencyHeaders.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -39,6 +39,6 @@ public class CreateMovieTest : BaseMockServerTest
         var response = await Client.Imdb.CreateMovieAsync(
             new CreateMovieRequest { Title = "title", Rating = 1.1 }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -28,9 +27,6 @@ public class GetMovieTest : BaseMockServerTest
             );
 
         var response = await Client.Imdb.GetMovieAsync("movieId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Movie>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -39,6 +39,6 @@ public class CreateMovieTest : BaseMockServerTest
         var response = await Client.Imdb.CreateMovieAsync(
             new CreateMovieRequest { Title = "title", Rating = 1.1 }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -28,9 +27,6 @@ public class GetMovieTest : BaseMockServerTest
             );
 
         var response = await Client.Imdb.GetMovieAsync("movieId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Movie>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -39,6 +39,6 @@ public class CreateMovieTest : BaseMockServerTest
         var response = await Client.Imdb.CreateMovieAsync(
             new CreateMovieRequest { Title = "title", Rating = 1.1 }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -28,9 +27,6 @@ public class GetMovieTest : BaseMockServerTest
             );
 
         var response = await Client.Imdb.GetMovieAsync("movieId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Movie>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -39,6 +39,6 @@ public class CreateMovieTest : BaseMockServerTest
         var response = await Client.Imdb.CreateMovieAsync(
             new CreateMovieRequest { Title = "title", Rating = 1.1 }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -28,9 +27,6 @@ public class GetMovieTest : BaseMockServerTest
             );
 
         var response = await Client.Imdb.GetMovieAsync("movieId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Movie>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Unit/MockServer/CreateMovieTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -39,6 +39,6 @@ public class CreateMovieTest : BaseMockServerTest
         var response = await Client.Imdb.CreateMovieAsync(
             new CreateMovieRequest { Title = "title", Rating = 1.1 }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Unit/MockServer/GetMovieTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -28,9 +27,6 @@ public class GetMovieTest : BaseMockServerTest
             );
 
         var response = await Client.Imdb.GetMovieAsync("movieId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Movie>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthExplicit;
-using SeedInferredAuthExplicit.Core;
+using SeedInferredAuthExplicit.Test.Utils;
 
 namespace SeedInferredAuthExplicit.Test.Unit.MockServer;
 
@@ -55,9 +55,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthExplicit;
-using SeedInferredAuthExplicit.Core;
+using SeedInferredAuthExplicit.Test.Utils;
 
 namespace SeedInferredAuthExplicit.Test.Unit.MockServer;
 
@@ -57,9 +57,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthExplicit.Core;
+
+namespace SeedInferredAuthExplicit.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Unit/MockServer/GetTokenTest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Unit/MockServer/GetTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthImplicitApiKey;
-using SeedInferredAuthImplicitApiKey.Core;
+using SeedInferredAuthImplicitApiKey.Test.Utils;
 
 namespace SeedInferredAuthImplicitApiKey.Test.Unit.MockServer;
 
@@ -35,9 +35,6 @@ public class GetTokenTest : BaseMockServerTest
             );
 
         var response = await Client.Auth.GetTokenAsync(new GetTokenRequest { ApiKey = "api_key" });
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthImplicitApiKey.Core;
+
+namespace SeedInferredAuthImplicitApiKey.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthImplicitNoExpiry;
-using SeedInferredAuthImplicitNoExpiry.Core;
+using SeedInferredAuthImplicitNoExpiry.Test.Utils;
 
 namespace SeedInferredAuthImplicitNoExpiry.Test.Unit.MockServer;
 
@@ -54,9 +54,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthImplicitNoExpiry;
-using SeedInferredAuthImplicitNoExpiry.Core;
+using SeedInferredAuthImplicitNoExpiry.Test.Utils;
 
 namespace SeedInferredAuthImplicitNoExpiry.Test.Unit.MockServer;
 
@@ -56,9 +56,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthImplicitNoExpiry.Core;
+
+namespace SeedInferredAuthImplicitNoExpiry.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthImplicit;
-using SeedInferredAuthImplicit.Core;
+using SeedInferredAuthImplicit.Test.Utils;
 
 namespace SeedInferredAuthImplicit.Test.Unit.MockServer;
 
@@ -53,9 +53,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthImplicit;
-using SeedInferredAuthImplicit.Core;
+using SeedInferredAuthImplicit.Test.Utils;
 
 namespace SeedInferredAuthImplicit.Test.Unit.MockServer;
 
@@ -55,9 +55,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthImplicit.Core;
+
+namespace SeedInferredAuthImplicit.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthImplicit;
-using SeedInferredAuthImplicit.Core;
+using SeedInferredAuthImplicit.Test.Utils;
 
 namespace SeedInferredAuthImplicit.Test.Unit.MockServer;
 
@@ -55,9 +55,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedInferredAuthImplicit;
-using SeedInferredAuthImplicit.Core;
+using SeedInferredAuthImplicit.Test.Utils;
 
 namespace SeedInferredAuthImplicit.Test.Unit.MockServer;
 
@@ -57,9 +57,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedInferredAuthImplicit.Core;
+
+namespace SeedInferredAuthImplicit.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedLicense.Core;
+
+namespace SeedLicense.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedLicense.Core;
+
+namespace SeedLicense.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Unit/MockServer/SendTest.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Unit/MockServer/SendTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedLiteral;
-using SeedLiteral.Core;
+using SeedLiteral.Test.Utils;
 
 namespace SeedLiteral.Test.Unit.MockServer;
 
@@ -48,10 +48,7 @@ public class SendTest : BaseMockServerTest
                 Query = "query",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SendResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -95,9 +92,6 @@ public class SendTest : BaseMockServerTest
                 Query = "What is the weather today",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SendResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Unit/MockServer/SendTest_.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Unit/MockServer/SendTest_.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedLiteral;
-using SeedLiteral.Core;
+using SeedLiteral.Test.Utils;
 
 namespace SeedLiteral.Test.Unit.MockServer;
 
@@ -87,10 +87,7 @@ public class SendTest_ : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SendResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -158,9 +155,6 @@ public class SendTest_ : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SendResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedLiteral.Core;
+
+namespace SeedLiteral.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Unit/MockServer/SendTest.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Unit/MockServer/SendTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedLiteral;
-using SeedLiteral.Core;
+using SeedLiteral.Test.Utils;
 
 namespace SeedLiteral.Test.Unit.MockServer;
 
@@ -48,10 +48,7 @@ public class SendTest : BaseMockServerTest
                 Query = "query",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SendResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -95,9 +92,6 @@ public class SendTest : BaseMockServerTest
                 Query = "What is the weather today",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SendResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Unit/MockServer/SendTest_.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Unit/MockServer/SendTest_.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedLiteral;
-using SeedLiteral.Core;
+using SeedLiteral.Test.Utils;
 
 namespace SeedLiteral.Test.Unit.MockServer;
 
@@ -87,10 +87,7 @@ public class SendTest_ : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SendResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -158,9 +155,6 @@ public class SendTest_ : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SendResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedLiteral.Core;
+
+namespace SeedLiteral.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedLiteralsUnions.Core;
+
+namespace SeedLiteralsUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMixedCase.Core;
+
+namespace SeedMixedCase.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Unit/MockServer/CreateTest.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Unit/MockServer/CreateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedMixedFileDirectory;
-using SeedMixedFileDirectory.Core;
+using SeedMixedFileDirectory.Test.Utils;
 
 namespace SeedMixedFileDirectory.Test.Unit.MockServer;
 
@@ -53,9 +53,6 @@ public class CreateTest : BaseMockServerTest
         var response = await Client.Organization.CreateAsync(
             new CreateOrganizationRequest { Name = "name" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Organization>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Unit/MockServer/ListTest.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Unit/MockServer/ListTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedMixedFileDirectory;
-using SeedMixedFileDirectory.Core;
+using SeedMixedFileDirectory.Test.Utils;
 
 namespace SeedMixedFileDirectory.Test.Unit.MockServer;
 
@@ -41,12 +41,6 @@ public class ListTest : BaseMockServerTest
             );
 
         var response = await Client.User.ListAsync(new ListUsersRequest { Limit = 1 });
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<IEnumerable<SeedMixedFileDirectory.User>>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Unit/MockServer/User/Events/GetMetadataTest.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Unit/MockServer/User/Events/GetMetadataTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedMixedFileDirectory.Core;
 using SeedMixedFileDirectory.Test.Unit.MockServer;
+using SeedMixedFileDirectory.Test.Utils;
 using SeedMixedFileDirectory.User_.Events;
 
 namespace SeedMixedFileDirectory.Test.Unit.MockServer.User.Events;
@@ -38,9 +38,6 @@ public class GetMetadataTest : BaseMockServerTest
         var response = await Client.User.Events.Metadata.GetMetadataAsync(
             new GetEventMetadataRequest { Id = "id" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Metadata>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Unit/MockServer/User/ListEventsTest.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Unit/MockServer/User/ListEventsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
-using SeedMixedFileDirectory.Core;
 using SeedMixedFileDirectory.Test.Unit.MockServer;
+using SeedMixedFileDirectory.Test.Utils;
 using SeedMixedFileDirectory.User_;
 
 namespace SeedMixedFileDirectory.Test.Unit.MockServer.User;
@@ -42,9 +42,6 @@ public class ListEventsTest : BaseMockServerTest
         var response = await Client.User.Events.ListEventsAsync(
             new ListUserEventsRequest { Limit = 1 }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<Event>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMixedFileDirectory.Core;
+
+namespace SeedMixedFileDirectory.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedMultiLineDocs;
-using SeedMultiLineDocs.Core;
+using SeedMultiLineDocs.Test.Utils;
 
 namespace SeedMultiLineDocs.Test.Unit.MockServer;
 
@@ -43,9 +43,6 @@ public class CreateUserTest : BaseMockServerTest
         var response = await Client.User.CreateUserAsync(
             new CreateUserRequest { Name = "name", Age = 1 }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMultiLineDocs.Core;
+
+namespace SeedMultiLineDocs.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMultiUrlEnvironmentNoDefault.Core;
+
+namespace SeedMultiUrlEnvironmentNoDefault.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/Unit/MockServer/GetPresignedUrlTest.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/Unit/MockServer/GetPresignedUrlTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedMultiUrlEnvironment;
-using SeedMultiUrlEnvironment.Core;
+using SeedMultiUrlEnvironment.Test.Utils;
 
 namespace SeedMultiUrlEnvironment.Test.Unit.MockServer;
 
@@ -38,6 +38,6 @@ public class GetPresignedUrlTest : BaseMockServerTest
         var response = await Client.S3.GetPresignedUrlAsync(
             new GetPresignedUrlRequest { S3Key = "s3Key" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMultiUrlEnvironment.Core;
+
+namespace SeedMultiUrlEnvironment.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/Unit/MockServer/GetPresignedUrlTest.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/Unit/MockServer/GetPresignedUrlTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedMultiUrlEnvironment;
-using SeedMultiUrlEnvironment.Core;
+using SeedMultiUrlEnvironment.Test.Utils;
 
 namespace SeedMultiUrlEnvironment.Test.Unit.MockServer;
 
@@ -38,6 +38,6 @@ public class GetPresignedUrlTest : BaseMockServerTest
         var response = await Client.S3.GetPresignedUrlAsync(
             new GetPresignedUrlRequest { S3Key = "s3Key" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedMultiUrlEnvironment.Core;
+
+namespace SeedMultiUrlEnvironment.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/Unit/MockServer/UploadJsonDocumentTest.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/Unit/MockServer/UploadJsonDocumentTest.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
-using OneOf;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -62,15 +61,7 @@ public class UploadJsonDocumentTest : BaseMockServerTest
                 Title = "title",
             }
         );
-        Assert.That(
-            response.Value,
-            Is.EqualTo(
-                    JsonUtils
-                        .Deserialize<OneOf<DocumentMetadata, DocumentUploadResult>>(mockResponse)
-                        .Value
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -110,14 +101,6 @@ public class UploadJsonDocumentTest : BaseMockServerTest
             );
 
         var response = await Client.UploadJsonDocumentAsync(new UploadDocumentRequest());
-        Assert.That(
-            response.Value,
-            Is.EqualTo(
-                    JsonUtils
-                        .Deserialize<OneOf<DocumentMetadata, DocumentUploadResult>>(mockResponse)
-                        .Value
-                )
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/Unit/MockServer/GetDummyTest.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/Unit/MockServer/GetDummyTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedNoEnvironment.Core;
+using SeedNoEnvironment.Test.Utils;
 
 namespace SeedNoEnvironment.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class GetDummyTest : BaseMockServerTest
             );
 
         var response = await Client.Dummy.GetDummyAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNoEnvironment.Core;
+
+namespace SeedNoEnvironment.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/Unit/MockServer/GetUsersTest.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/Unit/MockServer/GetUsersTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedNoRetries;
-using SeedNoRetries.Core;
+using SeedNoRetries.Test.Utils;
 
 namespace SeedNoRetries.Test.Unit.MockServer;
 
@@ -33,9 +32,6 @@ public class GetUsersTest : BaseMockServerTest
             );
 
         var response = await Client.Retries.GetUsersAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNoRetries.Core;
+
+namespace SeedNoRetries.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Unit/MockServer/CreateTestTest.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Unit/MockServer/CreateTestTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -43,10 +43,7 @@ public class CreateTestTest : BaseMockServerTest
         var response = await Client.CreateTestAsync(
             new RootObject { NormalField = "normalField", NullableField = "nullableField" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<RootObject>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -79,9 +76,6 @@ public class CreateTestTest : BaseMockServerTest
             );
 
         var response = await Client.CreateTestAsync(new RootObject());
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<RootObject>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Unit/MockServer/GetTestTest.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Unit/MockServer/GetTestTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -27,10 +26,7 @@ public class GetTestTest : BaseMockServerTest
             );
 
         var response = await Client.GetTestAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<RootObject>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -52,9 +48,6 @@ public class GetTestTest : BaseMockServerTest
             );
 
         var response = await Client.GetTestAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<RootObject>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/CreateComplexProfileTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/CreateComplexProfileTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -405,9 +405,6 @@ public class CreateComplexProfileTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ComplexProfile>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -80,9 +80,6 @@ public class CreateUserTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<UserResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/FilterByRoleTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/FilterByRoleTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -74,10 +74,6 @@ public class FilterByRoleTest : BaseMockServerTest
                 SecondaryRole = UserRole.Admin,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<UserResponse>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/GetComplexProfileTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/GetComplexProfileTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -135,9 +134,6 @@ public class GetComplexProfileTest : BaseMockServerTest
             );
 
         var response = await Client.NullableOptional.GetComplexProfileAsync("profileId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ComplexProfile>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/GetNotificationSettingsTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/GetNotificationSettingsTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -34,9 +33,6 @@ public class GetNotificationSettingsTest : BaseMockServerTest
             );
 
         var response = await Client.NullableOptional.GetNotificationSettingsAsync("userId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NotificationMethod?>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/GetSearchResultsTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/GetSearchResultsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -87,10 +87,6 @@ public class GetSearchResultsTest : BaseMockServerTest
                 IncludeTypes = new List<string>() { "includeTypes", "includeTypes" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<SearchResult>?>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/GetUserTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/GetUserTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -42,9 +41,6 @@ public class GetUserTest : BaseMockServerTest
             );
 
         var response = await Client.NullableOptional.GetUserAsync("userId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<UserResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/ListUsersTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/ListUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -75,10 +75,6 @@ public class ListUsersTest : BaseMockServerTest
                 SortBy = "sortBy",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<UserResponse>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/SearchUsersTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/SearchUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -75,10 +75,6 @@ public class SearchUsersTest : BaseMockServerTest
                 IsActive = true,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<UserResponse>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/TestDeserializationTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/TestDeserializationTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -216,10 +216,6 @@ public class TestDeserializationTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<DeserializationTestResponse>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/UpdateComplexProfileTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/UpdateComplexProfileTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -221,9 +221,6 @@ public class UpdateComplexProfileTest : BaseMockServerTest
                 NullableArray = new List<string>() { "nullableArray", "nullableArray" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ComplexProfile>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/UpdateTagsTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/UpdateTagsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -58,9 +58,6 @@ public class UpdateTagsTest : BaseMockServerTest
                 Labels = new List<string>() { "labels", "labels" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/UpdateUserTest.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Unit/MockServer/UpdateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -81,9 +81,6 @@ public class UpdateUserTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<UserResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNullableOptional.Core;
+
+namespace SeedNullableOptional.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/CreateComplexProfileTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/CreateComplexProfileTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -405,9 +405,6 @@ public class CreateComplexProfileTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ComplexProfile>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -80,9 +80,6 @@ public class CreateUserTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<UserResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/FilterByRoleTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/FilterByRoleTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -74,10 +74,6 @@ public class FilterByRoleTest : BaseMockServerTest
                 SecondaryRole = UserRole.Admin,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<UserResponse>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/GetComplexProfileTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/GetComplexProfileTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -135,9 +134,6 @@ public class GetComplexProfileTest : BaseMockServerTest
             );
 
         var response = await Client.NullableOptional.GetComplexProfileAsync("profileId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ComplexProfile>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/GetNotificationSettingsTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/GetNotificationSettingsTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -34,9 +33,6 @@ public class GetNotificationSettingsTest : BaseMockServerTest
             );
 
         var response = await Client.NullableOptional.GetNotificationSettingsAsync("userId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<NotificationMethod?>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/GetSearchResultsTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/GetSearchResultsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -87,10 +87,6 @@ public class GetSearchResultsTest : BaseMockServerTest
                 IncludeTypes = new List<string>() { "includeTypes", "includeTypes" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<SearchResult>?>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/GetUserTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/GetUserTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -42,9 +41,6 @@ public class GetUserTest : BaseMockServerTest
             );
 
         var response = await Client.NullableOptional.GetUserAsync("userId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<UserResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/ListUsersTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/ListUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -75,10 +75,6 @@ public class ListUsersTest : BaseMockServerTest
                 SortBy = "sortBy",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<UserResponse>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/SearchUsersTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/SearchUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -75,10 +75,6 @@ public class SearchUsersTest : BaseMockServerTest
                 IsActive = true,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<UserResponse>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/TestDeserializationTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/TestDeserializationTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -216,10 +216,6 @@ public class TestDeserializationTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<DeserializationTestResponse>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/UpdateComplexProfileTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/UpdateComplexProfileTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -221,9 +221,6 @@ public class UpdateComplexProfileTest : BaseMockServerTest
                 NullableArray = new List<string>() { "nullableArray", "nullableArray" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<ComplexProfile>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/UpdateTagsTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/UpdateTagsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -58,9 +58,6 @@ public class UpdateTagsTest : BaseMockServerTest
                 Labels = new List<string>() { "labels", "labels" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<string>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/UpdateUserTest.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Unit/MockServer/UpdateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullableOptional;
-using SeedNullableOptional.Core;
+using SeedNullableOptional.Test.Utils;
 
 namespace SeedNullableOptional.Test.Unit.MockServer;
 
@@ -81,9 +81,6 @@ public class UpdateUserTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<UserResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNullableOptional.Core;
+
+namespace SeedNullableOptional.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/Unit/MockServer/TestMethodNameTest.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/Unit/MockServer/TestMethodNameTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -49,10 +49,7 @@ public class TestMethodNameTest : BaseMockServerTest
                 Body = new PlainObject { Id = "id", Name = "name" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<object>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -91,9 +88,6 @@ public class TestMethodNameTest : BaseMockServerTest
                 Body = new PlainObject(),
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<object>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedNullable;
-using SeedNullable.Core;
+using SeedNullable.Test.Utils;
 
 namespace SeedNullable.Test.Unit.MockServer;
 
@@ -108,9 +108,6 @@ public class CreateUserTest : BaseMockServerTest
                 Avatar = "avatar",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Unit/MockServer/DeleteUserTest.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Unit/MockServer/DeleteUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullable;
-using SeedNullable.Core;
+using SeedNullable.Test.Utils;
 
 namespace SeedNullable.Test.Unit.MockServer;
 
@@ -38,6 +38,6 @@ public class DeleteUserTest : BaseMockServerTest
         var response = await Client.Nullable.DeleteUserAsync(
             new DeleteUserRequest { Username = "xy" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Unit/MockServer/GetUsersTest.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Unit/MockServer/GetUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullable;
-using SeedNullable.Core;
+using SeedNullable.Test.Utils;
 
 namespace SeedNullable.Test.Unit.MockServer;
 
@@ -104,9 +104,6 @@ public class GetUsersTest : BaseMockServerTest
                 Extra = true,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNullable.Core;
+
+namespace SeedNullable.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedNullable;
-using SeedNullable.Core;
+using SeedNullable.Test.Utils;
 
 namespace SeedNullable.Test.Unit.MockServer;
 
@@ -108,9 +108,6 @@ public class CreateUserTest : BaseMockServerTest
                 Avatar = "avatar",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Unit/MockServer/DeleteUserTest.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Unit/MockServer/DeleteUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullable;
-using SeedNullable.Core;
+using SeedNullable.Test.Utils;
 
 namespace SeedNullable.Test.Unit.MockServer;
 
@@ -38,6 +38,6 @@ public class DeleteUserTest : BaseMockServerTest
         var response = await Client.Nullable.DeleteUserAsync(
             new DeleteUserRequest { Username = "xy" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Unit/MockServer/GetUsersTest.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Unit/MockServer/GetUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedNullable;
-using SeedNullable.Core;
+using SeedNullable.Test.Utils;
 
 namespace SeedNullable.Test.Unit.MockServer;
 
@@ -104,9 +104,6 @@ public class GetUsersTest : BaseMockServerTest
                 Extra = true,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNullable.Core;
+
+namespace SeedNullable.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentials;
-using SeedOauthClientCredentials.Core;
+using SeedOauthClientCredentials.Test.Utils;
 
 namespace SeedOauthClientCredentials.Test.Unit.MockServer;
 
@@ -57,9 +57,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentials;
-using SeedOauthClientCredentials.Core;
+using SeedOauthClientCredentials.Test.Utils;
 
 namespace SeedOauthClientCredentials.Test.Unit.MockServer;
 
@@ -55,9 +55,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentials.Core;
+
+namespace SeedOauthClientCredentials.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Unit/MockServer/GetTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Unit/MockServer/GetTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentialsDefault;
-using SeedOauthClientCredentialsDefault.Core;
+using SeedOauthClientCredentialsDefault.Test.Utils;
 
 namespace SeedOauthClientCredentialsDefault.Test.Unit.MockServer;
 
@@ -48,9 +48,6 @@ public class GetTokenTest : BaseMockServerTest
                 GrantType = "client_credentials",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsDefault.Core;
+
+namespace SeedOauthClientCredentialsDefault.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentialsEnvironmentVariables;
-using SeedOauthClientCredentialsEnvironmentVariables.Core;
+using SeedOauthClientCredentialsEnvironmentVariables.Test.Utils;
 
 namespace SeedOauthClientCredentialsEnvironmentVariables.Test.Unit.MockServer;
 
@@ -53,9 +53,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentialsEnvironmentVariables;
-using SeedOauthClientCredentialsEnvironmentVariables.Core;
+using SeedOauthClientCredentialsEnvironmentVariables.Test.Utils;
 
 namespace SeedOauthClientCredentialsEnvironmentVariables.Test.Unit.MockServer;
 
@@ -55,9 +55,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsEnvironmentVariables.Core;
+
+namespace SeedOauthClientCredentialsEnvironmentVariables.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentialsMandatoryAuth;
-using SeedOauthClientCredentialsMandatoryAuth.Core;
+using SeedOauthClientCredentialsMandatoryAuth.Test.Utils;
 
 namespace SeedOauthClientCredentialsMandatoryAuth.Test.Unit.MockServer;
 
@@ -53,10 +53,7 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -105,9 +102,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "read:users",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentialsMandatoryAuth;
-using SeedOauthClientCredentialsMandatoryAuth.Core;
+using SeedOauthClientCredentialsMandatoryAuth.Test.Utils;
 
 namespace SeedOauthClientCredentialsMandatoryAuth.Test.Unit.MockServer;
 
@@ -55,10 +55,7 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -109,9 +106,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "read:users",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsMandatoryAuth.Core;
+
+namespace SeedOauthClientCredentialsMandatoryAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Unit/MockServer/Auth/GetTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Unit/MockServer/Auth/GetTokenTest.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using SeedOauthClientCredentials.Auth;
-using SeedOauthClientCredentials.Core;
 using SeedOauthClientCredentials.Test.Unit.MockServer;
+using SeedOauthClientCredentials.Test.Utils;
 
 namespace SeedOauthClientCredentials.Test.Unit.MockServer.Auth;
 
@@ -54,9 +54,6 @@ public class GetTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentials.Core;
+
+namespace SeedOauthClientCredentials.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Unit/MockServer/GetTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Unit/MockServer/GetTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentialsReference;
-using SeedOauthClientCredentialsReference.Core;
+using SeedOauthClientCredentialsReference.Test.Utils;
 
 namespace SeedOauthClientCredentialsReference.Test.Unit.MockServer;
 
@@ -42,10 +42,7 @@ public class GetTokenTest : BaseMockServerTest
         var response = await Client.Auth.GetTokenAsync(
             new GetTokenRequest { ClientId = "client_id", ClientSecret = "client_secret" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -83,9 +80,6 @@ public class GetTokenTest : BaseMockServerTest
         var response = await Client.Auth.GetTokenAsync(
             new GetTokenRequest { ClientId = "client_id", ClientSecret = "client_secret" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsReference.Core;
+
+namespace SeedOauthClientCredentialsReference.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentialsWithVariables;
-using SeedOauthClientCredentialsWithVariables.Core;
+using SeedOauthClientCredentialsWithVariables.Test.Utils;
 
 namespace SeedOauthClientCredentialsWithVariables.Test.Unit.MockServer;
 
@@ -53,9 +53,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentialsWithVariables;
-using SeedOauthClientCredentialsWithVariables.Core;
+using SeedOauthClientCredentialsWithVariables.Test.Utils;
 
 namespace SeedOauthClientCredentialsWithVariables.Test.Unit.MockServer;
 
@@ -55,9 +55,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentialsWithVariables.Core;
+
+namespace SeedOauthClientCredentialsWithVariables.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentials;
-using SeedOauthClientCredentials.Core;
+using SeedOauthClientCredentials.Test.Utils;
 
 namespace SeedOauthClientCredentials.Test.Unit.MockServer;
 
@@ -52,10 +52,7 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -103,9 +100,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "read:users",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentials;
-using SeedOauthClientCredentials.Core;
+using SeedOauthClientCredentials.Test.Utils;
 
 namespace SeedOauthClientCredentials.Test.Unit.MockServer;
 
@@ -54,10 +54,7 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -107,9 +104,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "read:users",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentials.Core;
+
+namespace SeedOauthClientCredentials.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentials;
-using SeedOauthClientCredentials.Core;
+using SeedOauthClientCredentials.Test.Utils;
 
 namespace SeedOauthClientCredentials.Test.Unit.MockServer;
 
@@ -52,10 +52,7 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -103,9 +100,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "read:users",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedOauthClientCredentials;
-using SeedOauthClientCredentials.Core;
+using SeedOauthClientCredentials.Test.Utils;
 
 namespace SeedOauthClientCredentials.Test.Unit.MockServer;
 
@@ -54,10 +54,7 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -107,9 +104,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "read:users",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedOauthClientCredentials.Core;
+
+namespace SeedOauthClientCredentials.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/object/src/SeedObject.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/object/src/SeedObject.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedObject.Core;
+
+namespace SeedObject.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedObjectsWithImports.Core;
+
+namespace SeedObjectsWithImports.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalBodyTest.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalBodyTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedObjectsWithImports.Core;
+using SeedObjectsWithImports.Test.Utils;
 
 namespace SeedObjectsWithImports.Test.Unit.MockServer;
 
@@ -45,6 +45,6 @@ public class SendOptionalBodyTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalNullableWithAllOptionalPropertiesTest.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalNullableWithAllOptionalPropertiesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedObjectsWithImports;
-using SeedObjectsWithImports.Core;
+using SeedObjectsWithImports.Test.Utils;
 
 namespace SeedObjectsWithImports.Test.Unit.MockServer;
 
@@ -42,9 +42,6 @@ public class SendOptionalNullableWithAllOptionalPropertiesTest : BaseMockServerT
             "id",
             new DeployParams { UpdateDraft = true }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<DeployResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalTypedBodyTest.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalTypedBodyTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedObjectsWithImports;
-using SeedObjectsWithImports.Core;
+using SeedObjectsWithImports.Test.Utils;
 
 namespace SeedObjectsWithImports.Test.Unit.MockServer;
 
@@ -38,6 +38,6 @@ public class SendOptionalTypedBodyTest : BaseMockServerTest
         var response = await Client.Optional.SendOptionalTypedBodyAsync(
             new SendOptionalBodyRequest { Message = "message" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedObjectsWithImports.Core;
+
+namespace SeedObjectsWithImports.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalBodyTest.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalBodyTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedObjectsWithImports.Core;
+using SeedObjectsWithImports.Test.Utils;
 
 namespace SeedObjectsWithImports.Test.Unit.MockServer;
 
@@ -45,6 +45,6 @@ public class SendOptionalBodyTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalNullableWithAllOptionalPropertiesTest.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalNullableWithAllOptionalPropertiesTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedObjectsWithImports;
-using SeedObjectsWithImports.Core;
+using SeedObjectsWithImports.Test.Utils;
 
 namespace SeedObjectsWithImports.Test.Unit.MockServer;
 
@@ -42,9 +42,6 @@ public class SendOptionalNullableWithAllOptionalPropertiesTest : BaseMockServerT
             "id",
             new DeployParams { UpdateDraft = true }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<DeployResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalTypedBodyTest.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Unit/MockServer/SendOptionalTypedBodyTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedObjectsWithImports;
-using SeedObjectsWithImports.Core;
+using SeedObjectsWithImports.Test.Utils;
 
 namespace SeedObjectsWithImports.Test.Unit.MockServer;
 
@@ -38,6 +38,6 @@ public class SendOptionalTypedBodyTest : BaseMockServerTest
         var response = await Client.Optional.SendOptionalTypedBodyAsync(
             new SendOptionalBodyRequest { Message = "message" }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedObjectsWithImports.Core;
+
+namespace SeedObjectsWithImports.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/Unit/MockServer/EchoTest.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/Unit/MockServer/EchoTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPackageYml;
-using SeedPackageYml.Core;
+using SeedPackageYml.Test.Utils;
 
 namespace SeedPackageYml.Test.Unit.MockServer;
 
@@ -37,7 +37,7 @@ public class EchoTest : BaseMockServerTest
             );
 
         var response = await Client.EchoAsync("id", new EchoRequest { Name = "name", Size = 1 });
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -73,6 +73,6 @@ public class EchoTest : BaseMockServerTest
             "id-ksfd9c1",
             new EchoRequest { Name = "Hello world!", Size = 20 }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPackageYml.Core;
+
+namespace SeedPackageYml.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPagination.Core;
+
+namespace SeedPagination.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPagination.Core;
+
+namespace SeedPagination.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPagination.Core;
+
+namespace SeedPagination.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPagination.Core;
+
+namespace SeedPagination.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -53,9 +53,6 @@ public class CreateUserTest : BaseMockServerTest
                 Tags = new List<string>() { "tags", "tags" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetOrganizationTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetOrganizationTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -38,9 +37,6 @@ public class GetOrganizationTest : BaseMockServerTest
             "tenant_id",
             "organization_id"
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Organization>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetOrganizationUserTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetOrganizationUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -42,9 +42,6 @@ public class GetOrganizationUserTest : BaseMockServerTest
                 UserId = "user_id",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetUserMetadataTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetUserMetadataTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -42,9 +42,6 @@ public class GetUserMetadataTest : BaseMockServerTest
                 Version = 1,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetUserSpecificsTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetUserSpecificsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -43,9 +43,6 @@ public class GetUserSpecificsTest : BaseMockServerTest
                 Thought = "thought",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetUserTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/GetUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -37,9 +37,6 @@ public class GetUserTest : BaseMockServerTest
         var response = await Client.User.GetUserAsync(
             new GetUsersRequest { TenantId = "tenant_id", UserId = "user_id" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/SearchOrganizationsTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/SearchOrganizationsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -49,10 +49,6 @@ public class SearchOrganizationsTest : BaseMockServerTest
             "organization_id",
             new SearchOrganizationsRequest { Limit = 1 }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<Organization>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/SearchUsersTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/SearchUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -52,9 +52,6 @@ public class SearchUsersTest : BaseMockServerTest
                 Limit = 1,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/UpdateUserTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Unit/MockServer/UpdateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -57,9 +57,6 @@ public class UpdateUserTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPathParameters.Core;
+
+namespace SeedPathParameters.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/CreateUserTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/CreateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -53,9 +53,6 @@ public class CreateUserTest : BaseMockServerTest
                 Tags = new List<string>() { "tags", "tags" },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetOrganizationTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetOrganizationTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -38,9 +37,6 @@ public class GetOrganizationTest : BaseMockServerTest
             "tenant_id",
             "organization_id"
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Organization>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetOrganizationUserTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetOrganizationUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -40,9 +40,6 @@ public class GetOrganizationUserTest : BaseMockServerTest
             "user_id",
             new GetOrganizationUserRequest()
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetUserMetadataTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetUserMetadataTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -40,9 +40,6 @@ public class GetUserMetadataTest : BaseMockServerTest
             1,
             new GetUserMetadataRequest()
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetUserSpecificsTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetUserSpecificsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -41,9 +41,6 @@ public class GetUserSpecificsTest : BaseMockServerTest
             "thought",
             new GetUserSpecificsRequest()
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetUserTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/GetUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -39,9 +39,6 @@ public class GetUserTest : BaseMockServerTest
             "user_id",
             new GetUsersRequest()
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/SearchOrganizationsTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/SearchOrganizationsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -49,10 +49,6 @@ public class SearchOrganizationsTest : BaseMockServerTest
             "organization_id",
             new SearchOrganizationsRequest { Limit = 1 }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<Organization>>(mockResponse))
-                .UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/SearchUsersTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/SearchUsersTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -49,9 +49,6 @@ public class SearchUsersTest : BaseMockServerTest
             "user_id",
             new SearchUsersRequest { Limit = 1 }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<User>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/UpdateUserTest.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Unit/MockServer/UpdateUserTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedPathParameters;
-using SeedPathParameters.Core;
+using SeedPathParameters.Test.Utils;
 
 namespace SeedPathParameters.Test.Unit.MockServer;
 
@@ -57,9 +57,6 @@ public class UpdateUserTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPathParameters.Core;
+
+namespace SeedPathParameters.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPlainText.Core;
+
+namespace SeedPlainText.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPropertyAccess.Core;
+
+namespace SeedPropertyAccess.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedPublicObject.Core;
+
+namespace SeedPublicObject.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/Unit/MockServer/SearchTest.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/Unit/MockServer/SearchTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -109,9 +109,6 @@ public class SearchTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SearchResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/Unit/MockServer/SearchTest.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/Unit/MockServer/SearchTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -109,9 +109,6 @@ public class SearchTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SearchResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/Unit/MockServer/GetUsernameTest.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/Unit/MockServer/GetUsernameTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedQueryParameters;
-using SeedQueryParameters.Core;
+using SeedQueryParameters.Test.Utils;
 
 namespace SeedQueryParameters.Test.Unit.MockServer;
 
@@ -105,9 +105,6 @@ public class GetUsernameTest : BaseMockServerTest
                 Filter = ["filter"],
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedQueryParameters.Core;
+
+namespace SeedQueryParameters.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/Unit/MockServer/GetUsernameTest.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/Unit/MockServer/GetUsernameTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedRequestParameters;
-using SeedRequestParameters.Core;
+using SeedRequestParameters.Test.Utils;
 
 namespace SeedRequestParameters.Test.Unit.MockServer;
 
@@ -109,9 +109,6 @@ public class GetUsernameTest : BaseMockServerTest
                 BigIntParam = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedRequestParameters.Core;
+
+namespace SeedRequestParameters.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/Unit/MockServer/GetUsernameTest.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/Unit/MockServer/GetUsernameTest.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using NUnit.Framework;
 using SeedRequestParameters;
-using SeedRequestParameters.Core;
+using SeedRequestParameters.Test.Utils;
 
 namespace SeedRequestParameters.Test.Unit.MockServer;
 
@@ -109,9 +109,6 @@ public class GetUsernameTest : BaseMockServerTest
                 BigIntParam = "1000000",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedRequestParameters.Core;
+
+namespace SeedRequestParameters.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Unit/MockServer/GetFooTest.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Unit/MockServer/GetFooTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -46,7 +46,7 @@ public class GetFooTest : BaseMockServerTest
                 RequiredNullableBaz = "required_nullable_baz",
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<Foo>(mockResponse)).UsingDefaults());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -84,6 +84,6 @@ public class GetFooTest : BaseMockServerTest
                 RequiredNullableBaz = "required_nullable_baz",
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<Foo>(mockResponse)).UsingDefaults());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Unit/MockServer/UpdateFooTest.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Unit/MockServer/UpdateFooTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -53,6 +53,6 @@ public class UpdateFooTest : BaseMockServerTest
                 NonNullableText = "non_nullable_text",
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<Foo>(mockResponse)).UsingDefaults());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Unit/MockServer/GetFooTest.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Unit/MockServer/GetFooTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -46,7 +46,7 @@ public class GetFooTest : BaseMockServerTest
                 RequiredNullableBaz = "required_nullable_baz",
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<Foo>(mockResponse)).UsingDefaults());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -84,6 +84,6 @@ public class GetFooTest : BaseMockServerTest
                 RequiredNullableBaz = "required_nullable_baz",
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<Foo>(mockResponse)).UsingDefaults());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Unit/MockServer/UpdateFooTest.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Unit/MockServer/UpdateFooTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -53,6 +53,6 @@ public class UpdateFooTest : BaseMockServerTest
                 NonNullableText = "non_nullable_text",
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<Foo>(mockResponse)).UsingDefaults());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedNurseryApi.Core;
+
+namespace SeedNurseryApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedResponseProperty.Core;
+
+namespace SeedResponseProperty.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedServerSentEvents.Core;
+
+namespace SeedServerSentEvents.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedServerSentEvents.Core;
+
+namespace SeedServerSentEvents.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/Unit/MockServer/GetTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedSimpleApi;
-using SeedSimpleApi.Core;
+using SeedSimpleApi.Test.Utils;
 
 namespace SeedSimpleApi.Test.Unit.MockServer;
 
@@ -28,9 +27,6 @@ public class GetTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetAsync("id");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedSimpleApi.Core;
+
+namespace SeedSimpleApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/Unit/MockServer/GetTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedSimpleApi;
-using SeedSimpleApi.Core;
+using SeedSimpleApi.Test.Utils;
 
 namespace SeedSimpleApi.Test.Unit.MockServer;
 
@@ -28,9 +27,6 @@ public class GetTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetAsync("id");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedSimpleApi.Core;
+
+namespace SeedSimpleApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/Unit/MockServer/GetTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedSimpleApi;
-using SeedSimpleApi.Core;
+using SeedSimpleApi.Test.Utils;
 
 namespace SeedSimpleApi.Test.Unit.MockServer;
 
@@ -28,9 +27,6 @@ public class GetTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetAsync("id");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedSimpleApi.Core;
+
+namespace SeedSimpleApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Unit/MockServer/GetAccountTest.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Unit/MockServer/GetAccountTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -26,25 +25,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -53,13 +46,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -72,25 +62,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -99,13 +83,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -123,8 +104,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "practitioner": {
@@ -133,8 +113,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "id": "id",
@@ -142,25 +121,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -169,13 +142,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -190,8 +160,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "practitioner": {
@@ -200,8 +169,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "id": "id",
@@ -209,25 +177,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -236,13 +198,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -260,8 +219,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "practitioner": {
@@ -270,8 +228,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "id": "id",
@@ -279,25 +236,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -306,13 +257,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -334,8 +282,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "practitioner": {
@@ -344,8 +291,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "id": "id",
@@ -353,25 +299,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -380,13 +320,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -401,8 +338,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "practitioner": {
@@ -411,8 +347,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "id": "id",
@@ -420,25 +355,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -447,13 +376,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -471,8 +397,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "practitioner": {
@@ -481,8 +406,7 @@ public class GetAccountTest : BaseMockServerTest
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     "id": "id",
@@ -490,25 +414,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -517,13 +435,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -545,8 +460,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
@@ -555,8 +469,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -565,25 +478,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -592,13 +499,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -611,25 +515,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -638,13 +536,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -661,8 +556,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -671,15 +565,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     {
@@ -692,8 +584,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -702,15 +593,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     }
                   ],
@@ -726,8 +615,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -736,15 +624,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     }
                   }
@@ -762,8 +648,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
@@ -772,8 +657,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -782,25 +666,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -809,13 +687,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -828,25 +703,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -855,13 +724,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -878,8 +744,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -888,15 +753,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     {
@@ -909,8 +772,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -919,15 +781,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     }
                   ],
@@ -943,8 +803,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -953,15 +812,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     }
                   }
@@ -982,8 +839,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
@@ -992,8 +848,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -1002,25 +857,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -1029,13 +878,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -1048,25 +894,19 @@ public class GetAccountTest : BaseMockServerTest
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     ],
@@ -1075,13 +915,10 @@ public class GetAccountTest : BaseMockServerTest
                       "account": {
                         "resource_type": "Account",
                         "name": "name",
-                        "patient": null,
-                        "practitioner": null,
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       }
                     }
@@ -1098,8 +935,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -1108,15 +944,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     },
                     {
@@ -1129,8 +963,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -1139,15 +972,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     }
                   ],
@@ -1163,8 +994,7 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "practitioner": {
@@ -1173,15 +1003,13 @@ public class GetAccountTest : BaseMockServerTest
                         "id": "id",
                         "related_resources": [],
                         "memo": {
-                          "description": "description",
-                          "account": null
+                          "description": "description"
                         }
                       },
                       "id": "id",
                       "related_resources": [],
                       "memo": {
-                        "description": "description",
-                        "account": null
+                        "description": "description"
                       }
                     }
                   }
@@ -1202,9 +1030,6 @@ public class GetAccountTest : BaseMockServerTest
             );
 
         var response = await Client.GetAccountAsync("account_id");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Account>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Unit/MockServer/GetDummyTest.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Unit/MockServer/GetDummyTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedSingleUrlEnvironmentDefault.Core;
+using SeedSingleUrlEnvironmentDefault.Test.Utils;
 
 namespace SeedSingleUrlEnvironmentDefault.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class GetDummyTest : BaseMockServerTest
             );
 
         var response = await Client.Dummy.GetDummyAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedSingleUrlEnvironmentDefault.Core;
+
+namespace SeedSingleUrlEnvironmentDefault.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Unit/MockServer/GetDummyTest.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Unit/MockServer/GetDummyTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedSingleUrlEnvironmentNoDefault.Core;
+using SeedSingleUrlEnvironmentNoDefault.Test.Utils;
 
 namespace SeedSingleUrlEnvironmentNoDefault.Test.Unit.MockServer;
 
@@ -23,6 +23,6 @@ public class GetDummyTest : BaseMockServerTest
             );
 
         var response = await Client.Dummy.GetDummyAsync();
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedSingleUrlEnvironmentNoDefault.Core;
+
+namespace SeedSingleUrlEnvironmentNoDefault.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedStreaming.Core;
+
+namespace SeedStreaming.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/streaming/src/SeedStreaming.Test/Unit/MockServer/GenerateTest.cs
+++ b/seed/csharp-sdk/streaming/src/SeedStreaming.Test/Unit/MockServer/GenerateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedStreaming;
-using SeedStreaming.Core;
+using SeedStreaming.Test.Utils;
 
 namespace SeedStreaming.Test.Unit.MockServer;
 
@@ -42,10 +42,7 @@ public class GenerateTest : BaseMockServerTest
         var response = await Client.Dummy.GenerateAsync(
             new Generateequest { Stream = false, NumEvents = 1 }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<StreamResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -83,9 +80,6 @@ public class GenerateTest : BaseMockServerTest
         var response = await Client.Dummy.GenerateAsync(
             new Generateequest { Stream = false, NumEvents = 5 }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<StreamResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/streaming/src/SeedStreaming.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/streaming/src/SeedStreaming.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedStreaming.Core;
+
+namespace SeedStreaming.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUndiscriminatedUnionWithResponseProperty.Core;
+
+namespace SeedUndiscriminatedUnionWithResponseProperty.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/CallTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/CallTest.cs
@@ -1,7 +1,6 @@
-using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -52,9 +51,7 @@ public class CallTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -101,8 +98,6 @@ public class CallTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/CallTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/CallTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions;
 using SeedUndiscriminatedUnions.Core;
@@ -51,7 +52,9 @@ public class CallTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 
     [NUnit.Framework.Test]
@@ -98,6 +101,8 @@ public class CallTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/DuplicateTypesUnionTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/DuplicateTypesUnionTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -34,8 +33,6 @@ public class DuplicateTypesUnionTest : BaseMockServerTest
             );
 
         var response = await Client.Union.DuplicateTypesUnionAsync("string");
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/DuplicateTypesUnionTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/DuplicateTypesUnionTest.cs
@@ -1,5 +1,5 @@
+using System.Text.Json;
 using NUnit.Framework;
-using OneOf;
 using SeedUndiscriminatedUnions.Core;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
@@ -34,16 +34,8 @@ public class DuplicateTypesUnionTest : BaseMockServerTest
             );
 
         var response = await Client.Union.DuplicateTypesUnionAsync("string");
-        Assert.That(
-            response.Value,
-            Is.EqualTo(
-                    JsonUtils
-                        .Deserialize<OneOf<string, IEnumerable<string>, int, HashSet<string>>>(
-                            mockResponse
-                        )
-                        .Value
-                )
-                .UsingDefaults()
-        );
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetMetadataTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetMetadataTest.cs
@@ -1,6 +1,5 @@
+using System.Text.Json;
 using NUnit.Framework;
-using OneOf;
-using SeedUndiscriminatedUnions;
 using SeedUndiscriminatedUnions.Core;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
@@ -27,13 +26,9 @@ public class GetMetadataTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetMetadataAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<Dictionary<OneOf<KeyType, string>, string>>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 
     [NUnit.Framework.Test]
@@ -57,12 +52,8 @@ public class GetMetadataTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetMetadataAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(
-                    JsonUtils.Deserialize<Dictionary<OneOf<KeyType, string>, string>>(mockResponse)
-                )
-                .UsingDefaults()
-        );
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetMetadataTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetMetadataTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -26,9 +25,7 @@ public class GetMetadataTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetMetadataAsync();
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -52,8 +49,6 @@ public class GetMetadataTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetMetadataAsync();
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetTest.cs
@@ -1,5 +1,5 @@
+using System.Text.Json;
 using NUnit.Framework;
-using OneOf;
 using SeedUndiscriminatedUnions.Core;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
@@ -34,23 +34,8 @@ public class GetTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetAsync("string");
-        Assert.That(
-            response.Value,
-            Is.EqualTo(
-                    JsonUtils
-                        .Deserialize<
-                            OneOf<
-                                string,
-                                IEnumerable<string>,
-                                int,
-                                IEnumerable<int>,
-                                IEnumerable<IEnumerable<int>>,
-                                HashSet<string>
-                            >
-                        >(mockResponse)
-                        .Value
-                )
-                .UsingDefaults()
-        );
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -34,8 +33,6 @@ public class GetTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetAsync("string");
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/NestedUnionsTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/NestedUnionsTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -34,8 +33,6 @@ public class NestedUnionsTest : BaseMockServerTest
             );
 
         var response = await Client.Union.NestedUnionsAsync("string");
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/NestedUnionsTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/NestedUnionsTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions.Core;
 
@@ -33,6 +34,8 @@ public class NestedUnionsTest : BaseMockServerTest
             );
 
         var response = await Client.Union.NestedUnionsAsync("string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/TestCamelCasePropertiesTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/TestCamelCasePropertiesTest.cs
@@ -1,7 +1,6 @@
-using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -45,9 +44,7 @@ public class TestCamelCasePropertiesTest : BaseMockServerTest
                 PaymentMethod = new TokenizeCard { Method = "method", CardNumber = "cardNumber" },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -91,8 +88,6 @@ public class TestCamelCasePropertiesTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/TestCamelCasePropertiesTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/TestCamelCasePropertiesTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions;
 using SeedUndiscriminatedUnions.Core;
@@ -44,7 +45,9 @@ public class TestCamelCasePropertiesTest : BaseMockServerTest
                 PaymentMethod = new TokenizeCard { Method = "method", CardNumber = "cardNumber" },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 
     [NUnit.Framework.Test]
@@ -88,6 +91,8 @@ public class TestCamelCasePropertiesTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/UpdateMetadataTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/UpdateMetadataTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions.Core;
 
@@ -45,7 +46,9 @@ public class UpdateMetadataTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 
     [NUnit.Framework.Test]
@@ -87,6 +90,8 @@ public class UpdateMetadataTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/UpdateMetadataTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/UpdateMetadataTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -46,9 +45,7 @@ public class UpdateMetadataTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -90,8 +87,6 @@ public class UpdateMetadataTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUndiscriminatedUnions.Core;
+
+namespace SeedUndiscriminatedUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/CallTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/CallTest.cs
@@ -1,7 +1,6 @@
-using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -52,9 +51,7 @@ public class CallTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -101,8 +98,6 @@ public class CallTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/CallTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/CallTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions;
 using SeedUndiscriminatedUnions.Core;
@@ -51,7 +52,9 @@ public class CallTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 
     [NUnit.Framework.Test]
@@ -98,6 +101,8 @@ public class CallTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/DuplicateTypesUnionTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/DuplicateTypesUnionTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -34,8 +33,6 @@ public class DuplicateTypesUnionTest : BaseMockServerTest
             );
 
         var response = await Client.Union.DuplicateTypesUnionAsync("string");
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/DuplicateTypesUnionTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/DuplicateTypesUnionTest.cs
@@ -1,5 +1,5 @@
+using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions;
 using SeedUndiscriminatedUnions.Core;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
@@ -34,9 +34,8 @@ public class DuplicateTypesUnionTest : BaseMockServerTest
             );
 
         var response = await Client.Union.DuplicateTypesUnionAsync("string");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<UnionWithDuplicateTypes>(mockResponse)).UsingDefaults()
-        );
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetMetadataTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetMetadataTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -26,9 +25,7 @@ public class GetMetadataTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetMetadataAsync();
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -52,8 +49,6 @@ public class GetMetadataTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetMetadataAsync();
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetMetadataTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetMetadataTest.cs
@@ -1,5 +1,5 @@
+using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions;
 using SeedUndiscriminatedUnions.Core;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
@@ -26,10 +26,9 @@ public class GetMetadataTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetMetadataAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<Key, string>>(mockResponse)).UsingDefaults()
-        );
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 
     [NUnit.Framework.Test]
@@ -53,9 +52,8 @@ public class GetMetadataTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetMetadataAsync();
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<Dictionary<Key, string>>(mockResponse)).UsingDefaults()
-        );
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetTest.cs
@@ -1,5 +1,5 @@
+using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions;
 using SeedUndiscriminatedUnions.Core;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
@@ -34,9 +34,8 @@ public class GetTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetAsync("string");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<MyUnion>(mockResponse)).UsingDefaults()
-        );
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/GetTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -34,8 +33,6 @@ public class GetTest : BaseMockServerTest
             );
 
         var response = await Client.Union.GetAsync("string");
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/NestedUnionsTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/NestedUnionsTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -34,8 +33,6 @@ public class NestedUnionsTest : BaseMockServerTest
             );
 
         var response = await Client.Union.NestedUnionsAsync("string");
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/NestedUnionsTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/NestedUnionsTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions.Core;
 
@@ -33,6 +34,8 @@ public class NestedUnionsTest : BaseMockServerTest
             );
 
         var response = await Client.Union.NestedUnionsAsync("string");
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/TestCamelCasePropertiesTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/TestCamelCasePropertiesTest.cs
@@ -1,7 +1,6 @@
-using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -45,9 +44,7 @@ public class TestCamelCasePropertiesTest : BaseMockServerTest
                 PaymentMethod = new TokenizeCard { Method = "method", CardNumber = "cardNumber" },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -91,8 +88,6 @@ public class TestCamelCasePropertiesTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/TestCamelCasePropertiesTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/TestCamelCasePropertiesTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions;
 using SeedUndiscriminatedUnions.Core;
@@ -44,7 +45,9 @@ public class TestCamelCasePropertiesTest : BaseMockServerTest
                 PaymentMethod = new TokenizeCard { Method = "method", CardNumber = "cardNumber" },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 
     [NUnit.Framework.Test]
@@ -88,6 +91,8 @@ public class TestCamelCasePropertiesTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<string>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/UpdateMetadataTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/UpdateMetadataTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NUnit.Framework;
 using SeedUndiscriminatedUnions.Core;
 
@@ -45,7 +46,9 @@ public class UpdateMetadataTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 
     [NUnit.Framework.Test]
@@ -87,6 +90,8 @@ public class UpdateMetadataTest : BaseMockServerTest
                 },
             }
         );
-        Assert.That(response, Is.EqualTo(JsonUtils.Deserialize<bool>(mockResponse)));
+        var actualJson = JsonUtils.SerializeToElement(response);
+        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
+        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/UpdateMetadataTest.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Unit/MockServer/UpdateMetadataTest.cs
@@ -1,6 +1,5 @@
-using System.Text.Json;
 using NUnit.Framework;
-using SeedUndiscriminatedUnions.Core;
+using SeedUndiscriminatedUnions.Test.Utils;
 
 namespace SeedUndiscriminatedUnions.Test.Unit.MockServer;
 
@@ -46,9 +45,7 @@ public class UpdateMetadataTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -90,8 +87,6 @@ public class UpdateMetadataTest : BaseMockServerTest
                 },
             }
         );
-        var actualJson = JsonUtils.SerializeToElement(response);
-        var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
-        Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUndiscriminatedUnions.Core;
+
+namespace SeedUndiscriminatedUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/Key.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/Key.cs
@@ -230,7 +230,7 @@ public class Key
             );
         }
 
-        public override Key? ReadAsPropertyName(
+        public override Key ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/MetadataUnion.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/MetadataUnion.cs
@@ -234,7 +234,7 @@ public class MetadataUnion
             );
         }
 
-        public override MetadataUnion? ReadAsPropertyName(
+        public override MetadataUnion ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/MyUnion.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/MyUnion.cs
@@ -419,7 +419,7 @@ public class MyUnion
             );
         }
 
-        public override MyUnion? ReadAsPropertyName(
+        public override MyUnion ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/NestedUnionL1.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/NestedUnionL1.cs
@@ -354,7 +354,7 @@ public class NestedUnionL1
             );
         }
 
-        public override NestedUnionL1? ReadAsPropertyName(
+        public override NestedUnionL1 ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/NestedUnionL2.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/NestedUnionL2.cs
@@ -277,7 +277,7 @@ public class NestedUnionL2
             );
         }
 
-        public override NestedUnionL2? ReadAsPropertyName(
+        public override NestedUnionL2 ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/NestedUnionRoot.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/NestedUnionRoot.cs
@@ -314,7 +314,7 @@ public class NestedUnionRoot
             );
         }
 
-        public override NestedUnionRoot? ReadAsPropertyName(
+        public override NestedUnionRoot ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/PaymentMethodUnion.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/PaymentMethodUnion.cs
@@ -242,7 +242,7 @@ public class PaymentMethodUnion
             );
         }
 
-        public override PaymentMethodUnion? ReadAsPropertyName(
+        public override PaymentMethodUnion ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithDuplicateTypes.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithDuplicateTypes.cs
@@ -338,7 +338,7 @@ public class UnionWithDuplicateTypes
             );
         }
 
-        public override UnionWithDuplicateTypes? ReadAsPropertyName(
+        public override UnionWithDuplicateTypes ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithIdenticalPrimitives.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithIdenticalPrimitives.cs
@@ -270,7 +270,7 @@ public class UnionWithIdenticalPrimitives
             );
         }
 
-        public override UnionWithIdenticalPrimitives? ReadAsPropertyName(
+        public override UnionWithIdenticalPrimitives ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithIdenticalStrings.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithIdenticalStrings.cs
@@ -166,7 +166,7 @@ public class UnionWithIdenticalStrings
             value.Visit(str => writer.WriteStringValue(str));
         }
 
-        public override UnionWithIdenticalStrings? ReadAsPropertyName(
+        public override UnionWithIdenticalStrings ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithReservedNames.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithReservedNames.cs
@@ -263,7 +263,7 @@ public class UnionWithReservedNames
             );
         }
 
-        public override UnionWithReservedNames? ReadAsPropertyName(
+        public override UnionWithReservedNames ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithTypeAliases.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Union/Types/UnionWithTypeAliases.cs
@@ -276,7 +276,7 @@ public class UnionWithTypeAliases
             );
         }
 
-        public override UnionWithTypeAliases? ReadAsPropertyName(
+        public override UnionWithTypeAliases ReadAsPropertyName(
             ref Utf8JsonReader reader,
             System.Type typeToConvert,
             JsonSerializerOptions options

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUnions.Core;
+
+namespace SeedUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUnions.Core;
+
+namespace SeedUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUnions.Core;
+
+namespace SeedUnions.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Unit/MockServer/PostObjectTest.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Unit/MockServer/PostObjectTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedUnknownAsAny;
-using SeedUnknownAsAny.Core;
+using SeedUnknownAsAny.Test.Utils;
 
 namespace SeedUnknownAsAny.Test.Unit.MockServer;
 
@@ -47,9 +47,6 @@ public class PostObjectTest : BaseMockServerTest
         var response = await Client.Unknown.PostObjectAsync(
             new MyObject { Unknown = new Dictionary<object, object?>() { { "key", "value" } } }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<object>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Unit/MockServer/PostTest.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Unit/MockServer/PostTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SeedUnknownAsAny.Core;
+using SeedUnknownAsAny.Test.Utils;
 
 namespace SeedUnknownAsAny.Test.Unit.MockServer;
 
@@ -44,9 +44,6 @@ public class PostTest : BaseMockServerTest
         var response = await Client.Unknown.PostAsync(
             new Dictionary<object, object?>() { { "key", "value" } }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<IEnumerable<object>>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedUnknownAsAny.Core;
+
+namespace SeedUnknownAsAny.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi.Test/Unit/MockServer/SubmitFormDataTest.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi.Test/Unit/MockServer/SubmitFormDataTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedApi;
-using SeedApi.Core;
+using SeedApi.Test.Utils;
 
 namespace SeedApi.Test.Unit.MockServer;
 
@@ -41,10 +41,7 @@ public class SubmitFormDataTest : BaseMockServerTest
         var response = await Client.SubmitFormDataAsync(
             new PostSubmitRequest { Username = "username", Email = "email" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<PostSubmitResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 
     [NUnit.Framework.Test]
@@ -81,9 +78,6 @@ public class SubmitFormDataTest : BaseMockServerTest
         var response = await Client.SubmitFormDataAsync(
             new PostSubmitRequest { Username = "johndoe", Email = "john@example.com" }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<PostSubmitResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/url-form-encoded/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/url-form-encoded/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/validation/src/SeedValidation.Test/Unit/MockServer/CreateTest.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation.Test/Unit/MockServer/CreateTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedValidation;
-using SeedValidation.Core;
+using SeedValidation.Test.Utils;
 
 namespace SeedValidation.Test.Unit.MockServer;
 
@@ -52,9 +52,6 @@ public class CreateTest : BaseMockServerTest
                 Shape = Shape.Square,
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SeedValidation.Type>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/validation/src/SeedValidation.Test/Unit/MockServer/GetTest.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation.Test/Unit/MockServer/GetTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedValidation;
-using SeedValidation.Core;
+using SeedValidation.Test.Utils;
 
 namespace SeedValidation.Test.Unit.MockServer;
 
@@ -44,9 +44,6 @@ public class GetTest : BaseMockServerTest
                 Name = "fern",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<SeedValidation.Type>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/validation/src/SeedValidation.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedValidation.Core;
+
+namespace SeedValidation.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/variables/src/SeedVariables.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedVariables.Core;
+
+namespace SeedVariables.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/Unit/MockServer/GetUserTest.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/Unit/MockServer/GetUserTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedVersion;
-using SeedVersion.Core;
+using SeedVersion.Test.Utils;
 
 namespace SeedVersion.Test.Unit.MockServer;
 
@@ -27,9 +26,6 @@ public class GetUserTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetUserAsync("userId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedVersion.Core;
+
+namespace SeedVersion.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/version/src/SeedVersion.Test/Unit/MockServer/GetUserTest.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion.Test/Unit/MockServer/GetUserTest.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using SeedVersion;
-using SeedVersion.Core;
+using SeedVersion.Test.Utils;
 
 namespace SeedVersion.Test.Unit.MockServer;
 
@@ -27,9 +26,6 @@ public class GetUserTest : BaseMockServerTest
             );
 
         var response = await Client.User.GetUserAsync("userId");
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<User>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/version/src/SeedVersion.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedVersion.Core;
+
+namespace SeedVersion.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedApi.Core;
+
+namespace SeedApi.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedWebsocketBearerAuth.Core;
+
+namespace SeedWebsocketBearerAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Unit/MockServer/GetTokenWithClientCredentialsTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedWebsocketAuth;
-using SeedWebsocketAuth.Core;
+using SeedWebsocketAuth.Test.Utils;
 
 namespace SeedWebsocketAuth.Test.Unit.MockServer;
 
@@ -54,9 +54,6 @@ public class GetTokenWithClientCredentialsTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Unit/MockServer/RefreshTokenTest.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Unit/MockServer/RefreshTokenTest.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 using SeedWebsocketAuth;
-using SeedWebsocketAuth.Core;
+using SeedWebsocketAuth.Test.Utils;
 
 namespace SeedWebsocketAuth.Test.Unit.MockServer;
 
@@ -56,9 +56,6 @@ public class RefreshTokenTest : BaseMockServerTest
                 Scope = "scope",
             }
         );
-        Assert.That(
-            response,
-            Is.EqualTo(JsonUtils.Deserialize<TokenResponse>(mockResponse)).UsingDefaults()
-        );
+        JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedWebsocketAuth.Core;
+
+namespace SeedWebsocketAuth.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedWebsocket.Core;
+
+namespace SeedWebsocket.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/Utils/JsonAssert.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/Utils/JsonAssert.cs
@@ -1,0 +1,19 @@
+using global::System.Text.Json;
+using NUnit.Framework;
+using SeedWebsocket.Core;
+
+namespace SeedWebsocket.Test.Utils;
+
+internal static class JsonAssert
+{
+    /// <summary>
+    /// Asserts that the serialized JSON of an object equals the expected JSON string.
+    /// Uses JsonElement comparison for reliable deep equality of collections and union types.
+    /// </summary>
+    internal static void AreEqual(object actual, string expectedJson)
+    {
+        var actualElement = JsonUtils.SerializeToElement(actual);
+        var expectedElement = JsonUtils.Deserialize<JsonElement>(expectedJson);
+        Assert.That(actualElement, Is.EqualTo(expectedElement).UsingJsonElementComparer());
+    }
+}


### PR DESCRIPTION
## Description
Wire tests are refactored to check equality by JSON:
```
var actualJson = JsonUtils.SerializeToElement(response);
var expectedJson = JsonUtils.Deserialize<JsonElement>(mockResponse);
Assert.That(actualJson, Is.EqualTo(expectedJson).UsingJsonElementComparer());
```
The previous direct use of equality was subject to subtle problems where heavily nested undiscriminated unions' default equality methods would occasionally relegate to reference equality, which would fail unduly.

Also fixes a problem surfaced by the above change where optional but not nullable attributes would be omitted in the wire tests as though they were explicit nulls.

Also fixes a warning where an override in undiscriminated unions would be nullable while its overridee would not. (One-liner.)

## Changes Made
Changes to the wire test generator.

## Testing
Currently includes a relevant seed commit where you can see the changes; regenerating them all now.
- [X] Unit tests added/updated
- [X] Manual testing completed
