### PR TITLE
fix(cli): ensure product switcher placement defaults to header if undefined

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.55.5
+  changelogEntry:
+    - summary: |
+        Fix default value for `switcher-placement` in docs.yml layout configuration.
+      type: fix
+  createdAt: "2026-01-30"
+  irVersion: 63
+
 - version: 3.55.4
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -441,7 +441,7 @@ function convertLayoutConfig(
                   ? CjsFdrSdk.docs.v1.commons.SearchbarPlacement.HeaderTabs
                   : CjsFdrSdk.docs.v1.commons.SearchbarPlacement.Sidebar,
         switcherPlacement:
-            layout.switcherPlacement === "header"
+            !layout.switcherPlacement || layout.switcherPlacement === "header"
                 ? CjsFdrSdk.docs.v1.commons.SwitcherPlacement.Header
                 : CjsFdrSdk.docs.v1.commons.SwitcherPlacement.Sidebar,
         tabsPlacement:


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
- fixes default value for `switcherPlacement` in docs.yml

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- ensures default is header is not provided

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
