### PR TITLE
feat(php): add support for explicit nulls in PHP SDKs

### DIFF
--- a/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
@@ -19,6 +19,9 @@ abstract class JsonSerializableType implements \JsonSerializable
     /** @var array<string, mixed> Extra properties from JSON that don't map to class properties */
     private array $__additionalProperties = [];
 
+    /** @var array<string, true> Properties that have been explicitly set via setter methods */
+    private array $__explicitlySetProperties = [];
+
     /**
      * Serializes the object to a JSON string.
      *
@@ -80,7 +83,8 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $value = JsonSerializer::serializeObject($value);
             }
 
-            if ($value !== null) {
+            // Include the value if it's not null, OR if it was explicitly set (even to null)
+            if ($value !== null || array_key_exists($property->getName(), $this->__explicitlySetProperties)) {
                 $result[$jsonKey] = $value;
             }
         }
@@ -191,6 +195,17 @@ abstract class JsonSerializableType implements \JsonSerializable
     public function getAdditionalProperties(): array
     {
         return $this->__additionalProperties;
+    }
+
+    /**
+     * Mark a property as explicitly set.
+     * This ensures the property will be included in JSON serialization even if null.
+     *
+     * @param string $propertyName The name of the property to mark as explicitly set.
+     */
+    protected function _setField(string $propertyName): void
+    {
+        $this->__explicitlySetProperties[$propertyName] = true;
     }
 
     /**

--- a/generators/php/base/src/context/AbstractPhpGeneratorContext.ts
+++ b/generators/php/base/src/context/AbstractPhpGeneratorContext.ts
@@ -599,13 +599,15 @@ export abstract class AbstractPhpGeneratorContext<
     }
 
     public getSetterMethod({ name, field }: { name: Name; field: php.Field }): php.Method {
+        const propertyName = this.getPropertyName(name);
         return php.method({
             name: this.getPropertySetterName(name),
             access: php.Access.Public,
             parameters: [php.parameter({ name: "value", type: field.type })],
             return_: SELF,
             body: php.codeblock((writer) => {
-                writer.write(`$this->${this.getPropertyName(name)} = $value;`);
+                writer.writeLine(`$this->${propertyName} = $value;`);
+                writer.writeLine(`$this->_setField('${propertyName}');`);
                 writer.write("return $this;");
             })
         });

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.26.0
+  changelogEntry:
+    - summary: |
+        Add support for explicit nulls in PHP SDKs. Setter methods now mark properties as explicitly set, ensuring that null values are included in JSON serialization when intentionally set via setters. This distinguishes between omitting an optional property and explicitly setting it to null.
+      type: feat
+  createdAt: "2026-02-04"
+  irVersion: 62
+
 - version: 1.25.4
   changelogEntry:
     - summary: |

--- a/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
@@ -19,6 +19,9 @@ abstract class JsonSerializableType implements \JsonSerializable
     /** @var array<string, mixed> Extra properties from JSON that don't map to class properties */
     private array $__additionalProperties = [];
 
+    /** @var array<string, true> Properties that have been explicitly set via setter methods */
+    private array $__explicitlySetProperties = [];
+
     /**
      * Serializes the object to a JSON string.
      *
@@ -80,7 +83,8 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $value = JsonSerializer::serializeObject($value);
             }
 
-            if ($value !== null) {
+            // Include the value if it's not null, OR if it was explicitly set (even to null)
+            if ($value !== null || array_key_exists($property->getName(), $this->__explicitlySetProperties)) {
                 $result[$jsonKey] = $value;
             }
         }
@@ -191,6 +195,17 @@ abstract class JsonSerializableType implements \JsonSerializable
     public function getAdditionalProperties(): array
     {
         return $this->__additionalProperties;
+    }
+
+    /**
+     * Mark a property as explicitly set.
+     * This ensures the property will be included in JSON serialization even if null.
+     *
+     * @param string $propertyName The name of the property to mark as explicitly set.
+     */
+    protected function _setField(string $propertyName): void
+    {
+        $this->__explicitlySetProperties[$propertyName] = true;
     }
 
     /**

--- a/seed/php-sdk/imdb/private/src/Imdb/Types/CreateMovieRequest.php
+++ b/seed/php-sdk/imdb/private/src/Imdb/Types/CreateMovieRequest.php
@@ -46,6 +46,7 @@ class CreateMovieRequest extends JsonSerializableType
     public function setTitle(string $value): self
     {
         $this->title = $value;
+        $this->_setField('title');
         return $this;
     }
 
@@ -63,6 +64,7 @@ class CreateMovieRequest extends JsonSerializableType
     public function setRating(float $value): self
     {
         $this->rating = $value;
+        $this->_setField('rating');
         return $this;
     }
 

--- a/seed/php-sdk/imdb/private/src/Imdb/Types/Movie.php
+++ b/seed/php-sdk/imdb/private/src/Imdb/Types/Movie.php
@@ -54,6 +54,7 @@ class Movie extends JsonSerializableType
     public function setId(string $value): self
     {
         $this->id = $value;
+        $this->_setField('id');
         return $this;
     }
 
@@ -71,6 +72,7 @@ class Movie extends JsonSerializableType
     public function setTitle(string $value): self
     {
         $this->title = $value;
+        $this->_setField('title');
         return $this;
     }
 
@@ -88,6 +90,7 @@ class Movie extends JsonSerializableType
     public function setRating(float $value): self
     {
         $this->rating = $value;
+        $this->_setField('rating');
         return $this;
     }
 

--- a/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
@@ -19,6 +19,9 @@ abstract class JsonSerializableType implements \JsonSerializable
     /** @var array<string, mixed> Extra properties from JSON that don't map to class properties */
     private array $__additionalProperties = [];
 
+    /** @var array<string, true> Properties that have been explicitly set via setter methods */
+    private array $__explicitlySetProperties = [];
+
     /**
      * Serializes the object to a JSON string.
      *
@@ -80,7 +83,8 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $value = JsonSerializer::serializeObject($value);
             }
 
-            if ($value !== null) {
+            // Include the value if it's not null, OR if it was explicitly set (even to null)
+            if ($value !== null || array_key_exists($property->getName(), $this->__explicitlySetProperties)) {
                 $result[$jsonKey] = $value;
             }
         }
@@ -191,6 +195,17 @@ abstract class JsonSerializableType implements \JsonSerializable
     public function getAdditionalProperties(): array
     {
         return $this->__additionalProperties;
+    }
+
+    /**
+     * Mark a property as explicitly set.
+     * This ensures the property will be included in JSON serialization even if null.
+     *
+     * @param string $propertyName The name of the property to mark as explicitly set.
+     */
+    protected function _setField(string $propertyName): void
+    {
+        $this->__explicitlySetProperties[$propertyName] = true;
     }
 
     /**

--- a/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
@@ -19,6 +19,9 @@ abstract class JsonSerializableType implements \JsonSerializable
     /** @var array<string, mixed> Extra properties from JSON that don't map to class properties */
     private array $__additionalProperties = [];
 
+    /** @var array<string, true> Properties that have been explicitly set via setter methods */
+    private array $__explicitlySetProperties = [];
+
     /**
      * Serializes the object to a JSON string.
      *
@@ -80,7 +83,8 @@ abstract class JsonSerializableType implements \JsonSerializable
                 $value = JsonSerializer::serializeObject($value);
             }
 
-            if ($value !== null) {
+            // Include the value if it's not null, OR if it was explicitly set (even to null)
+            if ($value !== null || array_key_exists($property->getName(), $this->__explicitlySetProperties)) {
                 $result[$jsonKey] = $value;
             }
         }
@@ -191,6 +195,17 @@ abstract class JsonSerializableType implements \JsonSerializable
     public function getAdditionalProperties(): array
     {
         return $this->__additionalProperties;
+    }
+
+    /**
+     * Mark a property as explicitly set.
+     * This ensures the property will be included in JSON serialization even if null.
+     *
+     * @param string $propertyName The name of the property to mark as explicitly set.
+     */
+    protected function _setField(string $propertyName): void
+    {
+        $this->__explicitlySetProperties[$propertyName] = true;
     }
 
     /**


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-8455

Adds support for explicitly sending `null` into a request in PHP SDKs. This distinguishes between:
1. The user sending a value on purpose
2. The user omitting an optional property on purpose  
3. The user sending `null` into a nullable property on purpose

This follows the same pattern implemented in Go ([#9487](https://github.com/fern-api/fern/pull/9487)) and builds on the earlier PHP proposal ([#6454](https://github.com/fern-api/fern/pull/6454)).

## Changes Made
- Added `$__explicitlySetProperties` array to `JsonSerializableType` to track which properties have been explicitly set via setter methods
- Modified `jsonSerialize()` to include null values for properties that are in the explicitly set list
- Added protected `_setField()` method that setter methods call to mark a property as explicitly set
- Updated setter method generation in `AbstractPhpGeneratorContext.ts` to call `_setField()` after setting the value

## Testing
- [x] Seed tests pass for `nullable`, `imdb:private`, and `property-access` fixtures
- [x] Lint checks pass
- [ ] Unit tests added/updated (no dedicated unit test for explicit nulls runtime behavior)

## Human Review Checklist
- [ ] Verify the `_setField()` call is correctly placed in generated setter methods
- [ ] Verify the `jsonSerialize()` logic correctly includes explicitly set null values
- [ ] Note: This feature only works when using setter methods (generated when `propertyAccess: private` is configured)

---
Link to Devin run: https://app.devin.ai/sessions/1083205353f540de8ce484f39d15ac55
Requested by: @iamnamananand996