### PR TITLE
fix(ci): prevent double publish of dev CLI on non-release pushes

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -81,7 +81,6 @@ jobs:
           git_version="$(./scripts/git-version.sh)"
           pnpm seed publish cli --ver ${git_version} --dev --log-level debug
 
-  # Test prod and try to publish, the publish command will handle if there's no diff
   live-test:
     if: ${{ inputs.version == null && github.repository == 'fern-api/fern' }}
     environment: Fern Prod
@@ -106,8 +105,8 @@ jobs:
           ./scripts/live-test.sh "$cli_path" "$FERN_TOKEN" "true"
 
   prod:
-    needs: [live-test]
-    if: ${{ inputs.version == null }}
+    needs: [live-test, detect-release-bump]
+    if: ${{ inputs.version == null && needs.detect-release-bump.outputs.is_release_bump == 'true' }}
     runs-on: ubuntu-latest
     env:
       NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -143,6 +143,10 @@ jobs:
           echo "Preview of the current file (${current_commit})"
           head packages/cli/cli/versions.yml
 
+          # Publish dev CLI at the same version as prod
+          pnpm seed publish cli --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml --log-level debug --dev
+          
+          # Publish prod CLI
           pnpm seed publish cli --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml --log-level debug
           pnpm seed register cli
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -143,10 +143,6 @@ jobs:
           echo "Preview of the current file (${current_commit})"
           head packages/cli/cli/versions.yml
 
-          # Publish dev CLI at the same version as prod
-          pnpm seed publish cli --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml --log-level debug --dev
-          
-          # Publish prod CLI
           pnpm seed publish cli --changelog packages/cli/cli/versions.yml --previous-changelog tmp_cli_previous_versions.yml --log-level debug
           pnpm seed register cli
 


### PR DESCRIPTION
## Description

Refs: https://app.devin.ai/sessions/72aa0b929bbf4cf7a9bda9d0d0c9b4c0
Requested by: @Swimburger

The `prod` job in `publish-cli.yml` was attempting to publish the dev CLI on **every** push to main, not just release bumps. This caused `npm publish` failures when re-publishing an already-published version (e.g. `@fern-api/fern-api-dev@3.64.4`).

**Root cause**: The `prod` job's changelog comparison uses `git log -n 2 -- versions.yml` to find the last two commits that touched `versions.yml`. This comparison is independent of the current push — it always finds the same "new" version. So after a release bump successfully publishes, the next regular push re-triggers `prod` and tries to publish the same version again.

## Changes Made

- Gate the `prod` job on `detect-release-bump` by adding it to `needs` and requiring `is_release_bump == 'true'` in the `if` condition
- Remove an inaccurate comment that claimed "the publish command will handle if there's no diff"

The dev CLI publish is intentionally kept in the `prod` job so that on release bumps, both `@fern-api/fern-api-dev` and `@fern-api/fern-api` are published at the same release version.

## Testing

- [ ] Manual testing completed

> **Note**: This is a CI workflow-only change that cannot be validated by automated tests. Please review the GitHub Actions control flow carefully.

## Human Review Checklist

- [ ] Verify the `detect-release-bump` output (`is_release_bump`) is correctly referenced in the new `prod` condition
- [ ] Confirm that GitHub Actions' implicit `success()` check means `prod` is skipped when `detect-release-bump` is skipped (forks, manual dispatch) — since a skipped `needs` job causes `success()` to return false
- [ ] Confirm the `manual` job path (which publishes both dev + prod CLI with an explicit version) is unaffected by this change
- [ ] Confirm that on manual dispatch (`inputs.version != null`), `prod` is still correctly skipped (it was already skipped due to `inputs.version == null` being false)
- [ ] Confirm that on forks (`github.repository != 'fern-api/fern'`), `prod` remains skipped (both `detect-release-bump` and `live-test` are skipped → implicit `success()` is false)
- [ ] Consider whether the `detect-release-bump` job's `fetch-depth: 2` and `HEAD~1..HEAD` diff is reliable for merge commits or squash merges to main