### PR TITLE
fix(go): wire tests use custom client initializer

### DIFF
--- a/generators/go-v2/sdk/src/wire-tests/OAuthWireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/OAuthWireTestGenerator.ts
@@ -320,7 +320,7 @@ export class OAuthWireTestGenerator {
         writer.writeLine("\ttransport := &requestCapturingTransport{}");
         writer.writeLine("\thttpClient := &http.Client{Transport: transport}");
         writer.newLine();
-        writer.writeLine("\tc := client.NewClient(");
+        writer.writeLine(`\tc := client.${this.context.getClientConstructorName()}(`);
         writer.writeLine('\t\toption.WithBaseURL("http://localhost:8080"),');
         writer.writeLine("\t\toption.WithHTTPClient(httpClient),");
         writer.writeLine('\t\toption.WithClientCredentials("test_client_id", "test_client_secret"),');
@@ -391,7 +391,7 @@ export class OAuthWireTestGenerator {
         writer.writeLine('\tcustomHeaders.Set("X-Custom-Header", "custom-value")');
         writer.writeLine('\tcustomHeaders.Set("X-Sandbox-Auth", "sandbox-token-123")');
         writer.newLine();
-        writer.writeLine("\tc := client.NewClient(");
+        writer.writeLine(`\tc := client.${this.context.getClientConstructorName()}(`);
         writer.writeLine('\t\toption.WithBaseURL("http://localhost:8080"),');
         writer.writeLine("\t\toption.WithHTTPClient(httpClient),");
         writer.writeLine('\t\toption.WithClientCredentials("test_client_id", "test_client_secret"),');

--- a/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -607,7 +607,7 @@ export class WireTestGenerator {
             writer.writeNode(
                 go.invokeFunc({
                     func: go.typeReference({
-                        name: "NewClient",
+                        name: this.context.getClientConstructorName(),
                         importPath: this.context.getRootClientImportPath()
                     }),
                     arguments_: [

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.23.5
+  changelogEntry:
+    - summary: |
+        Fix wire tests to use configured `clientConstructorName` instead of hardcoded `NewClient`.
+      type: fix
+  createdAt: "2026-02-03"
+  irVersion: 61
+
 - version: 1.23.4
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/imdb/with-wiremock-tests/.fern/metadata.json
+++ b/seed/go-sdk/imdb/with-wiremock-tests/.fern/metadata.json
@@ -5,7 +5,8 @@
   "generatorConfig": {
     "enableWireTests": true,
     "packageName": "testPackageName",
-    "errorCodes": "per-endpoint"
+    "errorCodes": "per-endpoint",
+    "clientConstructorName": "NewIMDBClient"
   },
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/imdb/with-wiremock-tests/README.md
+++ b/seed/go-sdk/imdb/with-wiremock-tests/README.md
@@ -37,7 +37,7 @@ import (
 )
 
 func do() {
-    client := client.NewClient(
+    client := client.NewIMDBClient(
         option.WithToken(
             "<token>",
         ),

--- a/seed/go-sdk/imdb/with-wiremock-tests/client/client.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/client/client.go
@@ -17,7 +17,7 @@ type Client struct {
 	caller  *internal.Caller
 }
 
-func NewClient(opts ...option.RequestOption) *Client {
+func NewIMDBClient(opts ...option.RequestOption) *Client {
 	options := core.NewRequestOptions(opts...)
 	return &Client{
 		Imdb:    imdb.NewClient(options),

--- a/seed/go-sdk/imdb/with-wiremock-tests/client/client_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/client/client_test.go
@@ -10,14 +10,14 @@ import (
 	time "time"
 )
 
-func TestNewClient(t *testing.T) {
+func TestNewIMDBClient(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		c := NewClient()
+		c := NewIMDBClient()
 		assert.Empty(t, c.baseURL)
 	})
 
 	t.Run("base url", func(t *testing.T) {
-		c := NewClient(
+		c := NewIMDBClient(
 			option.WithBaseURL("test.co"),
 		)
 		assert.Equal(t, "test.co", c.baseURL)
@@ -27,7 +27,7 @@ func TestNewClient(t *testing.T) {
 		httpClient := &http.Client{
 			Timeout: 5 * time.Second,
 		}
-		c := NewClient(
+		c := NewIMDBClient(
 			option.WithHTTPClient(httpClient),
 		)
 		assert.Empty(t, c.baseURL)
@@ -36,7 +36,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("http header", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set("X-API-Tenancy", "test")
-		c := NewClient(
+		c := NewIMDBClient(
 			option.WithHTTPHeader(header),
 		)
 		assert.Empty(t, c.baseURL)

--- a/seed/go-sdk/imdb/with-wiremock-tests/dynamic-snippets/example0/snippet.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/dynamic-snippets/example0/snippet.go
@@ -8,7 +8,7 @@ import (
 )
 
 func do() {
-    client := client.NewClient(
+    client := client.NewIMDBClient(
         option.WithBaseURL(
             "https://api.fern.com",
         ),

--- a/seed/go-sdk/imdb/with-wiremock-tests/dynamic-snippets/example1/snippet.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/dynamic-snippets/example1/snippet.go
@@ -7,7 +7,7 @@ import (
 )
 
 func do() {
-    client := client.NewClient(
+    client := client.NewIMDBClient(
         option.WithBaseURL(
             "https://api.fern.com",
         ),

--- a/seed/go-sdk/imdb/with-wiremock-tests/dynamic-snippets/example2/snippet.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/dynamic-snippets/example2/snippet.go
@@ -7,7 +7,7 @@ import (
 )
 
 func do() {
-    client := client.NewClient(
+    client := client.NewIMDBClient(
         option.WithBaseURL(
             "https://api.fern.com",
         ),

--- a/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
@@ -70,7 +70,7 @@ func TestImdbCreateMovieWithWireMock(
 		wiremockPort = "8080"
 	}
 	WireMockBaseURL := "http://localhost:" + wiremockPort
-	client := client.NewClient(
+	client := client.NewIMDBClient(
 		option.WithBaseURL(WireMockBaseURL),
 	)
 	request := &testPackageName.CreateMovieRequest{
@@ -97,7 +97,7 @@ func TestImdbGetMovieWithWireMock(
 		wiremockPort = "8080"
 	}
 	WireMockBaseURL := "http://localhost:" + wiremockPort
-	client := client.NewClient(
+	client := client.NewIMDBClient(
 		option.WithBaseURL(WireMockBaseURL),
 	)
 	_, invocationErr := client.Imdb.GetMovie(

--- a/seed/go-sdk/imdb/with-wiremock-tests/snippet.json
+++ b/seed/go-sdk/imdb/with-wiremock-tests/snippet.json
@@ -8,7 +8,7 @@
             },
             "snippet": {
                 "type": "go",
-                "client": "import (\n\tcontext \"context\"\n\tfern \"github.com/imdb/fern\"\n\tfernclient \"github.com/imdb/fern/client\"\n\toption \"github.com/imdb/fern/option\"\n)\n\nclient := fernclient.NewClient(\n\toption.WithToken(\n\t\t\"\u003cYOUR_AUTH_TOKEN\u003e\",\n\t),\n)\nresponse, err := client.Imdb.CreateMovie(\n\tcontext.TODO(),\n\t\u0026fern.CreateMovieRequest{\n\t\tTitle:  \"title\",\n\t\tRating: 1.1,\n\t},\n)\n"
+                "client": "import (\n\tcontext \"context\"\n\tfern \"github.com/imdb/fern\"\n\tfernclient \"github.com/imdb/fern/client\"\n\toption \"github.com/imdb/fern/option\"\n)\n\nclient := fernclient.NewIMDBClient(\n\toption.WithToken(\n\t\t\"\u003cYOUR_AUTH_TOKEN\u003e\",\n\t),\n)\nresponse, err := client.Imdb.CreateMovie(\n\tcontext.TODO(),\n\t\u0026fern.CreateMovieRequest{\n\t\tTitle:  \"title\",\n\t\tRating: 1.1,\n\t},\n)\n"
             }
         },
         {
@@ -19,7 +19,7 @@
             },
             "snippet": {
                 "type": "go",
-                "client": "import (\n\tcontext \"context\"\n\tfernclient \"github.com/imdb/fern/client\"\n\toption \"github.com/imdb/fern/option\"\n)\n\nclient := fernclient.NewClient(\n\toption.WithToken(\n\t\t\"\u003cYOUR_AUTH_TOKEN\u003e\",\n\t),\n)\nresponse, err := client.Imdb.GetMovie(\n\tcontext.TODO(),\n\t\"movieId\",\n)\n"
+                "client": "import (\n\tcontext \"context\"\n\tfernclient \"github.com/imdb/fern/client\"\n\toption \"github.com/imdb/fern/option\"\n)\n\nclient := fernclient.NewIMDBClient(\n\toption.WithToken(\n\t\t\"\u003cYOUR_AUTH_TOKEN\u003e\",\n\t),\n)\nresponse, err := client.Imdb.GetMovie(\n\tcontext.TODO(),\n\t\"movieId\",\n)\n"
             }
         }
     ]

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -131,13 +131,14 @@ fixtures:
         enableWireTests: true
         packageName: testPackageName
         errorCodes: per-endpoint
+        clientConstructorName: NewIMDBClient
     - outputFolder: no-custom-config
       customConfig: null
     - outputFolder: package-path
       customConfig:
         packagePath: inhereplease
     - outputFolder: deep-package-path
-      customConfig: 
+      customConfig:
         packagePath: all/the/way/in/here/please
   undiscriminated-unions:
     - outputFolder: no-custom-config
@@ -316,8 +317,8 @@ allowedFailures:
   - variables
 
   # Will include these back in once we fix dynamic snippets for inline file properties
-  - file-upload:no-custom-config 
-  - file-upload:package-name 
+  - file-upload:no-custom-config
+  - file-upload:package-name
   - file-upload-openapi
 
   - pagination-custom:.


### PR DESCRIPTION
## Description
Fixes wire tests to use the configured `clientConstructorName` when specified instead of hardcoding `NewClient`.

## Changes Made
Wire test generator in go-v2.

## Testing
Added wire tests to `imdb:with-wiremock-tests`.
- [X] Unit tests added/updated
- [X] Manual testing completed
