### PR TITLE
fix: suppress spurious warning count when logWarnings is false

### DIFF
--- a/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
@@ -419,19 +419,18 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
                     ? ` for ${errorCollector.relativeFilepathToSpec}`
                     : "";
 
-                // TODO(kenny): we should do something more useful with the warnings here, or remove.
-
                 if (errorStats.numErrors > 0) {
                     context.logger.log(
                         "error",
                         `API validation${specInfo} completed with ${errorStats.numErrors} errors and ${errorStats.numWarnings} warnings.`
                     );
-                } else if (errorStats.numWarnings > 0) {
+                } else if (errorStats.numWarnings > 0 && logWarnings) {
+                    // Only show warning count if logWarnings is true, since the user can see the details
                     context.logger.log(
                         "warn",
                         `API validation${specInfo} completed with ${errorStats.numWarnings} warnings.`
                     );
-                } else {
+                } else if (errorStats.numWarnings === 0) {
                     context.logger.log("info", `All checks passed when parsing OpenAPI${specInfo}.`);
                 }
 


### PR DESCRIPTION
## Description
Refs: Slack thread from Lisa White asking about API validation warnings

When running `fern docs dev`, users see a message like "API validation for fern/apis/experience-api/experience.yaml completed with 1 warnings" but have no way to see the actual warning details. This is confusing because:
1. The `--warnings` flag doesn't work for `fern docs dev`
2. The `--logLevel` flag doesn't help
3. The warnings are often spurious (from example generation when something is null but wasn't expected to be)

This PR suppresses the warning count message when `logWarnings` is false, since showing a count without the ability to see details is not useful.

## Changes Made
- Modified the condition for showing the warning count message to also check `logWarnings`
- When `logWarnings` is false and there are only warnings (no errors), no message is shown
- Removed the TODO comment that was already noting this issue

## Testing
- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual testing with an OpenAPI spec that produces warnings

## Human Review Checklist
- [ ] Verify the new behavior is correct: when `logWarnings=false` and there are warnings but no errors, no message is logged (silent)
- [ ] Consider if this silent behavior is acceptable vs. alternative approaches

---
Link to Devin run: https://app.devin.ai/sessions/81e3d432f92b47df8bee442429641578
Requested by: Chris McDonnell (@cdonel707)