### PR TITLE
fix(cli): global header should use literal example provided in generators.yml

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/dates.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/dates.json
@@ -15,8 +15,8 @@
               "examples": [
                 {
                   "headers": {
-                    "date_header": "[object Object]",
-                    "date_time_header": "[object Object]",
+                    "date_header": "date_header",
+                    "date_time_header": "date_time_header",
                   },
                   "request": {},
                   "response": {
@@ -99,8 +99,8 @@
         status-code: 200
       examples:
         - headers:
-            date_header: '[object Object]'
-            date_time_header: '[object Object]'
+            date_header: date_header
+            date_time_header: date_time_header
           request: {}
           response:
             body:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/security-auth-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/security-auth-edge-cases.json
@@ -15,7 +15,7 @@
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                 },
               ],
@@ -44,7 +44,7 @@
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                 },
               ],
@@ -65,7 +65,7 @@
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                 },
               ],
@@ -82,7 +82,7 @@
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                 },
               ],
@@ -104,7 +104,7 @@
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                 },
               ],
@@ -166,7 +166,7 @@ service:
         openapi: ../openapi.yml
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
     getPublic:
       path: /public
       method: GET
@@ -174,7 +174,7 @@ service:
         openapi: ../openapi.yml
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
     getProtected:
       path: /protected
       method: GET
@@ -184,7 +184,7 @@ service:
         openapi: ../openapi.yml
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
     getSecure:
       path: /secure
       method: GET
@@ -195,7 +195,7 @@ service:
         openapi: ../openapi.yml
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
     getFlexible:
       path: /flexible
       method: GET
@@ -208,7 +208,7 @@ service:
         openapi: ../openapi.yml
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
   source:
     openapi: ../openapi.yml
 ",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/speechify.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/speechify.json
@@ -798,7 +798,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "response": {
                     "body": {
@@ -834,7 +834,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -867,7 +867,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "response": {
                     "body": [
@@ -905,7 +905,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -972,7 +972,7 @@ service:
         status-code: 200
       examples:
         - headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
           response:
             body:
               - api_key: api_key
@@ -997,7 +997,7 @@ service:
         status-code: 200
       examples:
         - headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
           response:
             body:
               api_key: api_key
@@ -1024,7 +1024,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
     UpdateApiKey:
       path: /v1/token/{id}
       method: PATCH
@@ -1051,7 +1051,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
           request: string
           response:
             body:
@@ -1091,7 +1091,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "request": {
                     "input": "input",
@@ -1168,7 +1168,7 @@ simba-turbo ModelTurbo",
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "request": {
                     "input": "input",
@@ -1266,7 +1266,7 @@ simba-turbo ModelTurbo",
                 {
                   "headers": {
                     "Accept": "audio/mpeg",
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "request": {
                     "input": "input",
@@ -1634,7 +1634,7 @@ service:
         - root.InternalServerError
       examples:
         - headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
           request:
             input: input
             voice_id: voice_id
@@ -1716,7 +1716,7 @@ service:
         - root.InternalServerError
       examples:
         - headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
           request:
             input: input
             voice_id: voice_id
@@ -1805,7 +1805,7 @@ service:
       examples:
         - headers:
             Accept: audio/mpeg
-            Authorization: '[object Object]'
+            Authorization: Authorization
           request:
             input: input
             voice_id: voice_id
@@ -1839,7 +1839,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "request": {
                     "grant_type": "client_credentials",
@@ -2011,7 +2011,7 @@ service:
         - root.BadRequestError
       examples:
         - headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
           request:
             grant_type: client_credentials
           response:
@@ -2049,7 +2049,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "request": {
                     "consent": "consent",
@@ -2126,7 +2126,7 @@ This should include the fullName and email of the consenting individual.",
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "path-parameters": {
                     "id": "id",
@@ -2163,7 +2163,7 @@ This should include the fullName and email of the consenting individual.",
               "examples": [
                 {
                   "headers": {
-                    "Authorization": "[object Object]",
+                    "Authorization": "Authorization",
                   },
                   "response": {
                     "body": [
@@ -2226,7 +2226,7 @@ service:
         - root.InternalServerError
       examples:
         - headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
           response:
             body:
               - avatar_image: avatar_image
@@ -2281,7 +2281,7 @@ service:
         - root.InternalServerError
       examples:
         - headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
           request:
             name: name
             consent: consent
@@ -2316,7 +2316,7 @@ service:
         - path-parameters:
             id: id
           headers:
-            Authorization: '[object Object]'
+            Authorization: Authorization
   source:
     openapi: ../openapi.json
 ",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/superagent.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/superagent.json
@@ -117,7 +117,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "request": {
                     "name": "name",
@@ -185,7 +185,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "agentId": "agentId",
@@ -229,7 +229,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "agentId": "agentId",
@@ -270,7 +270,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "response": {
                     "body": {
@@ -305,7 +305,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "agentId": "agentId",
@@ -356,7 +356,7 @@ types:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "agentId": "agentId",
@@ -430,7 +430,7 @@ types:
         status-code: 200
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -469,7 +469,7 @@ types:
         - root.UnprocessableEntityError
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             name: name
             type: type
@@ -499,7 +499,7 @@ types:
         - path-parameters:
             agentId: agentId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -526,7 +526,7 @@ types:
         - path-parameters:
             agentId: agentId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -556,7 +556,7 @@ types:
         - path-parameters:
             agentId: agentId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             key: value
           response:
@@ -593,7 +593,7 @@ types:
         - path-parameters:
             agentId: agentId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             input:
               key: value
@@ -630,7 +630,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "request": {
                     "description": "description",
@@ -680,7 +680,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "tokenId": "tokenId",
@@ -724,7 +724,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "tokenId": "tokenId",
@@ -765,7 +765,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "response": {
                     "body": {
@@ -811,7 +811,7 @@ imports:
         status-code: 200
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -838,7 +838,7 @@ imports:
         - root.UnprocessableEntityError
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             description: description
           response:
@@ -867,7 +867,7 @@ imports:
         - path-parameters:
             tokenId: tokenId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -894,7 +894,7 @@ imports:
         - path-parameters:
             tokenId: tokenId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -924,7 +924,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "request": {
                     "email": "email",
@@ -972,7 +972,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "request": {
                     "email": "email",
@@ -1049,7 +1049,7 @@ service:
         - root.UnprocessableEntityError
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             email: email
             password: password
@@ -1081,7 +1081,7 @@ service:
         - root.UnprocessableEntityError
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             email: email
             password: password
@@ -1116,7 +1116,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "request": {
                     "name": "name",
@@ -1185,7 +1185,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "documentId": "documentId",
@@ -1229,7 +1229,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "documentId": "documentId",
@@ -1270,7 +1270,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "response": {
                     "body": {
@@ -1316,7 +1316,7 @@ service:
         status-code: 200
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -1355,7 +1355,7 @@ service:
         - root.UnprocessableEntityError
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             type: type
             url: url
@@ -1386,7 +1386,7 @@ service:
         - path-parameters:
             documentId: documentId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -1413,7 +1413,7 @@ service:
         - path-parameters:
             documentId: documentId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -1447,7 +1447,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "request": {
                     "input_variables": [],
@@ -1503,7 +1503,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "promptId": "promptId",
@@ -1547,7 +1547,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "promptId": "promptId",
@@ -1588,7 +1588,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "response": {
                     "body": {
@@ -1623,7 +1623,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "promptId": "promptId",
@@ -1685,7 +1685,7 @@ imports:
         status-code: 200
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -1715,7 +1715,7 @@ imports:
         - root.UnprocessableEntityError
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             name: name
             input_variables: []
@@ -1746,7 +1746,7 @@ imports:
         - path-parameters:
             promptId: promptId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -1773,7 +1773,7 @@ imports:
         - path-parameters:
             promptId: promptId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -1803,7 +1803,7 @@ imports:
         - path-parameters:
             promptId: promptId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             key: value
           response:
@@ -1839,7 +1839,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "request": {
                     "name": "name",
@@ -1894,7 +1894,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "toolId": "toolId",
@@ -1938,7 +1938,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "toolId": "toolId",
@@ -1979,7 +1979,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "response": {
                     "body": {
@@ -2025,7 +2025,7 @@ imports:
         status-code: 200
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -2055,7 +2055,7 @@ imports:
         - root.UnprocessableEntityError
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           request:
             name: name
             type: type
@@ -2085,7 +2085,7 @@ imports:
         - path-parameters:
             toolId: toolId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -2112,7 +2112,7 @@ imports:
         - path-parameters:
             toolId: toolId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -2140,7 +2140,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "response": {
                     "body": {
@@ -2186,7 +2186,7 @@ imports:
         status-code: 200
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -2214,7 +2214,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "path-parameters": {
                     "userId": "userId",
@@ -2255,7 +2255,7 @@ imports:
               "examples": [
                 {
                   "headers": {
-                    "X_SUPERAGENT_API_KEY": "[object Object]",
+                    "X_SUPERAGENT_API_KEY": "X_SUPERAGENT_API_KEY",
                   },
                   "response": {
                     "body": {
@@ -2300,7 +2300,7 @@ imports:
         status-code: 200
       examples:
         - headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value
@@ -2324,7 +2324,7 @@ imports:
         - path-parameters:
             userId: userId
           headers:
-            X_SUPERAGENT_API_KEY: '[object Object]'
+            X_SUPERAGENT_API_KEY: X_SUPERAGENT_API_KEY
           response:
             body:
               key: value

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-retries.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-retries.json
@@ -44,7 +44,7 @@
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                   "request": {
                     "message": "message",
@@ -87,7 +87,7 @@ service:
         content-type: application/json
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
           request:
             message: message
       retries:
@@ -115,7 +115,7 @@ service:
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                   "request": {
                     "message": "message",
@@ -155,7 +155,7 @@ service:
         content-type: application/json
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
           request:
             message: message
       audiences:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-streaming-with-stream-condition.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-streaming-with-stream-condition.json
@@ -16,8 +16,8 @@
               "examples": [
                 {
                   "headers": {
-                    "Request-Timeout": "[object Object]",
-                    "Request-Timeout-Millis": "[object Object]",
+                    "Request-Timeout": "Request-Timeout",
+                    "Request-Timeout-Millis": "Request-Timeout-Millis",
                   },
                   "request": {
                     "query": "How can I use the Vectara platform?",
@@ -70,8 +70,8 @@
               "examples": [
                 {
                   "headers": {
-                    "Request-Timeout": "[object Object]",
-                    "Request-Timeout-Millis": "[object Object]",
+                    "Request-Timeout": "Request-Timeout",
+                    "Request-Timeout-Millis": "Request-Timeout-Millis",
                   },
                   "request": {
                     "query": "How can I use the Vectara platform?",
@@ -189,8 +189,8 @@
         format: json
       examples:
         - headers:
-            Request-Timeout: '[object Object]'
-            Request-Timeout-Millis: '[object Object]'
+            Request-Timeout: Request-Timeout
+            Request-Timeout-Millis: Request-Timeout-Millis
           request:
             query: How can I use the Vectara platform?
             stream_response: true
@@ -223,8 +223,8 @@
         status-code: 200
       examples:
         - headers:
-            Request-Timeout: '[object Object]'
-            Request-Timeout-Millis: '[object Object]'
+            Request-Timeout: Request-Timeout
+            Request-Timeout-Millis: Request-Timeout-Millis
           request:
             query: How can I use the Vectara platform?
             stream_response: false

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-token-variable-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-token-variable-name.json
@@ -54,7 +54,7 @@
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                   "request": {
                     "prompt": "prompt",
@@ -117,7 +117,7 @@
         status-code: 200
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
           request:
             prompt: prompt
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-version.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-version.json
@@ -54,7 +54,7 @@
               "examples": [
                 {
                   "headers": {
-                    "X-API-Key": "[object Object]",
+                    "X-API-Key": "X-API-Key",
                   },
                   "request": {
                     "prompt": "prompt",
@@ -117,7 +117,7 @@
         status-code: 200
       examples:
         - headers:
-            X-API-Key: '[object Object]'
+            X-API-Key: X-API-Key
           request:
             prompt: prompt
           response:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -63,21 +63,20 @@ export function buildEndpointExample({
         for (const [header, info] of Object.entries(globalHeaders)) {
             // set global header example value
             if (info != null && typeof info === "object" && info.type != null) {
-                // handling header types
+                // Extract the literal value from the type if it's a literal type.
+                // Only literal types have a fixed, known value we can use for examples.
                 const valueToUse = recursivelyVisitRawTypeReference<void | string>({
                     type: info.type,
                     _default: undefined,
                     validation: undefined,
-                    // generic visitor to extract the string value from the literal
-                    // todo: add handling for other types in this visitor
                     visitor: {
-                        primitive: (primitive) => primitive.toString(),
-                        map: (map) => map.toString(),
-                        list: (list) => list,
-                        optional: (optional) => optional,
-                        nullable: (nullable) => nullable,
-                        set: (set) => set,
-                        named: (named) => named,
+                        primitive: noop,
+                        map: noop,
+                        list: noop,
+                        optional: (inner) => inner,
+                        nullable: (inner) => inner,
+                        set: noop,
+                        named: noop,
                         literal: (literal) => {
                             if (literal.type === "string") {
                                 return literal.string;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpointExample.ts
@@ -61,11 +61,6 @@ export function buildEndpointExample({
 
         // Global header handling
         for (const [header, info] of Object.entries(globalHeaders)) {
-            // ignore global headers that are already in the endpoint headers
-            if (endpointHeaderNames.has(header)) {
-                continue;
-            }
-
             // set global header example value
             if (info != null && typeof info === "object" && info.type != null) {
                 // handling header types
@@ -96,18 +91,31 @@ export function buildEndpointExample({
                 });
 
                 if (valueToUse != null) {
-                    namedFullExamples.push({
+                    // If this header already exists from endpoint, override it; otherwise add it
+                    const existingIdx = namedFullExamples.findIndex((e) => e.name === header);
+                    const newExample = {
                         name: header,
                         value: FullExample.literal(LiteralExample.string(valueToUse))
-                    });
+                    };
+                    if (existingIdx >= 0) {
+                        namedFullExamples[existingIdx] = newExample;
+                    } else {
+                        namedFullExamples.push(newExample);
+                    }
+                    continue;
                 }
-            } else {
-                // Adds a header example using the header name as the value when no type information is available
-                namedFullExamples.push({
-                    name: header,
-                    value: FullExample.primitive(PrimitiveExample.string(header))
-                });
             }
+
+            // Skip if already in endpoint headers and no override value was found
+            if (endpointHeaderNames.has(header)) {
+                continue;
+            }
+
+            // Adds a header example using the header name as the value when no type information is available
+            namedFullExamples.push({
+                name: header,
+                value: FullExample.primitive(PrimitiveExample.string(header))
+            });
         }
 
         example.headers = convertHeaderExamples({

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -3,6 +3,7 @@
   changelogEntry:
     - summary: |
         Fix header example generation to use global header literal values when defined in generators.yml
+      type: fix
   createdAt: "2026-02-03"
   irVersion: 63
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.58.1
+  changelogEntry:
+    - summary: |
+        Fix header example generation to use global header literal values when defined in generators.yml
+      type: fix
+  createdAt: "2026-02-03"
+  irVersion: 63
+
 - version: 3.58.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
When a literal header example is provided in `generators.yml`, use that example in the Fern definition over an auto-generated placeholder. Also fixes a bug where non-literal header types were producing `"[object Object]"` in examples.

## Changes Made
- Updated OpenAPI-IR to Fern definition parsing (`buildEndpointExample.ts`)
- Fixed visitor to only extract values from literal types
- Global header literal values now override endpoint header examples

## Testing
 - [x] Unit tests added/updated
 - [x] Manual testing completed