### PR TITLE
feat(cli): improve .fernignore to prevent generation of new files

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,7 +2,7 @@
 - version: 3.64.0
   changelogEntry:
     - summary: |
-        Improve `.fernignore` to prevent initial generation of files. Previously, `.fernignore` only prevented overwriting existing files during SDK regeneration.
+        Improve `.fernignore` to prevent generation of new files. Previously, `.fernignore` only prevented modification or deletion of existing files during SDK regeneration.
       type: feat
   createdAt: "2026-02-04"
   irVersion: 63

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.64.0
+  changelogEntry:
+    - summary: |
+        Improve `.fernignore` to prevent initial generation of files. Previously, `.fernignore` only prevented overwriting existing files during SDK regeneration.
+      type: feat
+  createdAt: "2026-02-04"
+  irVersion: 63
+
 - version: 3.63.0
   changelogEntry:
     - summary: |

--- a/packages/cli/ete-tests/src/tests/generate/fernignore.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/fernignore.test.ts
@@ -1,6 +1,6 @@
 import { FERNIGNORE_FILENAME } from "@fern-api/configuration";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { writeFile } from "fs/promises";
+import { mkdir, writeFile } from "fs/promises";
 
 import { runFernCli } from "../../utils/runFernCli";
 import { init } from "../init/init";
@@ -8,6 +8,11 @@ import { init } from "../init/init";
 const FERNIGNORE_FILECONTENTS = `
 fern.js
 **/*.txt
+`;
+
+const FERNIGNORE_PREVENT_INITIAL_GENERATION_FILECONTENTS = `
+src/Client.ts
+src/core/
 `;
 
 const FERN_JS_FILENAME = "fern.js";
@@ -53,6 +58,44 @@ describe("fern generate --local", () => {
         await runFernCli(["generate", "--local", "--keepDocker"], {
             cwd: pathOfDirectory
         });
+    }, 360_000);
+
+    // eslint-disable-next-line jest/expect-expect
+    it("Prevent initial generation of files listed in .fernignore", async () => {
+        const pathOfDirectory = await init();
+
+        // Create output directory with .fernignore BEFORE first generation
+        const absolutePathToLocalOutput = join(pathOfDirectory, RelativeFilePath.of("sdks/typescript"));
+        await mkdir(absolutePathToLocalOutput, { recursive: true });
+
+        // Write .fernignore that excludes src/Client.ts and src/core/ directory
+        const absolutePathToFernignore = join(absolutePathToLocalOutput, RelativeFilePath.of(FERNIGNORE_FILENAME));
+        await writeFile(absolutePathToFernignore, FERNIGNORE_PREVENT_INITIAL_GENERATION_FILECONTENTS);
+
+        // Run first generation - excluded files should NOT be created
+        await runFernCli(["generate", "--local", "--keepDocker"], {
+            cwd: pathOfDirectory
+        });
+
+        // Verify .fernignore still exists
+        await expectPathExists(absolutePathToFernignore);
+
+        // Verify src/Client.ts was NOT generated (exact file match test)
+        const absolutePathToClientTs = join(absolutePathToLocalOutput, RelativeFilePath.of("src/Client.ts"));
+        await expectPathDoesNotExist(absolutePathToClientTs);
+
+        // Verify src/core/ directory was NOT generated (directory pattern test)
+        const absolutePathToCore = join(absolutePathToLocalOutput, RelativeFilePath.of("src/core"));
+        await expectPathDoesNotExist(absolutePathToCore);
+
+        // Run generation again to ensure it's stable
+        await runFernCli(["generate", "--local", "--keepDocker"], {
+            cwd: pathOfDirectory
+        });
+
+        // Files should still not exist
+        await expectPathDoesNotExist(absolutePathToClientTs);
+        await expectPathDoesNotExist(absolutePathToCore);
     }, 360_000);
 });
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -298,6 +298,7 @@ export class LocalTaskHandler {
 
         // Undo changes to fernignore paths
         await this.runGitCommand(["reset", "--", ...fernIgnorePaths], this.absolutePathToLocalOutput);
+        await this.runGitCommand(["clean", "-fd", "--", ...fernIgnorePaths], this.absolutePathToLocalOutput);
         await this.runGitCommand(["restore", "."], this.absolutePathToLocalOutput);
     }
 
@@ -335,7 +336,7 @@ export class LocalTaskHandler {
 
         // Undo changes to fernignore paths
         await this.runGitCommand(["reset", "--", ...fernIgnorePaths], tmpOutputResolutionDir);
-
+        await this.runGitCommand(["clean", "-fd", "--", ...fernIgnorePaths], tmpOutputResolutionDir);
         await this.runGitCommand(["restore", "."], tmpOutputResolutionDir);
 
         // remove .git dir before copying files over


### PR DESCRIPTION
## Description

Refs: User request from @aditya-arolkar-swe

Improves `.fernignore` to prevent generation of new files, not just prevent modification or deletion of existing files during SDK regeneration. This allows users to exclude files and directories from being created in the first place.

**Link to Devin run:** https://app.devin.ai/sessions/afdef0b07370432ea61a1a91874209d0

## Changes Made

- Added `git clean -fd -- ...fernIgnorePaths` command after `git reset` in `LocalTaskHandler.ts` to remove newly generated files that match `.fernignore` patterns
- This simple approach leverages git's existing pathspec matching to clean up files that shouldn't have been generated
- Added test case "Prevent initial generation of files listed in .fernignore"
- [ ] Updated README.md generator (if applicable) - N/A

## Updates since last revision

- **Simplified implementation**: Per feedback, replaced the complex file filtering approach (copyDirectoryWithExclusions, shouldExcludeFile, etc.) with a simple `git clean` command that removes files matching fernignore patterns after they're copied
- **Removed changes to ClonedRepository.ts and GitHub.ts**: The simpler approach only requires changes to LocalTaskHandler.ts
- **No new dependencies**: No longer uses minimatch or any additional packages
- **Updated changelog wording**: Changed "initial generation" to "new files" and clarified that previously it prevented "modification or deletion" per review feedback

## Testing

- [x] Unit tests added/updated - Added test case "Prevent initial generation of files listed in .fernignore" 
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify `git clean -fd -- <paths>` correctly removes files/directories matching the fernignore patterns without affecting other files
- [ ] Note: This feature only applies when `.fernignore` exists in the output directory (the `copyGeneratedFilesWithFernIgnore*` code paths)
- [ ] Verify test correctly exercises the new behavior (that `src/Client.ts` and `src/core/` would be generated without the .fernignore exclusion)