### PR TITLE
fix(csharp): `useDefaultRequestParameterValues` no longer modifies request body properties

### DIFF
--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -8,7 +8,6 @@ import {
     TypeId,
     TypeReference
 } from "@fern-fern/ir-sdk/api";
-import { DefaultValueExtractor, ExtractedDefault } from "../../DefaultValueExtractor";
 import { getContentTypeFromRequestBody } from "../../endpoint/utils/getContentTypeFromRequestBody";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext";
 
@@ -20,11 +19,8 @@ export declare namespace TestClass {
 }
 
 export class MockEndpointGenerator extends WithGeneration {
-    private readonly defaultValueExtractor: DefaultValueExtractor;
-
     constructor(private readonly context: SdkGeneratorContext) {
         super(context.generation);
-        this.defaultValueExtractor = new DefaultValueExtractor(context);
     }
 
     public generateForExample(endpoint: HttpEndpoint, example: ExampleEndpointCall): ast.CodeBlock {
@@ -305,13 +301,8 @@ export class MockEndpointGenerator extends WithGeneration {
      */
     private filterInlinedRequestBody(
         exampleRequest: ExampleRequestBody.InlinedRequestBody,
-        endpoint: HttpEndpoint
+        _endpoint: HttpEndpoint
     ): Record<string, unknown> {
-        const useDefaults = this.generation.settings.useDefaultRequestParameterValues;
-
-        // Get the set of wire values present in the example
-        const exampleWireValues = new Set(exampleRequest.properties.map((prop) => prop.name.wireValue));
-
         // Build the result with filtering and datetime normalization
         const result: Record<string, unknown> = {};
 
@@ -331,61 +322,7 @@ export class MockEndpointGenerator extends WithGeneration {
             }
         }
 
-        // Add default values for properties not present in the example when useDefaults is enabled
-        if (useDefaults && endpoint.requestBody?.type === "inlinedRequestBody") {
-            const allProperties = [
-                ...endpoint.requestBody.properties,
-                ...(endpoint.requestBody.extendedProperties ?? [])
-            ];
-            for (const prop of allProperties) {
-                // Skip if already in the example
-                if (exampleWireValues.has(prop.name.wireValue)) {
-                    continue;
-                }
-                // Skip read-only properties
-                if (prop.propertyAccess === "READ_ONLY") {
-                    continue;
-                }
-                // Get the default value for this property
-                const defaultValue = this.defaultValueExtractor.extractDefault(prop.valueType);
-                if (defaultValue != null) {
-                    result[prop.name.wireValue] = this.parseDefaultValue(defaultValue);
-                }
-            }
-        }
-
         return result;
-    }
-
-    /**
-     * Parses a default value string into its JSON representation.
-     */
-    private parseDefaultValue(defaultValue: ExtractedDefault): unknown {
-        switch (defaultValue.csharpType) {
-            case "string":
-                return defaultValue.value
-                    .slice(1, -1)
-                    .replace(/\\"/g, '"')
-                    .replace(/\\r/g, "\r")
-                    .replace(/\\n/g, "\n")
-                    .replace(/\\t/g, "\t")
-                    .replace(/\\\\/g, "\\"); // Must be last to avoid double-unescaping
-            case "int":
-            case "long":
-            case "uint":
-            case "ulong":
-            case "float":
-            case "double":
-                return parseFloat(defaultValue.value.replace(/[LlFfDd]$/, ""));
-            case "bool":
-                return defaultValue.value === "true";
-            case "BigInteger": {
-                const match = defaultValue.value.match(/BigInteger\.Parse\("(.+)"\)/);
-                return match ? match[1] : defaultValue.value;
-            }
-            default:
-                return defaultValue.value;
-        }
     }
 
     /**

--- a/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -183,15 +183,10 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
             },
             inlinedRequestBody: (request) => {
                 for (const property of [...request.properties, ...(request.extendedProperties ?? [])]) {
-                    const defaultValue = this.getDefaultIfEnabled(property.valueType, useDefaults);
-
                     const field = generateField(class_, {
                         property,
                         className: this.classReference.name,
-                        context: this.context,
-                        initializerOverride:
-                            defaultValue != null ? this.csharp.codeblock(defaultValue.value) : undefined,
-                        useRequiredOverride: defaultValue != null ? false : undefined
+                        context: this.context
                     });
 
                     if (isProtoRequest) {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.20.3
+  changelogEntry:
+    - summary: |
+        Fix `useDefaultRequestParameterValues` to only apply defaults to query parameters and headers, not to inlined request body properties.
+      type: fix
+  createdAt: "2026-01-30"
+  irVersion: 62
+
 - version: 2.20.2
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/User/Requests/CreateUsernameRequest.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/User/Requests/CreateUsernameRequest.cs
@@ -16,7 +16,7 @@ public record CreateUsernameRequest
     public required string Password { get; set; }
 
     [JsonPropertyName("name")]
-    public string Name { get; set; } = "test";
+    public required string Name { get; set; }
 
     /// <inheritdoc />
     public override string ToString()


### PR DESCRIPTION
## Description
To be consistent with the Go and Java implementations, `useDefaultRequestParameterValues` now only applies defaults to query parameters and headers, not to request body properties.

## Changes Made
Removed some code related to `useDefaultRequestParameterValues`.

## Testing
See the `request-parameters` fixture which was regenerated; removes a single default. Confirmed this works with Auth0.
- [X] Unit tests added/updated
- [X] Manual testing completed
