### PR TITLE
fix(cli): fix AsyncAPI publish messages not generating send methods

### DIFF
--- a/packages/cli/api-importers/asyncapi-to-ir/src/2.x/channel/ChannelConverter2_X.ts
+++ b/packages/cli/api-importers/asyncapi-to-ir/src/2.x/channel/ChannelConverter2_X.ts
@@ -1,11 +1,4 @@
-import {
-    HttpHeader,
-    PathParameter,
-    QueryParameter,
-    TypeReference,
-    WebSocketMessage,
-    WebSocketMessageBody
-} from "@fern-api/ir-sdk";
+import { HttpHeader, PathParameter, QueryParameter, WebSocketMessage, WebSocketMessageBody } from "@fern-api/ir-sdk";
 import { constructHttpPath } from "@fern-api/ir-utils";
 import { Converters } from "@fern-api/v3-importer-commons";
 import { camelCase, startCase } from "lodash-es";
@@ -141,7 +134,6 @@ export class ChannelConverter2_X extends AbstractChannelConverter<AsyncAPIV2.Cha
         operation: AsyncAPIV2.PublishEvent | AsyncAPIV2.SubscribeEvent;
         origin: "server" | "client";
     }): WebSocketMessage | undefined {
-        let convertedSchema: Converters.SchemaConverters.SchemaConverter.ConvertedSchema | undefined = undefined;
         const action = origin === "server" ? "subscribe" : "publish";
         const breadcrumbs = [...this.breadcrumbs, action];
 
@@ -155,6 +147,10 @@ export class ChannelConverter2_X extends AbstractChannelConverter<AsyncAPIV2.Cha
 
         const schemaId = startCase(camelCase(`${this.channelPath}_${action}`)).replace(/ /g, "");
 
+        let schemaOrReferenceConverterOutput:
+            | Converters.SchemaConverters.SchemaOrReferenceConverter.Output
+            | undefined = undefined;
+
         if ("oneOf" in operation.message) {
             const schemaOrReferenceConverter = new Converters.SchemaConverters.SchemaOrReferenceConverter({
                 context: this.context,
@@ -162,51 +158,30 @@ export class ChannelConverter2_X extends AbstractChannelConverter<AsyncAPIV2.Cha
                 schemaOrReference: operation.message,
                 schemaIdOverride: schemaId
             });
-            const schemaOrReferenceConverterOutput = schemaOrReferenceConverter.convert();
-            if (schemaOrReferenceConverterOutput != null && schemaOrReferenceConverterOutput.schema != null) {
-                convertedSchema = schemaOrReferenceConverterOutput.schema;
-                this.inlinedTypes = {
-                    ...this.inlinedTypes,
-                    ...schemaOrReferenceConverterOutput.inlinedTypes
-                };
-            }
+            schemaOrReferenceConverterOutput = schemaOrReferenceConverter.convert();
         } else if (context.isMessageWithPayload(operation.message)) {
-            const payloadSchema = context.resolveMaybeReference<OpenAPIV3.SchemaObject>({
+            // Pass the payload directly to the converter (which may be a reference or a schema)
+            // so it can properly handle references to existing types
+            const schemaOrReferenceConverter = new Converters.SchemaConverters.SchemaOrReferenceConverter({
+                context: this.context,
+                breadcrumbs,
                 schemaOrReference: operation.message.payload,
-                breadcrumbs
+                schemaIdOverride: schemaId
             });
-            if (payloadSchema != null) {
-                const schemaOrReferenceConverter = new Converters.SchemaConverters.SchemaOrReferenceConverter({
-                    context: this.context,
-                    breadcrumbs,
-                    schemaOrReference: payloadSchema,
-                    schemaIdOverride: schemaId
-                });
-                const schemaOrReferenceConverterOutput = schemaOrReferenceConverter.convert();
-                if (schemaOrReferenceConverterOutput != null && schemaOrReferenceConverterOutput.schema != null) {
-                    convertedSchema = schemaOrReferenceConverterOutput.schema;
-                    this.inlinedTypes = {
-                        ...this.inlinedTypes,
-                        ...schemaOrReferenceConverterOutput.inlinedTypes
-                    };
-                }
-            }
+            schemaOrReferenceConverterOutput = schemaOrReferenceConverter.convert();
         }
 
-        if (convertedSchema != null) {
-            const convertedTypeDeclaration = convertedSchema;
+        if (schemaOrReferenceConverterOutput != null) {
+            // Add any inlined types from the conversion
+            this.inlinedTypes = {
+                ...this.inlinedTypes,
+                ...schemaOrReferenceConverterOutput.inlinedTypes
+            };
 
-            const typeReference = TypeReference.named({
-                fernFilepath: context.createFernFilepath(),
-                name: convertedTypeDeclaration.typeDeclaration.name.name,
-                typeId: convertedTypeDeclaration.typeDeclaration.name.typeId,
-                displayName: undefined,
-                default: undefined,
-                inline: false
-            });
-
+            // Use the type reference from the converter output directly
+            // This handles both references (where schema is undefined) and inline schemas
             const body = WebSocketMessageBody.reference({
-                bodyType: typeReference,
+                bodyType: schemaOrReferenceConverterOutput.type,
                 docs: operation.description
             });
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.56.10
+  changelogEntry:
+    - summary: |
+        Fix AsyncAPI v2 publish operations not generating send methods in SDKs. The converter was not properly handling message payloads that reference existing schemas, causing client-to-server messages to be silently dropped from the IR.
+      type: fix
+  createdAt: "2026-02-02"
+  irVersion: 63
+
 - version: 3.56.9
   changelogEntry:
     - summary: |

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/asyncapi-json-refs-fdr.snap
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/asyncapi-json-refs-fdr.snap
@@ -131,7 +131,14 @@
             {
               "description": undefined,
               "headers": {},
-              "messages": [],
+              "messages": [
+                {
+                  "body": {
+                    "key": "value",
+                  },
+                  "type": "subscribe",
+                },
+              ],
               "name": undefined,
               "path": "/plant/updates",
               "pathParameters": {},
@@ -140,7 +147,21 @@
           ],
           "headers": [],
           "id": "plantUpdates",
-          "messages": [],
+          "messages": [
+            {
+              "availability": undefined,
+              "body": {
+                "type": "reference",
+                "value": {
+                  "type": "unknown",
+                },
+              },
+              "description": undefined,
+              "displayName": "subscribe",
+              "origin": "server",
+              "type": "subscribe",
+            },
+          ],
           "name": "Plant Updates",
           "path": {
             "parts": [

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/asyncapi-json-refs-ir.snap
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/asyncapi-json-refs-ir.snap
@@ -1105,7 +1105,25 @@
         {
           "docs": undefined,
           "headers": [],
-          "messages": [],
+          "messages": [
+            {
+              "body": {
+                "_visit": [Function],
+                "jsonExample": {
+                  "key": "value",
+                },
+                "shape": {
+                  "_visit": [Function],
+                  "type": "unknown",
+                  "unknown": {
+                    "key": "value",
+                  },
+                },
+                "type": "reference",
+              },
+              "type": "subscribe",
+            },
+          ],
           "name": undefined,
           "pathParameters": [],
           "queryParameters": [],
@@ -1113,7 +1131,25 @@
         },
       ],
       "headers": [],
-      "messages": [],
+      "messages": [
+        {
+          "availability": undefined,
+          "body": {
+            "_visit": [Function],
+            "bodyType": {
+              "_visit": [Function],
+              "type": "unknown",
+            },
+            "docs": undefined,
+            "type": "reference",
+          },
+          "displayName": "subscribe",
+          "docs": undefined,
+          "methodName": undefined,
+          "origin": "server",
+          "type": "subscribe",
+        },
+      ],
       "name": {
         "camelCase": {
           "safeName": "plantUpdates",


### PR DESCRIPTION
## Description

Refs: Customer request from Immix

Link to Devin run: https://app.devin.ai/sessions/50ce682058004d24beb034e75ffe07d7
Requested by: @fern-support

Fixes an issue where AsyncAPI v2 publish operations (client-to-server messages) were not generating send methods in generated SDKs. The IR was only containing server-origin messages, causing websocket clients to be missing the ability to send subscription requests.

## Changes Made

- Modified `ChannelConverter2_X.convertMessage()` to pass the payload directly to `SchemaOrReferenceConverter` instead of resolving it first
- Changed the condition from requiring `schema != null` to just checking if the converter output is non-null
- Uses `schemaOrReferenceConverterOutput.type` directly instead of creating a new TypeReference from the converted schema
- Removed unused `TypeReference` import
- Added versions.yml entry (v3.56.10)
- Updated AsyncAPI JSON refs test snapshots to reflect the fix

**Root cause**: When a message payload is a reference to an existing schema (e.g., `$ref: "#/components/schemas/SubscribeRequest"`), the `SchemaOrReferenceConverter.maybeConvertReferenceObject` returns output WITHOUT the `schema` property (only `type` and `inlinedTypes`). The original code required `schema != null` to proceed, which caused publish messages with schema references to be silently dropped.

## Testing

- [x] Snapshot tests updated (`asyncapi-json-refs-fdr.snap`, `asyncapi-json-refs-ir.snap`)
- [ ] Manual testing with Immix AsyncAPI spec

## Human Review Checklist

1. **Verify publish operations specifically**: The updated snapshots show subscribe (server→client) messages now being generated. Please verify that publish (client→server) operations also work correctly with the Immix AsyncAPI spec.
2. **Logic correctness**: The converter's `type` property should be valid for both reference and inline schema cases
3. **Both branches affected**: The change to the `oneOf` branch (which also had the `schema != null` check) is intentional - both branches now use the same pattern