### PR TITLE
fix(cli): validate broken links in sections with paths, not just pages

### DIFF
--- a/packages/cli/ete-tests/src/tests/broken-links/__snapshots__/broken-links.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/broken-links/__snapshots__/broken-links.test.ts.snap
@@ -15,3 +15,13 @@ exports[`fern docs broken-links > simple broken links 1`] = `
        
 [docs]:Found 4 errors and 0 warnings in"
 `;
+
+exports[`fern docs broken-links > broken links in sections with path property should be detected 1`] = `
+"[docs]: section-index.mdx
+        [error] broken link to /nonexistent/page
+        	fix here: section-index.mdx:11:21
+        [error] broken link to ./missing.mdx (resolved path: section-with-path/missing.mdx)
+        	fix here: section-index.mdx:12:25
+        
+[docs]: Found 2 errors and 0 warnings in"
+`;

--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -40,4 +40,14 @@ describe("fern docs broken-links", () => {
         // should NOT be flagged as broken links
         expect(stripAnsi(stdout)).toContain("All checks passed");
     }, 20_000);
+
+    it("broken links in sections with path property should be detected", async () => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("section-with-path")),
+            reject: false
+        });
+        // This fixture tests that markdown files referenced by sections with a path
+        // property are validated for broken links (not just pages)
+        expect(stripAnsi(stdout).slice(0, -15)).toMatchSnapshot();
+    }, 20_000);
 });

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/section-with-path/fern/child.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/section-with-path/fern/child.mdx
@@ -1,0 +1,11 @@
+# Child Page
+
+This is a child page within the section.
+
+## Valid Links
+
+1. valid link back to section index [../section-with-path](../section-with-path)
+
+## Content
+
+This page has no broken links.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/section-with-path/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/section-with-path/fern/docs.yml
@@ -1,0 +1,9 @@
+instances:
+  - url: ferndevtest.docs.dev.buildwithfern.com
+
+navigation:
+  - section: Section With Path
+    path: section-index.mdx
+    contents:
+      - page: Child Page
+        path: child.mdx

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/section-with-path/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/section-with-path/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "version": "*",
+  "organization": "fern"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/section-with-path/fern/section-index.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/section-with-path/fern/section-index.mdx
@@ -1,0 +1,12 @@
+# Section Index Page
+
+This is the index page for a section that has a path property.
+
+## Valid Links
+
+1. valid relative link to child [./child.mdx](./child.mdx)
+
+## Broken Links
+
+1. broken page link [/nonexistent/page](/nonexistent/page)
+2. broken relative link [./missing.mdx](./missing.mdx)

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
@@ -180,16 +180,15 @@ async function visitNavigationItem({
         availability: noop
     });
 
-    if (navigationItemIsPage(navigationItem)) {
-        const absoluteFilepath = resolve(dirname(absoluteFilepathToConfiguration), navigationItem.path);
+    const markdownPath = getNavigationItemMarkdownPath(navigationItem);
+    if (markdownPath != null) {
+        const absoluteFilepath = resolve(dirname(absoluteFilepathToConfiguration), markdownPath);
         if (await doesPathExist(absoluteFilepath)) {
             const fileStats = await stat(absoluteFilepath);
             const fileSizeMB = fileStats.size / (1024 * 1024);
 
             if (fileSizeMB > 1) {
-                context.logger.trace(
-                    `Processing large markdown file: ${navigationItem.path} (${fileSizeMB.toFixed(2)} MB)`
-                );
+                context.logger.trace(`Processing large markdown file: ${markdownPath} (${fileSizeMB.toFixed(2)} MB)`);
             }
 
             const startTime = performance.now();
@@ -197,16 +196,17 @@ async function visitNavigationItem({
             const readTime = performance.now() - startTime;
 
             if (readTime > 2000) {
-                context.logger.debug(`Slow file read: ${navigationItem.path} took ${readTime.toFixed(0)}ms`);
+                context.logger.debug(`Slow file read: ${markdownPath} took ${readTime.toFixed(0)}ms`);
             }
 
+            const title = getNavigationItemTitle(navigationItem);
             await visitor.markdownPage?.(
                 {
-                    title: navigationItem.page,
+                    title,
                     content,
                     absoluteFilepath
                 },
-                [...nodePath, navigationItem.path]
+                [...nodePath, markdownPath]
             );
 
             try {
@@ -218,9 +218,7 @@ async function visitNavigationItem({
                 const parseTime = performance.now() - parseStart;
 
                 if (parseTime > 2000) {
-                    context.logger.debug(
-                        `Slow image path parsing: ${navigationItem.path} took ${parseTime.toFixed(0)}ms`
-                    );
+                    context.logger.debug(`Slow image path parsing: ${markdownPath} took ${parseTime.toFixed(0)}ms`);
                 }
 
                 for (const filepath of filepaths) {
@@ -230,11 +228,11 @@ async function visitNavigationItem({
                             value: relative(absolutePathToFernFolder, filepath),
                             willBeUploaded: true
                         },
-                        [...nodePath, navigationItem.path]
+                        [...nodePath, markdownPath]
                     );
                 }
             } catch (err) {
-                context.logger.trace(`Failed to parse image paths in ${navigationItem.path}: ${err}`);
+                context.logger.trace(`Failed to parse image paths in ${markdownPath}: ${err}`);
             }
         }
     }
@@ -298,6 +296,33 @@ function navigationItemIsChangelog(
 function navigationItemIsPage(item: docsYml.RawSchemas.NavigationItem): item is docsYml.RawSchemas.PageConfiguration {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return (item as docsYml.RawSchemas.PageConfiguration)?.page != null;
+}
+
+function navigationItemIsSection(
+    item: docsYml.RawSchemas.NavigationItem
+): item is docsYml.RawSchemas.SectionConfiguration {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return (item as docsYml.RawSchemas.SectionConfiguration)?.section != null;
+}
+
+function getNavigationItemMarkdownPath(item: docsYml.RawSchemas.NavigationItem): string | undefined {
+    if (navigationItemIsPage(item)) {
+        return item.path;
+    }
+    if (navigationItemIsSection(item) && item.path != null) {
+        return item.path;
+    }
+    return undefined;
+}
+
+function getNavigationItemTitle(item: docsYml.RawSchemas.NavigationItem): string {
+    if (navigationItemIsPage(item)) {
+        return item.page;
+    }
+    if (navigationItemIsSection(item)) {
+        return item.section;
+    }
+    return "Unknown";
 }
 
 function navigationItemIsApi(


### PR DESCRIPTION
## Description
Refs: Slack thread from @Ryan-Amirthan

Fixes a bug where `fern check --strict-broken-links` was not validating markdown files referenced by sections with paths. Previously, only `page` navigation items were validated for broken links, but sections can also have a `path` property pointing to a markdown file that should be validated.

**Before**: A section like this would NOT have its markdown validated:
```yaml
- section: Carbide
  path: carbide/index.mdx  # Broken links in this file were NOT caught
  contents:
    - page: Customization
      path: ../customization.mdx  # This WAS validated
```

**After**: Both pages and sections with paths are validated for broken links.

## Changes Made
- Modified `visitNavigationItem()` to check for any navigation item with a markdown path, not just pages
- Added `navigationItemIsSection()` type guard to detect section configurations
- Added `getNavigationItemMarkdownPath()` helper to extract the path from pages or sections
- Added `getNavigationItemTitle()` helper to get the appropriate title for error messages
- Added test fixture `section-with-path` with a section containing broken links
- Added test case to verify broken links in sections are detected

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed - built the CLI locally and verified broken links are now caught in sections with paths

## Human Review Checklist
- [ ] Verify `navigationItemIsSection()` type guard correctly identifies section configurations
- [ ] Confirm there are no other navigation item types with `path` properties that should also be validated
- [ ] Verify the test snapshot format matches expected CLI output

---
Link to Devin run: https://app.devin.ai/sessions/37daae0937534529a452800b45252c99
Requested by: @Ryan-Amirthan