### PR TITLE
fix(java): install git in Docker container for podman environments

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
         dirmngr gnupg gnupg-l10n gnupg-utils gpg gpg-agent \
         gpg-wks-client gpg-wks-server gpgconf gpgsm gpgv \
         openssl libssl3 && \
+    apt-get install -y git && \
     apt-get purge -y --allow-remove-essential \
         python3.10 python3.10-minimal \
         python3 python3-minimal \

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.34.7
+  changelogEntry:
+    - summary: |
+        Install git in the Docker container to fix SDK generation failures in isolated environments
+        (e.g., Jenkins/Kubernetes with podman) where git is not available from the host.
+      type: fix
+  createdAt: "2026-02-02"
+  irVersion: 63
+
 - version: 3.34.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Slack thread in #devin-sdk-runs

Fixes Java SDK generation failures in isolated environments (e.g., Jenkins/Kubernetes with podman) where git is not available from the host. When running `fern generate --runner podman` in CI environments, the container doesn't have access to the host's git installation, causing repo cloning to fail.

## Changes Made

- Added explicit `apt-get install -y git` to the Java SDK Dockerfile to ensure git is available in the container regardless of the host environment
- Added version 3.34.7 changelog entry

## Testing

- [ ] Manual testing completed (Docker image build not tested locally)

## Human Review Checklist

- [ ] Verify the Dockerfile builds successfully with this change
- [ ] Confirm git installation placement (before purge/autoremove) is correct

---

Link to Devin run: https://app.devin.ai/sessions/c770230c4c7c413a819ff8f0b79c0f9c
Requested by: @aditya-arolkar-swe