### PR TITLE
fix(cli): add header and footer fields to serialization schema

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.60.1
+  changelogEntry:
+    - summary: |
+        Fix custom header and footer components not being recognized in docs.yml. The serialization schema
+        was missing the header and footer fields, causing validation errors when using these new fields.
+      type: fix
+  createdAt: "2026-02-03"
+  irVersion: 63
+
 - version: 3.60.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/DocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/DocsConfiguration.ts
@@ -70,6 +70,8 @@ export const DocsConfiguration: core.serialization.ObjectSchema<
     integrations: IntegrationsConfig.optional(),
     css: CssConfig.optional(),
     js: JsConfig.optional(),
+    header: core.serialization.string().optional(),
+    footer: core.serialization.string().optional(),
 });
 
 export declare namespace DocsConfiguration {
@@ -106,5 +108,7 @@ export declare namespace DocsConfiguration {
         integrations?: IntegrationsConfig.Raw | null;
         css?: CssConfig.Raw | null;
         js?: JsConfig.Raw | null;
+        header?: string | null;
+        footer?: string | null;
     }
 }


### PR DESCRIPTION
## Description

Refs: Follow-up fix for custom header/footer support added in v3.60.0

The v3.60.0 release added support for `header` and `footer` fields in docs.yml, but the serialization schema (zod validation) was not regenerated. This caused validation errors when users tried to use these new fields:

```
ERROR: Unexpected key "footer"
```

This PR regenerates the SDK types to include the missing `header` and `footer` fields in the serialization schema.

## Changes Made

- Regenerated `DocsConfiguration.ts` serialization schema to include `header` and `footer` optional string fields
- Added version 3.60.1 changelog entry

## Testing

- [x] Verified the serialization schema now includes both fields
- [ ] Manual testing will be done via fern-platform smoke test once this is published

## Human Review Checklist

- [ ] Verify the serialization schema changes are correct (optional string fields)
- [ ] Confirm version entry follows existing format

---

Link to Devin run: https://app.devin.ai/sessions/c277db88db984051b4b7bf2a36ec6ff0
Requested by: Sandeep Dinesh (@thesandlord)