### PR TITLE
fix(cli): make AsyncAPI parsing failures fatal

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
@@ -73,10 +73,10 @@ export function parse({
     };
     let documentIndex = 0;
     for (const document of documents) {
-        try {
-            const source = document.source != null ? document.source : OpenApiIrSource.openapi({ file: "<memory>" });
-            switch (document.type) {
-                case "openapi": {
+        const source = document.source != null ? document.source : OpenApiIrSource.openapi({ file: "<memory>" });
+        switch (document.type) {
+            case "openapi": {
+                try {
                     const openapiIr = generateIrFromV3({
                         taskContext: context,
                         openApi: document.value,
@@ -86,55 +86,53 @@ export function parse({
                     });
                     ir = merge(ir, openapiIr, getParseOptions({ options: document.settings, overrides: options }));
                     documentIndex++;
-                    break;
+                } catch (error) {
+                    context.logger.debug(`Skipping parsing document ${document.value.info?.title}`);
+                    if (error instanceof Error) {
+                        context.logger.debug(error.message, error.stack ? "\n" + error.stack : "");
+                    }
                 }
-                case "asyncapi": {
-                    const parsedAsyncAPI = parseAsyncAPI({
-                        document: document.value,
-                        taskContext: context,
-                        options: getParseOptions({ options: document.settings, overrides: options }),
-                        source,
-                        asyncApiOptions: getParseAsyncOptions({ options: document.settings }),
-                        namespace: document.namespace
-                    });
-                    if (parsedAsyncAPI.servers != null) {
-                        ir.websocketServers = [
-                            ...ir.websocketServers,
-                            ...parsedAsyncAPI.servers.map((server) => ({
-                                ...server,
-                                audiences: undefined,
-                                description: undefined,
-                                defaultUrl: undefined,
-                                urlTemplate: undefined,
-                                variables: undefined
-                            }))
-                        ];
-                    }
-                    if (parsedAsyncAPI.channels != null) {
-                        ir.channels = {
-                            ...ir.channels,
-                            ...parsedAsyncAPI.channels
-                        };
-                    }
-                    if (parsedAsyncAPI.groupedSchemas != null) {
-                        ir.groupedSchemas = mergeSchemaMaps(ir.groupedSchemas, parsedAsyncAPI.groupedSchemas);
-                    }
-                    if (parsedAsyncAPI.basePath != null) {
-                        ir.basePath = parsedAsyncAPI.basePath;
-                    }
-                    documentIndex++;
-                    break;
+                break;
+            }
+            case "asyncapi": {
+                const parsedAsyncAPI = parseAsyncAPI({
+                    document: document.value,
+                    taskContext: context,
+                    options: getParseOptions({ options: document.settings, overrides: options }),
+                    source,
+                    asyncApiOptions: getParseAsyncOptions({ options: document.settings }),
+                    namespace: document.namespace
+                });
+                if (parsedAsyncAPI.servers != null) {
+                    ir.websocketServers = [
+                        ...ir.websocketServers,
+                        ...parsedAsyncAPI.servers.map((server) => ({
+                            ...server,
+                            audiences: undefined,
+                            description: undefined,
+                            defaultUrl: undefined,
+                            urlTemplate: undefined,
+                            variables: undefined
+                        }))
+                    ];
                 }
-                default:
-                    assertNever(document);
+                if (parsedAsyncAPI.channels != null) {
+                    ir.channels = {
+                        ...ir.channels,
+                        ...parsedAsyncAPI.channels
+                    };
+                }
+                if (parsedAsyncAPI.groupedSchemas != null) {
+                    ir.groupedSchemas = mergeSchemaMaps(ir.groupedSchemas, parsedAsyncAPI.groupedSchemas);
+                }
+                if (parsedAsyncAPI.basePath != null) {
+                    ir.basePath = parsedAsyncAPI.basePath;
+                }
+                documentIndex++;
+                break;
             }
-        } catch (error) {
-            context.logger.debug(
-                `Skipping parsing document ${document.type === "openapi" ? document.value.info?.title : document.source?.file}`
-            );
-            if (error instanceof Error) {
-                context.logger.debug(error.message, error.stack ? "\n" + error.stack : "");
-            }
+            default:
+                assertNever(document);
         }
     }
     return ir;

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.64.3
+  changelogEntry:
+    - summary: |
+        Make AsyncAPI parsing failures fatal. Previously, when an AsyncAPI document failed to parse, it was logged at debug level and skipped. Now, parsing failures will cause `fern check` and generation to fail with an error.
+      type: fix
+  createdAt: "2026-02-05"
+  irVersion: 63
+
 - version: 3.64.2
   changelogEntry:
     - summary: |

--- a/packages/cli/workspace/lazy-fern-workspace/src/loaders/OpenAPILoader.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/loaders/OpenAPILoader.ts
@@ -76,26 +76,19 @@ export class OpenAPILoader {
                 }
 
                 if (contents.includes("asyncapi")) {
-                    try {
-                        const asyncAPI = await loadAsyncAPI({
-                            context,
-                            absoluteFilePath: spec.absoluteFilepath,
-                            absoluteFilePathToOverrides: spec.absoluteFilepathToOverrides
-                        });
-                        documents.push({
-                            type: "asyncapi",
-                            value: asyncAPI,
-                            source,
-                            namespace: spec.namespace,
-                            settings: getParseOptions({ options: spec.settings })
-                        });
-                        continue;
-                    } catch (error) {
-                        context.logger.error(
-                            `Failed to parse AsyncAPI document at ${spec.absoluteFilepath}: ${error}. Skipping...`
-                        );
-                        continue;
-                    }
+                    const asyncAPI = await loadAsyncAPI({
+                        context,
+                        absoluteFilePath: spec.absoluteFilepath,
+                        absoluteFilePathToOverrides: spec.absoluteFilepathToOverrides
+                    });
+                    documents.push({
+                        type: "asyncapi",
+                        value: asyncAPI,
+                        source,
+                        namespace: spec.namespace,
+                        settings: getParseOptions({ options: spec.settings })
+                    });
+                    continue;
                 }
 
                 if (contents.includes("openrpc")) {


### PR DESCRIPTION
## Description

Refs: Slack thread about AsyncAPI parsing failures being silently skipped

Previously, when an AsyncAPI document failed to parse, it was logged at debug level with "Skipping parsing document" and the CLI continued. This made it easy to miss configuration issues. Now, AsyncAPI parsing failures will cause `fern check` and generation to fail with an error.

**Link to Devin run:** https://app.devin.ai/sessions/69b905a8948a427485624f081ccc25f4
**Requested by:** @tjb9dc

## Changes Made

- Removed try-catch around AsyncAPI parsing in `parse.ts` - errors now propagate up
- Removed try-catch around AsyncAPI loading in `OpenAPILoader.ts` - loading failures now propagate up
- OpenAPI parsing behavior unchanged (still logs and skips on failure)
- Added version 3.64.3 changelog entry

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed (lint checks pass)

## Human Review Checklist

- [ ] Verify this is a **breaking change** for users with invalid AsyncAPI documents that were previously silently skipped
- [ ] Confirm the asymmetric behavior is intentional: AsyncAPI failures are now fatal, while OpenAPI failures still skip silently
- [ ] Consider if users need a way to opt-out of this stricter behavior