### PR TITLE
feat(cli): add --generator option to fern generate command

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -574,6 +574,10 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     type: "string",
                     description: "The group to generate"
                 })
+                .option("generator", {
+                    type: "string",
+                    description: "The name of a specific generator to run"
+                })
                 .option("mode", {
                     choices: Object.values(GenerationMode),
                     description: "Defaults to the mode specified in generators.yml"
@@ -703,6 +707,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     cliContext,
                     version: argv.version,
                     groupName: argv.group,
+                    generatorName: argv.generator,
                     shouldLogS3Url: argv.printZipUrl,
                     keepDocker: argv.keepDocker,
                     useLocalDocker: argv.local || argv.runner != null,
@@ -752,6 +757,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 cliContext,
                 version: argv.version,
                 groupName: argv.group,
+                generatorName: argv.generator,
                 shouldLogS3Url: argv.printZipUrl,
                 keepDocker: argv.keepDocker,
                 useLocalDocker: argv.local,

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -726,6 +726,9 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 if (argv.group != null) {
                     cliContext.logger.warn("--group is ignored when generating docs");
                 }
+                if (argv.generator != null) {
+                    cliContext.logger.warn("--generator is ignored when generating docs");
+                }
                 if (argv.version != null) {
                     cliContext.logger.warn("--version is ignored when generating docs");
                 }

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -66,37 +66,20 @@ export async function generateWorkspace({
         return;
     }
 
-    // When --generator is specified without --group, find which groups contain the generator
-    let resolvedGroupNames: string[];
-    if (generatorName != null && groupName == null) {
-        const allGroups = workspace.generatorsConfiguration.groups;
-        const matchingGroups = allGroups.filter((group) => group.generators.some((gen) => gen.name === generatorName));
-        if (matchingGroups.length === 0) {
-            const allGeneratorNames = [
-                ...new Set(allGroups.flatMap((group) => group.generators.map((gen) => gen.name)))
-            ];
-            return context.failAndThrow(
-                `Generator '${generatorName}' not found in any group. ` +
-                    `Available generators: ${allGeneratorNames.join(", ")}`
-            );
-        }
-        resolvedGroupNames = matchingGroups.map((group) => group.groupName);
-    } else {
-        const groupNameOrDefault = groupName ?? workspace.generatorsConfiguration.defaultGroup;
-        if (groupNameOrDefault == null) {
-            return context.failAndThrow(
-                `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}`
-            );
-        }
-
-        // Resolve group aliases - if the groupName is an alias, expand it to multiple groups
-        resolvedGroupNames = resolveGroupAlias(
-            groupNameOrDefault,
-            workspace.generatorsConfiguration.groupAliases,
-            workspace.generatorsConfiguration.groups.map((g) => g.groupName),
-            context
+    const groupNameOrDefault = groupName ?? workspace.generatorsConfiguration.defaultGroup;
+    if (groupNameOrDefault == null) {
+        return context.failAndThrow(
+            `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}`
         );
     }
+
+    // Resolve group aliases - if the groupName is an alias, expand it to multiple groups
+    const resolvedGroupNames = resolveGroupAlias(
+        groupNameOrDefault,
+        workspace.generatorsConfiguration.groupAliases,
+        workspace.generatorsConfiguration.groups.map((g) => g.groupName),
+        context
+    );
 
     const { ai } = workspace.generatorsConfiguration;
 

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -23,6 +23,7 @@ export async function generateWorkspace({
     projectConfig,
     context,
     groupName,
+    generatorName,
     version,
     shouldLogS3Url,
     token,
@@ -42,6 +43,7 @@ export async function generateWorkspace({
     context: TaskContext;
     version: string | undefined;
     groupName: string | undefined;
+    generatorName: string | undefined;
     shouldLogS3Url: boolean;
     token: FernToken | undefined;
     useLocalDocker: boolean;
@@ -64,20 +66,37 @@ export async function generateWorkspace({
         return;
     }
 
-    const groupNameOrDefault = groupName ?? workspace.generatorsConfiguration.defaultGroup;
-    if (groupNameOrDefault == null) {
-        return context.failAndThrow(
-            `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}`
+    // When --generator is specified without --group, find which groups contain the generator
+    let resolvedGroupNames: string[];
+    if (generatorName != null && groupName == null) {
+        const allGroups = workspace.generatorsConfiguration.groups;
+        const matchingGroups = allGroups.filter((group) => group.generators.some((gen) => gen.name === generatorName));
+        if (matchingGroups.length === 0) {
+            const allGeneratorNames = [
+                ...new Set(allGroups.flatMap((group) => group.generators.map((gen) => gen.name)))
+            ];
+            return context.failAndThrow(
+                `Generator '${generatorName}' not found in any group. ` +
+                    `Available generators: ${allGeneratorNames.join(", ")}`
+            );
+        }
+        resolvedGroupNames = matchingGroups.map((group) => group.groupName);
+    } else {
+        const groupNameOrDefault = groupName ?? workspace.generatorsConfiguration.defaultGroup;
+        if (groupNameOrDefault == null) {
+            return context.failAndThrow(
+                `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}`
+            );
+        }
+
+        // Resolve group aliases - if the groupName is an alias, expand it to multiple groups
+        resolvedGroupNames = resolveGroupAlias(
+            groupNameOrDefault,
+            workspace.generatorsConfiguration.groupAliases,
+            workspace.generatorsConfiguration.groups.map((g) => g.groupName),
+            context
         );
     }
-
-    // Resolve group aliases - if the groupName is an alias, expand it to multiple groups
-    const resolvedGroupNames = resolveGroupAlias(
-        groupNameOrDefault,
-        workspace.generatorsConfiguration.groupAliases,
-        workspace.generatorsConfiguration.groups.map((g) => g.groupName),
-        context
-    );
 
     const { ai } = workspace.generatorsConfiguration;
 
@@ -101,6 +120,19 @@ export async function generateWorkspace({
             );
             if (group == null) {
                 return context.failAndThrow(`Group '${resolvedGroupName}' does not exist.`);
+            }
+
+            // Filter to specific generator if --generator is specified
+            if (generatorName != null) {
+                const filteredGenerators = group.generators.filter((gen) => gen.name === generatorName);
+                if (filteredGenerators.length === 0) {
+                    const availableGenerators = group.generators.map((gen) => gen.name);
+                    return context.failAndThrow(
+                        `Generator '${generatorName}' not found in group '${resolvedGroupName}'. ` +
+                            `Available generators: ${availableGenerators.join(", ")}`
+                    );
+                }
+                group = { ...group, generators: filteredGenerators };
             }
 
             // Apply lfs-override if specified

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -21,6 +21,7 @@ export async function generateAPIWorkspaces({
     cliContext,
     version,
     groupName,
+    generatorName,
     shouldLogS3Url,
     keepDocker,
     useLocalDocker,
@@ -38,6 +39,7 @@ export async function generateAPIWorkspaces({
     cliContext: CliContext;
     version: string | undefined;
     groupName: string | undefined;
+    generatorName: string | undefined;
     shouldLogS3Url: boolean;
     useLocalDocker: boolean;
     keepDocker: boolean;
@@ -73,7 +75,8 @@ export async function generateAPIWorkspaces({
         const resolvedGroupNames = resolveGroupNamesForWorkspace(groupName, workspace.generatorsConfiguration);
         for (const generator of workspace.generatorsConfiguration?.groups
             .filter((group) => resolvedGroupNames == null || resolvedGroupNames.includes(group.groupName))
-            .flatMap((group) => group.generators) ?? []) {
+            .flatMap((group) => group.generators)
+            .filter((generator) => generatorName == null || generator.name === generatorName) ?? []) {
             const { shouldProceed } = await checkOutputDirectory(
                 generator.absolutePathToLocalOutput,
                 cliContext,
@@ -97,14 +100,16 @@ export async function generateAPIWorkspaces({
                     generators: workspace.generatorsConfiguration?.groups
                         .filter((group) => resolvedGroupNames == null || resolvedGroupNames.includes(group.groupName))
                         .map((group) => {
-                            return group.generators.map((generator) => {
-                                return {
-                                    name: generator.name,
-                                    version: generator.version,
-                                    outputMode: generator.outputMode.type,
-                                    config: generator.config
-                                };
-                            });
+                            return group.generators
+                                .filter((generator) => generatorName == null || generator.name === generatorName)
+                                .map((generator) => {
+                                    return {
+                                        name: generator.name,
+                                        version: generator.version,
+                                        outputMode: generator.outputMode.type,
+                                        config: generator.config
+                                    };
+                                });
                         })
                 };
             })
@@ -131,6 +136,7 @@ export async function generateAPIWorkspaces({
                     context,
                     version,
                     groupName,
+                    generatorName,
                     shouldLogS3Url,
                     token,
                     useLocalDocker,

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.65.0
+  changelogEntry:
+    - summary: |
+        Add `--generator` option to `fern generate` to run a specific generator by name. Works with `--group` to filter within a group, or without `--group` to find and run the generator across all groups.
+      type: feat
+  createdAt: "2026-02-05"
+  irVersion: 63
+
 - version: 3.64.6
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,7 +2,7 @@
 - version: 3.65.0
   changelogEntry:
     - summary: |
-        Add `--generator` option to `fern generate` to run a specific generator by name. Works with `--group` to filter within a group, or without `--group` to find and run the generator across all groups.
+        Add `--generator` option to `fern generate` to run a specific generator by name. Filters within the resolved group (from `--group` or `default-group`) to only run the specified generator.
       type: feat
   createdAt: "2026-02-05"
   irVersion: 63


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger

[Link to Devin run](https://app.devin.ai/sessions/ee419eae83394b32b91df5a36c899eb8)

Adds a `--generator` option to `fern generate` that allows running a specific generator by name, filtering within the resolved group.

## Changes Made

- Added `--generator <name>` CLI option to the `fern generate` command
- **With `--group`**: filters generators within the specified group to only run the named one
- **Without `--group`**: respects the `default-group` setting (same as today), then filters to the named generator within that group
- Added warning when `--generator` is used with `--docs` (consistent with `--group`/`--version` warnings)
- Generator name filtering also applied to output directory checks and PostHog telemetry
- Added `versions.yml` entry (3.65.0) for the new feature

## Human review checklist

- [x] **`versions.yml` changelog wording**: Updated to accurately describe the behavior — generator is filtered within the resolved group (from `--group` or `default-group`)
- [ ] **Exact string match on `gen.name`**: Generator matching uses exact string comparison (e.g. `fernapi/fern-typescript-node-sdk`). This is consistent with how other config values work, but worth confirming no partial/prefix matching is desired.
- [ ] **Pre-existing inconsistency (not introduced by this PR)**: In the default generate path (no `--api`), `useLocalDocker` doesn't consider `argv.runner != null`, unlike the `--api` path. This is visible in the diff context but is pre-existing.

## Testing
- [x] Lint/format passes (`pnpm run check`)
- [x] Manual testing: built CLI locally, verified `--generator` appears in `--help`, tested with valid/invalid generator names
- [ ] Unit tests added/updated