### PR TITLE
feat(cli): Update UI with task status tracking

### DIFF
--- a/packages/cli/cli-v2/src/api/adapter/LegacyFernWorkspaceAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyFernWorkspaceAdapter.ts
@@ -21,7 +21,7 @@ export namespace LegacyFernWorkspaceAdapter {
         /** CLI version for workspace metadata */
         cliVersion: string;
 
-        /** Task for log display */
+        /** The current task */
         task: Task;
     }
 }

--- a/packages/cli/cli-v2/src/api/checker/ApiChecker.ts
+++ b/packages/cli/cli-v2/src/api/checker/ApiChecker.ts
@@ -5,9 +5,9 @@ import { AbsoluteFilePath, join, RelativeFilePath, relativize } from "@fern-api/
 import chalk from "chalk";
 import type { Context } from "../../context/Context";
 import { Colors, formatMessage, Icons } from "../../ui/format";
+import { Task } from "../../ui/Task";
 import type { Workspace } from "../../workspace/Workspace";
 import { ApiDefinitionValidator } from "../validator/ApiDefinitionValidator";
-import { Task } from "../../ui/Task";
 
 const INDENT = {
     /** Base indent for file paths */

--- a/packages/cli/cli-v2/src/api/checker/ApiChecker.ts
+++ b/packages/cli/cli-v2/src/api/checker/ApiChecker.ts
@@ -7,6 +7,7 @@ import type { Context } from "../../context/Context";
 import { Colors, formatMessage, Icons } from "../../ui/format";
 import type { Workspace } from "../../workspace/Workspace";
 import { ApiDefinitionValidator } from "../validator/ApiDefinitionValidator";
+import { Task } from "../../ui/Task";
 
 const INDENT = {
     /** Base indent for file paths */
@@ -39,6 +40,9 @@ export declare namespace ApiChecker {
 
         /** Output stream for writing results (defaults to process.stderr) */
         stream?: NodeJS.WriteStream;
+
+        /** The current task, if any */
+        task?: Task;
     }
 
     export interface Result {
@@ -63,11 +67,13 @@ export class ApiChecker {
     private readonly context: Context;
     private readonly cliVersion: string;
     private readonly stream: NodeJS.WriteStream;
+    private readonly task: Task | undefined;
 
     constructor(config: ApiChecker.Config) {
         this.context = config.context;
         this.cliVersion = config.cliVersion;
         this.stream = config.stream ?? process.stderr;
+        this.task = config.task;
     }
 
     /**
@@ -102,7 +108,8 @@ export class ApiChecker {
 
         const validator = new ApiDefinitionValidator({
             context: this.context,
-            cliVersion: this.cliVersion
+            cliVersion: this.cliVersion,
+            task: this.task
         });
 
         const allViolations: ApiChecker.ResolvedViolation[] = [];
@@ -157,7 +164,7 @@ export class ApiChecker {
 
     private writeHeader(): void {
         this.stream.write("\n");
-        this.stream.write(`${Icons.info} ${chalk.bold("Validating API definitions")}\n`);
+        this.stream.write(`${Icons.info} ${chalk.bold(`Validate APIs`)}\n`);
         this.stream.write("\n");
     }
 
@@ -382,5 +389,9 @@ export class ApiChecker {
             return `${Math.round(ms)}ms`;
         }
         return `${(ms / 1000).toFixed(1)}s`;
+    }
+
+    private maybePluralApis(apis: string[]): string {
+        return apis.length === 1 ? "API" : "APIs";
     }
 }

--- a/packages/cli/cli-v2/src/api/validator/ApiDefinitionValidator.ts
+++ b/packages/cli/cli-v2/src/api/validator/ApiDefinitionValidator.ts
@@ -5,13 +5,13 @@ import { LazyFernWorkspace, OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { validateOSSWorkspace } from "@fern-api/oss-validator";
 import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter";
 import type { Context } from "../../context/Context";
+import { Task } from "../../ui/Task";
 import { LegacyApiSpecAdapter } from "../adapter/LegacyApiSpecAdapter";
 import type { ApiDefinition } from "../config/ApiDefinition";
 import type { ApiSpec } from "../config/ApiSpec";
 import { isConjureSpec } from "../config/ConjureSpec";
 import type { FernSpec } from "../config/FernSpec";
 import { isFernSpec } from "../config/FernSpec";
-import { Task } from "../../ui/Task";
 
 /**
  * Validates ApiDefinitions before generation.

--- a/packages/cli/cli-v2/src/api/validator/ApiDefinitionValidator.ts
+++ b/packages/cli/cli-v2/src/api/validator/ApiDefinitionValidator.ts
@@ -11,6 +11,7 @@ import type { ApiSpec } from "../config/ApiSpec";
 import { isConjureSpec } from "../config/ConjureSpec";
 import type { FernSpec } from "../config/FernSpec";
 import { isFernSpec } from "../config/FernSpec";
+import { Task } from "../../ui/Task";
 
 /**
  * Validates ApiDefinitions before generation.
@@ -26,6 +27,9 @@ export namespace ApiDefinitionValidator {
 
         /** CLI version for workspace metadata */
         cliVersion: string;
+
+        /** The current task, if any */
+        task?: Task;
     }
 
     export interface Result {
@@ -50,7 +54,7 @@ export class ApiDefinitionValidator {
 
     constructor(config: ApiDefinitionValidator.Config) {
         this.context = config.context;
-        this.taskContext = new TaskContextAdapter({ context: this.context });
+        this.taskContext = new TaskContextAdapter({ context: this.context, task: config.task });
         this.cliVersion = config.cliVersion;
     }
 

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -8,9 +8,12 @@ import type { GlobalArgs } from "../../../context/GlobalArgs";
 import { CliError } from "../../../errors/CliError";
 import type { Target } from "../../../sdk/config/Target";
 import { GeneratorPipeline } from "../../../sdk/generator/GeneratorPipeline";
-import { TaskGroup } from "../../../ui/TaskGroup";
+import { SdkStageOverrides, SdkTaskGroup } from "../../../sdk/task/SdkTaskGroup";
 import type { Workspace } from "../../../workspace/Workspace";
 import { command } from "../../_internal/command";
+import { GitOutputModeSchema, GitOutputSchema } from "../../../../../config/lib/schemas";
+import { assertNever } from "@fern-api/core-utils";
+import type { TaskStageLabels } from "../../../ui/TaskStageLabels";
 
 export declare namespace GenerateCommand {
     export interface Args extends GlobalArgs {
@@ -85,62 +88,58 @@ export class GenerateCommand {
         const token = args.local ? undefined : await context.getTokenOrPrompt();
         const runtime = args.local ? "local" : "remote";
 
-        const taskGroup = new TaskGroup({ context });
+        const taskGroup = new SdkTaskGroup({ context });
+        for (const target of targets) {
+            const stageOverrides: SdkStageOverrides | undefined =
+                target.output.git != null
+                    ? {
+                          output: this.getGitOutputStageLabels(target.output.git.mode ?? "pr")
+                      }
+                    : undefined;
 
-        const skippedTargets = targets.filter((t) => checkResult.invalidApis.has(t.api));
-        for (const target of skippedTargets) {
             taskGroup.addTask({
                 id: target.name,
                 name: target.name,
-                status: "skipped",
-                skipReason: `API '${target.api}' has errors`
+                stageOverrides
             });
         }
 
-        for (const target of validTargets) {
-            taskGroup.addTask({
-                id: target.name,
-                name: target.name
-            });
-        }
+        const sdkInitialism = this.maybePluralSdks(targets);
 
         await taskGroup.start({
-            title: "Generating SDKs",
+            title: `Generating ${sdkInitialism}`,
             subtitle: `org: ${workspace.sdks.org}`
         });
 
         await Promise.all(
-            validTargets.map(async (target) => {
-                const apiDefinition = workspace.apis[target.api];
-                if (apiDefinition == null) {
-                    const message = `API '${target.api}' not found in workspace`;
-                    taskGroup.updateTask({
-                        id: target.name,
-                        update: { status: "error", error: message }
-                    });
-                    return;
-                }
-
+            targets.map(async (target) => {
                 const task = taskGroup.getTask(target.name);
                 if (task == null) {
                     // This should be unreachable.
                     throw new Error(`Internal error; task '${target.name}' not found`);
                 }
 
-                taskGroup.updateTask({
-                    id: target.name,
-                    update: {
-                        status: "running",
-                        currentStep: `${target.image}:${target.version}`
-                    }
-                });
+                task.start();
 
+                task.stage.validation.start();
+                const apiDefinition = workspace.apis[target.api];
+                if (apiDefinition == null) {
+                    task.stage.validation.fail(`API not found in workspace`);
+                    return;
+                }
+                if (checkResult.invalidApis.has(target.api)) {
+                    task.stage.validation.fail(`API is invalid`);
+                    return;
+                }
+                task.stage.validation.complete();
+
+                task.stage.generator.start();
                 const pipelineResult = await pipeline.run({
                     organization: workspace.org,
                     ai: workspace.ai,
-                    task,
                     target,
                     apiDefinition,
+                    task: task.getTask(),
                     audiences: this.parseAudiences(args.audience),
                     runtime,
                     containerEngine: args["container-engine"] ?? "docker",
@@ -151,32 +150,37 @@ export class GenerateCommand {
                     version: args.version
                 });
                 if (!pipelineResult.success) {
-                    taskGroup.updateTask({
-                        id: target.name,
-                        update: {
-                            status: "error",
-                            error: pipelineResult.error
-                        }
-                    });
+                    task.stage.generator.fail(pipelineResult.error);
                     return;
                 }
-                taskGroup.updateTask({
-                    id: target.name,
-                    update: {
-                        status: "success",
-                        output: pipelineResult.output
-                    }
-                });
+                task.stage.generator.complete();
+                task.stage.output.complete();
+                task.complete(pipelineResult.output);
             })
         );
 
-        const summary = taskGroup.complete({
-            successMessage: `Successfully generated ${this.maybePluralSdks(validTargets)}`,
-            errorMessage: `Failed to generate ${this.maybePluralSdks(validTargets)}`
+        const summary = taskGroup.finish({
+            successMessage: `Successfully generated ${sdkInitialism}`,
+            errorMessage: `Failed to generate ${sdkInitialism}`
         });
 
         if (summary.failedCount > 0) {
             throw CliError.exit();
+        }
+    }
+
+    private validateArgs(args: GenerateCommand.Args): void {
+        if (args.output != null && !args.preview) {
+            throw new Error("The --output flag can only be used with --preview");
+        }
+        if (args["container-engine"] != null && !args.local) {
+            throw new Error("The --container-engine flag can only be used with --local");
+        }
+        if (args.group != null && args.target != null) {
+            throw new Error("The --group and --target flags cannot be used together");
+        }
+        if (args.group == null && args.target == null) {
+            throw new Error("A --target or --group must be specified");
         }
     }
 
@@ -206,9 +210,6 @@ export class GenerateCommand {
         return targets;
     }
 
-    /**
-     * Filter targets by group name. If no group is specified, returns all targets.
-     */
     private filterTargetsByGroup(targets: Target[], groupName: string | undefined): Target[] {
         if (groupName == null) {
             return targets;
@@ -226,23 +227,33 @@ export class GenerateCommand {
         };
     }
 
-    private validateArgs(args: GenerateCommand.Args): void {
-        if (args.output != null && !args.preview) {
-            throw new Error("The --output flag can only be used with --preview");
-        }
-        if (args["container-engine"] != null && !args.local) {
-            throw new Error("The --container-engine flag can only be used with --local");
-        }
-        if (args.group != null && args.target != null) {
-            throw new Error("The --group and --target flags cannot be used together");
-        }
-        if (args.group == null && args.target == null) {
-            throw new Error("A --target or --group must be specified");
-        }
-    }
-
     private maybePluralSdks(targets: Target[]): string {
         return targets.length === 1 ? "SDK" : "SDKs";
+    }
+
+    private getGitOutputStageLabels(mode: GitOutputModeSchema): Partial<TaskStageLabels> {
+        switch (mode) {
+            case "push":
+                return {
+                    pending: "Push to repository",
+                    running: "Pushing to repository...",
+                    success: "Pushed to repository"
+                };
+            case "release":
+                return {
+                    pending: "Create release",
+                    running: "Creating release...",
+                    success: "Created release"
+                };
+            case "pr":
+                return {
+                    pending: "Create pull request",
+                    running: "Creating pull request...",
+                    success: "Created pull request"
+                };
+            default:
+                assertNever(mode);
+        }
     }
 }
 

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -1,7 +1,9 @@
 import type { Audiences } from "@fern-api/configuration";
 import type { ContainerRunner } from "@fern-api/core-utils";
+import { assertNever } from "@fern-api/core-utils";
 import { resolve } from "@fern-api/fs-utils";
 import type { Argv } from "yargs";
+import { GitOutputModeSchema } from "../../../../../config/lib/schemas";
 import { ApiChecker } from "../../../api/checker/ApiChecker";
 import type { Context } from "../../../context/Context";
 import type { GlobalArgs } from "../../../context/GlobalArgs";
@@ -9,11 +11,9 @@ import { CliError } from "../../../errors/CliError";
 import type { Target } from "../../../sdk/config/Target";
 import { GeneratorPipeline } from "../../../sdk/generator/GeneratorPipeline";
 import { SdkStageOverrides, SdkTaskGroup } from "../../../sdk/task/SdkTaskGroup";
+import type { TaskStageLabels } from "../../../ui/TaskStageLabels";
 import type { Workspace } from "../../../workspace/Workspace";
 import { command } from "../../_internal/command";
-import { GitOutputModeSchema, GitOutputSchema } from "../../../../../config/lib/schemas";
-import { assertNever } from "@fern-api/core-utils";
-import type { TaskStageLabels } from "../../../ui/TaskStageLabels";
 
 export declare namespace GenerateCommand {
     export interface Args extends GlobalArgs {

--- a/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
@@ -15,10 +15,14 @@ import { TaskContextLogger } from "./TaskContextLogger";
 /**
  * Adapts the CLI context to the legacy TaskContext interface.
  *
- * When a task is provided, logs are written to the task's log display.
+ * When a task is provided, logs are written to the task's log display
+ * and to the log file via TaskContextLogger.
+ *
  * When no task is provided (e.g., during validation), logs are written
  * directly to stderr, filtered by logLevel (defaults to Warn).
  *
+ * @param context - The CLI context
+ * @param task - Optional task for log file writing
  * @param logLevel - Minimum log level to display. Defaults to Warn (only warnings and errors).
  *                   Pass LogLevel.Info to include info messages (e.g., for device code flow).
  */
@@ -29,9 +33,9 @@ export class TaskContextAdapter implements TaskContext {
 
     constructor({ context, task, logLevel = LogLevel.Warn }: { context: Context; task?: Task; logLevel?: LogLevel }) {
         if (task != null) {
-            this.logger = new TaskContextLogger({ context, task });
+            this.logger = new TaskContextLogger({ context, task, logLevel });
         } else {
-            // When no task is provided, use a simple logger that writes to stderr.
+            // When no task is provided, write directly to stderr.
             this.logger = createLogger((level: LogLevel, ...args: string[]) => {
                 if (LOG_LEVELS.indexOf(level) >= LOG_LEVELS.indexOf(logLevel)) {
                     context.stderr.log(level, ...args);

--- a/packages/cli/cli-v2/src/context/adapter/TaskContextLogger.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextLogger.ts
@@ -1,12 +1,12 @@
-import { Logger, LogLevel } from "@fern-api/logger";
+import { LOG_LEVELS, Logger, LogLevel } from "@fern-api/logger";
 import type { Task } from "../../ui/Task";
 import type { Context } from "../Context";
 
 export class TaskContextLogger implements Logger {
     private readonly context: Context;
     private readonly task: Task;
+    private readonly logLevel: LogLevel;
 
-    private logLevel: LogLevel;
     private enabled: boolean = true;
     private collectedErrors: string[] = [];
 
@@ -32,7 +32,7 @@ export class TaskContextLogger implements Logger {
         const message = args.join(" ");
         this.context.logFileWriter.write({ taskName: this.task.name, level: LogLevel.Debug, message });
 
-        if (this.enabled && this.context.logLevel === LogLevel.Debug) {
+        if (this.shouldLogToTask(LogLevel.Debug)) {
             if (this.task.logs == null) {
                 this.task.logs = [];
             }
@@ -44,11 +44,11 @@ export class TaskContextLogger implements Logger {
         const message = args.join(" ");
         this.context.logFileWriter.write({ taskName: this.task.name, level: LogLevel.Info, message });
 
-        // Given how noisy info logs are, we capture them as debug logs in the UI.
-        if (this.enabled && this.context.logLevel === LogLevel.Debug) {
+        if (this.shouldLogToTask(LogLevel.Info)) {
             if (this.task.logs == null) {
                 this.task.logs = [];
             }
+            // Display info as debug in the UI since info logs tend to be noisy.
             this.task.logs.push({ level: "debug", message });
         }
     }
@@ -57,7 +57,7 @@ export class TaskContextLogger implements Logger {
         const message = args.join(" ");
         this.context.logFileWriter.write({ taskName: this.task.name, level: LogLevel.Warn, message });
 
-        if (this.enabled) {
+        if (this.shouldLogToTask(LogLevel.Warn)) {
             if (this.task.logs == null) {
                 this.task.logs = [];
             }
@@ -69,7 +69,7 @@ export class TaskContextLogger implements Logger {
         const message = args.join(" ");
         this.context.logFileWriter.write({ taskName: this.task.name, level: LogLevel.Error, message });
 
-        if (this.enabled) {
+        if (this.shouldLogToTask(LogLevel.Error)) {
             this.collectedErrors.push(message);
             if (this.task.logs == null) {
                 this.task.logs = [];
@@ -79,12 +79,26 @@ export class TaskContextLogger implements Logger {
     }
 
     public log(level: LogLevel, ...args: string[]): void {
-        if (level === LogLevel.Debug) {
-            this.debug(...args);
-        } else if (level === LogLevel.Warn) {
-            this.warn(...args);
-        } else if (level === LogLevel.Error) {
-            this.error(...args);
+        switch (level) {
+            case LogLevel.Debug:
+                this.debug(...args);
+                break;
+            case LogLevel.Info:
+                this.info(...args);
+                break;
+            case LogLevel.Warn:
+                this.warn(...args);
+                break;
+            case LogLevel.Error:
+                this.error(...args);
+                break;
         }
+    }
+
+    /**
+     * Check if a message at the given level should be logged to the task's UI.
+     */
+    private shouldLogToTask(level: LogLevel): boolean {
+        return this.enabled && LOG_LEVELS.indexOf(level) >= LOG_LEVELS.indexOf(this.logLevel);
     }
 }

--- a/packages/cli/cli-v2/src/sdk/generator/GeneratorPipeline.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/GeneratorPipeline.ts
@@ -32,7 +32,7 @@ export namespace GeneratorPipeline {
         cliVersion: string;
     }
     export interface RunArgs {
-        /** Task for log display */
+        /** The current task */
         task: Task;
 
         /** The target to generate */
@@ -127,6 +127,7 @@ export class GeneratorPipeline {
             cliVersion: this.cliVersion
         });
         const result = await generationRunner.run({
+            task: args.task,
             target: args.target,
             apiDefinition: args.apiDefinition,
             organization: args.organization,
@@ -136,7 +137,6 @@ export class GeneratorPipeline {
             keepContainer: args.keepContainer,
             preview: args.preview,
             outputPath: args.outputPath,
-            task: args.task,
             containerEngine: args.containerEngine
         });
         if (!result.success) {
@@ -166,14 +166,14 @@ export class GeneratorPipeline {
             apiDefinition: args.apiDefinition,
             organization: args.organization,
             token: args.token,
+            task: args.task,
             ai: args.ai,
             audiences: args.audiences,
             version: args.version,
             shouldLogS3Url: args.shouldLogS3Url,
             preview: args.preview,
             outputPath: args.outputPath,
-            fernignorePath: args.fernignorePath,
-            task: args.task
+            fernignorePath: args.fernignorePath
         });
         if (!result.success) {
             return {

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyGenerationRunner.ts
@@ -26,7 +26,7 @@ export namespace LegacyGenerationRunner {
     }
 
     export interface RunArgs {
-        /** Task for log display */
+        /** The current task */
         task: Task;
 
         /** The target to generate */

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -3,6 +3,7 @@ import type { Audiences } from "@fern-api/configuration";
 import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import { LogLevel } from "@fern-api/logger";
 import { runRemoteGenerationForAPIWorkspace } from "@fern-api/remote-workspace-runner";
 import { TaskResult } from "@fern-api/task-context";
 import type { AiConfig } from "../../ai/config/AiConfig";
@@ -26,7 +27,7 @@ export namespace LegacyRemoteGenerationRunner {
         cliVersion: string;
     }
     export interface RunArgs {
-        /** Task for log display */
+        /** The current task */
         task: Task;
 
         /** The target to generate */
@@ -75,6 +76,13 @@ export namespace LegacyRemoteGenerationRunner {
     }
 }
 
+interface GitOutput {
+    pullRequestUrl?: string;
+    commitHash?: string;
+    branchUrl?: string;
+    releaseUrl?: string;
+}
+
 export class LegacyRemoteGenerationRunner {
     private readonly context: Context;
     private readonly cliVersion: string;
@@ -87,7 +95,11 @@ export class LegacyRemoteGenerationRunner {
     }
 
     public async run(args: LegacyRemoteGenerationRunner.RunArgs): Promise<LegacyRemoteGenerationRunner.Result> {
-        const taskContext = new TaskContextAdapter({ task: args.task, context: this.context });
+        const taskContext = new TaskContextAdapter({
+            context: this.context,
+            task: args.task,
+            logLevel: LogLevel.Info // Capture INFO logs to parse git output URLs
+        });
         try {
             const generatorInvocation = await this.invocationAdapter.adapt(args.target);
             const generatorGroup: generatorsYml.GeneratorGroup = {
@@ -127,12 +139,10 @@ export class LegacyRemoteGenerationRunner {
                 };
             }
 
+            const gitOutput = this.extractGitOutputFromTaskLogs(args.task);
             return {
                 success: true,
-                output:
-                    absolutePathToPreview != null
-                        ? [absolutePathToPreview.toString()]
-                        : this.context.resolveTargetOutputs(args.target)
+                output: this.resolveOutput(args, gitOutput)
             };
         } catch (error) {
             return {
@@ -175,5 +185,66 @@ export class LegacyRemoteGenerationRunner {
             }
         }
         return undefined;
+    }
+
+    /**
+     * Extract git output URLs from task logs.
+     *
+     * The remote generation service logs messages like:
+     *  - "Created pull request: https://github.com/owner/repo/pull/123"
+     *  - "Created commit abc123"
+     *  - "Pushed branch: https://github.com/owner/repo/tree/branch-name"
+     *  - "Release tagged. View here: https://github.com/owner/repo/releases/tag/v1.0.0"
+     */
+    private extractGitOutputFromTaskLogs(task: Task): GitOutput | undefined {
+        const gitOutput: GitOutput = {};
+        for (const log of task.logs ?? []) {
+            const prMatch = log.message.match(/Created pull request: (.+)/);
+            if (prMatch != null) {
+                gitOutput.pullRequestUrl = prMatch[1];
+            }
+
+            const commitMatch = log.message.match(/Created commit (\w+)/);
+            if (commitMatch != null) {
+                gitOutput.commitHash = commitMatch[1];
+            }
+
+            const branchMatch = log.message.match(/Pushed branch: (.+)/);
+            if (branchMatch != null) {
+                gitOutput.branchUrl = branchMatch[1];
+            }
+
+            const releaseMatch = log.message.match(/Release tagged\. View here: (.+)/);
+            if (releaseMatch != null) {
+                gitOutput.releaseUrl = releaseMatch[1];
+            }
+        }
+        return Object.keys(gitOutput).length > 0 ? gitOutput : undefined;
+    }
+
+    /**
+     * Resolve output URLs/paths for display.
+     */
+    private resolveOutput(
+        args: LegacyRemoteGenerationRunner.RunArgs,
+        gitOutput: GitOutput | undefined
+    ): string[] | undefined {
+        const absolutePathToPreview = this.getAbsolutePathToPreview(args);
+        if (absolutePathToPreview != null) {
+            return [absolutePathToPreview.toString()];
+        }
+        if (gitOutput != null) {
+            if (gitOutput.pullRequestUrl != null) {
+                return [gitOutput.pullRequestUrl];
+            }
+            if (gitOutput.releaseUrl != null) {
+                return [gitOutput.releaseUrl];
+            }
+            if (gitOutput.branchUrl != null) {
+                return [gitOutput.branchUrl];
+            }
+        }
+        // Fall back to target config (repo URL or local path).
+        return this.context.resolveTargetOutputs(args.target);
     }
 }

--- a/packages/cli/cli-v2/src/sdk/task/SdkTask.ts
+++ b/packages/cli/cli-v2/src/sdk/task/SdkTask.ts
@@ -1,0 +1,64 @@
+import type { Task } from "../../ui/Task";
+import type { TaskGroup } from "../../ui/TaskGroup";
+import { TaskStageController } from "../../ui/TaskStageController";
+
+/**
+ * Represents a single SDK generation task with type-safe stage controls.
+ */
+export class SdkTask {
+    private readonly id: string;
+    private readonly taskGroup: TaskGroup;
+
+    public readonly stage: {
+        readonly validation: TaskStageController;
+        readonly generator: TaskStageController;
+        readonly output: TaskStageController;
+    };
+
+    constructor({ id, taskGroup }: { id: string; taskGroup: TaskGroup }) {
+        this.id = id;
+        this.taskGroup = taskGroup;
+
+        this.stage = {
+            validation: new TaskStageController({ taskId: id, taskGroup, stageId: "validation" }),
+            generator: new TaskStageController({ taskId: id, taskGroup, stageId: "generator" }),
+            output: new TaskStageController({ taskId: id, taskGroup, stageId: "output" })
+        };
+    }
+
+    /**
+     * Get the underlying Task object for this SdkTask.
+     */
+    public getTask(): Task {
+        const task = this.taskGroup.getTask(this.id);
+        if (task == null) {
+            // This should be unreachable.
+            throw new Error(`Internal error; task '${this.id}' does not exist`);
+        }
+        return task;
+    }
+
+    /** Mark the task as running */
+    public start(currentStep?: string): void {
+        this.taskGroup.updateTask({
+            id: this.id,
+            update: { status: "running", currentStep }
+        });
+    }
+
+    /** Mark the task as successfully completed */
+    public complete(output?: string[]): void {
+        this.taskGroup.updateTask({
+            id: this.id,
+            update: { status: "success", output }
+        });
+    }
+
+    /** Mark the task as failed */
+    public fail(error?: string): void {
+        this.taskGroup.updateTask({
+            id: this.id,
+            update: { status: "error", error }
+        });
+    }
+}

--- a/packages/cli/cli-v2/src/sdk/task/SdkTaskGroup.ts
+++ b/packages/cli/cli-v2/src/sdk/task/SdkTaskGroup.ts
@@ -1,0 +1,108 @@
+import type { Context } from "../../context/Context";
+import { TaskGroup } from "../../ui/TaskGroup";
+import type { TaskStageDefinition } from "../../ui/TaskStage";
+import type { TaskStageLabels } from "../../ui/TaskStageLabels";
+import { SdkTask } from "./SdkTask";
+import type { SdkTaskStageId } from "./SdkTaskStageId";
+
+/** Stage label overrides keyed by stage ID */
+export type SdkStageOverrides = Partial<Record<SdkTaskStageId, Partial<TaskStageLabels>>>;
+
+/**
+ * Manages SDK generation tasks with visual progress tracking.
+ */
+export class SdkTaskGroup {
+    private readonly taskGroup: TaskGroup;
+    private readonly tasks: Record<string, SdkTask> = {};
+    private readonly defaultStages: TaskStageDefinition[] = [
+        {
+            id: "validation",
+            labels: {
+                pending: "Validate API",
+                running: "Validating API...",
+                success: "Validated API"
+            }
+        },
+        {
+            id: "generator",
+            labels: {
+                pending: "Run generator",
+                running: "Running generator...",
+                success: "Generator completed"
+            }
+        },
+        {
+            id: "output",
+            labels: {
+                pending: "Write output",
+                running: "Writing output...",
+                success: "Wrote output"
+            }
+        }
+    ];
+
+    constructor({ context }: { context: Context }) {
+        this.tasks = {};
+        this.taskGroup = new TaskGroup({ context });
+    }
+
+    public addTask({
+        id,
+        name,
+        stageOverrides
+    }: {
+        id: string;
+        name?: string;
+        stageOverrides?: SdkStageOverrides;
+    }): SdkTask {
+        const displayName = name ?? id;
+        this.taskGroup.addTask({ id, name: displayName });
+
+        const stages = this.buildStages(stageOverrides);
+        this.taskGroup.setStages(id, stages);
+
+        const task = new SdkTask({ taskGroup: this.taskGroup, id });
+        this.tasks[id] = task;
+        return task;
+    }
+
+    public getTask(id: string): SdkTask | undefined {
+        return this.tasks[id];
+    }
+
+    public async start(header: { title: string; subtitle?: string }): Promise<void> {
+        await this.taskGroup.start(header);
+    }
+
+    public finish({
+        successMessage,
+        errorMessage
+    }: {
+        successMessage: string;
+        errorMessage: string;
+    }): TaskGroup.CompleteResult {
+        return this.taskGroup.complete({
+            successMessage,
+            errorMessage
+        });
+    }
+
+    /**
+     * Build stage definitions, merging any overrides with defaults.
+     */
+    private buildStages(overrides?: SdkStageOverrides): TaskStageDefinition[] {
+        if (overrides == null) {
+            return this.defaultStages;
+        }
+        return this.defaultStages.map((stage) => {
+            const override = overrides[stage.id as SdkTaskStageId];
+            if (override == null) {
+                return stage;
+            }
+            return {
+                ...stage,
+                labels: { ...stage.labels, ...override }
+            };
+        });
+    }
+}

--- a/packages/cli/cli-v2/src/sdk/task/SdkTaskStageId.ts
+++ b/packages/cli/cli-v2/src/sdk/task/SdkTaskStageId.ts
@@ -1,0 +1,2 @@
+/** The stage IDs used in SDK generation tasks */
+export type SdkTaskStageId = "validation" | "generator" | "output";

--- a/packages/cli/cli-v2/src/ui/Task.ts
+++ b/packages/cli/cli-v2/src/ui/Task.ts
@@ -1,5 +1,6 @@
 import type { TaskLog } from "./TaskLog";
 import type { TaskStatus } from "./TaskStatus";
+import type { TaskStage } from "./TaskStage";
 
 export interface Task {
     /** Unique identifier for the task */
@@ -22,4 +23,6 @@ export interface Task {
     endTime?: number;
     /** Logs collected during task execution */
     logs?: TaskLog[];
+    /** Structured stages for progress tracking */
+    stages?: TaskStage[];
 }

--- a/packages/cli/cli-v2/src/ui/Task.ts
+++ b/packages/cli/cli-v2/src/ui/Task.ts
@@ -1,6 +1,6 @@
 import type { TaskLog } from "./TaskLog";
-import type { TaskStatus } from "./TaskStatus";
 import type { TaskStage } from "./TaskStage";
+import type { TaskStatus } from "./TaskStatus";
 
 export interface Task {
     /** Unique identifier for the task */

--- a/packages/cli/cli-v2/src/ui/TaskGroup.ts
+++ b/packages/cli/cli-v2/src/ui/TaskGroup.ts
@@ -5,6 +5,7 @@ import { Context } from "../context/Context";
 import { formatMultilineText } from "./format";
 import type { Task } from "./Task";
 import type { TaskLog } from "./TaskLog";
+import type { TaskStage, TaskStageDefinition } from "./TaskStage";
 import type { TaskStatus } from "./TaskStatus";
 
 export declare namespace TaskGroup {
@@ -28,6 +29,9 @@ export declare namespace TaskGroup {
  * Uses TtyAwareLogger for all TTY coordination (clear/repaint/cursor).
  */
 export class TaskGroup {
+    private static readonly MAX_DISPLAYED_LOGS_TTY = 10;
+    private static readonly URL_PATTERN = /https?:\/\/[^\s]+/;
+
     private readonly context: Context;
     private readonly ttyAwareLogger: TtyAwareLogger;
     private readonly stream: NodeJS.WriteStream;
@@ -101,7 +105,6 @@ export class TaskGroup {
         if (task == null) {
             return this;
         }
-
         const prevStatus = task.status;
         if (update.status != null) {
             task.status = update.status;
@@ -115,16 +118,63 @@ export class TaskGroup {
         if (update.output !== undefined) {
             task.output = update.output;
         }
-
-        // Register with TtyAwareLogger when first task starts running
         if (prevStatus !== "running" && task.status === "running") {
             task.startTime = Date.now();
         }
-
         if (prevStatus === "running" && (task.status === "success" || task.status === "error")) {
             task.endTime = Date.now();
         }
+        return this;
+    }
 
+    /**
+     * Define all stages upfront so users see the full journey. All stages start as "pending".
+     */
+    public setStages(taskId: string, stages: TaskStageDefinition[]): this {
+        const task = this.tasks[taskId];
+        if (task == null) {
+            return this;
+        }
+        task.stages = stages.map((stage) => ({
+            id: stage.id,
+            status: "pending" as const,
+            labels: stage.labels
+        }));
+        return this;
+    }
+
+    /**
+     * Update a stage's status by ID. The displayed label automatically changes based on the status.
+     */
+    public updateStage({
+        taskId,
+        stageId,
+        status,
+        options
+    }: {
+        taskId: string;
+        stageId: string;
+        status: TaskStatus;
+        options?: { detail?: string; error?: string };
+    }): this {
+        const task = this.tasks[taskId];
+        if (task == null) {
+            return this;
+        }
+        if (task.stages == null) {
+            return this;
+        }
+        const stage = task.stages.find((s) => s.id === stageId);
+        if (stage == null) {
+            return this;
+        }
+        stage.status = status;
+        if (options?.detail !== undefined) {
+            stage.detail = options.detail;
+        }
+        if (options?.error !== undefined) {
+            stage.error = options.error;
+        }
         return this;
     }
 
@@ -207,26 +257,49 @@ export class TaskGroup {
 
     private formatTaskLine(task: Task, spinnerFrame: string): string | undefined {
         const name = chalk.bold(task.name);
-        const logLines = this.formatTaskLogs(task.logs);
+        const hasStages = task.stages != null && task.stages.length > 0;
+
         switch (task.status) {
-            case "pending":
+            case "pending": {
+                // Show pending tasks with stages so users see the full journey.
+                if (hasStages) {
+                    const stageLines = this.formatTaskStages(task.stages, spinnerFrame);
+                    return `${chalk.dim("○")} ${chalk.dim(name)}${stageLines}`;
+                }
                 return undefined;
+            }
             case "running": {
+                if (hasStages) {
+                    const stageLines = this.formatTaskStages(task.stages, spinnerFrame, task.logs);
+                    return `${spinnerFrame} ${name}${stageLines}`;
+                }
                 const step = task.currentStep != null ? `  ${chalk.dim(task.currentStep)}` : "";
-                return `${spinnerFrame} ${name}${step}${logLines}`;
+                return `${spinnerFrame} ${name}${step}`;
             }
             case "success": {
                 const duration = this.formatTaskDuration(task);
+                if (hasStages) {
+                    const stageLines = this.formatTaskStages(task.stages, spinnerFrame);
+                    const outputLines =
+                        task.output != null && task.output.length > 0
+                            ? task.output.map((output) => `\n    ${chalk.dim("→")} ${chalk.cyan(output)}`).join("")
+                            : "";
+                    return `${chalk.green("✓")} ${name}${duration}${stageLines}${outputLines}`;
+                }
                 const outputLines =
                     task.output != null && task.output.length > 0
                         ? task.output.map((output) => `\n    ${chalk.dim("→")} ${chalk.cyan(output)}`).join("")
                         : "";
-                return `${chalk.green("✓")} ${name}${duration}${logLines}${outputLines}`;
+                return `${chalk.green("✓")} ${name}${duration}${outputLines}`;
             }
             case "error": {
                 const duration = this.formatTaskDuration(task);
+                if (hasStages) {
+                    const stageLines = this.formatTaskStages(task.stages, spinnerFrame, task.logs);
+                    return `${chalk.red("✗")} ${name}${duration}${stageLines}`;
+                }
                 const errorLines = formatMultilineText({ text: task.error, colorFn: chalk.red.bind(chalk) });
-                return `${chalk.red("x")} ${name}${duration}${logLines}${errorLines}`;
+                return `${chalk.red("✗")} ${name}${duration}${errorLines}`;
             }
             case "skipped": {
                 const reason = task.skipReason != null ? `skipped: ${task.skipReason}` : "skipped";
@@ -237,14 +310,99 @@ export class TaskGroup {
         }
     }
 
-    private static readonly MAX_DISPLAYED_LOGS_TTY = 10;
+    /**
+     * Format the stages for a task as indented lines. When a stage fails, logs are shown under it.
+     */
+    private formatTaskStages(stages: TaskStage[] | undefined, spinnerFrame: string, logs?: TaskLog[]): string {
+        if (stages == null || stages.length === 0) {
+            return "";
+        }
 
-    private static readonly URL_PATTERN = /https?:\/\//i;
+        const lines: string[] = [];
+        for (const stage of stages) {
+            const icon = this.getStageIcon(stage.status, spinnerFrame);
+            let line = `\n    ${icon} ${this.getStageLabel(stage)}`;
 
-    private formatTaskLogs(logs: TaskLog[] | undefined): string {
+            if (stage.detail != null) {
+                line += `\n        ${chalk.dim(stage.detail)}`;
+            }
+
+            // Show logs under the failed stage.
+            if (stage.status === "error") {
+                const logLines = this.formatTaskLogs(logs, { baseIndent: 8 });
+                if (logLines.length > 0) {
+                    line += logLines;
+                }
+                if (stage.error != null) {
+                    line += `\n        ${chalk.red(stage.error)}`;
+                }
+            }
+
+            lines.push(line);
+        }
+
+        return lines.join("");
+    }
+
+    /**
+     * Get the appropriate icon for a stage status.
+     *
+     * Uses a static arrow (▸) for running stages to avoid visual noise
+     * from having multiple spinners (the parent task already has a spinner).
+     */
+    private getStageIcon(status: TaskStage["status"], _spinnerFrame: string): string {
+        switch (status) {
+            case "pending":
+                return chalk.dim("○");
+            case "running":
+                return chalk.cyan("▸");
+            case "success":
+                return chalk.green("✓");
+            case "error":
+                return chalk.red("✗");
+            case "skipped":
+                return chalk.dim("○");
+            default:
+                assertNever(status);
+        }
+    }
+
+    /**
+     * Get the formatted label for a stage based on its status.
+     * Uses the appropriate label from the stage's labels map.
+     */
+    private getStageLabel(stage: TaskStage): string {
+        const label = stage.labels[stage.status] ?? stage.labels.pending;
+        switch (stage.status) {
+            case "pending":
+                return chalk.dim(label);
+            case "running":
+                return chalk.cyan(label);
+            case "success":
+                return label;
+            case "error":
+                return chalk.red(label);
+            case "skipped":
+                return chalk.dim(label);
+            default:
+                assertNever(stage.status);
+        }
+    }
+
+    /**
+     * Format task logs for display.
+     *
+     * @param logs - The logs to format
+     * @param options - Formatting options
+     * @param options.baseIndent - Number of spaces for base indentation (default: 8 for stage nesting)
+     */
+    private formatTaskLogs(logs: TaskLog[] | undefined, options?: { baseIndent?: number }): string {
         if (logs == null || logs.length === 0) {
             return "";
         }
+
+        const baseIndent = options?.baseIndent ?? 8;
+        const indentStr = " ".repeat(baseIndent);
 
         // In TTY mode (interactive), limit logs to avoid overwhelming the display.
         // In CI/non-TTY mode, show all logs since the console can handle scrolling.
@@ -266,23 +424,27 @@ export class TaskGroup {
             .map((log) => {
                 switch (log.level) {
                     case "debug": {
-                        // For debug logs, we want to truncate the message to prevent line wrapping in TTY mode.
+                        // For debug logs, truncate to prevent line wrapping in TTY mode.
                         const maxMessageLength = shouldLimit ? this.getMaxLogMessageLength() : Infinity;
                         const message = shouldLimit ? this.truncateMessage(log.message, maxMessageLength) : log.message;
                         const icon = chalk.dim("•");
-                        return `\n    ${icon} ${chalk.dim(message)}`;
+                        return `\n${indentStr}${icon} ${chalk.dim(message)}`;
                     }
                     case "warn":
                         return formatMultilineText({
                             text: log.message,
                             colorFn: chalk.yellow.bind(chalk),
-                            icon: chalk.yellow("⚠")
+                            icon: chalk.yellow("⚠"),
+                            baseIndent,
+                            continuationIndent: baseIndent + 2
                         });
                     case "error":
                         return formatMultilineText({
                             text: log.message,
                             colorFn: chalk.red.bind(chalk),
-                            icon: chalk.red("✗")
+                            icon: chalk.red("✗"),
+                            baseIndent,
+                            continuationIndent: baseIndent + 2
                         });
                     default:
                         assertNever(log.level);
@@ -291,7 +453,7 @@ export class TaskGroup {
             .join("");
 
         if (hiddenCount > 0) {
-            return `\n    ${chalk.dim(`... ${hiddenCount} earlier logs hidden ...`)}${formattedLogs}`;
+            return `\n${indentStr}${chalk.dim(`... ${hiddenCount} earlier logs hidden ...`)}${formattedLogs}`;
         }
 
         return formattedLogs;
@@ -299,15 +461,11 @@ export class TaskGroup {
 
     /**
      * Maximum characters for a log message line in TTY mode.
-     * This prevents terminal line wrapping which breaks the paint/clear cycle.
-     *
-     * Account for: box prefix "│ " (2) + indent "    " (4) + icon + space "• " (2) = 8 chars
-     * Use 72 chars for message to stay under 80 col, or scale with terminal width.
      */
     private getMaxLogMessageLength(): number {
         const terminalWidth = this.stream.columns ?? 80;
-        // Reserve space for: "│     • " prefix (8 chars) + some margin
-        return Math.max(40, terminalWidth - 12);
+        // Reserve space for indent + icon prefix + some margin
+        return Math.max(40, terminalWidth - 16);
     }
 
     private truncateMessage(message: string, maxLength: number): string {

--- a/packages/cli/cli-v2/src/ui/TaskStage.ts
+++ b/packages/cli/cli-v2/src/ui/TaskStage.ts
@@ -1,5 +1,5 @@
-import { TaskStatus } from "./TaskStatus";
 import type { TaskStageLabels } from "./TaskStageLabels";
+import { TaskStatus } from "./TaskStatus";
 
 /**
  * Defines a stage with labels for each possible status.

--- a/packages/cli/cli-v2/src/ui/TaskStage.ts
+++ b/packages/cli/cli-v2/src/ui/TaskStage.ts
@@ -1,0 +1,32 @@
+import { TaskStatus } from "./TaskStatus";
+import type { TaskStageLabels } from "./TaskStageLabels";
+
+/**
+ * Defines a stage with labels for each possible status.
+ * Used to configure stages upfront before execution.
+ */
+export interface TaskStageDefinition {
+    /** Unique identifier for this stage (e.g., "configuration", "validation") */
+    id: string;
+    /** Labels to display for each status */
+    labels: TaskStageLabels;
+}
+
+/**
+ * Represents the runtime state of a stage within a task's execution.
+ *
+ * Stages provide structured progress tracking, showing users what work
+ * is done vs. what remains.
+ */
+export interface TaskStage {
+    /** Unique identifier for this stage */
+    id: string;
+    /** Current status of this stage */
+    status: TaskStatus;
+    /** Labels for each status */
+    labels: TaskStageLabels;
+    /** Optional extra info (e.g., image version) */
+    detail?: string;
+    /** Error message if status is "error" */
+    error?: string;
+}

--- a/packages/cli/cli-v2/src/ui/TaskStageController.ts
+++ b/packages/cli/cli-v2/src/ui/TaskStageController.ts
@@ -1,0 +1,60 @@
+import type { TaskGroup } from "./TaskGroup";
+
+/**
+ * Controls a single task stage's status.
+ */
+export class TaskStageController {
+    private readonly taskGroup: TaskGroup;
+    private readonly taskId: string;
+    private readonly stageId: string;
+
+    constructor({
+        taskGroup,
+        taskId,
+        stageId
+    }: {
+        taskGroup: TaskGroup;
+        taskId: string;
+        stageId: string;
+    }) {
+        this.taskGroup = taskGroup;
+        this.taskId = taskId;
+        this.stageId = stageId;
+    }
+
+    public start(detail?: string): void {
+        this.taskGroup.updateStage({
+            taskId: this.taskId,
+            stageId: this.stageId,
+            status: "running",
+            options: { detail }
+        });
+    }
+
+    public complete(detail?: string): void {
+        this.taskGroup.updateStage({
+            taskId: this.taskId,
+            stageId: this.stageId,
+            status: "success",
+            options: { detail }
+        });
+    }
+
+    public fail(error?: string): void {
+        this.taskGroup.updateStage({
+            taskId: this.taskId,
+            stageId: this.stageId,
+            status: "error"
+        });
+        // If at least one stage fails, the task should fail.
+        const task = this.taskGroup.getTask(this.taskId);
+        if (task == null) {
+            // This should be unreachable.
+            return;
+        }
+        this.taskGroup.updateTask({
+            id: this.taskId,
+            update: { status: "error", error }
+        });
+    }
+}

--- a/packages/cli/cli-v2/src/ui/TaskStageLabels.ts
+++ b/packages/cli/cli-v2/src/ui/TaskStageLabels.ts
@@ -1,0 +1,18 @@
+/**
+ * The labels associated with a particular task stage.
+ *
+ * @example
+ * {
+ *     pending: "Load configuration",
+ *     running: "Loading configuration...",
+ *     success: "Loaded configuration",
+ *     error: "Failed to load configuration"
+ * }
+ */
+export interface TaskStageLabels {
+    pending: string;
+    running: string;
+    success: string;
+    error?: string;
+    skipped?: string;
+}


### PR DESCRIPTION
## Description

This updates the log format for the `fern sdk generate` command, and other future UI experiences in the terminal. With this, the user is now presented a clear path towards what actions will be taken, and a checklist of their progress thus far. Plus, the UI even adapts based on the _type_ of output they're creating (i.e. a GitHub PR, a release, or local files).

```sh
$ fern sdk generate --group prod --log-level debug --local

◆ Generating SDKs
  org: amckinney

┌─
│ ✗ typescript 69ms
│     ✓ Validated API
│     ✗ Generator completed
│         ✗ Cannot generate because output location is not local-file-system
│     ○ Create pull request
│ ✓ go 13.0s
│     ✓ Validated API
│     ✓ Generator completed
│     ✓ Wrote output
│     → /Users/alex/code/demo/sdks/go-sdk
└─

✕ Failed to generate SDKs in 13.0s
```

```sh
$ fern sdk generate --target typescript

◆ Generating SDK
  org: amckinney

┌─
│ ✓ typescript 24.2s
│     ✓ Validated API
│     ✓ Generator completed
│     ✓ Created pull request
│     → https://github.com/fern-demo/imdb-typescript/pull/39
└─

✓ Successfully generated SDK in 24.2s
```

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed
