### PR TITLE
fix(swift): prevent duplicate models in discriminated unions with $ref variants

### DIFF
--- a/generators/swift/base/src/context/register-discriminated-unions.ts
+++ b/generators/swift/base/src/context/register-discriminated-unions.ts
@@ -22,12 +22,17 @@ export function registerDiscriminatedUnionVariants({
                 const caseName = EnumWithAssociatedValues.sanitizeToCamelCase(
                     singleUnionType.discriminantValue.name.camelCase.unsafeName
                 );
+                const referencedTypeId =
+                    singleUnionType.shape.propertiesType === "samePropertiesAsObject"
+                        ? singleUnionType.shape.typeId
+                        : undefined;
                 return {
                     swiftType: swift.TypeReference.symbol(symbolName),
                     caseName: caseName,
                     symbolName,
                     discriminantWireValue: singleUnionType.discriminantValue.wireValue,
-                    docsContent: singleUnionType.docs
+                    docsContent: singleUnionType.docs,
+                    referencedTypeId
                 };
             });
             registry.registerDiscriminatedUnionVariants({ parentSymbol, variants });

--- a/generators/swift/codegen/src/name-registry/name-registry.ts
+++ b/generators/swift/codegen/src/name-registry/name-registry.ts
@@ -17,6 +17,7 @@ type DiscriminatedUnionVariant = {
     symbolName: string;
     discriminantWireValue: string;
     docsContent: string | undefined;
+    referencedTypeId: string | undefined;
 };
 
 export class NameRegistry {
@@ -445,11 +446,13 @@ export class NameRegistry {
         const sortedVariants = [...variants].sort((a, b) => a.caseName.localeCompare(b.caseName));
         this.discriminatedUnionVariantsByParentSymbolId.set(parentSymbolId, sortedVariants);
         sortedVariants.forEach((variant) => {
-            this.symbolRegistry.registerNestedType({
-                parentSymbol,
-                symbolName: variant.symbolName,
-                shape: { type: "struct" }
-            });
+            if (variant.referencedTypeId == null) {
+                this.symbolRegistry.registerNestedType({
+                    parentSymbol,
+                    symbolName: variant.symbolName,
+                    shape: { type: "struct" }
+                });
+            }
         });
         return sortedVariants;
     }
@@ -465,6 +468,9 @@ export class NameRegistry {
             variant,
             `Discriminated union variant symbol not found for discriminant wire value "${discriminantWireValue}" in parent symbol "${parentSymbolId}"`
         );
+        if (variant.referencedTypeId != null) {
+            return this.getSchemaTypeSymbolOrThrow(variant.referencedTypeId);
+        }
         const symbolId = this.symbolRegistry.inferSymbolIdForNestedType(parentSymbolId, variant.symbolName);
         return swift.Symbol.create(symbolId, variant.symbolName, { type: "struct" });
     }

--- a/generators/swift/dynamic-snippets/src/context/register-discriminated-unions.ts
+++ b/generators/swift/dynamic-snippets/src/context/register-discriminated-unions.ts
@@ -20,12 +20,15 @@ export function registerDiscriminatedUnionVariants({
                 const caseName = EnumWithAssociatedValues.sanitizeToCamelCase(
                     singleUnionType.discriminantValue.name.camelCase.unsafeName
                 );
+                const referencedTypeId =
+                    singleUnionType.type === "samePropertiesAsObject" ? singleUnionType.typeId : undefined;
                 return {
                     swiftType: swift.TypeReference.symbol(symbolName),
                     caseName: caseName,
                     symbolName,
                     discriminantWireValue: singleUnionType.discriminantValue.wireValue,
-                    docsContent: undefined
+                    docsContent: undefined,
+                    referencedTypeId
                 };
             });
             registry.registerDiscriminatedUnionVariants({ parentSymbol, variants });

--- a/generators/swift/model/src/union/DiscriminatedUnionGenerator.ts
+++ b/generators/swift/model/src/union/DiscriminatedUnionGenerator.ts
@@ -52,9 +52,17 @@ export class DiscriminatedUnionGenerator {
 
     private generateCasesForTypeDeclaration(): swift.EnumWithAssociatedValues.Case[] {
         return this.getAllVariants().map((variant) => {
+            const variantSymbol = this.context.project.nameRegistry.getDiscriminatedUnionVariantSymbolOrThrow(
+                this.symbol,
+                variant.discriminantWireValue
+            );
+            const symbolRef = this.context.project.nameRegistry.reference({
+                fromSymbol: this.symbol,
+                toSymbol: variantSymbol
+            });
             return {
                 unsafeName: variant.caseName,
-                associatedValue: [swift.TypeReference.symbol(variant.symbolName)],
+                associatedValue: [swift.TypeReference.symbol(symbolRef)],
                 docs: variant.docsContent ? swift.docComment({ summary: variant.docsContent }) : undefined
             };
         });
@@ -107,6 +115,10 @@ export class DiscriminatedUnionGenerator {
             swift.Statement.switch({
                 target: swift.Expression.reference("discriminant"),
                 cases: this.getAllVariants().map((variant) => {
+                    const variantSymbol = this.context.project.nameRegistry.getDiscriminatedUnionVariantSymbolOrThrow(
+                        this.symbol,
+                        variant.discriminantWireValue
+                    );
                     return {
                         pattern: swift.Expression.stringLiteral(variant.discriminantWireValue),
                         body: [
@@ -117,7 +129,7 @@ export class DiscriminatedUnionGenerator {
                                         swift.functionArgument({
                                             value: swift.Expression.try(
                                                 swift.Expression.structInitialization({
-                                                    unsafeName: variant.symbolName,
+                                                    unsafeName: variantSymbol.name,
                                                     arguments_: [
                                                         swift.functionArgument({
                                                             label: "from",
@@ -187,6 +199,13 @@ export class DiscriminatedUnionGenerator {
     }
 
     private generateEncodeMethod(): swift.Method {
+        const samePropertiesAsObjectTypeIds = new Set<string>();
+        for (const singleUnionType of this.unionTypeDeclaration.types) {
+            if (singleUnionType.shape.propertiesType === "samePropertiesAsObject") {
+                samePropertiesAsObjectTypeIds.add(singleUnionType.shape.typeId);
+            }
+        }
+
         return swift.method({
             unsafeName: "encode",
             accessLevel: swift.AccessLevel.Public,
@@ -202,29 +221,84 @@ export class DiscriminatedUnionGenerator {
             body: swift.CodeBlock.withStatements([
                 swift.Statement.switch({
                     target: swift.Expression.rawValue("self"),
-                    cases: this.getAllVariants().map((variant) => {
+                    cases: this.unionTypeDeclaration.types.map((singleUnionType) => {
+                        const variant = this.getAllVariants().find(
+                            (v) => v.discriminantWireValue === singleUnionType.discriminantValue.wireValue
+                        );
+                        if (variant == null) {
+                            throw new Error(
+                                `Variant not found for discriminant wire value: ${singleUnionType.discriminantValue.wireValue}`
+                            );
+                        }
+
+                        const isSamePropertiesAsObject =
+                            singleUnionType.shape.propertiesType === "samePropertiesAsObject";
+
+                        const encodeStatements: swift.Statement[] = [];
+
+                        if (isSamePropertiesAsObject) {
+                            encodeStatements.push(
+                                swift.Statement.variableDeclaration({
+                                    unsafeName: "container",
+                                    value: swift.Expression.methodCall({
+                                        target: swift.Expression.reference("encoder"),
+                                        methodName: "container",
+                                        arguments_: [
+                                            swift.functionArgument({
+                                                label: "keyedBy",
+                                                value: swift.Expression.rawValue("CodingKeys.self")
+                                            })
+                                        ]
+                                    })
+                                }),
+                                swift.Statement.expressionStatement(
+                                    swift.Expression.try(
+                                        swift.Expression.methodCall({
+                                            target: swift.Expression.reference("container"),
+                                            methodName: "encode",
+                                            arguments_: [
+                                                swift.functionArgument({
+                                                    value: swift.Expression.stringLiteral(
+                                                        singleUnionType.discriminantValue.wireValue
+                                                    )
+                                                }),
+                                                swift.functionArgument({
+                                                    label: "forKey",
+                                                    value: swift.Expression.enumCaseShorthand(
+                                                        this.unionTypeDeclaration.discriminant.name.camelCase.unsafeName
+                                                    )
+                                                })
+                                            ]
+                                        })
+                                    )
+                                )
+                            );
+                        }
+
+                        encodeStatements.push(
+                            swift.Statement.expressionStatement(
+                                swift.Expression.try(
+                                    swift.Expression.methodCall({
+                                        target: swift.Expression.reference("data"),
+                                        methodName: "encode",
+                                        arguments_: [
+                                            swift.functionArgument({
+                                                label: "to",
+                                                value: swift.Expression.reference("encoder")
+                                            })
+                                        ]
+                                    })
+                                )
+                            )
+                        );
+
                         return {
                             pattern: swift.Pattern.enumCaseValueBinding({
                                 caseName: variant.caseName,
                                 referenceName: "data",
                                 declarationType: swift.DeclarationType.Let
                             }),
-                            body: [
-                                swift.Statement.expressionStatement(
-                                    swift.Expression.try(
-                                        swift.Expression.methodCall({
-                                            target: swift.Expression.reference("data"),
-                                            methodName: "encode",
-                                            arguments_: [
-                                                swift.functionArgument({
-                                                    label: "to",
-                                                    value: swift.Expression.reference("encoder")
-                                                })
-                                            ]
-                                        })
-                                    )
-                                )
-                            ]
+                            body: encodeStatements
                         };
                     })
                 })
@@ -233,7 +307,13 @@ export class DiscriminatedUnionGenerator {
     }
 
     private generateNestedTypesForTypeDeclaration(): (swift.Struct | swift.EnumWithRawValues)[] {
-        const variantStructs = this.unionTypeDeclaration.types.map((singleUnionType) => {
+        const variantStructs: swift.Struct[] = [];
+
+        for (const singleUnionType of this.unionTypeDeclaration.types) {
+            if (singleUnionType.shape.propertiesType === "samePropertiesAsObject") {
+                continue;
+            }
+
             const constantPropertyDefinitions: StructGenerator.ConstantPropertyDefinition[] = [];
             const dataPropertyDefinitions: StructGenerator.DataPropertyDefinition[] = [];
             const variantSymbol = this.context.project.nameRegistry.getDiscriminatedUnionVariantSymbolOrThrow(
@@ -256,41 +336,23 @@ export class DiscriminatedUnionGenerator {
                         type: singleUnionType.shape.type
                     });
                 }
-            } else if (singleUnionType.shape.propertiesType === "samePropertiesAsObject") {
-                const variantProperties = this.context.getPropertiesOfDiscriminatedUnionVariant(
-                    singleUnionType.shape.typeId
-                );
-                constantPropertyDefinitions.push({
-                    unsafeName: sanitizeSelf(this.unionTypeDeclaration.discriminant.name.camelCase.unsafeName),
-                    rawName: this.unionTypeDeclaration.discriminant.wireValue,
-                    type: referencer.referenceSwiftType("String"),
-                    value: swift.Expression.stringLiteral(singleUnionType.discriminantValue.wireValue)
-                });
-                dataPropertyDefinitions.push(
-                    ...variantProperties
-                        .filter((p) => this.unionTypeDeclaration.discriminant.wireValue !== p.name.wireValue)
-                        .map((p) => ({
-                            unsafeName: sanitizeSelf(p.name.name.camelCase.unsafeName),
-                            rawName: p.name.wireValue,
-                            type: p.valueType,
-                            docsContent: p.docs
-                        }))
-                );
             } else if (singleUnionType.shape.propertiesType === "noProperties") {
                 noop();
             } else {
                 assertNever(singleUnionType.shape);
             }
 
-            return new StructGenerator({
-                symbol: variantSymbol,
-                constantPropertyDefinitions,
-                dataPropertyDefinitions,
-                additionalProperties: true,
-                docsContent: singleUnionType.docs,
-                context: this.context
-            }).generate();
-        });
+            variantStructs.push(
+                new StructGenerator({
+                    symbol: variantSymbol,
+                    constantPropertyDefinitions,
+                    dataPropertyDefinitions,
+                    additionalProperties: true,
+                    docsContent: singleUnionType.docs,
+                    context: this.context
+                }).generate()
+            );
+        }
 
         return [...variantStructs, this.generateCodingKeysEnum()];
     }

--- a/generators/swift/model/src/union/__test__/snapshots/UnionWithDuplicateVariantDiscriminant.swift
+++ b/generators/swift/model/src/union/__test__/snapshots/UnionWithDuplicateVariantDiscriminant.swift
@@ -26,117 +26,17 @@ public enum UnionWithDuplicateVariantDiscriminant: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
         case .variantA(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("variantA", forKey: .type)
             try data.encode(to: encoder)
         case .variantB(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("variantB", forKey: .type)
             try data.encode(to: encoder)
         case .variantC(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("variantC", forKey: .type)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct VariantA: Codable, Hashable, Sendable {
-        public let type: String = "variantA"
-        public let propertyA: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            propertyA: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.propertyA = propertyA
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.propertyA = try container.decode(String.self, forKey: .propertyA)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.propertyA, forKey: .propertyA)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case propertyA
-        }
-    }
-
-    public struct VariantB: Codable, Hashable, Sendable {
-        public let type: String = "variantB"
-        public let propertyB: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            propertyB: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.propertyB = propertyB
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.propertyB = try container.decode(String.self, forKey: .propertyB)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.propertyB, forKey: .propertyB)
-        }
-
-        public enum VariantB: String, Codable, Hashable, CaseIterable, Sendable {
-            case variantB
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case propertyB
-        }
-    }
-
-    public struct VariantC: Codable, Hashable, Sendable {
-        public let type: String = "variantC"
-        public let propertyC: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            propertyC: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.propertyC = propertyC
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.propertyC = try container.decode(String.self, forKey: .propertyC)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.propertyC, forKey: .propertyC)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case propertyC
         }
     }
 

--- a/generators/swift/model/src/union/__test__/snapshots/UnionWithSpecialCharacters.swift
+++ b/generators/swift/model/src/union/__test__/snapshots/UnionWithSpecialCharacters.swift
@@ -1,63 +1,63 @@
 public enum UnionWithSpecialCharacters: Codable, Hashable, Sendable {
-    case abc(Abc)
-    case abcdEfgh(AbcdEfgh)
-    case camelCase(CamelCase)
-    case dataPoint(DataPoint)
-    case kebabCaseValue(KebabCaseValue)
-    case leadingSpaces(LeadingSpaces)
-    case mixed123Values456(Mixed123Values456)
-    case oneAbc(OneAbc)
-    case oneHundredTwentyThreeAbc(OneHundredTwentyThreeAbc)
-    case pascalCase(PascalCase)
-    case sevenAgent(SevenAgent)
-    case snakeCaseValue(SnakeCaseValue)
-    case spacesInTheMiddle(SpacesInTheMiddle)
-    case special(Special)
-    case trailingSpaces(TrailingSpaces)
-    case twelveAbc(TwelveAbc)
-    case uppercase(Uppercase)
-    case userName(UserName)
+    case abc(UnionVariant)
+    case abcdEfgh(UnionVariant)
+    case camelCase(UnionVariant)
+    case dataPoint(UnionVariant)
+    case kebabCaseValue(UnionVariant)
+    case leadingSpaces(UnionVariant)
+    case mixed123Values456(UnionVariant)
+    case oneAbc(UnionVariant)
+    case oneHundredTwentyThreeAbc(UnionVariant)
+    case pascalCase(UnionVariant)
+    case sevenAgent(UnionVariant)
+    case snakeCaseValue(UnionVariant)
+    case spacesInTheMiddle(UnionVariant)
+    case special(UnionVariant)
+    case trailingSpaces(UnionVariant)
+    case twelveAbc(UnionVariant)
+    case uppercase(UnionVariant)
+    case userName(UnionVariant)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let discriminant = try container.decode(String.self, forKey: .type)
         switch discriminant {
         case "abc":
-            self = .abc(try Abc(from: decoder))
+            self = .abc(try UnionVariant(from: decoder))
         case "abcd-efgh":
-            self = .abcdEfgh(try AbcdEfgh(from: decoder))
+            self = .abcdEfgh(try UnionVariant(from: decoder))
         case "camelCase":
-            self = .camelCase(try CamelCase(from: decoder))
+            self = .camelCase(try UnionVariant(from: decoder))
         case "data@point":
-            self = .dataPoint(try DataPoint(from: decoder))
+            self = .dataPoint(try UnionVariant(from: decoder))
         case "kebab-case-value":
-            self = .kebabCaseValue(try KebabCaseValue(from: decoder))
+            self = .kebabCaseValue(try UnionVariant(from: decoder))
         case "  leading-spaces":
-            self = .leadingSpaces(try LeadingSpaces(from: decoder))
+            self = .leadingSpaces(try UnionVariant(from: decoder))
         case "mixed123Values456":
-            self = .mixed123Values456(try Mixed123Values456(from: decoder))
+            self = .mixed123Values456(try UnionVariant(from: decoder))
         case "1abc":
-            self = .oneAbc(try OneAbc(from: decoder))
+            self = .oneAbc(try UnionVariant(from: decoder))
         case "123abc":
-            self = .oneHundredTwentyThreeAbc(try OneHundredTwentyThreeAbc(from: decoder))
+            self = .oneHundredTwentyThreeAbc(try UnionVariant(from: decoder))
         case "PascalCase":
-            self = .pascalCase(try PascalCase(from: decoder))
+            self = .pascalCase(try UnionVariant(from: decoder))
         case "007agent":
-            self = .sevenAgent(try SevenAgent(from: decoder))
+            self = .sevenAgent(try UnionVariant(from: decoder))
         case "snake_case_value":
-            self = .snakeCaseValue(try SnakeCaseValue(from: decoder))
+            self = .snakeCaseValue(try UnionVariant(from: decoder))
         case "spaces in the middle":
-            self = .spacesInTheMiddle(try SpacesInTheMiddle(from: decoder))
+            self = .spacesInTheMiddle(try UnionVariant(from: decoder))
         case "!@#$%special":
-            self = .special(try Special(from: decoder))
+            self = .special(try UnionVariant(from: decoder))
         case "trailing-spaces ":
-            self = .trailingSpaces(try TrailingSpaces(from: decoder))
+            self = .trailingSpaces(try UnionVariant(from: decoder))
         case "12abc":
-            self = .twelveAbc(try TwelveAbc(from: decoder))
+            self = .twelveAbc(try UnionVariant(from: decoder))
         case "UPPERCASE":
-            self = .uppercase(try Uppercase(from: decoder))
+            self = .uppercase(try UnionVariant(from: decoder))
         case "user#name":
-            self = .userName(try UserName(from: decoder))
+            self = .userName(try UnionVariant(from: decoder))
         default:
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(
@@ -71,653 +71,77 @@ public enum UnionWithSpecialCharacters: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
         case .abc(let data):
-            try data.encode(to: encoder)
-        case .abcdEfgh(let data):
-            try data.encode(to: encoder)
-        case .camelCase(let data):
-            try data.encode(to: encoder)
-        case .dataPoint(let data):
-            try data.encode(to: encoder)
-        case .kebabCaseValue(let data):
-            try data.encode(to: encoder)
-        case .leadingSpaces(let data):
-            try data.encode(to: encoder)
-        case .mixed123Values456(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("abc", forKey: .type)
             try data.encode(to: encoder)
         case .oneAbc(let data):
-            try data.encode(to: encoder)
-        case .oneHundredTwentyThreeAbc(let data):
-            try data.encode(to: encoder)
-        case .pascalCase(let data):
-            try data.encode(to: encoder)
-        case .sevenAgent(let data):
-            try data.encode(to: encoder)
-        case .snakeCaseValue(let data):
-            try data.encode(to: encoder)
-        case .spacesInTheMiddle(let data):
-            try data.encode(to: encoder)
-        case .special(let data):
-            try data.encode(to: encoder)
-        case .trailingSpaces(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("1abc", forKey: .type)
             try data.encode(to: encoder)
         case .twelveAbc(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("12abc", forKey: .type)
             try data.encode(to: encoder)
-        case .uppercase(let data):
+        case .oneHundredTwentyThreeAbc(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("123abc", forKey: .type)
+            try data.encode(to: encoder)
+        case .sevenAgent(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("007agent", forKey: .type)
+            try data.encode(to: encoder)
+        case .abcdEfgh(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("abcd-efgh", forKey: .type)
+            try data.encode(to: encoder)
+        case .dataPoint(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("data@point", forKey: .type)
             try data.encode(to: encoder)
         case .userName(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("user#name", forKey: .type)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct Abc: Codable, Hashable, Sendable {
-        public let type: String = "abc"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+        case .snakeCaseValue(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct OneAbc: Codable, Hashable, Sendable {
-        public let type: String = "1abc"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("snake_case_value", forKey: .type)
+            try data.encode(to: encoder)
+        case .kebabCaseValue(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct TwelveAbc: Codable, Hashable, Sendable {
-        public let type: String = "12abc"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("kebab-case-value", forKey: .type)
+            try data.encode(to: encoder)
+        case .special(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct OneHundredTwentyThreeAbc: Codable, Hashable, Sendable {
-        public let type: String = "123abc"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("!@#$%special", forKey: .type)
+            try data.encode(to: encoder)
+        case .leadingSpaces(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct SevenAgent: Codable, Hashable, Sendable {
-        public let type: String = "007agent"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("  leading-spaces", forKey: .type)
+            try data.encode(to: encoder)
+        case .trailingSpaces(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct AbcdEfgh: Codable, Hashable, Sendable {
-        public let type: String = "abcd-efgh"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("trailing-spaces ", forKey: .type)
+            try data.encode(to: encoder)
+        case .spacesInTheMiddle(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct DataPoint: Codable, Hashable, Sendable {
-        public let type: String = "data@point"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("spaces in the middle", forKey: .type)
+            try data.encode(to: encoder)
+        case .uppercase(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct UserName: Codable, Hashable, Sendable {
-        public let type: String = "user#name"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("UPPERCASE", forKey: .type)
+            try data.encode(to: encoder)
+        case .camelCase(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct SnakeCaseValue: Codable, Hashable, Sendable {
-        public let type: String = "snake_case_value"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("camelCase", forKey: .type)
+            try data.encode(to: encoder)
+        case .pascalCase(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct KebabCaseValue: Codable, Hashable, Sendable {
-        public let type: String = "kebab-case-value"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("PascalCase", forKey: .type)
+            try data.encode(to: encoder)
+        case .mixed123Values456(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct Special: Codable, Hashable, Sendable {
-        public let type: String = "!@#$%special"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct LeadingSpaces: Codable, Hashable, Sendable {
-        public let type: String = "  leading-spaces"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct TrailingSpaces: Codable, Hashable, Sendable {
-        public let type: String = "trailing-spaces "
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct SpacesInTheMiddle: Codable, Hashable, Sendable {
-        public let type: String = "spaces in the middle"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct Uppercase: Codable, Hashable, Sendable {
-        public let type: String = "UPPERCASE"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct CamelCase: Codable, Hashable, Sendable {
-        public let type: String = "camelCase"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct PascalCase: Codable, Hashable, Sendable {
-        public let type: String = "PascalCase"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
-        }
-    }
-
-    public struct Mixed123Values456: Codable, Hashable, Sendable {
-        public let type: String = "mixed123Values456"
-        public let someValue: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            someValue: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.someValue = someValue
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.someValue = try container.decode(String.self, forKey: .someValue)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.someValue, forKey: .someValue)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case someValue = "some_value"
+            try container.encode("mixed123Values456", forKey: .type)
+            try data.encode(to: encoder)
         }
     }
 

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.25.5
+  changelogEntry:
+    - summary: |
+        Fixed a bug where discriminated unions with variants referencing other schemas via $ref generated duplicate inline structs instead of reusing the referenced types.
+      type: fix
+  createdAt: "2026-02-03"
+  irVersion: 61
+
 - version: 0.25.4
   changelogEntry:
     - summary: |

--- a/seed/swift-sdk/exhaustive/Sources/Schemas/Animal.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Schemas/Animal.swift
@@ -24,90 +24,14 @@ public enum Animal: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .cat(let data):
-            try data.encode(to: encoder)
         case .dog(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("dog", forKey: .animal)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct Dog: Codable, Hashable, Sendable {
-        public let animal: String = "dog"
-        public let name: String
-        public let likesToWoof: Bool
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            likesToWoof: Bool,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.likesToWoof = likesToWoof
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.likesToWoof = try container.decode(Bool.self, forKey: .likesToWoof)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+        case .cat(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.animal, forKey: .animal)
-            try container.encode(self.name, forKey: .name)
-            try container.encode(self.likesToWoof, forKey: .likesToWoof)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case animal
-            case name
-            case likesToWoof
-        }
-    }
-
-    public struct Cat: Codable, Hashable, Sendable {
-        public let animal: String = "cat"
-        public let name: String
-        public let likesToMeow: Bool
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            likesToMeow: Bool,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.likesToMeow = likesToMeow
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.likesToMeow = try container.decode(Bool.self, forKey: .likesToMeow)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.animal, forKey: .animal)
-            try container.encode(self.name, forKey: .name)
-            try container.encode(self.likesToMeow, forKey: .likesToMeow)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case animal
-            case name
-            case likesToMeow
+            try container.encode("cat", forKey: .animal)
+            try data.encode(to: encoder)
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/BigUnion.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/BigUnion.swift
@@ -105,1050 +105,122 @@ public enum BigUnion: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .activeDiamond(let data):
-            try data.encode(to: encoder)
-        case .attractiveScript(let data):
-            try data.encode(to: encoder)
-        case .circularCard(let data):
-            try data.encode(to: encoder)
-        case .colorfulCover(let data):
-            try data.encode(to: encoder)
-        case .diligentDeal(let data):
-            try data.encode(to: encoder)
-        case .disloyalValue(let data):
-            try data.encode(to: encoder)
-        case .distinctFailure(let data):
-            try data.encode(to: encoder)
-        case .falseMirror(let data):
-            try data.encode(to: encoder)
-        case .frozenSleep(let data):
-            try data.encode(to: encoder)
-        case .gaseousRoad(let data):
-            try data.encode(to: encoder)
-        case .gruesomeCoach(let data):
-            try data.encode(to: encoder)
-        case .harmoniousPlay(let data):
-            try data.encode(to: encoder)
-        case .hastyPain(let data):
-            try data.encode(to: encoder)
-        case .hoarseMouse(let data):
-            try data.encode(to: encoder)
-        case .jumboEnd(let data):
-            try data.encode(to: encoder)
-        case .limpingStep(let data):
-            try data.encode(to: encoder)
-        case .mistySnow(let data):
-            try data.encode(to: encoder)
         case .normalSweet(let data):
-            try data.encode(to: encoder)
-        case .popularLimit(let data):
-            try data.encode(to: encoder)
-        case .potableBad(let data):
-            try data.encode(to: encoder)
-        case .practicalPrinciple(let data):
-            try data.encode(to: encoder)
-        case .primaryBlock(let data):
-            try data.encode(to: encoder)
-        case .rotatingRatio(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("normalSweet", forKey: .type)
             try data.encode(to: encoder)
         case .thankfulFactor(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("thankfulFactor", forKey: .type)
             try data.encode(to: encoder)
-        case .totalWork(let data):
+        case .jumboEnd(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("jumboEnd", forKey: .type)
             try data.encode(to: encoder)
-        case .triangularRepair(let data):
+        case .hastyPain(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("hastyPain", forKey: .type)
             try data.encode(to: encoder)
-        case .uniqueStress(let data):
+        case .mistySnow(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("mistySnow", forKey: .type)
             try data.encode(to: encoder)
-        case .unwillingSmoke(let data):
+        case .distinctFailure(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("distinctFailure", forKey: .type)
+            try data.encode(to: encoder)
+        case .practicalPrinciple(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("practicalPrinciple", forKey: .type)
+            try data.encode(to: encoder)
+        case .limpingStep(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("limpingStep", forKey: .type)
             try data.encode(to: encoder)
         case .vibrantExcitement(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("vibrantExcitement", forKey: .type)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct NormalSweet: Codable, Hashable, Sendable {
-        public let type: String = "normalSweet"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+        case .activeDiamond(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct ThankfulFactor: Codable, Hashable, Sendable {
-        public let type: String = "thankfulFactor"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("activeDiamond", forKey: .type)
+            try data.encode(to: encoder)
+        case .popularLimit(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct JumboEnd: Codable, Hashable, Sendable {
-        public let type: String = "jumboEnd"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("popularLimit", forKey: .type)
+            try data.encode(to: encoder)
+        case .falseMirror(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct HastyPain: Codable, Hashable, Sendable {
-        public let type: String = "hastyPain"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("falseMirror", forKey: .type)
+            try data.encode(to: encoder)
+        case .primaryBlock(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct MistySnow: Codable, Hashable, Sendable {
-        public let type: String = "mistySnow"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("primaryBlock", forKey: .type)
+            try data.encode(to: encoder)
+        case .rotatingRatio(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct DistinctFailure: Codable, Hashable, Sendable {
-        public let type: String = "distinctFailure"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("rotatingRatio", forKey: .type)
+            try data.encode(to: encoder)
+        case .colorfulCover(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct PracticalPrinciple: Codable, Hashable, Sendable {
-        public let type: String = "practicalPrinciple"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("colorfulCover", forKey: .type)
+            try data.encode(to: encoder)
+        case .disloyalValue(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct LimpingStep: Codable, Hashable, Sendable {
-        public let type: String = "limpingStep"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("disloyalValue", forKey: .type)
+            try data.encode(to: encoder)
+        case .gruesomeCoach(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct VibrantExcitement: Codable, Hashable, Sendable {
-        public let type: String = "vibrantExcitement"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("gruesomeCoach", forKey: .type)
+            try data.encode(to: encoder)
+        case .totalWork(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct ActiveDiamond: Codable, Hashable, Sendable {
-        public let type: String = "activeDiamond"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("totalWork", forKey: .type)
+            try data.encode(to: encoder)
+        case .harmoniousPlay(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct PopularLimit: Codable, Hashable, Sendable {
-        public let type: String = "popularLimit"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("harmoniousPlay", forKey: .type)
+            try data.encode(to: encoder)
+        case .uniqueStress(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct FalseMirror: Codable, Hashable, Sendable {
-        public let type: String = "falseMirror"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("uniqueStress", forKey: .type)
+            try data.encode(to: encoder)
+        case .unwillingSmoke(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct PrimaryBlock: Codable, Hashable, Sendable {
-        public let type: String = "primaryBlock"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("unwillingSmoke", forKey: .type)
+            try data.encode(to: encoder)
+        case .frozenSleep(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct RotatingRatio: Codable, Hashable, Sendable {
-        public let type: String = "rotatingRatio"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("frozenSleep", forKey: .type)
+            try data.encode(to: encoder)
+        case .diligentDeal(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct ColorfulCover: Codable, Hashable, Sendable {
-        public let type: String = "colorfulCover"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("diligentDeal", forKey: .type)
+            try data.encode(to: encoder)
+        case .attractiveScript(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct DisloyalValue: Codable, Hashable, Sendable {
-        public let type: String = "disloyalValue"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("attractiveScript", forKey: .type)
+            try data.encode(to: encoder)
+        case .hoarseMouse(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct GruesomeCoach: Codable, Hashable, Sendable {
-        public let type: String = "gruesomeCoach"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("hoarseMouse", forKey: .type)
+            try data.encode(to: encoder)
+        case .circularCard(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct TotalWork: Codable, Hashable, Sendable {
-        public let type: String = "totalWork"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("circularCard", forKey: .type)
+            try data.encode(to: encoder)
+        case .potableBad(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct HarmoniousPlay: Codable, Hashable, Sendable {
-        public let type: String = "harmoniousPlay"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("potableBad", forKey: .type)
+            try data.encode(to: encoder)
+        case .triangularRepair(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct UniqueStress: Codable, Hashable, Sendable {
-        public let type: String = "uniqueStress"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+            try container.encode("triangularRepair", forKey: .type)
+            try data.encode(to: encoder)
+        case .gaseousRoad(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct UnwillingSmoke: Codable, Hashable, Sendable {
-        public let type: String = "unwillingSmoke"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct FrozenSleep: Codable, Hashable, Sendable {
-        public let type: String = "frozenSleep"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct DiligentDeal: Codable, Hashable, Sendable {
-        public let type: String = "diligentDeal"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct AttractiveScript: Codable, Hashable, Sendable {
-        public let type: String = "attractiveScript"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct HoarseMouse: Codable, Hashable, Sendable {
-        public let type: String = "hoarseMouse"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct CircularCard: Codable, Hashable, Sendable {
-        public let type: String = "circularCard"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct PotableBad: Codable, Hashable, Sendable {
-        public let type: String = "potableBad"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct TriangularRepair: Codable, Hashable, Sendable {
-        public let type: String = "triangularRepair"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
-        }
-    }
-
-    public struct GaseousRoad: Codable, Hashable, Sendable {
-        public let type: String = "gaseousRoad"
-        public let value: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            value: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.value = value
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.value = try container.decode(String.self, forKey: .value)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.value, forKey: .value)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case value
+            try container.encode("gaseousRoad", forKey: .type)
+            try data.encode(to: encoder)
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/Shape.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/Shape.swift
@@ -25,77 +25,13 @@ public enum Shape: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
         case .circle(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("circle", forKey: .type)
             try data.encode(to: encoder)
         case .square(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("square", forKey: .type)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct Circle: Codable, Hashable, Sendable {
-        public let type: String = "circle"
-        public let radius: Double
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            radius: Double,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.radius = radius
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.radius = try container.decode(Double.self, forKey: .radius)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.radius, forKey: .radius)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case radius
-        }
-    }
-
-    public struct Square: Codable, Hashable, Sendable {
-        public let type: String = "square"
-        public let length: Double
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            length: Double,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.length = length
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.length = try container.decode(Double.self, forKey: .length)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.length, forKey: .length)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case length
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/Union.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/Union.swift
@@ -25,9 +25,9 @@ public enum Union: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .bar(let data):
-            try data.encode(to: encoder)
         case .foo(let data):
+            try data.encode(to: encoder)
+        case .bar(let data):
             try data.encode(to: encoder)
         }
     }

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithBaseProperties.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithBaseProperties.swift
@@ -27,11 +27,13 @@ public enum UnionWithBaseProperties: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .foo(let data):
-            try data.encode(to: encoder)
         case .integer(let data):
             try data.encode(to: encoder)
         case .string(let data):
+            try data.encode(to: encoder)
+        case .foo(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("foo", forKey: .type)
             try data.encode(to: encoder)
         }
     }
@@ -101,40 +103,6 @@ public enum UnionWithBaseProperties: Codable, Hashable, Sendable {
         enum CodingKeys: String, CodingKey, CaseIterable {
             case type
             case value
-        }
-    }
-
-    public struct Foo: Codable, Hashable, Sendable {
-        public let type: Swift.String = "foo"
-        public let name: Swift.String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [Swift.String: JSONValue]
-
-        public init(
-            name: Swift.String,
-            additionalProperties: [Swift.String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(Swift.String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithDiscriminant.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithDiscriminant.swift
@@ -25,9 +25,9 @@ public enum UnionWithDiscriminant: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .bar(let data):
-            try data.encode(to: encoder)
         case .foo(let data):
+            try data.encode(to: encoder)
+        case .bar(let data):
             try data.encode(to: encoder)
         }
     }

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithDuplicateTypes.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithDuplicateTypes.swift
@@ -1,17 +1,17 @@
 import Foundation
 
 public enum UnionWithDuplicateTypes: Codable, Hashable, Sendable {
-    case foo1(Foo1)
-    case foo2(Foo2)
+    case foo1(Foo)
+    case foo2(Foo)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let discriminant = try container.decode(String.self, forKey: .type)
         switch discriminant {
         case "foo1":
-            self = .foo1(try Foo1(from: decoder))
+            self = .foo1(try Foo(from: decoder))
         case "foo2":
-            self = .foo2(try Foo2(from: decoder))
+            self = .foo2(try Foo(from: decoder))
         default:
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(
@@ -25,77 +25,13 @@ public enum UnionWithDuplicateTypes: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
         case .foo1(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("foo1", forKey: .type)
             try data.encode(to: encoder)
         case .foo2(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("foo2", forKey: .type)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct Foo1: Codable, Hashable, Sendable {
-        public let type: String = "foo1"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
-        }
-    }
-
-    public struct Foo2: Codable, Hashable, Sendable {
-        public let type: String = "foo2"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithDuplicativeDiscriminants.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithDuplicativeDiscriminants.swift
@@ -25,85 +25,13 @@ public enum UnionWithDuplicativeDiscriminants: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
         case .firstItemType(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("firstItemType", forKey: .type)
             try data.encode(to: encoder)
         case .secondItemType(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("secondItemType", forKey: .type)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct FirstItemType: Codable, Hashable, Sendable {
-        public let type: String = "firstItemType"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        public enum FirstItemType: String, Codable, Hashable, CaseIterable, Sendable {
-            case firstItemType
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
-        }
-    }
-
-    public struct SecondItemType: Codable, Hashable, Sendable {
-        public let type: String = "secondItemType"
-        public let title: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            title: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.title = title
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.title = try container.decode(String.self, forKey: .title)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.title, forKey: .title)
-        }
-
-        public enum SecondItemType: String, Codable, Hashable, CaseIterable, Sendable {
-            case secondItemType
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case title
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithMultipleNoProperties.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithMultipleNoProperties.swift
@@ -27,46 +27,14 @@ public enum UnionWithMultipleNoProperties: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
+        case .foo(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("foo", forKey: .type)
+            try data.encode(to: encoder)
         case .empty1(let data):
             try data.encode(to: encoder)
         case .empty2(let data):
             try data.encode(to: encoder)
-        case .foo(let data):
-            try data.encode(to: encoder)
-        }
-    }
-
-    public struct Foo: Codable, Hashable, Sendable {
-        public let type: String = "foo"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithNoProperties.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithNoProperties.swift
@@ -24,44 +24,12 @@ public enum UnionWithNoProperties: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
+        case .foo(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("foo", forKey: .type)
+            try data.encode(to: encoder)
         case .empty(let data):
             try data.encode(to: encoder)
-        case .foo(let data):
-            try data.encode(to: encoder)
-        }
-    }
-
-    public struct Foo: Codable, Hashable, Sendable {
-        public let type: String = "foo"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithNullableReference.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithNullableReference.swift
@@ -24,9 +24,9 @@ public enum UnionWithNullableReference: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .bar(let data):
-            try data.encode(to: encoder)
         case .foo(let data):
+            try data.encode(to: encoder)
+        case .bar(let data):
             try data.encode(to: encoder)
         }
     }

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithOptionalReference.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithOptionalReference.swift
@@ -24,9 +24,9 @@ public enum UnionWithOptionalReference: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .bar(let data):
-            try data.encode(to: encoder)
         case .foo(let data):
+            try data.encode(to: encoder)
+        case .bar(let data):
             try data.encode(to: encoder)
         }
     }

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithSameNumberTypes.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithSameNumberTypes.swift
@@ -27,11 +27,11 @@ public enum UnionWithSameNumberTypes: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .anyNumber(let data):
+        case .positiveInt(let data):
             try data.encode(to: encoder)
         case .negativeInt(let data):
             try data.encode(to: encoder)
-        case .positiveInt(let data):
+        case .anyNumber(let data):
             try data.encode(to: encoder)
         }
     }

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithSameStringTypes.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithSameStringTypes.swift
@@ -29,9 +29,9 @@ public enum UnionWithSameStringTypes: Codable, Hashable, Sendable {
         switch self {
         case .customFormat(let data):
             try data.encode(to: encoder)
-        case .patternString(let data):
-            try data.encode(to: encoder)
         case .regularString(let data):
+            try data.encode(to: encoder)
+        case .patternString(let data):
             try data.encode(to: encoder)
         }
     }

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithSingleElement.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithSingleElement.swift
@@ -22,41 +22,9 @@ public enum UnionWithSingleElement: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
         case .foo(let data):
-            try data.encode(to: encoder)
-        }
-    }
-
-    public struct Foo: Codable, Hashable, Sendable {
-        public let type: String = "foo"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
+            try container.encode("foo", forKey: .type)
+            try data.encode(to: encoder)
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithSubTypes.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithSubTypes.swift
@@ -25,83 +25,13 @@ public enum UnionWithSubTypes: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
         case .foo(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("foo", forKey: .type)
             try data.encode(to: encoder)
         case .fooExtended(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("fooExtended", forKey: .type)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct Foo: Codable, Hashable, Sendable {
-        public let type: String = "foo"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
-        }
-    }
-
-    public struct FooExtended: Codable, Hashable, Sendable {
-        public let type: String = "fooExtended"
-        public let name: String
-        public let age: Int
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            age: Int,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.age = age
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.age = try container.decode(Int.self, forKey: .age)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-            try container.encode(self.age, forKey: .age)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
-            case age
         }
     }
 

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithTime.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithTime.swift
@@ -27,11 +27,11 @@ public enum UnionWithTime: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
+        case .value(let data):
+            try data.encode(to: encoder)
         case .date(let data):
             try data.encode(to: encoder)
         case .datetime(let data):
-            try data.encode(to: encoder)
-        case .value(let data):
             try data.encode(to: encoder)
         }
     }

--- a/seed/swift-sdk/unions/Sources/Schemas/UnionWithoutKey.swift
+++ b/seed/swift-sdk/unions/Sources/Schemas/UnionWithoutKey.swift
@@ -25,79 +25,14 @@ public enum UnionWithoutKey: Codable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws -> Void {
         switch self {
-        case .bar(let data):
-            try data.encode(to: encoder)
         case .foo(let data):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("foo", forKey: .type)
             try data.encode(to: encoder)
-        }
-    }
-
-    public struct Foo: Codable, Hashable, Sendable {
-        public let type: String = "foo"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
+        case .bar(let data):
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
-        }
-    }
-
-    /// This is a bar field.
-    public struct Bar: Codable, Hashable, Sendable {
-        public let type: String = "bar"
-        public let name: String
-        /// Additional properties that are not explicitly defined in the schema
-        public let additionalProperties: [String: JSONValue]
-
-        public init(
-            name: String,
-            additionalProperties: [String: JSONValue] = .init()
-        ) {
-            self.name = name
-            self.additionalProperties = additionalProperties
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.name = try container.decode(String.self, forKey: .name)
-            self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
-        }
-
-        public func encode(to encoder: Encoder) throws -> Void {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try encoder.encodeAdditionalProperties(self.additionalProperties)
-            try container.encode(self.type, forKey: .type)
-            try container.encode(self.name, forKey: .name)
-        }
-
-        /// Keys for encoding/decoding struct properties.
-        enum CodingKeys: String, CodingKey, CaseIterable {
-            case type
-            case name
+            try container.encode("bar", forKey: .type)
+            try data.encode(to: encoder)
         }
     }
 


### PR DESCRIPTION
## Description
Refs: Customer issue from Josh Studt in Slack

Fixes a bug where the Swift generator created duplicate inline structs for discriminated union variants that reference other schemas via `$ref`. Previously, when a discriminated union had a variant with `samePropertiesAsObject` (the IR representation of a `$ref`), the generator would create both a standalone struct file AND a duplicate inline struct nested inside the union enum.

**Link to Devin run:** https://app.devin.ai/sessions/a915811a65c74e589d2a1df71dc169b9
**Requested by:** @tstanmay13

## Changes Made
- Added `referencedTypeId` field to track when a discriminated union variant references an existing type
- Modified `NameRegistry` to skip registering nested types for `samePropertiesAsObject` variants and return the referenced schema type symbol instead
- Updated `DiscriminatedUnionGenerator` to:
  - Skip generating nested structs for `samePropertiesAsObject` variants
  - Encode the discriminant separately before encoding the referenced type's data
- Applied same fix to dynamic-snippets context (different IR structure)
- Updated seed test outputs for `unions` and `exhaustive` fixtures
- Updated unit test snapshots to reflect new behavior

## Testing
- [x] Ran `pnpm run check` - lint passes
- [x] Ran seed tests for `unions` fixture - passes
- [x] Ran seed tests for `exhaustive` fixture - passes
- [x] Unit tests pass with updated snapshots
- [ ] Full CI validation pending

## Human Review Checklist
- [ ] **Breaking change**: Users referencing inline types (e.g., `UnionWithSubTypes.Foo`) will now need to use standalone types (`Foo`). Verify this is acceptable.
- [ ] Verify the encoding logic for `samePropertiesAsObject` variants produces correct JSON (discriminant property should be merged with the referenced type's properties)
- [ ] Check that `singleProperty` and `noProperties` union variants still work correctly (they should still generate inline structs)
- [ ] Note: Some encode switch case ordering changed because iteration now uses `unionTypeDeclaration.types` instead of sorted variants - this is intentional and doesn't affect functionality