### PR TITLE
fix(cli): decode JSON Pointer escape sequences in AsyncAPI V3 parser

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
@@ -39,9 +39,16 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
         const MESSAGE_REFERENCE_PREFIX = "#/components/messages/";
 
         if (message.$ref.startsWith(CHANNELS_PATH_PART)) {
-            const parts = message.$ref.split("/");
-            const channelPath = parts[2];
-            const messageKey = parts[4];
+            // Extract the path after #/channels/ and before /messages/
+            const afterChannels = message.$ref.substring(CHANNELS_PATH_PART.length);
+            const messagesIndex = afterChannels.indexOf("/messages/");
+            if (messagesIndex === -1) {
+                throw new Error(`Failed to resolve message reference ${message.$ref}: missing /messages/ segment`);
+            }
+            // Decode JSON Pointer escape sequences: ~1 -> / and ~0 -> ~
+            // See RFC 6901: https://datatracker.ietf.org/doc/html/rfc6901#section-3
+            const channelPath = afterChannels.substring(0, messagesIndex).replace(/~1/g, "/").replace(/~0/g, "~");
+            const messageKey = afterChannels.substring(messagesIndex + "/messages/".length);
 
             if (channelPath == null || messageKey == null || !this.document.channels?.[channelPath]) {
                 throw new Error(`Failed to resolve message reference ${message.$ref} in channel ${channelPath}`);

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -401,10 +401,15 @@ export function parseAsyncAPIV3({
 }
 
 function getChannelPathFromOperation(operation: AsyncAPIV3.Operation): string {
+    if (operation.channel == null) {
+        throw new Error(`Operation is missing 'channel' property. Operation: ${JSON.stringify(operation)}`);
+    }
     if (!operation.channel.$ref.startsWith(CHANNEL_REFERENCE_PREFIX)) {
         throw new Error(`Failed to resolve channel path from operation ${operation.channel.$ref}`);
     }
-    return operation.channel.$ref.substring(CHANNEL_REFERENCE_PREFIX.length);
+    // Decode JSON Pointer escape sequences: ~1 -> / and ~0 -> ~
+    // See RFC 6901: https://datatracker.ietf.org/doc/html/rfc6901#section-3
+    return operation.channel.$ref.substring(CHANNEL_REFERENCE_PREFIX.length).replace(/~1/g, "/").replace(/~0/g, "~");
 }
 
 function convertChannelParameterLocation(location: string): {

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.60.2
+  changelogEntry:
+    - summary: |
+        Fix AsyncAPI V3 parser to properly decode JSON Pointer escape sequences in channel references.
+        Channel paths containing slashes (e.g., `/api/v1/ws`) are encoded as `~1` in JSON Pointer references
+        per RFC 6901. The parser now correctly decodes `~1` to `/` and `~0` to `~` when resolving channel
+        references, enabling proper parsing of AsyncAPI specs with URL-like channel paths.
+      type: fix
+  createdAt: "2026-02-04"
+  irVersion: 63
+
 - version: 3.60.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Investigation for Smallest AI websocket generation issue

Fixes the AsyncAPI V3 parser to properly decode JSON Pointer escape sequences in channel references per [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901#section-3).

When AsyncAPI specs have channel paths containing slashes (e.g., `/api/v1/ws`), these are encoded as `~1` in JSON Pointer `$ref` values (e.g., `#/channels/~1api~1v1~1ws`). The parser was not decoding these escape sequences, causing channel lookups to fail and AsyncAPI documents to be skipped during parsing.

## Changes Made

- Added JSON Pointer escape sequence decoding (`~1` → `/`, `~0` → `~`) in `getChannelPathFromOperation()` 
- Rewrote message reference resolution in `AsyncAPIV3ParserContext.resolveMessageReference()` to properly extract and decode channel paths before lookup
- Added defensive null check for `operation.channel` with descriptive error message
- Added changelog entry for version 3.60.2

## Testing

- [x] Manual testing with minimal AsyncAPI V3 fixture containing URL-encoded channel paths
- [x] Verified websocket client code is generated correctly after fix
- [x] Lint checks pass (`pnpm run check`)
- [ ] Seed test fixture not added (consider adding for regression prevention)

## Human Review Checklist

- [ ] Verify escape sequence decoding order is correct (`~1` before `~0` matters per RFC 6901)
- [ ] Consider whether a seed test fixture should be added for AsyncAPI specs with encoded channel paths

---

Link to Devin run: https://app.devin.ai/sessions/6edd55620e9c49c2a7edd190fe1e16d7
Requested by: @fern-support