### PR TITLE
fix(cli): add API load endpoint for EndpointRequestSnippet in fern docs dev

### DIFF
--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1,5 +1,5 @@
 import { wrapWithHttps } from "@fern-api/docs-resolver";
-import { DocsV1Read, DocsV2Read, FernNavigation } from "@fern-api/fdr-sdk";
+import { DocsV1Read, DocsV2Read, FdrAPI, FernNavigation } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, dirname, doesPathExist, listFiles, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { runExeca } from "@fern-api/logging-execa";
 import { Project } from "@fern-api/project-loader";
@@ -703,6 +703,19 @@ export async function runAppPreviewServer({
 
     app.get(/^\/_local\/(.*)/, (req, res) => {
         return res.sendFile(`/${req.params[0]}`);
+    });
+
+    // Endpoint to load API definition by ID (used by getEndpointByLocator in the docs bundle)
+    // This enables EndpointRequestSnippet and other components that need to look up API definitions
+    app.get("/registry/api/load/:apiDefinitionId", (req, res) => {
+        const { apiDefinitionId } = req.params;
+        const definition = docsDefinition ?? EMPTY_DOCS_DEFINITION;
+        const api = definition.apis[FdrAPI.ApiDefinitionId(apiDefinitionId)];
+        if (api != null) {
+            res.json(api);
+        } else {
+            res.status(404).json({ error: "ApiDoesNotExistError" });
+        }
     });
 
     // Start backend server first and wait for it to be ready


### PR DESCRIPTION
## Description

Refs: Slack thread from @Ryan-Amirthan

Fixes `<EndpointRequestSnippet>` component not rendering in `fern docs dev` while working correctly in production preview docs.

**Link to Devin run:** https://app.devin.ai/sessions/14a16999e1804d4a8ce81b56914a8719
**Requested by:** @Ryan-Amirthan, Sandeep Dinesh

## Changes Made

- Added `/registry/api/load/:apiDefinitionId` endpoint to the local docs preview backend server
- This endpoint is called by `getEndpointByLocator()` in the docs bundle when looking up API definitions for components like `EndpointRequestSnippet`

### Root Cause

The `EndpointRequestSnippet` component requires an `endpointDefinition` prop injected by the `rehype-endpoint-example-snippets` MDX plugin. This plugin calls `loader.getEndpointByLocator()` which:
1. First tries to find the API in the cached docs definition
2. Falls back to calling the FDR API at `/registry/api/load/{apiDefinitionId}`

In local dev, the fallback FDR endpoint wasn't implemented, causing the lookup to fail silently and the component to not render.

## Testing

- [ ] Manual testing with `fern docs dev` on a repo using `EndpointRequestSnippet` (not completed - needs verification)
- [x] Lint passes
- [x] Type check passes for the modified file

## Human Review Checklist

- [ ] Verify the response format (`definition.apis[...]`) matches what the FDR SDK client expects
- [ ] Verify the error response `{ error: "ApiDoesNotExistError" }` matches the FDR SDK's expected format
- [ ] Test with `fern docs dev` on square-docs repo, navigating to `docs/merchant-custom-attributes-api/custom-attribute-definitions#create-a-merchant-custom-attribute-definition`