### PR TITLE
fix(cli): reduce memory usage for docs generation with many API versions

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.53.2
+  changelogEntry:
+    - summary: |
+        Reduce memory usage when generating docs for customers with many API versions by processing versions in batches of 5 instead of all in parallel.
+      type: fix
+  createdAt: "2026-01-30"
+  irVersion: 63
+
 - version: 3.53.1
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -913,13 +913,23 @@ export class DocsDefinitionResolver {
             );
         }
 
+        // Process versions in batches to reduce memory usage for customers with many API versions.
+        // Each version generates a large IR and API definition, so processing all in parallel
+        // can cause memory issues (e.g., 35 versions * ~100-200MB each = 3.5-7GB).
+        const BATCH_SIZE = 5;
+        const children: FernNavigation.V1.VersionNode[] = [];
+        for (let i = 0; i < versioned.versions.length; i += BATCH_SIZE) {
+            const batch = versioned.versions.slice(i, i + BATCH_SIZE);
+            const batchResults = await Promise.all(
+                batch.map((item, batchIdx) => this.toVersionNode(item, parentSlug, i + batchIdx === 0))
+            );
+            children.push(...batchResults);
+        }
+
         return {
             id,
             type: "versioned",
-            // TODO: should the first version always be default? We should make this configurable.
-            children: await Promise.all(
-                versioned.versions.map((item, idx) => this.toVersionNode(item, parentSlug, idx === 0))
-            )
+            children
         };
     }
 


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-api/square-docs/actions/runs/21499874019/job/61943599251?pr=144#step:4:828

Fixes memory issues when generating docs for customers with many API versions (e.g., 35 versions). The CLI was running out of memory even with 4GB heap size.

**Link to Devin run:** https://app.devin.ai/sessions/d37bd943484245c792621538188840dc
**Requested by:** @thesandlord

## Changes Made

- Modified `toVersionedNode()` in `DocsDefinitionResolver.ts` to process versions in batches of 5 instead of all in parallel
- Each version generates a large IR and API definition (~100-200MB), so processing 35 versions in parallel via `Promise.all()` was causing 3.5-7GB memory usage
- Batched processing reduces peak memory from 35x to 5x the per-version footprint

## Human Review Checklist

- [ ] Verify the `isDefault` logic is correct: `i + batchIdx === 0` should only be true for the very first version
- [ ] Consider if batch size of 5 is appropriate (balances memory vs speed)
- [ ] Note: Other `Promise.all()` usages in navigation methods were not changed - only `toVersionedNode` since versions are the primary memory concern

## Testing

- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing with customer's 35-version docs site recommended