### PR TITLE
fix(cli): make unrecognized generators non-blocking during upgrade and add java-model alias

### DIFF
--- a/packages/cli/cli/src/commands/upgrade/__test__/upgradeGenerator.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/__test__/upgradeGenerator.test.ts
@@ -10,11 +10,22 @@ import { loadAndUpdateGenerators } from "../upgradeGenerator";
 
 vi.mock("@fern-api/configuration-loader", () => ({
     getPathToGeneratorsConfiguration: vi.fn(),
-    getGeneratorNameOrThrow: vi.fn((name: string) => {
+    normalizeGeneratorName: vi.fn((name: string) => {
         if (!name.includes("/")) {
-            return `fernapi/${name}`;
+            name = `fernapi/${name}`;
         }
-        return name;
+        const knownGenerators = [
+            "fernapi/fern-typescript-sdk",
+            "fernapi/fern-python-sdk",
+            "fernapi/fern-java-sdk",
+            "fernapi/fern-java-model",
+            "fernapi/fern-csharp-sdk",
+            "fernapi/fern-go-sdk"
+        ];
+        if (knownGenerators.includes(name)) {
+            return name;
+        }
+        return undefined;
     }),
     getLatestGeneratorVersion: vi.fn(),
     addDefaultDockerOrgIfNotPresent: vi.fn((name: string) => {

--- a/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
@@ -1,9 +1,9 @@
 import {
     addDefaultDockerOrgIfNotPresent,
-    getGeneratorNameOrThrow,
     getLatestGeneratorVersion,
     getPathToGeneratorsConfiguration,
-    loadRawGeneratorsConfiguration
+    loadRawGeneratorsConfiguration,
+    normalizeGeneratorName
 } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
@@ -141,7 +141,13 @@ export async function loadAndUpdateGenerators({
             const generatorName = generator.get("name") as string;
             // Normalize the generator name to add default Docker org prefix if not present
             // This is needed because the YAML may contain shorthand names like "fern-csharp-sdk"
-            const normalizedGeneratorName = getGeneratorNameOrThrow(generatorName, context);
+            const normalizedGeneratorName = normalizeGeneratorName(generatorName);
+            if (normalizedGeneratorName == null) {
+                context.logger.warn(
+                    `Skipping unrecognized generator: ${generatorName}. The generator will not be upgraded.`
+                );
+                continue;
+            }
 
             // Normalize the generator filter to add default Docker org prefix if not present
             const normalizedGeneratorFilter =

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.64.6
+  changelogEntry:
+    - summary: |
+        Fix `fern generator upgrade` failing when encountering unrecognized generator names. Previously, an unrecognized generator (e.g. `fernapi/java-model`) would block the entire upgrade process. Now unrecognized generators are skipped with a warning, allowing the remaining generators to be upgraded. Also adds support for the `java-model` legacy generator name alias.
+      type: fix
+  createdAt: "2026-02-05"
+  irVersion: 63
+
 - version: 3.64.5
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/__test__/getGeneratorName.test.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/__test__/getGeneratorName.test.ts
@@ -124,6 +124,11 @@ describe("normalizeGeneratorName", () => {
         expect(normalizeGeneratorName("fern-java-sdk")).toBe(GeneratorName.JAVA_SDK);
         expect(normalizeGeneratorName("fernapi/fern-java-sdk")).toBe(GeneratorName.JAVA_SDK);
     });
+
+    it("resolves legacy alias java-model to fern-java-model", () => {
+        expect(normalizeGeneratorName("java-model")).toBe(GeneratorName.JAVA_MODEL);
+        expect(normalizeGeneratorName("fernapi/java-model")).toBe(GeneratorName.JAVA_MODEL);
+    });
 });
 
 describe("getGeneratorNameOrThrow", () => {

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorName.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorName.ts
@@ -49,7 +49,8 @@ export function getGeneratorNameOrThrow(generatorName: string, context: TaskCont
 }
 
 const GENERATOR_NAME_ALIASES: Record<string, string> = {
-    "fernapi/java-model": GeneratorName.JAVA_MODEL
+    "fernapi/java-model": GeneratorName.JAVA_MODEL,
+    "fernapi/fern-typescript-node-sdk": GeneratorName.TYPESCRIPT_SDK
 };
 
 export function normalizeGeneratorName(generatorName: string): GeneratorName | undefined {

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorName.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorName.ts
@@ -48,8 +48,16 @@ export function getGeneratorNameOrThrow(generatorName: string, context: TaskCont
     return normalizedGeneratorName;
 }
 
+const GENERATOR_NAME_ALIASES: Record<string, string> = {
+    "fernapi/java-model": GeneratorName.JAVA_MODEL
+};
+
 export function normalizeGeneratorName(generatorName: string): GeneratorName | undefined {
     generatorName = addDefaultDockerOrgIfNotPresent(generatorName);
+    const aliased = GENERATOR_NAME_ALIASES[generatorName];
+    if (aliased != null) {
+        generatorName = aliased;
+    }
     if (isGeneratorName(generatorName)) {
         return generatorName;
     }


### PR DESCRIPTION
## Description

Refs: Reported by @Swimburger

Running `fern generator upgrade` fails entirely when a `generators.yml` contains an unrecognized generator name (e.g. `fernapi/java-model`). This PR fixes two issues:

1. Unrecognized generators no longer block the upgrade of other generators
2. Legacy generator name aliases are now resolved (e.g. `java-model` → `fern-java-model`, `fern-typescript-node-sdk` → `fern-typescript-sdk`)

[Link to Devin run](https://app.devin.ai/sessions/cc3767dde07d48c98c6b468cb0efc3b8)

## Changes Made

- **`upgradeGenerator.ts`**: Replaced `getGeneratorNameOrThrow` with `normalizeGeneratorName`. When a generator name can't be normalized, a warning is logged and that generator is skipped (via `continue`) instead of aborting the entire upgrade.
- **`getGeneratorName.ts`**: Added a `GENERATOR_NAME_ALIASES` map with two entries:
  - `fernapi/java-model` → `GeneratorName.JAVA_MODEL` (`fernapi/fern-java-model`)
  - `fernapi/fern-typescript-node-sdk` → `GeneratorName.TYPESCRIPT_SDK` (`fernapi/fern-typescript-sdk`)
  
  The alias lookup runs inside `normalizeGeneratorName` before the enum check.
- Updated test mocks and added a test case for the `java-model` alias resolution.
- Added `versions.yml` entry for v3.64.6.

## Testing

- [x] Unit tests updated (`upgradeGenerator.test.ts` mock updated to use `normalizeGeneratorName`)
- [x] Unit test added for `java-model` alias resolution (`getGeneratorName.test.ts`)
- [x] `pnpm run check` passes

## Review Checklist

- [ ] **`fern-typescript-node-sdk` alias**: Note that `fernapi/fern-typescript-node-sdk` already exists as its own entry in the `GeneratorName` enum (`TYPESCRIPT_NODE_SDK`). The alias maps it to `TYPESCRIPT_SDK` instead — confirm this consolidation is intentional.
- [ ] No unit test was added for the `fern-typescript-node-sdk` alias specifically — only `java-model` is covered in tests.
- [ ] `getGeneratorNameOrThrow` is still used in `addGenerator.ts` (intentional — adding a new generator should still reject unknown names).