### PR TITLE
fix(cli): map OpenAPI `type: number` with `format: integer` to int instead of float

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertNumber.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertNumber.ts
@@ -75,7 +75,7 @@ export function convertNumber({
             namespace,
             groupName
         });
-    } else if (format === "int32") {
+    } else if (format === "integer" || format === "int32") {
         return wrapPrimitive({
             nameOverride,
             generatedName,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/number-integer-format.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/number-integer-format.json
@@ -1,0 +1,186 @@
+{
+  "title": "Test spec for `number` type with `integer` format.",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "Post",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "PostRequest",
+      "request": {
+        "schema": {
+          "generatedName": "PostRequest",
+          "schema": "Request",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "A simple API response.",
+        "schema": {
+          "generatedName": "PostResponse",
+          "schema": "Response",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/post",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {},
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "shippingCost": {
+                  "value": {
+                    "value": 4999,
+                    "type": "int"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "Request": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "requestShippingCost",
+            "key": "shippingCost",
+            "schema": {
+              "generatedName": "RequestShippingCost",
+              "description": "Cost of shipping in the currency's lowest denomination.",
+              "value": {
+                "description": "Cost of shipping in the currency's lowest denomination.",
+                "schema": {
+                  "minimum": 0,
+                  "maximum": 999999,
+                  "example": 4999,
+                  "type": "int"
+                },
+                "generatedName": "RequestShippingCost",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "description": "A generic request type used throughout the API.\n",
+        "generatedName": "Request",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "Response": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "responseShippingCost",
+            "key": "shippingCost",
+            "schema": {
+              "generatedName": "ResponseShippingCost",
+              "description": "Cost of shipping in the currency's lowest denomination.",
+              "value": {
+                "description": "Cost of shipping in the currency's lowest denomination.",
+                "schema": {
+                  "minimum": 0,
+                  "maximum": 999999,
+                  "example": 4999,
+                  "type": "int"
+                },
+                "generatedName": "ResponseShippingCost",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "description": "A generic response type used throughout the API.\n",
+        "generatedName": "Response",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/number-integer-format.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/number-integer-format.json
@@ -1,0 +1,151 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "Post": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {},
+                  "response": {
+                    "body": {
+                      "shippingCost": 4999,
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/post",
+              "request": {
+                "body": {
+                  "properties": {
+                    "shippingCost": {
+                      "docs": "Cost of shipping in the currency's lowest denomination.",
+                      "type": "optional<integer>",
+                      "validation": {
+                        "exclusiveMax": undefined,
+                        "exclusiveMin": undefined,
+                        "max": 999999,
+                        "min": 0,
+                        "multipleOf": undefined,
+                      },
+                    },
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "Request",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "A simple API response.",
+                "status-code": 200,
+                "type": "Response",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "Response": {
+            "docs": "A generic response type used throughout the API.
+",
+            "inline": undefined,
+            "properties": {
+              "shippingCost": {
+                "docs": "Cost of shipping in the currency's lowest denomination.",
+                "type": "optional<integer>",
+                "validation": {
+                  "exclusiveMax": undefined,
+                  "exclusiveMin": undefined,
+                  "max": 999999,
+                  "min": 0,
+                  "multipleOf": undefined,
+                },
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    Post:
+      path: /post
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      request:
+        name: Request
+        body:
+          properties:
+            shippingCost:
+              type: optional<integer>
+              docs: Cost of shipping in the currency's lowest denomination.
+              validation:
+                min: 0
+                max: 999999
+        content-type: application/json
+      response:
+        docs: A simple API response.
+        type: Response
+        status-code: 200
+      examples:
+        - request: {}
+          response:
+            body:
+              shippingCost: 4999
+  source:
+    openapi: ../openapi.yml
+types:
+  Response:
+    docs: |
+      A generic response type used throughout the API.
+    properties:
+      shippingCost:
+        type: optional<integer>
+        docs: Cost of shipping in the currency's lowest denomination.
+        validation:
+          min: 0
+          max: 999999
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Test spec for `number` type with `integer` format.",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Test spec for `number` type with `integer` format.
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/number-integer-format/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/number-integer-format/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/number-integer-format/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/number-integer-format/openapi.yml
@@ -1,0 +1,49 @@
+openapi: 3.0.3
+info:
+  title: Test spec for `number` type with `integer` format.
+  version: 1.0.0
+
+paths:
+  /post:
+    post:
+      operationId: Post
+      requestBody:
+        required: true
+        description: A simple API request.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Request"
+      responses:
+        "200":
+          description: A simple API response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+
+components:
+  schemas:
+    Request:
+      description: |
+        A generic request type used throughout the API.
+      properties:
+        shippingCost:
+          type: number
+          format: integer
+          description: Cost of shipping in the currency's lowest denomination.
+          example: 4999
+          minimum: 0
+          maximum: 999999
+
+    Response:
+      description: |
+        A generic response type used throughout the API.
+      properties:
+        shippingCost:
+          type: number
+          format: integer
+          description: Cost of shipping in the currency's lowest denomination.
+          example: 4999
+          minimum: 0
+          maximum: 999999

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.67.1
+  changelogEntry:
+    - summary: |
+        Fix OpenAPI `type: number` with `format: integer` being incorrectly mapped to `float` instead of `integer`. The number converter now recognizes `format: integer` and maps it to an `int` primitive type.
+      type: fix
+  createdAt: "2026-02-06"
+  irVersion: 63
+
 - version: 3.67.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs FBE-652

When an OpenAPI spec declares a field as `type: number` with `format: integer`, the OpenAPI-to-IR converter was falling through to the default case in `convertNumber()` and mapping it to `float`. This caused downstream generators (e.g. C# SDK) to emit `float?` instead of `int?`.

## Changes Made

- Added `format === "integer"` check to the `int32` branch in `convertNumber.ts`, so `type: number, format: integer` maps to `int` instead of `float`
- Added `number-integer-format` test fixture with OpenAPI spec and snapshots validating the fix

## Testing

- [x] New openapi-ir-to-fern test fixture (`number-integer-format`) with snapshot tests
- [x] `pnpm run check` passes

## Review Checklist

- [ ] Confirm that mapping `format: integer` → `int` (int32) is the correct default. An alternative would be `int64`. The `int32` branch was chosen because it mirrors how `convertInteger` defaults to `int32` when no specific format is given.
- [ ] Verify no other format strings (beyond those already handled) should also be added to `convertNumber`

---

Link to Devin run: https://app.devin.ai/sessions/eb620e481db7485f9d92b2b65c5b68ec
Requested by: @Swimburger