### PR TITLE
fix(cli): handle markdown snippets inside link syntax in broken link checker

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.55.1
+  changelogEntry:
+    - summary: |
+        Fix false positive in `fern check --strict-broken-links` when markdown snippets are used inside link syntax (e.g., `[text](<Markdown src="..." />)`). The broken link checker now properly decodes URL-encoded hrefs before detecting Markdown components.
+      type: fix
+  createdAt: "2026-01-30"
+  irVersion: 63
+
 - version: 3.55.0
   changelogEntry:
     - summary: |

--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -40,4 +40,14 @@ describe("fern docs broken-links", () => {
         // should NOT be flagged as broken links
         expect(stripAnsi(stdout)).toContain("All checks passed");
     }, 20_000);
+
+    it("markdown snippets inside link syntax should not be flagged as broken links", async () => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("markdown-snippet-in-link")),
+            reject: false
+        });
+        // This fixture tests that Markdown components used inside link syntax
+        // (e.g., [text](<Markdown src="..." />)) should NOT be flagged as broken links
+        expect(stripAnsi(stdout)).toContain("All checks passed");
+    }, 20_000);
 });

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/markdown-snippet-in-link/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/markdown-snippet-in-link/fern/docs.yml
@@ -1,0 +1,6 @@
+instances:
+  - url: ferndevtest.docs.dev.buildwithfern.com
+
+navigation:
+  - page: Test Page
+    path: test.mdx

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/markdown-snippet-in-link/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/markdown-snippet-in-link/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "0.53.0"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/markdown-snippet-in-link/fern/snippets/link-target.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/markdown-snippet-in-link/fern/snippets/link-target.mdx
@@ -1,0 +1,1 @@
+https://example.com/android

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/markdown-snippet-in-link/fern/test.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/markdown-snippet-in-link/fern/test.mdx
@@ -1,0 +1,8 @@
+# Test Page
+
+This page tests that Markdown snippets used inside link syntax are not flagged as broken links.
+
+**Applies to:** [Android](<Markdown src="./snippets/link-target.mdx" />) | [iOS](<Markdown src="./snippets/link-target.mdx" />)
+
+The above syntax uses `<Markdown src="..." />` inside a markdown link `[text](url)`.
+This should NOT be flagged as a broken link.

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/collect-links.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/collect-links.ts
@@ -118,7 +118,34 @@ export function collectLinksAndSources({
             if (node.type === "element") {
                 const href = node.properties.href;
                 if (typeof href === "string") {
-                    links.push({ href, sourceFilepath: absoluteFilepath, position: node.position });
+                    // Check if the href looks like a Markdown component that was parsed as a link
+                    // This happens when using syntax like [text](<Markdown src="..." />)
+                    // The angle brackets are stripped, leaving "Markdown src=..." as the href
+                    // The href may be URL-encoded (e.g., %20 for space, %22 for quote), so we decode it first
+                    let decodedHref: string;
+                    try {
+                        decodedHref = decodeURIComponent(href);
+                    } catch {
+                        // If decoding fails, use the original href
+                        decodedHref = href;
+                    }
+                    const markdownComponentMatch = decodedHref.match(/^Markdown\s+src=["']([^"']+)["']\s*\/$/);
+                    if (markdownComponentMatch != null) {
+                        // Extract the src and add it to the content queue as a markdown file
+                        if (absoluteFilepath != null) {
+                            const src = markdownComponentMatch[1];
+                            if (src != null) {
+                                const resolvedImportPath = resolve(dirname(absoluteFilepath), src);
+                                contentQueue.push({
+                                    content: readFile(resolvedImportPath),
+                                    absoluteFilepath: resolvedImportPath
+                                });
+                            }
+                        }
+                        // Don't add this as a link since it's not a real URL
+                    } else {
+                        links.push({ href, sourceFilepath: absoluteFilepath, position: node.position });
+                    }
                 }
 
                 const src = node.properties.src;


### PR DESCRIPTION
## Description

Refs: Reported in Slack by @Ryan-Amirthan

Fixes a false positive in `fern check --strict-broken-links` when markdown snippets are used inside link syntax (e.g., `[text](<Markdown src="..." />)`). The broken link checker was incorrectly flagging these as broken links even though they render correctly on the live site.

**Link to Devin run:** https://app.devin.ai/sessions/5b5392e30c6e462bae15e48731b5f460

## Changes Made

- Updated `collect-links.ts` to detect and properly handle Markdown components that appear as link hrefs
- When the markdown parser encounters `[text](<Markdown src="..." />)`, it URL-encodes the href. The fix decodes the href before matching against the Markdown component pattern
- When a Markdown component is detected, the referenced file is added to the content queue for processing (consistent with standalone `<Markdown>` components) instead of being flagged as a broken link
- Added test fixture and test case to verify the fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify the regex pattern `/^Markdown\s+src=["']([^"']+)["']\s*\/$/` handles expected variations of the Markdown component syntax
- [ ] Confirm the test fixture accurately reproduces the reported issue from square-docs