### PR TITLE
feat(openapi): add enable-numeric-enums setting for OpenAPI specs

### DIFF
--- a/fern/apis/generators-yml/definition/generators.yml
+++ b/fern/apis/generators-yml/definition/generators.yml
@@ -464,6 +464,14 @@ types:
           The default format to use for integer types when no format is specified in the OpenAPI schema.
           Defaults to int32.
         default: int32
+      enable-numeric-enums:
+        type: optional<boolean>
+        docs: |
+          If true, integer and number enums in OpenAPI specs will be converted to enum types
+          with string representations of the numeric values (e.g., enum: [8000, 16000] becomes
+          an enum with values "8000" and "16000"). If false, numeric enums are treated as
+          plain integer/number types. Defaults to false.
+        default: false
 
   ResolveAliases:
     discriminated: false

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -2006,6 +2006,16 @@
               "type": "null"
             }
           ]
+        },
+        "enable-numeric-enums": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -2492,6 +2502,16 @@
           "oneOf": [
             {
               "$ref": "#/definitions/generators.DefaultIntegerFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enable-numeric-enums": {
+          "oneOf": [
+            {
+              "type": "boolean"
             },
             {
               "type": "null"

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/options.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/options.ts
@@ -102,6 +102,12 @@ export interface ParseOpenAPIOptions {
      * The order to use for path parameters in generated code.
      */
     pathParameterOrder: generatorsYml.PathParameterOrder;
+
+    /**
+     * If true, integer and number enums in OpenAPI specs will be converted to enum types
+     * with string representations of the numeric values. Defaults to false.
+     */
+    enableNumericEnums: boolean;
 }
 
 export const DEFAULT_PARSE_OPENAPI_SETTINGS: ParseOpenAPIOptions = {
@@ -136,7 +142,8 @@ export const DEFAULT_PARSE_OPENAPI_SETTINGS: ParseOpenAPIOptions = {
     coerceOptionalSchemasToNullable: false,
     removeDiscriminantsFromSchemas: generatorsYml.RemoveDiscriminantsFromSchemas.Always,
     defaultIntegerFormat: generatorsYml.DefaultIntegerFormat.Int32,
-    pathParameterOrder: generatorsYml.PathParameterOrder.UrlOrder
+    pathParameterOrder: generatorsYml.PathParameterOrder.UrlOrder,
+    enableNumericEnums: false
 };
 
 function mergeOptions<T extends object>(params: {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -428,6 +428,60 @@ export function convertSchemaObject(
             schema.enum = [schema.const];
         }
 
+        // numeric enums (integer or number type with enum values)
+        if (
+            schema.enum != null &&
+            (schema.type === "integer" || schema.type === "number") &&
+            context.options.enableNumericEnums
+        ) {
+            // Cut 'null' from enum since functionality is achieved by 'nullable'
+            schema.enum = schema.enum.filter((value) => value !== null);
+
+            // Convert numeric values to strings for enum representation
+            const stringEnumValues = schema.enum.map((value) => String(value));
+
+            const fernEnum = getFernEnum(schema);
+
+            if (
+                context.options.coerceEnumsToLiterals &&
+                stringEnumValues.length === 1 &&
+                stringEnumValues[0] != null &&
+                fernEnum == null
+            ) {
+                return convertLiteral({
+                    nameOverride,
+                    generatedName,
+                    title,
+                    wrapAsOptional,
+                    wrapAsNullable,
+                    value: stringEnumValues[0],
+                    description,
+                    availability,
+                    namespace,
+                    groupName
+                });
+            }
+
+            return convertEnum({
+                nameOverride,
+                generatedName,
+                title,
+                fernEnum,
+                enumVarNames: getExtension<string[]>(schema, [OpenAPIExtension.ENUM_VAR_NAMES]),
+                enumValues: stringEnumValues,
+                _default: schema.default != null ? String(schema.default) : undefined,
+                description,
+                availability,
+                wrapAsOptional,
+                wrapAsNullable,
+                namespace,
+                groupName,
+                context,
+                source,
+                inline: undefined
+            });
+        }
+
         // enums
         if (
             schema.enum != null &&

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/anyOf.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/anyOf.json
@@ -103,6 +103,7 @@
     "coerceOptionalSchemasToNullable": false,
     "removeDiscriminantsFromSchemas": "always",
     "defaultIntegerFormat": "int32",
-    "pathParameterOrder": "url-order"
+    "pathParameterOrder": "url-order",
+    "enableNumericEnums": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/application-json.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/application-json.json
@@ -83,6 +83,7 @@
     "coerceOptionalSchemasToNullable": false,
     "removeDiscriminantsFromSchemas": "always",
     "defaultIntegerFormat": "int32",
-    "pathParameterOrder": "url-order"
+    "pathParameterOrder": "url-order",
+    "enableNumericEnums": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/availability.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/availability.json
@@ -318,6 +318,7 @@
     "coerceOptionalSchemasToNullable": false,
     "removeDiscriminantsFromSchemas": "always",
     "defaultIntegerFormat": "int32",
-    "pathParameterOrder": "url-order"
+    "pathParameterOrder": "url-order",
+    "enableNumericEnums": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/const.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/const.json
@@ -117,6 +117,7 @@
     "coerceOptionalSchemasToNullable": false,
     "removeDiscriminantsFromSchemas": "always",
     "defaultIntegerFormat": "int32",
-    "pathParameterOrder": "url-order"
+    "pathParameterOrder": "url-order",
+    "enableNumericEnums": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/dates.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/dates.json
@@ -127,6 +127,7 @@
     "coerceOptionalSchemasToNullable": false,
     "removeDiscriminantsFromSchemas": "always",
     "defaultIntegerFormat": "int32",
-    "pathParameterOrder": "url-order"
+    "pathParameterOrder": "url-order",
+    "enableNumericEnums": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-schema-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-schema-reference.json
@@ -115,6 +115,7 @@
     "coerceOptionalSchemasToNullable": false,
     "removeDiscriminantsFromSchemas": "always",
     "defaultIntegerFormat": "int32",
-    "pathParameterOrder": "url-order"
+    "pathParameterOrder": "url-order",
+    "enableNumericEnums": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/preserve-single-schema-oneof.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/preserve-single-schema-oneof.json
@@ -82,6 +82,7 @@
     "coerceOptionalSchemasToNullable": false,
     "removeDiscriminantsFromSchemas": "always",
     "defaultIntegerFormat": "int32",
-    "pathParameterOrder": "url-order"
+    "pathParameterOrder": "url-order",
+    "enableNumericEnums": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-reference.json
@@ -70,6 +70,7 @@
     "coerceOptionalSchemasToNullable": false,
     "removeDiscriminantsFromSchemas": "always",
     "defaultIntegerFormat": "int32",
-    "pathParameterOrder": "url-order"
+    "pathParameterOrder": "url-order",
+    "enableNumericEnums": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/numeric-enums-disabled.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/numeric-enums-disabled.json
@@ -1,0 +1,245 @@
+{
+  "title": "Numeric Enums Test API",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "Configure audio settings",
+      "audiences": [],
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "PostAudioSettingsRequest",
+      "request": {
+        "schema": {
+          "generatedName": "PostAudioSettingsRequest",
+          "schema": "AudioSettings",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Successful response",
+        "schema": {
+          "generatedName": "PostAudioSettingsResponse",
+          "schema": "AudioSettings",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/audio/settings",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "sample_rate": {
+                "value": {
+                  "value": 1,
+                  "type": "int"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "sample_rate": {
+                  "value": {
+                    "value": 1,
+                    "type": "int"
+                  },
+                  "type": "primitive"
+                },
+                "priority": {
+                  "value": {
+                    "value": 1,
+                    "type": "int"
+                  },
+                  "type": "primitive"
+                },
+                "format": {
+                  "value": "wav",
+                  "type": "enum"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "AudioSettings": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "audioSettingsSampleRate",
+            "key": "sample_rate",
+            "schema": {
+              "generatedName": "AudioSettingsSampleRate",
+              "schema": "SampleRate",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          },
+          {
+            "conflict": {},
+            "generatedName": "audioSettingsPriority",
+            "key": "priority",
+            "schema": {
+              "generatedName": "AudioSettingsPriority",
+              "value": {
+                "generatedName": "AudioSettingsPriority",
+                "schema": "Priority",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          },
+          {
+            "conflict": {},
+            "generatedName": "audioSettingsFormat",
+            "key": "format",
+            "schema": {
+              "generatedName": "AudioSettingsFormat",
+              "value": {
+                "generatedName": "AudioSettingsFormat",
+                "schema": "AudioFormat",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "AudioSettings",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "SampleRate": {
+        "description": "Audio sample rate in Hz",
+        "schema": {
+          "type": "int"
+        },
+        "generatedName": "SampleRate",
+        "groupName": [],
+        "type": "primitive"
+      },
+      "Priority": {
+        "description": "Priority level (1=Low, 2=Medium, 3=High)",
+        "schema": {
+          "type": "int"
+        },
+        "generatedName": "Priority",
+        "groupName": [],
+        "type": "primitive"
+      },
+      "AudioFormat": {
+        "description": "Audio output format",
+        "generatedName": "AudioFormat",
+        "values": [
+          {
+            "generatedName": "wav",
+            "value": "wav",
+            "casing": {}
+          },
+          {
+            "generatedName": "mp3",
+            "value": "mp3",
+            "casing": {}
+          },
+          {
+            "generatedName": "aac",
+            "value": "aac",
+            "casing": {}
+          }
+        ],
+        "groupName": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/numeric-enums-enabled.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/numeric-enums-enabled.json
@@ -1,0 +1,272 @@
+{
+  "title": "Numeric Enums Test API",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "Configure audio settings",
+      "audiences": [],
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "PostAudioSettingsRequest",
+      "request": {
+        "schema": {
+          "generatedName": "PostAudioSettingsRequest",
+          "schema": "AudioSettings",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Successful response",
+        "schema": {
+          "generatedName": "PostAudioSettingsResponse",
+          "schema": "AudioSettings",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/audio/settings",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "sample_rate": {
+                "value": "8000",
+                "type": "enum"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "sample_rate": {
+                  "value": "8000",
+                  "type": "enum"
+                },
+                "priority": {
+                  "value": "1",
+                  "type": "enum"
+                },
+                "format": {
+                  "value": "wav",
+                  "type": "enum"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "AudioSettings": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "audioSettingsSampleRate",
+            "key": "sample_rate",
+            "schema": {
+              "generatedName": "AudioSettingsSampleRate",
+              "schema": "SampleRate",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          },
+          {
+            "conflict": {},
+            "generatedName": "audioSettingsPriority",
+            "key": "priority",
+            "schema": {
+              "generatedName": "AudioSettingsPriority",
+              "value": {
+                "generatedName": "AudioSettingsPriority",
+                "schema": "Priority",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          },
+          {
+            "conflict": {},
+            "generatedName": "audioSettingsFormat",
+            "key": "format",
+            "schema": {
+              "generatedName": "AudioSettingsFormat",
+              "value": {
+                "generatedName": "AudioSettingsFormat",
+                "schema": "AudioFormat",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "AudioSettings",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "SampleRate": {
+        "description": "Audio sample rate in Hz",
+        "generatedName": "SampleRate",
+        "values": [
+          {
+            "generatedName": "EightThousand",
+            "value": "8000",
+            "casing": {}
+          },
+          {
+            "generatedName": "16000",
+            "value": "16000",
+            "casing": {}
+          },
+          {
+            "generatedName": "24000",
+            "value": "24000",
+            "casing": {}
+          }
+        ],
+        "groupName": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "Priority": {
+        "description": "Priority level (1=Low, 2=Medium, 3=High)",
+        "generatedName": "Priority",
+        "values": [
+          {
+            "generatedName": "One",
+            "value": "1",
+            "casing": {}
+          },
+          {
+            "generatedName": "Two",
+            "value": "2",
+            "casing": {}
+          },
+          {
+            "generatedName": "Three",
+            "value": "3",
+            "casing": {}
+          }
+        ],
+        "groupName": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "AudioFormat": {
+        "description": "Audio output format",
+        "generatedName": "AudioFormat",
+        "values": [
+          {
+            "generatedName": "wav",
+            "value": "wav",
+            "casing": {}
+          },
+          {
+            "generatedName": "mp3",
+            "value": "mp3",
+            "casing": {}
+          },
+          {
+            "generatedName": "aac",
+            "value": "aac",
+            "casing": {}
+          }
+        ],
+        "groupName": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/numeric-enums-disabled.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/numeric-enums-disabled.json
@@ -1,0 +1,154 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "configureAudioSettings": {
+              "auth": undefined,
+              "display-name": "Configure audio settings",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "sample_rate": 1,
+                  },
+                  "response": {
+                    "body": {
+                      "format": "wav",
+                      "priority": 1,
+                      "sample_rate": 1,
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/audio/settings",
+              "request": {
+                "body": "AudioSettings",
+                "content-type": "application/json",
+              },
+              "response": {
+                "docs": "Successful response",
+                "status-code": 200,
+                "type": "AudioSettings",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "AudioFormat": {
+            "docs": "Audio output format",
+            "enum": [
+              "wav",
+              "mp3",
+              "aac",
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "AudioSettings": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "format": "optional<AudioFormat>",
+              "priority": "optional<Priority>",
+              "sample_rate": "SampleRate",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "Priority": {
+            "docs": "Priority level (1=Low, 2=Medium, 3=High)",
+            "type": "integer",
+          },
+          "SampleRate": {
+            "docs": "Audio sample rate in Hz",
+            "type": "integer",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    configureAudioSettings:
+      path: /audio/settings
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      display-name: Configure audio settings
+      request:
+        body: AudioSettings
+        content-type: application/json
+      response:
+        docs: Successful response
+        type: AudioSettings
+        status-code: 200
+      examples:
+        - request:
+            sample_rate: 1
+          response:
+            body:
+              sample_rate: 1
+              priority: 1
+              format: wav
+  source:
+    openapi: ../openapi.yml
+types:
+  AudioSettings:
+    properties:
+      sample_rate: SampleRate
+      priority: optional<Priority>
+      format: optional<AudioFormat>
+    source:
+      openapi: ../openapi.yml
+  SampleRate:
+    type: integer
+    docs: Audio sample rate in Hz
+  Priority:
+    type: integer
+    docs: Priority level (1=Low, 2=Medium, 3=High)
+  AudioFormat:
+    enum:
+      - wav
+      - mp3
+      - aac
+    docs: Audio output format
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Numeric Enums Test API",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Numeric Enums Test API
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/numeric-enums-enabled.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/numeric-enums-enabled.json
@@ -1,0 +1,196 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "configureAudioSettings": {
+              "auth": undefined,
+              "display-name": "Configure audio settings",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "sample_rate": "8000",
+                  },
+                  "response": {
+                    "body": {
+                      "format": "wav",
+                      "priority": "1",
+                      "sample_rate": "8000",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/audio/settings",
+              "request": {
+                "body": "AudioSettings",
+                "content-type": "application/json",
+              },
+              "response": {
+                "docs": "Successful response",
+                "status-code": 200,
+                "type": "AudioSettings",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "AudioFormat": {
+            "docs": "Audio output format",
+            "enum": [
+              "wav",
+              "mp3",
+              "aac",
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "AudioSettings": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "format": "optional<AudioFormat>",
+              "priority": "optional<Priority>",
+              "sample_rate": "SampleRate",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "Priority": {
+            "docs": "Priority level (1=Low, 2=Medium, 3=High)",
+            "enum": [
+              {
+                "name": "One",
+                "value": "1",
+              },
+              {
+                "name": "Two",
+                "value": "2",
+              },
+              {
+                "name": "Three",
+                "value": "3",
+              },
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "SampleRate": {
+            "docs": "Audio sample rate in Hz",
+            "enum": [
+              {
+                "name": "EightThousand",
+                "value": "8000",
+              },
+              "16000",
+              "24000",
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    configureAudioSettings:
+      path: /audio/settings
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      display-name: Configure audio settings
+      request:
+        body: AudioSettings
+        content-type: application/json
+      response:
+        docs: Successful response
+        type: AudioSettings
+        status-code: 200
+      examples:
+        - request:
+            sample_rate: '8000'
+          response:
+            body:
+              sample_rate: '8000'
+              priority: '1'
+              format: wav
+  source:
+    openapi: ../openapi.yml
+types:
+  AudioSettings:
+    properties:
+      sample_rate: SampleRate
+      priority: optional<Priority>
+      format: optional<AudioFormat>
+    source:
+      openapi: ../openapi.yml
+  SampleRate:
+    enum:
+      - value: '8000'
+        name: EightThousand
+      - '16000'
+      - '24000'
+    docs: Audio sample rate in Hz
+    source:
+      openapi: ../openapi.yml
+  Priority:
+    enum:
+      - value: '1'
+        name: One
+      - value: '2'
+        name: Two
+      - value: '3'
+        name: Three
+    docs: Priority level (1=Low, 2=Medium, 3=High)
+    source:
+      openapi: ../openapi.yml
+  AudioFormat:
+    enum:
+      - wav
+      - mp3
+      - aac
+    docs: Audio output format
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Numeric Enums Test API",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Numeric Enums Test API
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-disabled/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-disabled/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-disabled/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-disabled/fern/generators.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings:
+        enable-numeric-enums: false

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-disabled/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-disabled/openapi.yml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: Numeric Enums Test API
+  version: 1.0.0
+paths:
+  /audio/settings:
+    post:
+      summary: Configure audio settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AudioSettings"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AudioSettings"
+components:
+  schemas:
+    AudioSettings:
+      type: object
+      properties:
+        sample_rate:
+          $ref: "#/components/schemas/SampleRate"
+        priority:
+          $ref: "#/components/schemas/Priority"
+        format:
+          $ref: "#/components/schemas/AudioFormat"
+      required:
+        - sample_rate
+    SampleRate:
+      type: integer
+      enum:
+        - 8000
+        - 16000
+        - 24000
+      description: Audio sample rate in Hz
+    Priority:
+      type: integer
+      enum:
+        - 1
+        - 2
+        - 3
+      description: Priority level (1=Low, 2=Medium, 3=High)
+    AudioFormat:
+      type: string
+      enum:
+        - wav
+        - mp3
+        - aac
+      description: Audio output format

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-enabled/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-enabled/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-enabled/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-enabled/fern/generators.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings:
+        enable-numeric-enums: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-enabled/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/numeric-enums-enabled/openapi.yml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: Numeric Enums Test API
+  version: 1.0.0
+paths:
+  /audio/settings:
+    post:
+      summary: Configure audio settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AudioSettings"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AudioSettings"
+components:
+  schemas:
+    AudioSettings:
+      type: object
+      properties:
+        sample_rate:
+          $ref: "#/components/schemas/SampleRate"
+        priority:
+          $ref: "#/components/schemas/Priority"
+        format:
+          $ref: "#/components/schemas/AudioFormat"
+      required:
+        - sample_rate
+    SampleRate:
+      type: integer
+      enum:
+        - 8000
+        - 16000
+        - 24000
+      description: Audio sample rate in Hz
+    Priority:
+      type: integer
+      enum:
+        - 1
+        - 2
+        - 3
+      description: Priority level (1=Low, 2=Medium, 3=High)
+    AudioFormat:
+      type: string
+      enum:
+        - wav
+        - mp3
+        - aac
+      description: Audio output format

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.56.0
+  changelogEntry:
+    - summary: |
+        Add `enable-numeric-enums` setting for OpenAPI specs. When enabled, integer and number enums in OpenAPI specs are converted to enum types with string representations of the numeric values (e.g., `enum: [8000, 16000]` becomes an enum with values "8000" and "16000"). This is useful for APIs that use numeric enums for values like sample rates or port numbers. Defaults to false.
+      type: feat
+  createdAt: "2026-01-30"
+  irVersion: 63
+
 - version: 3.55.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -47,7 +47,8 @@ const UNDEFINED_API_DEFINITION_SETTINGS: generatorsYml.APIDefinitionSettings = {
     coerceOptionalSchemasToNullable: undefined,
     removeDiscriminantsFromSchemas: undefined,
     pathParameterOrder: undefined,
-    defaultIntegerFormat: undefined
+    defaultIntegerFormat: undefined,
+    enableNumericEnums: undefined
 };
 
 export async function convertGeneratorsConfiguration({
@@ -140,7 +141,8 @@ function parseOpenApiDefinitionSettingsSchema(
         groupMultiApiEnvironments: settings?.["group-multi-api-environments"],
         groupEnvironmentsByHost: settings?.["group-environments-by-host"],
         defaultIntegerFormat: settings?.["default-integer-format"],
-        pathParameterOrder: settings?.["path-parameter-order"]
+        pathParameterOrder: settings?.["path-parameter-order"],
+        enableNumericEnums: settings?.["enable-numeric-enums"]
     };
 }
 

--- a/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
@@ -92,6 +92,7 @@ export interface APIDefinitionSettings {
     removeDiscriminantsFromSchemas: RemoveDiscriminantsFromSchemas | undefined;
     pathParameterOrder: generatorsYml.PathParameterOrder | undefined;
     defaultIntegerFormat: generatorsYml.DefaultIntegerFormat | undefined;
+    enableNumericEnums: boolean | undefined;
 }
 
 export interface APIDefinitionLocation {

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/OpenApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/OpenApiSettingsSchema.ts
@@ -60,4 +60,11 @@ export interface OpenApiSettingsSchema extends GeneratorsYml.BaseApiSettingsSche
      * Defaults to int32.
      */
     "default-integer-format"?: GeneratorsYml.DefaultIntegerFormat;
+    /**
+     * If true, integer and number enums in OpenAPI specs will be converted to enum types
+     * with string representations of the numeric values (e.g., enum: [8000, 16000] becomes
+     * an enum with values "8000" and "16000"). If false, numeric enums are treated as
+     * plain integer/number types. Defaults to false.
+     */
+    "enable-numeric-enums"?: boolean;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/OpenApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/OpenApiSettingsSchema.ts
@@ -34,6 +34,7 @@ export const OpenApiSettingsSchema: core.serialization.ObjectSchema<
         "resolve-aliases": ResolveAliases.optional(),
         "group-multi-api-environments": core.serialization.boolean().optional(),
         "default-integer-format": DefaultIntegerFormat.optional(),
+        "enable-numeric-enums": core.serialization.boolean().optional(),
     })
     .extend(BaseApiSettingsSchema);
 
@@ -56,5 +57,6 @@ export declare namespace OpenApiSettingsSchema {
         "resolve-aliases"?: ResolveAliases.Raw | null;
         "group-multi-api-environments"?: boolean | null;
         "default-integer-format"?: DefaultIntegerFormat.Raw | null;
+        "enable-numeric-enums"?: boolean | null;
     }
 }

--- a/packages/cli/workspace/browser-compatible-fern-workspace/src/OpenAPIWorkspace.ts
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/src/OpenAPIWorkspace.ts
@@ -60,7 +60,8 @@ export class OpenAPIWorkspace extends BaseOpenAPIWorkspaceSync {
             groupEnvironmentsByHost: spec.settings?.groupEnvironmentsByHost,
             removeDiscriminantsFromSchemas: spec.settings?.removeDiscriminantsFromSchemas,
             defaultIntegerFormat: spec.settings?.defaultIntegerFormat,
-            pathParameterOrder: spec.settings?.pathParameterOrder
+            pathParameterOrder: spec.settings?.pathParameterOrder,
+            enableNumericEnums: spec.settings?.enableNumericEnums
         });
         this.spec = spec;
         this.loader = new InMemoryOpenAPILoader();

--- a/packages/cli/workspace/commons/src/openapi/BaseOpenAPIWorkspace.ts
+++ b/packages/cli/workspace/commons/src/openapi/BaseOpenAPIWorkspace.ts
@@ -25,6 +25,7 @@ export declare namespace BaseOpenAPIWorkspace {
         removeDiscriminantsFromSchemas: generatorsYml.RemoveDiscriminantsFromSchemas | undefined;
         defaultIntegerFormat: generatorsYml.DefaultIntegerFormat | undefined;
         pathParameterOrder: generatorsYml.PathParameterOrder | undefined;
+        enableNumericEnums: boolean | undefined;
     }
 
     export type Settings = Partial<OpenAPISettings>;
@@ -48,6 +49,7 @@ export abstract class BaseOpenAPIWorkspace extends AbstractAPIWorkspace<BaseOpen
     public readonly removeDiscriminantsFromSchemas: generatorsYml.RemoveDiscriminantsFromSchemas | undefined;
     public readonly defaultIntegerFormat: generatorsYml.DefaultIntegerFormat | undefined;
     public readonly pathParameterOrder: generatorsYml.PathParameterOrder | undefined;
+    public readonly enableNumericEnums: boolean | undefined;
     private readonly converter: FernDefinitionConverter;
 
     constructor(args: BaseOpenAPIWorkspace.Args) {
@@ -69,6 +71,7 @@ export abstract class BaseOpenAPIWorkspace extends AbstractAPIWorkspace<BaseOpen
         this.removeDiscriminantsFromSchemas = args.removeDiscriminantsFromSchemas;
         this.defaultIntegerFormat = args.defaultIntegerFormat;
         this.pathParameterOrder = args.pathParameterOrder;
+        this.enableNumericEnums = args.enableNumericEnums;
         this.converter = new FernDefinitionConverter(args);
     }
 

--- a/packages/cli/workspace/commons/src/openapi/getAPIDefinitionSettings.ts
+++ b/packages/cli/workspace/commons/src/openapi/getAPIDefinitionSettings.ts
@@ -59,7 +59,8 @@ const FIELD_MAPPINGS: Partial<MappableFields> = {
     coerceOptionalSchemasToNullable: "coerceOptionalSchemasToNullable",
     removeDiscriminantsFromSchemas: "removeDiscriminantsFromSchemas",
     defaultIntegerFormat: "defaultIntegerFormat",
-    pathParameterOrder: "pathParameterOrder"
+    pathParameterOrder: "pathParameterOrder",
+    enableNumericEnums: "enableNumericEnums"
 };
 
 function setIfDefined<K extends keyof OpenAPISettings>(

--- a/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
@@ -106,7 +106,8 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
             exampleGeneration: specs[0]?.settings?.exampleGeneration,
             groupEnvironmentsByHost: specs.some((spec) => spec.settings?.groupEnvironmentsByHost),
             defaultIntegerFormat: specs[0]?.settings?.defaultIntegerFormat,
-            pathParameterOrder: specs[0]?.settings?.pathParameterOrder
+            pathParameterOrder: specs[0]?.settings?.pathParameterOrder,
+            enableNumericEnums: specs.some((spec) => spec.settings?.enableNumericEnums)
         });
         this.specs = specs;
         this.allSpecs = allSpecs;
@@ -131,7 +132,8 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
             groupMultiApiEnvironments: this.groupMultiApiEnvironments,
             groupEnvironmentsByHost: this.groupEnvironmentsByHost,
             defaultIntegerFormat: this.defaultIntegerFormat,
-            pathParameterOrder: this.pathParameterOrder
+            pathParameterOrder: this.pathParameterOrder,
+            enableNumericEnums: this.enableNumericEnums
         };
     }
 


### PR DESCRIPTION
## Description

Refs: Investigation into supporting integer enums in OpenAPI specs

Link to Devin run: https://app.devin.ai/sessions/1bbc2cf770f246aaa6c2c41de329ed13
Requested by: @fern-support

Adds a new `enable-numeric-enums` setting behind a feature flag to explore the downstream impact of supporting integer/number enums in OpenAPI specs. Currently, Fern's OpenAPI parser silently converts integer enums (e.g., `type: integer, enum: [8000, 16000, 24000]`) to plain integer types, losing the enum constraint information.

## Changes Made

- Added `enable-numeric-enums` option to `OpenAPISettingsSchema` in the Fern definition
- Updated `ParseOpenAPIOptions` interface and defaults in the parser
- Added numeric enum handling logic in `convertSchemas.ts` that converts integer/number enum values to string representations (e.g., `8000` → `"8000"`)
- Wired the option through `BaseOpenAPIWorkspace`, `OSSWorkspace`, and `OpenAPIWorkspace`
- Updated configuration loader to parse the new setting from YAML
- Added `enableNumericEnums` to `FIELD_MAPPINGS` in `getAPIDefinitionSettings.ts` to properly wire settings from generators.yml
- Added changelog entry for version 3.56.0

## Updates Since Last Revision

- Added fixture tests demonstrating the feature with two config variants:
  - `numeric-enums-enabled`: Shows integer enums converted to string enums (e.g., `SampleRate` becomes enum with values `"8000"`, `"16000"`, `"24000"`)
  - `numeric-enums-disabled`: Shows integer enums treated as plain `int` types
- Fixed missing field mapping in `getAPIDefinitionSettings.ts` that was preventing the setting from being passed through

## Important Limitations

The current implementation converts numeric enum values to strings because the Fern IR only supports string enum values. This means:
- Generated SDKs will have string enums like `"8000"` instead of numeric literals `8000`
- Full support would require IR changes to add a numeric enum type
- Generator updates would be needed to emit proper numeric literals

## Testing

To test locally from a separate repo:
```bash
# Build seed first
pnpm seed:build

# Run against a customer's fern folder
pnpm seed run --generator ts-sdk --path /path/to/fern/folder
```

- [x] `pnpm run check` passes (lint and type checking)
- [x] Fixture tests added (`numeric-enums-enabled` and `numeric-enums-disabled`)
- [x] Snapshots verify correct behavior for both enabled and disabled states

## Human Review Checklist

- [ ] Verify the enum conversion logic in `convertSchemas.ts` handles edge cases (null values, defaults, single-value enums)
- [ ] Confirm the generated enum names are acceptable (e.g., `"EightThousand"` for value `8000` - visible in snapshots)
- [ ] Assess whether the string-based approach is acceptable for the use case or if IR changes are required