### PR TITLE
fix(ci): increase fetch-depth in publish-generator workflows to fix race condition

### DIFF
--- a/.github/workflows/publish-generator-csharp-model.yml
+++ b/.github/workflows/publish-generator-csharp-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-csharp-model.yml
+++ b/.github/workflows/publish-generator-csharp-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-csharp-sdk.yml
+++ b/.github/workflows/publish-generator-csharp-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-csharp-sdk.yml
+++ b/.github/workflows/publish-generator-csharp-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-go-fiber.yml
+++ b/.github/workflows/publish-generator-go-fiber.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-go-fiber.yml
+++ b/.github/workflows/publish-generator-go-fiber.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-go-model.yml
+++ b/.github/workflows/publish-generator-go-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-go-model.yml
+++ b/.github/workflows/publish-generator-go-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-go-sdk.yml
+++ b/.github/workflows/publish-generator-go-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-go-sdk.yml
+++ b/.github/workflows/publish-generator-go-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-java-model.yml
+++ b/.github/workflows/publish-generator-java-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-java-model.yml
+++ b/.github/workflows/publish-generator-java-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-java-spring.yml
+++ b/.github/workflows/publish-generator-java-spring.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-java-spring.yml
+++ b/.github/workflows/publish-generator-java-spring.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 10
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/publish-generator-openapi.yml
+++ b/.github/workflows/publish-generator-openapi.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-openapi.yml
+++ b/.github/workflows/publish-generator-openapi.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-php-model.yml
+++ b/.github/workflows/publish-generator-php-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-php-model.yml
+++ b/.github/workflows/publish-generator-php-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-php-sdk.yml
+++ b/.github/workflows/publish-generator-php-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-php-sdk.yml
+++ b/.github/workflows/publish-generator-php-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-postman.yml
+++ b/.github/workflows/publish-generator-postman.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-postman.yml
+++ b/.github/workflows/publish-generator-postman.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-python-fastapi.yml
+++ b/.github/workflows/publish-generator-python-fastapi.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-python-fastapi.yml
+++ b/.github/workflows/publish-generator-python-fastapi.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-python-pydantic.yml
+++ b/.github/workflows/publish-generator-python-pydantic.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-python-pydantic.yml
+++ b/.github/workflows/publish-generator-python-pydantic.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-python-sdk.yml
+++ b/.github/workflows/publish-generator-python-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-python-sdk.yml
+++ b/.github/workflows/publish-generator-python-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ruby-model.yml
+++ b/.github/workflows/publish-generator-ruby-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ruby-model.yml
+++ b/.github/workflows/publish-generator-ruby-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ruby-sdk.yml
+++ b/.github/workflows/publish-generator-ruby-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ruby-sdk.yml
+++ b/.github/workflows/publish-generator-ruby-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-rust-model.yml
+++ b/.github/workflows/publish-generator-rust-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-rust-model.yml
+++ b/.github/workflows/publish-generator-rust-model.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-rust-sdk.yml
+++ b/.github/workflows/publish-generator-rust-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-rust-sdk.yml
+++ b/.github/workflows/publish-generator-rust-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-swift-sdk.yml
+++ b/.github/workflows/publish-generator-swift-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-swift-sdk.yml
+++ b/.github/workflows/publish-generator-swift-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ts-express.yml
+++ b/.github/workflows/publish-generator-ts-express.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ts-express.yml
+++ b/.github/workflows/publish-generator-ts-express.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ts-sdk.yml
+++ b/.github/workflows/publish-generator-ts-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ts-sdk.yml
+++ b/.github/workflows/publish-generator-ts-sdk.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 0
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/packages/seed/src/commands/publish/publishGenerator.ts
+++ b/packages/seed/src/commands/publish/publishGenerator.ts
@@ -25,7 +25,9 @@ export async function publishGenerator({
     context: TaskContext;
 }): Promise<void> {
     const generatorId = generator.workspaceName;
-    context.logger.info(`Publishing generator ${generatorId}@${version}...`);
+    context.logger.info(
+        `Publishing generator ${generatorId}@${typeof version === "string" ? version : "latest"}...`
+    );
 
     let publishVersion: string;
     if (typeof version !== "string") {

--- a/packages/seed/src/commands/publish/publishGenerator.ts
+++ b/packages/seed/src/commands/publish/publishGenerator.ts
@@ -25,9 +25,7 @@ export async function publishGenerator({
     context: TaskContext;
 }): Promise<void> {
     const generatorId = generator.workspaceName;
-    context.logger.info(
-        `Publishing generator ${generatorId}@${typeof version === "string" ? version : "latest"}...`
-    );
+    context.logger.info(`Publishing generator ${generatorId}@${typeof version === "string" ? version : "latest"}...`);
 
     let publishVersion: string;
     if (typeof version !== "string") {


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-api/fern/actions/runs/21721789767/job/62661553062

Fixes a race condition in generator Docker image publishing that caused `go-sdk@1.23.7` to silently fail to publish to DockerHub.

Link to Devin run: https://app.devin.ai/sessions/a9559ad371d9415e8dda67ba223e863e
Requested by: @tjb9dc

## Problem

The publish action finds the previous version of a `versions.yml` file by running:

```bash
previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
```

All publish-generator workflows (except `publish-generator-cli.yml`) use `fetch-depth: 2` combined with `ref: main`. This creates a **race condition**: if other commits land on `main` between the workflow trigger and the `actions/checkout` step, the shallow clone's HEAD is no longer the commit that changed the `versions.yml` file — it's whatever `main` points to at checkout time.

In the `go-sdk@1.23.7` failure:
1. Commit `2f114451489` (the 1.23.7 versions.yml change) landed on main, triggering the workflow
2. Before the runner checked out, two more commits landed: `4e5b669108c` and `d2a0b0a4225`
3. The shallow clone contained `d2a0b0a4225` (HEAD) and `4e5b669108c` (boundary) — neither touched `generators/go/sdk/versions.yml`
4. `git log -n 2 -- <file>` found only the grafted boundary commit (which matches all files due to having no parent), so `previous_commit == current_commit == d2a0b0a42`
5. The diff was empty → publish silently skipped

**Why it works 99% of the time:** In a `fetch-depth: 2` shallow clone, the grafted boundary commit (no parent) is treated by `git log -- <file>` as introducing all files. So normally HEAD (the triggering commit) matches + the boundary matches = 2 results, and the diff works correctly. It only fails when main advances before the runner checks out.

## Changes Made

- Changed `fetch-depth: 2` → `fetch-depth: 10` in all 23 `publish-generator-*.yml` workflows to provide sufficient history buffer while avoiding the cost of a full clone (`publish-generator-cli.yml` left unchanged at `fetch-depth: 0`)
- Fixed cosmetic bug in `publishGenerator.ts` where the log showed `go-sdk@[object Object]` instead of `go-sdk@latest` when the version is a `VersionFilePair` object (auto-trigger path) rather than a string

## Human Review Checklist

- [ ] Verify `fetch-depth: 10` provides enough buffer — would need 9+ commits to land between workflow trigger and runner checkout to hit the same issue again
- [ ] Consider manually re-publishing `go-sdk@1.23.7` via [workflow_dispatch](https://github.com/fern-api/fern/actions/workflows/publish-generator-go-sdk.yml) with version `1.23.7`
- [ ] Consider whether any other previously-missed Docker images need to be re-published (this race condition has existed since [`bba9dfead31`](https://github.com/fern-api/fern/commit/bba9dfead31) in May 2025)

## Testing

- Cannot be integration-tested locally — will be validated on the next generator version bump that merges to main
- These are workflow-only changes with a straightforward fix
- The cosmetic `[object Object]` fix is a trivial `typeof` check at the log callsite