### PR TITLE
feat(cli): add namespace prefix support for endpoint references

### DIFF
--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGeneratorContext.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGeneratorContext.ts
@@ -652,7 +652,7 @@ export abstract class AbstractDynamicSnippetsGeneratorContext {
         parsedEndpoint
     }: {
         endpoint: FernIr.dynamic.Endpoint;
-        parsedEndpoint: HttpEndpointReferenceParser.Parsed;
+        parsedEndpoint: { method: string; path: string; namespace?: string };
     }): boolean {
         return endpoint.location.method === parsedEndpoint.method && endpoint.location.path === parsedEndpoint.path;
     }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.56.0
+  changelogEntry:
+    - summary: |
+        Add namespace prefix support for endpoint references. When working with multiple OpenAPI specs that have namespaces, you can now disambiguate endpoints using the `namespace::METHOD /path` syntax (e.g., `oauth::POST /v2/token`). This is useful for OAuth configuration when multiple specs may have overlapping paths.
+      type: feat
+  createdAt: "2026-02-02"
+  irVersion: 63
+
 - version: 3.55.0
   changelogEntry:
     - summary: |

--- a/packages/cli/fern-definition/schema/src/__test__/HttpEndpointReferenceParser.test.ts
+++ b/packages/cli/fern-definition/schema/src/__test__/HttpEndpointReferenceParser.test.ts
@@ -19,5 +19,55 @@ describe("HttpEndpointReferenceParser", () => {
             const result = parser.validate("GET /api/v1.0/users");
             expect(result).toEqual({ type: "valid" });
         });
+
+        it("should validate an endpoint reference with a namespace prefix", () => {
+            const parser = new HttpEndpointReferenceParser();
+            const result = parser.validate("oauth::POST /v2/token");
+            expect(result).toEqual({ type: "valid" });
+        });
+
+        it("should invalidate an endpoint reference with invalid namespace syntax", () => {
+            const parser = new HttpEndpointReferenceParser();
+            const result = parser.validate("oauth:POST /v2/token");
+            expect(result).toEqual({ type: "invalid" });
+        });
+    });
+
+    describe("tryParse", () => {
+        it("should parse a basic endpoint reference", () => {
+            const parser = new HttpEndpointReferenceParser();
+            const result = parser.tryParse("GET /users");
+            expect(result).toEqual({
+                namespace: undefined,
+                method: "GET",
+                path: "/users"
+            });
+        });
+
+        it("should parse an endpoint reference with namespace prefix", () => {
+            const parser = new HttpEndpointReferenceParser();
+            const result = parser.tryParse("oauth::POST /v2/token");
+            expect(result).toEqual({
+                namespace: "oauth",
+                method: "POST",
+                path: "/v2/token"
+            });
+        });
+
+        it("should parse an endpoint reference with underscore in namespace", () => {
+            const parser = new HttpEndpointReferenceParser();
+            const result = parser.tryParse("iam_organizations::GET /v1/orgs");
+            expect(result).toEqual({
+                namespace: "iam_organizations",
+                method: "GET",
+                path: "/v1/orgs"
+            });
+        });
+
+        it("should return undefined for invalid references", () => {
+            const parser = new HttpEndpointReferenceParser();
+            const result = parser.tryParse("INVALID /users");
+            expect(result).toBeUndefined();
+        });
     });
 });

--- a/packages/cli/fern-definition/schema/src/utils/HttpEndpointReferenceParser.ts
+++ b/packages/cli/fern-definition/schema/src/utils/HttpEndpointReferenceParser.ts
@@ -2,6 +2,7 @@ export declare namespace HttpEndpointReferenceParser {
     interface Parsed {
         path: string;
         method: Method;
+        namespace: string | undefined;
     }
 
     type Method = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD";
@@ -18,11 +19,11 @@ export declare namespace HttpEndpointReferenceParser {
 }
 
 /**
- * Parses an HTTP endpoint reference like `POST /users/get`
+ * Parses an HTTP endpoint reference like `POST /users/get` or `namespace::POST /users/get`
  */
 export class HttpEndpointReferenceParser {
     //eslint-disable-next-line
-    private REFERENCE_REGEX = /^(GET|POST|PUT|DELETE|PATCH|HEAD)\s(\/\S*)$/;
+    private REFERENCE_REGEX = /^(?:(\w+)::)?(GET|POST|PUT|DELETE|PATCH|HEAD)\s(\/\S*)$/;
 
     public validate(reference: string): HttpEndpointReferenceParser.ValidationResult {
         const validFormat = this.REFERENCE_REGEX.test(reference);
@@ -38,12 +39,13 @@ export class HttpEndpointReferenceParser {
             return undefined;
         }
         const match = reference.match(this.REFERENCE_REGEX);
-        if (match == null || match[1] == null || match[2] == null) {
+        if (match == null || match[2] == null || match[3] == null) {
             return undefined;
         }
         return {
-            method: match[1] as HttpEndpointReferenceParser.Method,
-            path: match[2]
+            namespace: match[1], // undefined if no namespace prefix
+            method: match[2] as HttpEndpointReferenceParser.Method,
+            path: match[3]
         };
     }
 }

--- a/packages/cli/generation/ir-generator/src/resolvers/EndpointResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/EndpointResolver.ts
@@ -37,14 +37,23 @@ export class EndpointResolverImpl implements EndpointResolver {
     public resolveEndpointByMethodAndPath({
         method,
         path,
+        namespace,
         casingsGenerator
     }: {
         method: HttpMethod;
         path: string;
+        namespace: string | undefined;
         casingsGenerator: CasingsGenerator;
     }): ResolvedEndpoint | undefined {
         let result: ResolvedEndpoint | undefined = undefined;
         visitAllDefinitionFiles(this.workspace, (relativeFilepath, file, metadata) => {
+            // Check namespace match if specified
+            if (namespace != null) {
+                const fileNamespace = this.getNamespaceFromFilepath(relativeFilepath);
+                if (fileNamespace !== namespace) {
+                    return;
+                }
+            }
             const context = constructFernFileContext({
                 relativeFilepath,
                 definitionFile: file,
@@ -63,6 +72,13 @@ export class EndpointResolverImpl implements EndpointResolver {
             }
         });
         visitAllPackageMarkers(this.workspace, (relativeFilepath, packageMarker) => {
+            // Check namespace match if specified
+            if (namespace != null) {
+                const fileNamespace = this.getNamespaceFromFilepath(relativeFilepath);
+                if (fileNamespace !== namespace) {
+                    return;
+                }
+            }
             const context = constructFernFileContext({
                 relativeFilepath,
                 definitionFile: packageMarker,
@@ -82,6 +98,17 @@ export class EndpointResolverImpl implements EndpointResolver {
         return result;
     }
 
+    private getNamespaceFromFilepath(relativeFilepath: string): string | undefined {
+        const parts = relativeFilepath.split("/");
+        // If there's more than one part, the first part is the namespace
+        // e.g., "oauth/service.yml" -> namespace is "oauth"
+        // e.g., "service.yml" -> no namespace
+        if (parts.length > 1) {
+            return parts[0];
+        }
+        return undefined;
+    }
+
     public resolveEndpoint({
         endpoint,
         file
@@ -93,7 +120,9 @@ export class EndpointResolverImpl implements EndpointResolver {
         const parsedEndpointReference = referenceParser.tryParse(endpoint);
         if (parsedEndpointReference != null) {
             return this.resolveEndpointByMethodAndPath({
-                ...parsedEndpointReference,
+                method: parsedEndpointReference.method,
+                path: parsedEndpointReference.path,
+                namespace: parsedEndpointReference.namespace,
                 casingsGenerator: file.casingsGenerator
             });
         }


### PR DESCRIPTION
## Summary
- Add support for `namespace::METHOD /path` syntax in endpoint references (e.g., `oauth::POST /v2/token`)
- When working with multiple OpenAPI specs with namespaces, this allows disambiguation of endpoints with overlapping paths
- Useful for OAuth configuration in projects with many namespaced specs

## Test plan
- [x] Added unit tests for namespace parsing in `HttpEndpointReferenceParser.test.ts`
- [x] Verified existing endpoint references without namespace still work (backwards compatible)
- [x] Tested with Twilio API configuration with multiple namespaced OpenAPI specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)