### PR TITLE
feat(cli): Add API definition configuration

### DIFF
--- a/packages/cli/cli-v2/src/__test__/LegacyFernWorkspaceAdapter.test.ts
+++ b/packages/cli/cli-v2/src/__test__/LegacyFernWorkspaceAdapter.test.ts
@@ -16,7 +16,6 @@ describe("LegacyFernWorkspaceAdapter", () => {
     describe("Fern Definition Support", () => {
         it("detects Fern spec in API definition", async () => {
             const { apiDefinition } = await loadApiDefinition("fern-definition");
-
             expect(apiDefinition.specs).toHaveLength(1);
 
             const spec = apiDefinition.specs[0];
@@ -37,7 +36,6 @@ describe("LegacyFernWorkspaceAdapter", () => {
             expect(fernWorkspace.definition.rootApiFile).toBeDefined();
             expect(fernWorkspace.definition.rootApiFile.contents.name).toBe("api");
             expect(fernWorkspace.definition.rootApiFile.contents.auth).toBe("bearer");
-
             expect(fernWorkspace.definition.namedDefinitionFiles).toBeDefined();
 
             const definitionFileKeys = Object.keys(fernWorkspace.definition.namedDefinitionFiles);
@@ -76,7 +74,6 @@ describe("LegacyFernWorkspaceAdapter", () => {
     describe("OpenAPI Definition Support", () => {
         it("adapts OpenAPI spec to FernWorkspace using OSSWorkspace", async () => {
             const { cwd, apiDefinition } = await loadApiDefinition("simple-api");
-
             expect(apiDefinition.specs).toHaveLength(1);
 
             const firstSpec = apiDefinition.specs[0];
@@ -95,7 +92,6 @@ describe("LegacyFernWorkspaceAdapter", () => {
     describe("Conjure Definition Support", () => {
         it("detects Conjure spec in API definition", async () => {
             const { apiDefinition } = await loadApiDefinition("conjure-definition");
-
             expect(apiDefinition.specs).toHaveLength(1);
 
             const spec = apiDefinition.specs[0];
@@ -118,19 +114,13 @@ describe("LegacyFernWorkspaceAdapter", () => {
         it("correctly computes relative path from workspace root to conjure directory", async () => {
             const { cwd, apiDefinition } = await loadApiDefinition("conjure-definition");
 
-            // Verify the conjure spec has the correct absolute path
             const spec = apiDefinition.specs[0];
             expect(spec).toBeDefined();
             if (spec != null && isConjureSpec(spec)) {
-                // The path should be resolved to an absolute path
                 expect(spec.conjure.toString()).toContain("conjure-definition/conjure");
             }
 
             const adapter = createAdapter(cwd);
-
-            // The adapter should successfully create a workspace
-            // This validates that absoluteFilePath and relativePathToConjureDirectory
-            // are correctly set (if they weren't, ConjureWorkspace would fail)
             const fernWorkspace = await adapter.adapt(apiDefinition);
             expect(fernWorkspace).toBeDefined();
             expect(fernWorkspace.absoluteFilePath.toString()).toBe(cwd.toString());
@@ -155,6 +145,61 @@ describe("LegacyFernWorkspaceAdapter", () => {
             // Should not throw - multiple OpenAPI specs are allowed.
             const workspace = await adapter.adapt(apiDefinition);
             expect(workspace).toBeDefined();
+        });
+    });
+
+    describe("API Configuration Override", () => {
+        it("loads auth and authSchemes from fern.yml", async () => {
+            const { apiDefinition } = await loadApiDefinition("api-config-override");
+
+            expect(apiDefinition.auth).toBe("BasicAuth");
+            expect(apiDefinition.authSchemes).toBeDefined();
+            expect(apiDefinition.authSchemes?.BasicAuth).toBeDefined();
+        });
+
+        it("load environments from fern.yml", async () => {
+            const { apiDefinition } = await loadApiDefinition("api-config-override");
+
+            expect(apiDefinition.defaultEnvironment).toBe("production");
+            expect(apiDefinition.environments).toBeDefined();
+            expect(apiDefinition.environments?.production).toBeDefined();
+            expect(apiDefinition.environments?.staging).toBeDefined();
+
+            const prodEnv = apiDefinition.environments?.production;
+            if (typeof prodEnv === "object" && "url" in prodEnv) {
+                expect(prodEnv.url).toBe("https://api.production.example.com");
+            }
+        });
+
+        it("override auth scheme", async () => {
+            const { cwd, apiDefinition } = await loadApiDefinition("api-config-override");
+            const adapter = createAdapter(cwd);
+
+            const fernWorkspace = await adapter.adapt(apiDefinition);
+            expect(fernWorkspace).toBeDefined();
+            expect(fernWorkspace.definition).toBeDefined();
+
+            const rootApiFile = fernWorkspace.definition.rootApiFile;
+            expect(rootApiFile).toBeDefined();
+            expect(rootApiFile.contents.auth).toBe("BasicAuth");
+        });
+
+        it("override environments", async () => {
+            const { cwd, apiDefinition } = await loadApiDefinition("api-config-override");
+            const adapter = createAdapter(cwd);
+
+            const fernWorkspace = await adapter.adapt(apiDefinition);
+            expect(fernWorkspace).toBeDefined();
+
+            const rootApiFile = fernWorkspace.definition.rootApiFile;
+            expect(rootApiFile).toBeDefined();
+
+            const environments = rootApiFile.contents.environments;
+            expect(environments).toBeDefined();
+
+            const envKeys = Object.keys(environments ?? {});
+            expect(envKeys).toContain("production");
+            expect(envKeys).toContain("staging");
         });
     });
 });

--- a/packages/cli/cli-v2/src/__test__/fixtures/api-config-override/fern.yml
+++ b/packages/cli/cli-v2/src/__test__/fixtures/api-config-override/fern.yml
@@ -1,0 +1,27 @@
+edition: 2026-01-01
+org: test-org
+
+api:
+  auth: BasicAuth
+  authSchemes:
+    BasicAuth:
+      scheme: basic
+  defaultEnvironment: production
+  environments:
+    production:
+      url: https://api.production.example.com
+    staging:
+      url: https://api.staging.example.com
+  specs:
+    - openapi: openapi.yml
+
+sdks:
+  defaultGroup: local
+  targets:
+    typescript:
+      lang: typescript
+      version: 0.39.3
+      output:
+        path: ./generated/typescript
+      group:
+        - local

--- a/packages/cli/cli-v2/src/__test__/fixtures/api-config-override/openapi.yml
+++ b/packages/cli/cli-v2/src/__test__/fixtures/api-config-override/openapi.yml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: API Config Override Test
+  version: 1.0.0
+  description: Tests that fern.yml API config overrides OpenAPI security
+servers:
+  - url: https://api.openapi-default.com
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List all users
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: A list of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      name: X-API-Key
+      in: header

--- a/packages/cli/cli-v2/src/api/adapter/LegacyFernWorkspaceAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyFernWorkspaceAdapter.ts
@@ -1,11 +1,12 @@
 import type { FernWorkspace, OpenAPISpec, ProtobufSpec } from "@fern-api/api-workspace-commons";
-import { dirname, relativize } from "@fern-api/fs-utils";
+import type { generatorsYml } from "@fern-api/configuration";
+import { RawSchemas } from "@fern-api/fern-definition-schema";
+import { AbsoluteFilePath, dirname, relativize } from "@fern-api/fs-utils";
 import { ConjureWorkspace, LazyFernWorkspace, OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter";
 import type { Context } from "../../context/Context";
 import type { Task } from "../../ui/Task";
 import type { ApiDefinition } from "../config/ApiDefinition";
-import type { ApiSpec } from "../config/ApiSpec";
 import type { ConjureSpec } from "../config/ConjureSpec";
 import { isConjureSpec } from "../config/ConjureSpec";
 import type { FernSpec } from "../config/FernSpec";
@@ -45,7 +46,7 @@ export class LegacyFernWorkspaceAdapter {
      * Supports three mutually exclusive modes:
      *  - Fern definition: Uses LazyFernWorkspace
      *  - Conjure definition: Uses ConjureWorkspace
-     *  - OpenAPI/AsyncAPI/Protobuf: Uses OSSWorkspace (can be mixed together)
+     *  - OpenAPI/AsyncAPI/Protobuf/OpenRPC: Uses OSSWorkspace (can be mixed together)
      *
      * Note: Spec combination validation is performed earlier in ApiDefinitionConverter.
      */
@@ -58,7 +59,7 @@ export class LegacyFernWorkspaceAdapter {
         if (conjureSpec != null) {
             return this.adaptConjureSpec(conjureSpec);
         }
-        return this.adaptOssSpecs(definition.specs);
+        return this.adaptOssSpecs(definition);
     }
 
     private async adaptFernSpec(spec: FernSpec): Promise<FernWorkspace> {
@@ -91,9 +92,9 @@ export class LegacyFernWorkspaceAdapter {
         return conjureWorkspace.toFernWorkspace({ context: this.taskContext });
     }
 
-    private async adaptOssSpecs(specs: ApiSpec[]): Promise<FernWorkspace> {
+    private async adaptOssSpecs(definition: ApiDefinition): Promise<FernWorkspace> {
         // Filter out Fern and Conjure specs (handled separately).
-        const ossSpecs = specs.filter((spec) => !isFernSpec(spec) && !isConjureSpec(spec));
+        const ossSpecs = definition.specs.filter((spec) => !isFernSpec(spec) && !isConjureSpec(spec));
 
         const specAdapter = new LegacyApiSpecAdapter({ context: this.context });
         const v1Specs = specAdapter.convertAll(ossSpecs);
@@ -115,16 +116,59 @@ export class LegacyFernWorkspaceAdapter {
             return true;
         });
 
+        const apiConfig = this.buildApiConfiguration(definition);
+
         const ossWorkspace = new OSSWorkspace({
             specs: filteredSpecs,
             allSpecs,
             absoluteFilePath: this.context.cwd,
             cliVersion: this.cliVersion,
+            generatorsConfiguration: apiConfig != null ? this.buildGeneratorsConfiguration(apiConfig) : undefined,
             workspaceName: undefined,
-            generatorsConfiguration: undefined,
             changelog: undefined
         });
 
         return ossWorkspace.toFernWorkspace({ context: this.taskContext });
+    }
+
+    private buildApiConfiguration(definition: ApiDefinition): generatorsYml.SingleNamespaceAPIDefinition | undefined {
+        if (
+            definition.auth == null &&
+            definition.authSchemes == null &&
+            definition.environments == null &&
+            definition.headers == null &&
+            definition.defaultUrl == null &&
+            definition.defaultEnvironment == null
+        ) {
+            return undefined;
+        }
+        return {
+            type: "singleNamespace",
+            definitions: [],
+            auth: definition.auth as RawSchemas.ApiAuthSchema | undefined,
+            "auth-schemes": definition.authSchemes as
+                | Record<RawSchemas.AuthSchemeKey, RawSchemas.AuthSchemeDeclarationSchema>
+                | undefined,
+            "default-url": definition.defaultUrl,
+            "default-environment": definition.defaultEnvironment,
+            environments: definition.environments as Record<string, RawSchemas.EnvironmentSchema> | undefined,
+            headers: definition.headers as Record<string, RawSchemas.HttpHeaderSchema> | undefined
+        };
+    }
+
+    private buildGeneratorsConfiguration(
+        apiConfig: generatorsYml.SingleNamespaceAPIDefinition
+    ): generatorsYml.GeneratorsConfiguration {
+        return {
+            absolutePathToConfiguration: AbsoluteFilePath.of(this.context.cwd),
+            api: apiConfig,
+            defaultGroup: undefined,
+            groupAliases: {},
+            reviewers: undefined,
+            groups: [],
+            whitelabel: undefined,
+            ai: undefined,
+            rawConfiguration: {}
+        };
     }
 }

--- a/packages/cli/cli-v2/src/api/config/ApiDefinition.ts
+++ b/packages/cli/cli-v2/src/api/config/ApiDefinition.ts
@@ -1,3 +1,5 @@
+import type { schemas } from "@fern-api/config";
+
 import type { ApiSpec } from "./ApiSpec";
 
 /**
@@ -7,6 +9,16 @@ import type { ApiSpec } from "./ApiSpec";
 export interface ApiDefinition {
     /** The specs that compose this API definition */
     specs: ApiSpec[];
-
-    // TODO: Add support for auth schemes and other API configuration.
+    /** Reference to the auth scheme (e.g. "BearerAuth") */
+    auth?: string;
+    /** Auth scheme declarations (e.g. oauth, bearer, basic, header) */
+    authSchemes?: schemas.AuthSchemesSchema;
+    /** Default URL when no environment is specified */
+    defaultUrl?: string;
+    /** Default environment name */
+    defaultEnvironment?: string;
+    /** Named environments */
+    environments?: Record<string, schemas.EnvironmentSchema>;
+    /** Global headers */
+    headers?: Record<string, schemas.HeaderSchema>;
 }

--- a/packages/cli/cli-v2/src/api/config/converter/ApiDefinitionConverter.ts
+++ b/packages/cli/cli-v2/src/api/config/converter/ApiDefinitionConverter.ts
@@ -127,8 +127,19 @@ export class ApiDefinitionConverter {
             specs: api.specs,
             sourced: sourcedApi.specs
         });
+
+        const apiDefinition: ApiDefinition = {
+            specs,
+            auth: api.auth,
+            authSchemes: api.authSchemes,
+            defaultUrl: api.defaultUrl,
+            defaultEnvironment: api.defaultEnvironment,
+            environments: api.environments,
+            headers: api.headers
+        };
+
         return {
-            [DEFAULT_API_NAME]: { specs }
+            [DEFAULT_API_NAME]: apiDefinition
         };
     }
 
@@ -155,7 +166,15 @@ export class ApiDefinitionConverter {
                 specs: apiDef.specs,
                 sourced: sourcedApiDef.specs
             });
-            result[apiName] = { specs };
+            result[apiName] = {
+                specs,
+                auth: apiDef.auth,
+                authSchemes: apiDef.authSchemes,
+                defaultUrl: apiDef.defaultUrl,
+                defaultEnvironment: apiDef.defaultEnvironment,
+                environments: apiDef.environments,
+                headers: apiDef.headers
+            };
         }
         return result;
     }

--- a/packages/cli/config/src/schemas/ApiDefinitionSchema.ts
+++ b/packages/cli/config/src/schemas/ApiDefinitionSchema.ts
@@ -1,12 +1,24 @@
 import { z } from "zod";
+
 import { ApiSpecSchema } from "./ApiSpecSchema";
+import { AuthSchemesSchema } from "./AuthSchemesSchema";
+import { EnvironmentSchema } from "./EnvironmentSchema";
+import { HeaderSchema } from "./HeaderSchema";
 
 /**
  * An API definition contains one or more specs that together define a single API.
  * All specs in a definition are merged when generating IR.
+ *
+ * Also supports API-level configuration for auth, environments, and headers.
  */
 export const ApiDefinitionSchema = z.object({
-    specs: z.array(ApiSpecSchema)
+    specs: z.array(ApiSpecSchema),
+    auth: z.string().optional(),
+    defaultUrl: z.string().optional(),
+    defaultEnvironment: z.string().optional(),
+    environments: z.record(z.string(), EnvironmentSchema).optional(),
+    headers: z.record(z.string(), HeaderSchema).optional(),
+    authSchemes: AuthSchemesSchema.optional()
 });
 
 export type ApiDefinitionSchema = z.infer<typeof ApiDefinitionSchema>;

--- a/packages/cli/config/src/schemas/AuthSchemesSchema.ts
+++ b/packages/cli/config/src/schemas/AuthSchemesSchema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * Auth schemes names mapped to their configuration objects. The values
+ * support oauth, bearer, basic, and header auth schemes.
+ *
+ * For now, we use z.unknown() for the scheme values since they have
+ * complex nested structures that are validated by the legacy workspace
+ * system.
+ *
+ * Plus, these configurations might change over time, so we don't want
+ * to lock ourselves into a specific schema.
+ */
+export const AuthSchemesSchema = z.record(z.string(), z.unknown());
+
+export type AuthSchemesSchema = z.infer<typeof AuthSchemesSchema>;

--- a/packages/cli/config/src/schemas/EnvironmentSchema.ts
+++ b/packages/cli/config/src/schemas/EnvironmentSchema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { MultipleBaseUrlsEnvironmentSchema } from "./MultipleBaseUrlEnvironmentSchema";
+import { SingleBaseUrlEnvironmentSchema } from "./SingleBaseUrlEnvironmentSchema";
+
+export const EnvironmentSchema = z.union([
+    z.string(),
+    SingleBaseUrlEnvironmentSchema,
+    MultipleBaseUrlsEnvironmentSchema
+]);
+
+export type EnvironmentSchema = z.infer<typeof EnvironmentSchema>;

--- a/packages/cli/config/src/schemas/HeaderConfigSchema.ts
+++ b/packages/cli/config/src/schemas/HeaderConfigSchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const HeaderConfigSchema = z.object({
+    name: z.string().optional(),
+    env: z.string().optional(),
+    docs: z.string().optional()
+});
+
+export type HeaderConfigSchema = z.infer<typeof HeaderConfigSchema>;

--- a/packages/cli/config/src/schemas/HeaderSchema.ts
+++ b/packages/cli/config/src/schemas/HeaderSchema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+import { HeaderConfigSchema } from "./HeaderConfigSchema";
+
+export const HeaderSchema = z.union([z.string(), HeaderConfigSchema]);
+
+export type HeaderSchema = z.infer<typeof HeaderSchema>;

--- a/packages/cli/config/src/schemas/MultipleBaseUrlEnvironmentSchema.ts
+++ b/packages/cli/config/src/schemas/MultipleBaseUrlEnvironmentSchema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const MultipleBaseUrlsEnvironmentSchema = z.object({
+    urls: z.record(z.string(), z.string()),
+    docs: z.string().optional()
+});
+
+export type MultipleBaseUrlsEnvironmentSchema = z.infer<typeof MultipleBaseUrlsEnvironmentSchema>;

--- a/packages/cli/config/src/schemas/SingleBaseUrlEnvironmentSchema.ts
+++ b/packages/cli/config/src/schemas/SingleBaseUrlEnvironmentSchema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const SingleBaseUrlEnvironmentSchema = z.object({
+    url: z.string(),
+    docs: z.string().optional()
+});
+
+export type SingleBaseUrlEnvironmentSchema = z.infer<typeof SingleBaseUrlEnvironmentSchema>;

--- a/packages/cli/config/src/schemas/index.ts
+++ b/packages/cli/config/src/schemas/index.ts
@@ -3,14 +3,19 @@ export { AiProviderSchema } from "./AiProviderSchema";
 export { ApiDefinitionSchema } from "./ApiDefinitionSchema";
 export { ApiSpecSchema } from "./ApiSpecSchema";
 export { ApisSchema } from "./ApisSchema";
+export { AuthSchemesSchema } from "./AuthSchemesSchema";
 export { CliSchema } from "./CliSchema";
 export { CratesPublishSchema } from "./CratesPublishSchema";
+export { EnvironmentSchema } from "./EnvironmentSchema";
 export { FernYmlSchema } from "./FernYmlSchema";
 export { GitOutputModeSchema } from "./GitOutputModeSchema";
 export { GitOutputSchema } from "./GitOutputSchema";
+export { HeaderConfigSchema } from "./HeaderConfigSchema";
+export { HeaderSchema } from "./HeaderSchema";
 export { isWellKnownLicense, LicenseSchema } from "./LicenseSchema";
 export { MavenPublishSchema, MavenSignatureSchema } from "./MavenPublishSchema";
 export { AuthorSchema, MetadataSchema } from "./MetadataSchema";
+export { MultipleBaseUrlsEnvironmentSchema } from "./MultipleBaseUrlEnvironmentSchema";
 export { NpmPublishSchema } from "./NpmPublishSchema";
 export { NugetPublishSchema } from "./NugetPublishSchema";
 export { OutputSchema } from "./OutputSchema";
@@ -22,6 +27,7 @@ export { RubygemsPublishSchema } from "./RubygemsPublishSchema";
 export { SdksSchema } from "./SdksSchema";
 export { SdkTargetLanguageSchema } from "./SdkTargetLanguageSchema";
 export { SdkTargetSchema } from "./SdkTargetSchema";
+export { SingleBaseUrlEnvironmentSchema } from "./SingleBaseUrlEnvironmentSchema";
 
 export {
     AsyncApiSettingsSchema,

--- a/packages/cli/config/tsconfig.json
+++ b/packages/cli/config/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../../commons/core-utils"
-    },
-    {
-      "path": "../source"
     }
   ]
 }

--- a/packages/cli/configuration/src/generators-yml/index.ts
+++ b/packages/cli/configuration/src/generators-yml/index.ts
@@ -16,7 +16,8 @@ export {
     type GeneratorInvocation,
     type GeneratorsConfiguration,
     getPackageName,
-    type ProtoAPIDefinitionSchema
+    type ProtoAPIDefinitionSchema,
+    type SingleNamespaceAPIDefinition
 } from "./GeneratorsConfiguration";
 export { isRawProtobufAPIDefinitionSchema } from "./isRawProtobufAPIDefinitionSchema";
 export * from "./schemas";


### PR DESCRIPTION
## Description

This adds support for API-level settings which include:
- Auth schemes
- Environments
- Global headers

With this, the users can override these top-level constructs for the combination of specs they configure in a single API definition:

```yaml
# fern.yml
org: acme

api:
  auth: BasicAuth
  authSchemes:
    BasicAuth:
      scheme: basic
  defaultEnvironment: production
  environments:
    production:
      url: https://api.production.example.com
    staging:
      url: https://api.staging.example.com
  specs:
    - openapi: v1/openapi.yml
    - openapi: v2/openapi.yml

sdks:
  targets:
    typescript:
      version: 3.45.1
      output:
        path: ./sdks/typescript-sdk
    go:
      version: 1.23.3
      output:
        path: ./sdks/go-sdk
```

Note that the configuration keys are updated to use `camelCase` (i.e. `auth-schemes` is now `authSchemes`).

## Changes Made
- Add support for API-wide configuration overrides.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
