### PR TITLE
feat(cli): Add init command

### DIFF
--- a/packages/cli/auth/src/index.ts
+++ b/packages/cli/auth/src/index.ts
@@ -1,4 +1,6 @@
 export type { FernOrganizationToken, FernToken, FernUserToken } from "./FernToken.js";
+export type { OrganizationCheckResult } from "./orgs/checkOrganizationMembership.js";
+export { checkOrganizationMembership } from "./orgs/checkOrganizationMembership.js";
 export { createOrganizationIfDoesNotExist } from "./orgs/createOrganizationIfDoesNotExist.js";
 export { getOrganizationNameValidationError } from "./orgs/getOrganizationNameValidationError.js";
 export { getPathToTokenFile } from "./persistence/getPathToTokenFile.js";

--- a/packages/cli/auth/src/orgs/checkOrganizationMembership.ts
+++ b/packages/cli/auth/src/orgs/checkOrganizationMembership.ts
@@ -1,0 +1,48 @@
+import { createVenusService } from "@fern-api/core";
+import { FernVenusApi } from "@fern-api/venus-api-sdk";
+
+import { FernUserToken } from "../FernToken";
+
+export type OrganizationCheckResult =
+    | { type: "member" }
+    | { type: "not-found" }
+    | { type: "no-access" }
+    | { type: "unknown-error" };
+
+export async function checkOrganizationMembership({
+    organization,
+    token
+}: {
+    organization: string;
+    token: FernUserToken;
+}): Promise<OrganizationCheckResult> {
+    const venus = createVenusService({ token: token.value });
+
+    // First check if the user is a member of the organization.
+    const isMemberResponse = await venus.organization.isMember(FernVenusApi.OrganizationId(organization));
+    if (isMemberResponse.ok) {
+        if (isMemberResponse.body) {
+            return { type: "member" };
+        }
+        return { type: "no-access" };
+    }
+
+    // If the isMember call failed, check whether the org exists at all.
+    const getResponse = await venus.organization.get(FernVenusApi.OrganizationId(organization));
+    if (getResponse.ok) {
+        // Org exists but isMember failed; treat as no access.
+        return { type: "no-access" };
+    }
+
+    // Org doesn't exist (or we got an auth error checking it).
+    let result: OrganizationCheckResult = { type: "unknown-error" };
+    getResponse.error._visit({
+        unauthorizedError: () => {
+            result = { type: "no-access" };
+        },
+        _other: () => {
+            result = { type: "not-found" };
+        }
+    });
+    return result;
+}

--- a/packages/cli/cli-v2/src/__test__/loadFernYml.test.ts
+++ b/packages/cli/cli-v2/src/__test__/loadFernYml.test.ts
@@ -42,14 +42,14 @@ describe("loadFernYml", () => {
     it("finds fern.yml in the current directory", async () => {
         const result = await loadFernYml({ cwd: testDir });
 
-        expect(result.sourced.edition.value).toBe("2026-01-01");
+        expect(result.sourced.edition?.value).toBe("2026-01-01");
         expect(result.sourced.org.value).toBe("acme");
     });
 
     it("crawls up the directory tree to find fern.yml", async () => {
         const result = await loadFernYml({ cwd: nestedDir });
 
-        expect(result.sourced.edition.value).toBe("2026-01-01");
+        expect(result.sourced.edition?.value).toBe("2026-01-01");
         expect(result.sourced.org.value).toBe("acme");
     });
 
@@ -64,8 +64,8 @@ describe("loadFernYml", () => {
     it("preserves source location for top-level values", async () => {
         const result = await loadFernYml({ cwd: testDir });
 
-        expect(result.sourced.edition.$loc.line).toBe(1);
-        expect(result.sourced.edition.$loc.column).toBe(10);
+        expect(result.sourced.edition?.$loc.line).toBe(1);
+        expect(result.sourced.edition?.$loc.column).toBe(10);
         expect(result.sourced.org.$loc.line).toBe(2);
         expect(result.sourced.org.$loc.column).toBe(6);
     });
@@ -140,9 +140,8 @@ cli:
                 expect(error).toBeInstanceOf(ValidationError);
 
                 const validationError = error as ValidationError;
-                expect(validationError.issues.length).toBeGreaterThanOrEqual(2);
-                expect(validationError.issues[0]?.message).toContain("edition is required");
-                expect(validationError.issues[1]?.message).toContain("org is required");
+                expect(validationError.issues.length).toEqual(1);
+                expect(validationError.issues[0]?.message).toContain("org is required");
             }
         });
 

--- a/packages/cli/cli-v2/src/api/checker/ApiChecker.ts
+++ b/packages/cli/cli-v2/src/api/checker/ApiChecker.ts
@@ -7,6 +7,8 @@ import type { Context } from "../../context/Context.js";
 import { Colors, formatMessage, Icons } from "../../ui/format.js";
 import { Task } from "../../ui/Task.js";
 import type { Workspace } from "../../workspace/Workspace.js";
+import type { ApiSpecType } from "../config/ApiSpec.js";
+import { isFernSpec } from "../config/FernSpec.js";
 import { ApiDefinitionValidator } from "../validator/ApiDefinitionValidator.js";
 
 const INDENT = {
@@ -27,6 +29,8 @@ export declare namespace ApiChecker {
     export interface ResolvedViolation extends ValidationViolation {
         /** The API name this violation belongs to */
         apiName: string;
+        /** The type of spec this violation originates from */
+        apiSpecType: ApiSpecType;
         /** File path relative to user's current working directory */
         displayRelativeFilepath: string;
     }
@@ -127,7 +131,13 @@ export class ApiChecker {
                 validApis.add(apiName);
             }
 
-            const resolvedViolations = this.resolveViolationPaths(result.violations, result.workspaceRoot, apiName);
+            const apiSpecType: ApiSpecType = apiDefinition.specs.some(isFernSpec) ? "fern" : "openapi";
+            const resolvedViolations = this.resolveViolationPaths(
+                result.violations,
+                result.workspaceRoot,
+                apiName,
+                apiSpecType
+            );
             allViolations.push(...resolvedViolations);
         }
 
@@ -215,7 +225,8 @@ export class ApiChecker {
     private resolveViolationPaths(
         violations: ValidationViolation[],
         workspaceRoot: AbsoluteFilePath,
-        apiName: string
+        apiName: string,
+        apiSpecType: ApiSpecType
     ): ApiChecker.ResolvedViolation[] {
         return violations.map((violation) => {
             const absolutePath = join(workspaceRoot, RelativeFilePath.of(violation.relativeFilepath));
@@ -223,6 +234,7 @@ export class ApiChecker {
             return {
                 ...violation,
                 displayRelativeFilepath,
+                apiSpecType,
                 apiName
             };
         });
@@ -261,8 +273,12 @@ export class ApiChecker {
                     continue;
                 }
 
-                // Display file header.
-                this.stream.write(`${" ".repeat(baseIndent)}${chalk.underline(filePath)}\n`);
+                // Only display the file header for Fern definitions where the path
+                // corresponds to a real file on disk.
+                const firstFileViolation = fileViolations[0];
+                if (firstFileViolation != null && firstFileViolation.apiSpecType === "fern") {
+                    this.stream.write(`${" ".repeat(baseIndent)}${chalk.underline(filePath)}\n`);
+                }
 
                 // Group by location within the file.
                 const byLocation = this.groupViolationsBy(fileViolations, (v) => this.getLocationKey(v.nodePath));
@@ -282,8 +298,12 @@ export class ApiChecker {
 
                     for (const violation of locationViolations) {
                         const { icon, colorFn } = this.getSeverityStyle(violation.severity);
+                        const message =
+                            violation.apiSpecType === "fern"
+                                ? violation.message
+                                : this.stripSyntheticFilePaths(violation.message);
                         const formatted = formatMessage({
-                            message: violation.message,
+                            message,
                             colorFn,
                             icon,
                             indent: baseIndent + INDENT.VIOLATION,
@@ -361,6 +381,19 @@ export class ApiChecker {
             seen.add(key);
             return true;
         });
+    }
+
+    /**
+     * Strip synthetic file path references from violation messages for non-Fern specs.
+     *
+     * The validator produces messages like:
+     *   "- pet.yml -> getPetById /pet/{petId}"
+     * For non-Fern specs these file names are synthetic (they don't exist on disk),
+     * so we strip them to produce:
+     *   "- getPetById /pet/{petId}"
+     */
+    private stripSyntheticFilePaths(message: string): string {
+        return message.replace(/^(\s*- )\S+\.[a-zA-Z]+ -> /gm, "$1");
     }
 
     private countViolations(violations: ApiChecker.ResolvedViolation[]): { errorCount: number; warningCount: number } {

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -4,11 +4,23 @@ import { hideBin } from "yargs/helpers";
 import { addAuthCommand } from "./commands/auth/index.js";
 import { addCheckCommand } from "./commands/check/index.js";
 import { addConfigCommand } from "./commands/config/index.js";
+import { addInitCommand } from "./commands/init/index.js";
 import { addSdkCommand } from "./commands/sdk/index.js";
 import { GlobalArgs } from "./context/GlobalArgs.js";
 import { Version } from "./version.js";
+import { Icons } from "./ui/format.js";
+import chalk from "chalk";
+
+const TIMEOUT_MINUTES = 10;
+const TIMEOUT_MS = TIMEOUT_MINUTES * 60 * 1000;
 
 export async function runCliV2(argv?: string[]): Promise<void> {
+    const timeout = setTimeout(() => {
+        process.stderr.write(`${Icons.error} ${chalk.red(`Timed out after ${TIMEOUT_MINUTES} minutes.\n`)}`);
+        process.exit(1);
+    }, TIMEOUT_MS);
+    timeout.unref();
+
     const cli = createCliV2(argv);
     await cli.parse();
 }
@@ -43,6 +55,7 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
     addAuthCommand(cli);
     addCheckCommand(cli);
     addConfigCommand(cli);
+    addInitCommand(cli);
     addSdkCommand(cli);
 
     return cli;

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import type { Argv } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -7,9 +8,8 @@ import { addConfigCommand } from "./commands/config/index.js";
 import { addInitCommand } from "./commands/init/index.js";
 import { addSdkCommand } from "./commands/sdk/index.js";
 import { GlobalArgs } from "./context/GlobalArgs.js";
-import { Version } from "./version.js";
 import { Icons } from "./ui/format.js";
-import chalk from "chalk";
+import { Version } from "./version.js";
 
 const TIMEOUT_MINUTES = 10;
 const TIMEOUT_MS = TIMEOUT_MINUTES * 60 * 1000;

--- a/packages/cli/cli-v2/src/commands/auth/switch/command.ts
+++ b/packages/cli/cli-v2/src/commands/auth/switch/command.ts
@@ -66,7 +66,7 @@ export class SwitchCommand {
         const choices = accounts.map((account) => ({
             name: account.isActive ? `${account.user} ${chalk.dim("(current)")}` : account.user,
             value: account.user,
-            disabled: account.isActive ? "(current)" : false
+            disabled: account.isActive ? "" : false
         }));
 
         const { selectedUser } = await inquirer.prompt<{ selectedUser: string }>([

--- a/packages/cli/cli-v2/src/commands/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/check/command.ts
@@ -5,6 +5,8 @@ import type { GlobalArgs } from "../../context/GlobalArgs.js";
 import { CliError } from "../../errors/CliError.js";
 import type { Workspace } from "../../workspace/Workspace.js";
 import { command } from "../_internal/command.js";
+import { Icons } from "../../ui/format.js";
+import chalk from "chalk";
 
 export declare namespace CheckCommand {
     export interface Args extends GlobalArgs {
@@ -39,6 +41,14 @@ export class CheckCommand {
         if (hasErrors || (args.strict && hasWarnings)) {
             throw CliError.exit();
         }
+
+        if (hasWarnings) {
+            process.stderr.write(`${Icons.warning} ${chalk.yellow(`Found ${checkResult.warningCount} warnings`)}\n`);
+            process.stderr.write(chalk.dim("  Run 'fern check --strict' to treat warnings as errors\n"));
+            return;
+        }
+
+        process.stderr.write(`${Icons.success} ${chalk.green("All checks passed")}\n`);
     }
 
     private validateArgs(args: CheckCommand.Args, workspace: Workspace): void {

--- a/packages/cli/cli-v2/src/commands/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/check/command.ts
@@ -1,12 +1,12 @@
+import chalk from "chalk";
 import type { Argv } from "yargs";
 import { ApiChecker } from "../../api/checker/ApiChecker.js";
 import type { Context } from "../../context/Context.js";
 import type { GlobalArgs } from "../../context/GlobalArgs.js";
 import { CliError } from "../../errors/CliError.js";
+import { Icons } from "../../ui/format.js";
 import type { Workspace } from "../../workspace/Workspace.js";
 import { command } from "../_internal/command.js";
-import { Icons } from "../../ui/format.js";
-import chalk from "chalk";
 
 export declare namespace CheckCommand {
     export interface Args extends GlobalArgs {

--- a/packages/cli/cli-v2/src/commands/init/command.ts
+++ b/packages/cli/cli-v2/src/commands/init/command.ts
@@ -1,0 +1,191 @@
+import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import chalk from "chalk";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import type { Argv } from "yargs";
+import { FernYmlBuilder } from "../../config/fern-yml/FernYmlBuilder";
+import type { Context } from "../../context/Context";
+import type { GlobalArgs } from "../../context/GlobalArgs";
+import { CliError } from "../../errors/CliError";
+import { PETSTORE_OPENAPI_YML } from "../../init/templates/openapi.yml";
+import { Wizard } from "../../init/Wizard";
+import { Icons } from "../../ui/format";
+import { command } from "../_internal/command";
+import { assertNever } from "@fern-api/core-utils";
+
+export declare namespace InitCommand {
+    export interface Args extends GlobalArgs {
+        org?: string;
+        api?: string;
+        yes: boolean;
+    }
+}
+
+const FERN_YML_FILENAME = "fern.yml";
+const SPECS_DIR = "openapi";
+
+export class InitCommand {
+    public async handle(context: Context, args: InitCommand.Args): Promise<void> {
+        const fernYmlPath = join(context.cwd, RelativeFilePath.of(FERN_YML_FILENAME));
+        await this.validateArgs({ context, fernYmlPath, args });
+
+        const wizard = new Wizard({ context, args });
+        const result = await wizard.run();
+
+        await this.writeFernYml({
+            context,
+            fernYmlPath,
+            result
+        });
+        await this.writeApiSpec({ context, apiSource: result.apiSource });
+        this.printNextSteps({ context, result });
+    }
+
+    private async writeFernYml({
+        context,
+        fernYmlPath,
+        result
+    }: {
+        context: Context;
+        fernYmlPath: AbsoluteFilePath;
+        result: Wizard.Result;
+    }): Promise<void> {
+        const apiPath = this.resolveApiPath(result.apiSource);
+        const specFormat = result.apiSource.type === "sample" ? "openapi" : result.apiSource.format;
+
+        console.log("organization", result.organization);
+
+        const writer = new FernYmlBuilder();
+        const fernYmlContent = writer.build({
+            organization: result.organization,
+            languages: result.languages,
+            outputs: result.outputs,
+            specFormat,
+            apiPath,
+            defaultGroup: result.defaultGroup
+        });
+
+        await writeFile(fernYmlPath, fernYmlContent, "utf-8");
+        context.stderr.info(`\n  ${Icons.success} Created ${FERN_YML_FILENAME}`);
+    }
+
+    private async writeApiSpec({
+        context,
+        apiSource
+    }: {
+        context: Context;
+        apiSource: Wizard.ApiSource;
+    }): Promise<void> {
+        switch (apiSource.type) {
+            case "file":
+                // no-op; the file already exists on disk.
+                return;
+            case "url":
+                await this.writeSpecFile(context.cwd, apiSource.filename, apiSource.content);
+                context.stderr.info(`  ${Icons.success} Created ${SPECS_DIR}/${apiSource.filename}`);
+                return;
+            case "sample":
+                await this.writeSpecFile(context.cwd, "openapi.yml", PETSTORE_OPENAPI_YML);
+                context.stderr.info(`  ${Icons.success} Created ${SPECS_DIR}/openapi.yml`);
+                return;
+            default:
+                assertNever(apiSource);
+        }
+    }
+
+    private async writeSpecFile(cwd: AbsoluteFilePath, filename: string, content: string): Promise<void> {
+        const specsDir = join(cwd, RelativeFilePath.of(SPECS_DIR));
+        await mkdir(specsDir, { recursive: true });
+        const filePath = join(specsDir, RelativeFilePath.of(filename));
+        await writeFile(filePath, content, "utf-8");
+    }
+
+    private resolveApiPath(apiSource: Wizard.ApiSource): string {
+        switch (apiSource.type) {
+            case "file":
+                return apiSource.path;
+            case "url":
+                return `./${SPECS_DIR}/${apiSource.filename}`;
+            case "sample":
+                return `./${SPECS_DIR}/openapi.yml`;
+            default:
+                assertNever(apiSource);
+        }
+    }
+
+    private printNextSteps({ context, result }: { context: Context; result: Wizard.Result }): void {
+        context.stderr.info(`\n  ${Icons.success} ${chalk.bold("Your Fern project is ready!")}`);
+        context.stderr.info(`\n  ${chalk.bold("Next steps:")}`);
+
+        context.stderr.info(`    1. Validate your API definition:`);
+        context.stderr.info(chalk.cyan(`       fern check`));
+
+        const firstLang = result.languages[0];
+        if (result.languages.length === 1 && firstLang != null) {
+            context.stderr.info(`    2. Generate your SDK:`);
+            context.stderr.info(chalk.cyan(`       fern sdk generate --target ${firstLang}`));
+        } else {
+            context.stderr.info(`    2. Generate your SDKs:`);
+            context.stderr.info(chalk.cyan(`       fern sdk generate`));
+        }
+
+        context.stderr.info(`    3. Learn more:`);
+        context.stderr.info(chalk.cyan(`       https://buildwithfern.com/learn`));
+    }
+
+    private async validateArgs({
+        context,
+        fernYmlPath,
+        args
+    }: {
+        context: Context;
+        fernYmlPath: AbsoluteFilePath;
+        args: InitCommand.Args;
+    }): Promise<void> {
+        if (await doesPathExist(fernYmlPath)) {
+            throw new CliError({
+                message: `A ${FERN_YML_FILENAME} file already exists at ${fernYmlPath}`
+            });
+        }
+        if (args.api != null) {
+            const api = args.api;
+            if (!api.startsWith("http://") && !api.startsWith("https://")) {
+                const resolved = path.resolve(context.cwd, api);
+                if (!(await doesPathExist(AbsoluteFilePath.of(resolved)))) {
+                    throw new CliError({ message: `File not found: ${api}` });
+                }
+            }
+        }
+        if (!context.isTTY && !args.yes) {
+            throw new CliError({
+                message: "Cannot run interactive init in non-TTY environment. Use --yes for defaults."
+            });
+        }
+    }
+}
+
+export function addInitCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new InitCommand();
+    command(
+        cli,
+        "init",
+        "Initialize a new Fern project",
+        (context, args) => cmd.handle(context, args as InitCommand.Args),
+        (yargs) =>
+            yargs
+                .option("org", {
+                    type: "string",
+                    description: "Organization name (skips organization prompt)"
+                })
+                .option("api", {
+                    type: "string",
+                    description: "Path or URL to an API spec (skips API source prompt)"
+                })
+                .option("yes", {
+                    type: "boolean",
+                    alias: "y",
+                    description: "Accept all defaults (non-interactive mode)",
+                    default: false
+                })
+    );
+}

--- a/packages/cli/cli-v2/src/commands/init/command.ts
+++ b/packages/cli/cli-v2/src/commands/init/command.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import chalk from "chalk";
 import { mkdir, writeFile } from "fs/promises";
@@ -11,7 +12,6 @@ import { PETSTORE_OPENAPI_YML } from "../../init/templates/openapi.yml";
 import { Wizard } from "../../init/Wizard";
 import { Icons } from "../../ui/format";
 import { command } from "../_internal/command";
-import { assertNever } from "@fern-api/core-utils";
 
 export declare namespace InitCommand {
     export interface Args extends GlobalArgs {
@@ -52,8 +52,6 @@ export class InitCommand {
     }): Promise<void> {
         const apiPath = this.resolveApiPath(result.apiSource);
         const specFormat = result.apiSource.type === "sample" ? "openapi" : result.apiSource.format;
-
-        console.log("organization", result.organization);
 
         const writer = new FernYmlBuilder();
         const fernYmlContent = writer.build({

--- a/packages/cli/cli-v2/src/commands/init/index.ts
+++ b/packages/cli/cli-v2/src/commands/init/index.ts
@@ -1,0 +1,1 @@
+export { addInitCommand } from "./command";

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -51,12 +51,12 @@ export declare namespace GenerateCommand {
 
 export class GenerateCommand {
     public async handle(context: Context, args: GenerateCommand.Args): Promise<void> {
-        this.validateArgs(args);
-
         const workspace = await context.loadWorkspaceOrThrow();
         if (workspace.sdks == null) {
             throw new Error("No SDKs configured in fern.yml");
         }
+
+        this.validateArgs({ workspace, args });
 
         const targets = this.getTargets({
             workspace,
@@ -169,7 +169,7 @@ export class GenerateCommand {
         }
     }
 
-    private validateArgs(args: GenerateCommand.Args): void {
+    private validateArgs({ workspace, args }: { workspace: Workspace; args: GenerateCommand.Args }): void {
         if (args.output != null && !args.preview) {
             throw new Error("The --output flag can only be used with --preview");
         }
@@ -179,7 +179,8 @@ export class GenerateCommand {
         if (args.group != null && args.target != null) {
             throw new Error("The --group and --target flags cannot be used together");
         }
-        if (args.group == null && args.target == null) {
+        const defaultGroup = workspace.sdks?.defaultGroup;
+        if (defaultGroup == null && args.group == null && args.target == null) {
             throw new Error("A --target or --group must be specified");
         }
     }

--- a/packages/cli/cli-v2/src/config/fern-yml/FernYmlBuilder.ts
+++ b/packages/cli/cli-v2/src/config/fern-yml/FernYmlBuilder.ts
@@ -1,0 +1,93 @@
+import type { schemas } from "@fern-api/config";
+import yaml from "js-yaml";
+
+import type { Language } from "../../sdk/config/Language";
+
+const SCHEMA_COMMENT = "# yaml-language-server: $schema=https://schema.buildwithfern.dev/fern-yml.json";
+
+export namespace FernYmlBuilder {
+    export type SpecFormat = "openapi" | "asyncapi";
+
+    export interface OutputConfig {
+        type: "local" | "git";
+        path?: string;
+        repository?: string;
+        mode?: "pr" | "release" | "push";
+        group?: string;
+    }
+
+    export interface Options {
+        organization: string;
+        languages: Language[];
+        outputs: Map<Language, OutputConfig>;
+        specFormat: SpecFormat;
+        apiPath: string;
+        defaultGroup?: string;
+    }
+}
+
+/**
+ * Serializes a fern.yml configuration file.
+ */
+export class FernYmlBuilder {
+    /**
+     * Builds the full fern.yml content string from the given options.
+     */
+    public build(options: FernYmlBuilder.Options): string {
+        const targets: Record<string, schemas.SdkTargetSchema> = {};
+        for (const language of options.languages) {
+            const output = options.outputs.get(language);
+            if (output == null) {
+                continue;
+            }
+            const target: schemas.SdkTargetSchema = {
+                output: this.buildOutput(output),
+                ...(output.group != null ? { group: [output.group] } : {})
+            };
+            targets[language] = target;
+        }
+
+        const doc: Record<string, unknown> = {
+            org: options.organization,
+            api: {
+                specs: [this.buildSpec(options.specFormat, options.apiPath)]
+            },
+            sdks: {
+                ...(options.defaultGroup != null ? { defaultGroup: options.defaultGroup } : {}),
+                targets
+            }
+        };
+
+        const yamlContent = yaml.dump(doc, {
+            indent: 2,
+            lineWidth: 120,
+            noRefs: true,
+            sortKeys: false,
+            quotingType: '"',
+            forceQuotes: false
+        });
+
+        return `${SCHEMA_COMMENT}\n${yamlContent}`;
+    }
+
+    private buildSpec(specFormat: FernYmlBuilder.SpecFormat, apiPath: string): schemas.ApiSpecSchema {
+        if (specFormat === "asyncapi") {
+            return { asyncapi: apiPath };
+        }
+        return { openapi: apiPath };
+    }
+
+    private buildOutput(output: FernYmlBuilder.OutputConfig): schemas.OutputSchema {
+        if (output.type === "local") {
+            return {
+                path: output.path
+            };
+        }
+        return {
+            git: {
+                repository: output.repository ?? "",
+                ...(output.mode != null ? { mode: output.mode } : {})
+            }
+        };
+    }
+}

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -40,7 +40,7 @@ export class Context {
         this.cwd = cwd ?? AbsoluteFilePath.of(process.cwd());
         this.logLevel = logLevel ?? LogLevel.Info;
         this.ttyAwareLogger = new TtyAwareLogger(stdout, stderr);
-        this.logFileWriter = new LogFileWriter({ cwd: this.cwd });
+        this.logFileWriter = new LogFileWriter();
         this.stdout = createLogger((level: LogLevel, ...args: string[]) => this.log(level, ...args));
         this.stderr = createLogger((level: LogLevel, ...args: string[]) => this.logStderr(level, ...args));
 

--- a/packages/cli/cli-v2/src/context/LogFileWriter.ts
+++ b/packages/cli/cli-v2/src/context/LogFileWriter.ts
@@ -1,6 +1,7 @@
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { appendFileSync, mkdirSync, writeFileSync } from "fs";
+import { homedir } from "os";
 
 /**
  * Writes logs to a file for later inspection.
@@ -9,11 +10,10 @@ export class LogFileWriter {
     public readonly logFilePath: AbsoluteFilePath;
     private initialized = false;
 
-    constructor({ cwd }: { cwd: AbsoluteFilePath }) {
+    constructor() {
         const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
 
-        // TODO: Replace this with a local cache directory (e.g. `~/.cache/fern/v1/logs/...`).
-        const logsDir = join(cwd, RelativeFilePath.of(".fern/logs"));
+        const logsDir = join(AbsoluteFilePath.of(homedir()), RelativeFilePath.of(".cache/fern/v1/logs"));
         this.logFilePath = join(logsDir, RelativeFilePath.of(`${timestamp}.log`));
     }
 

--- a/packages/cli/cli-v2/src/init/Wizard.ts
+++ b/packages/cli/cli-v2/src/init/Wizard.ts
@@ -1,0 +1,804 @@
+import {
+    checkOrganizationMembership,
+    createOrganizationIfDoesNotExist,
+    FernUserToken,
+    getOrganizationNameValidationError,
+    verifyAndDecodeJwt
+} from "@fern-api/auth";
+import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
+import { LogLevel } from "@fern-api/logger";
+import { getTokenFromAuth0 } from "@fern-api/login";
+import chalk from "chalk";
+import { execSync } from "child_process";
+import inquirer from "inquirer";
+import path from "path";
+import type { FernYmlBuilder } from "../config/fern-yml/FernYmlBuilder";
+import { TaskContextAdapter } from "../context/adapter/TaskContextAdapter";
+import type { Context } from "../context/Context";
+import type { Language } from "../sdk/config/Language";
+import { Icons } from "../ui/format";
+
+const LANGUAGE_DISPLAY_NAMES: Record<Language, string> = {
+    typescript: "TypeScript",
+    python: "Python",
+    go: "Go",
+    java: "Java",
+    csharp: "C#",
+    ruby: "Ruby",
+    php: "PHP",
+    rust: "Rust",
+    swift: "Swift"
+};
+
+const LANGUAGE_ORDER: Language[] = ["typescript", "python", "go", "java", "csharp", "ruby", "php", "rust", "swift"];
+
+const FERN_BANNER = [
+    "███████╗███████╗██████╗ ███╗   ██╗",
+    "██╔════╝██╔════╝██╔══██╗████╗  ██║",
+    "█████╗  █████╗  ██████╔╝██╔██╗ ██║",
+    "██╔══╝  ██╔══╝  ██╔══██╗██║╚██╗██║",
+    "██║     ███████╗██║  ██║██║ ╚████║",
+    "╚═╝     ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝"
+]
+    .map((line) => `  ${chalk.green(line)}`)
+    .join("\n");
+
+const BACK_VALUE = "__back__";
+const BACK_CHOICE = new inquirer.Separator(" ");
+const BACK_OPTION = { name: chalk.dim("← Back"), value: BACK_VALUE };
+
+export declare namespace Wizard {
+    export interface Args {
+        org?: string;
+        api?: string;
+        yes: boolean;
+    }
+
+    export type ApiSource =
+        | { type: "file"; format: FernYmlBuilder.SpecFormat; path: string }
+        | { type: "url"; format: FernYmlBuilder.SpecFormat; url: string; filename: string; content: string }
+        | { type: "sample" };
+
+    export interface Result {
+        organization: string;
+        languages: Language[];
+        outputs: Map<Language, FernYmlBuilder.OutputConfig>;
+        apiSource: ApiSource;
+        specFormat: FernYmlBuilder.SpecFormat;
+        defaultGroup: string | undefined;
+    }
+}
+
+/**
+ * Thrown by a step to signal that the user wants to go back.
+ */
+class GoBackSignal {
+    readonly _tag = "GoBackSignal";
+}
+
+export class Wizard {
+    private readonly context: Context;
+    private readonly args: Wizard.Args;
+
+    constructor({ context, args }: { context: Context; args: Wizard.Args }) {
+        this.context = context;
+        this.args = args;
+    }
+
+    public async run(): Promise<Wizard.Result> {
+        this.printWelcomeBanner();
+
+        const result: Wizard.Result = {
+            organization: "",
+            languages: [],
+            outputs: new Map(),
+            apiSource: { type: "sample" },
+            specFormat: "openapi",
+            defaultGroup: undefined
+        };
+
+        const steps = ["organization", "product", "languages", "outputs", "specFormat", "apiSource"] as const;
+
+        let stepIndex = 0;
+        while (stepIndex < steps.length) {
+            const step = steps[stepIndex];
+            try {
+                switch (step) {
+                    case "organization": {
+                        const resolved = await this.promptOrganization();
+                        result.organization = resolved.organization;
+                        await this.maybeValidateOrganization({
+                            organization: result.organization,
+                            token: resolved.token
+                        });
+                        break;
+                    }
+                    case "product":
+                        await this.promptProduct();
+                        break;
+                    case "languages":
+                        result.languages = await this.promptLanguages();
+                        break;
+                    case "outputs":
+                        result.outputs = await this.promptOutputs(result.languages);
+                        break;
+                    case "specFormat":
+                        result.specFormat = await this.promptSpecFormat();
+                        break;
+                    case "apiSource":
+                        result.apiSource = await this.promptApiSource(result.specFormat);
+                        break;
+                }
+                stepIndex++;
+            } catch (error) {
+                if (error instanceof GoBackSignal) {
+                    stepIndex = Math.max(0, stepIndex - 1);
+                } else {
+                    throw error;
+                }
+            }
+        }
+
+        return {
+            ...result,
+            defaultGroup: result.outputs.size > 1 ? "default" : undefined
+        };
+    }
+
+    private printWelcomeBanner(): void {
+        if (!this.context.isTTY || this.args.yes) {
+            return;
+        }
+
+        this.context.stderr.info(`${FERN_BANNER}\n`);
+        this.context.stderr.info(`\n  ${chalk.bold.white("🌿 Welcome to Fern!")}`);
+        this.context.stderr.info(`  ${chalk.dim("Instant Docs and SDKs for your API")}`);
+        this.context.stderr.info(`  ${chalk.cyan.underline("https://buildwithfern.com/learn")}\n`);
+    }
+
+    private async promptOrganization(): Promise<{
+        organization: string;
+        token: FernUserToken | undefined;
+    }> {
+        if (this.args.org != null) {
+            const token = await this.maybeAuthenticate();
+            return { organization: this.args.org, token };
+        }
+        if (this.args.yes) {
+            const org = this.getDefaultOrgName();
+            const token = await this.maybeAuthenticate();
+            return { organization: org, token };
+        }
+        const { org } = await inquirer.prompt<{ org: string }>([
+            {
+                type: "input",
+                name: "org",
+                message: "Organization name:",
+                default: this.getDefaultOrgName(),
+                validate: (input: string) => {
+                    return getOrganizationNameValidationError(input) ?? true;
+                }
+            }
+        ]);
+        const token = await this.maybeAuthenticate();
+        return { organization: org, token };
+    }
+
+    private async maybeAuthenticate(): Promise<FernUserToken | undefined> {
+        if (!this.context.isTTY || this.args.yes) {
+            return undefined;
+        }
+        try {
+            const accountInfo = await this.context.tokenService.getActiveAccountInfo();
+            if (accountInfo?.tokenInfo != null && !accountInfo.tokenInfo.isExpired) {
+                this.context.stderr.info(`  ${Icons.success} Logged in as ${chalk.bold(accountInfo.user)}\n`);
+                return { type: "user", value: accountInfo.tokenInfo.token };
+            }
+
+            const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+                {
+                    type: "confirm",
+                    name: "confirm",
+                    message: "You are not logged in. Would you like to log in?",
+                    default: true
+                }
+            ]);
+            if (!confirm) {
+                this.context.stderr.info(chalk.dim("  Skipping login. You can log in later with: fern auth login\n"));
+                return undefined;
+            }
+
+            this.context.stderr.info(`  ${Icons.info} Opening browser to log in to Fern...`);
+            const taskContext = new TaskContextAdapter({ context: this.context, logLevel: LogLevel.Info });
+            const { accessToken, idToken } = await getTokenFromAuth0(taskContext, {
+                useDeviceCodeFlow: false,
+                forceReauth: false
+            });
+
+            const payload = await verifyAndDecodeJwt(idToken);
+            if (payload == null || payload.email == null) {
+                this.context.stderr.info(
+                    chalk.dim("  Could not authenticate. You can log in later with: fern auth login\n")
+                );
+                return undefined;
+            }
+
+            await this.context.tokenService.login(payload.email, accessToken);
+            this.context.stderr.info(`  ${Icons.success} Logged in as ${chalk.bold(payload.email)}\n`);
+
+            return { type: "user", value: accessToken };
+        } catch {
+            this.context.stderr.info(
+                chalk.dim("  Could not authenticate. You can log in later with: fern auth login\n")
+            );
+            return undefined;
+        }
+    }
+
+    private async maybeValidateOrganization({
+        organization,
+        token
+    }: {
+        organization: string;
+        token: FernUserToken | undefined;
+    }): Promise<void> {
+        if (token == null) {
+            return;
+        }
+
+        try {
+            const result = await checkOrganizationMembership({ organization, token });
+
+            switch (result.type) {
+                case "member":
+                    this.context.stderr.info(`  ${Icons.success} Organization "${organization}" found\n`);
+                    return;
+
+                case "not-found": {
+                    const taskContext = new TaskContextAdapter({ context: this.context });
+                    const created = await createOrganizationIfDoesNotExist({
+                        organization,
+                        token,
+                        context: taskContext
+                    });
+                    if (created) {
+                        this.context.stderr.info(`  ${Icons.success} Created organization "${organization}"\n`);
+                    }
+                    return;
+                }
+
+                case "no-access": {
+                    this.context.stderr.info(
+                        `\n  ${Icons.error} You don't have access to the organization "${organization}".\n`
+                    );
+
+                    const accounts = await this.context.tokenService.getAllAccountInfo();
+                    const hasMultipleAccounts = accounts.length > 1;
+
+                    const choices = [
+                        { name: "Request access", value: "request" },
+                        ...(hasMultipleAccounts ? [{ name: "Switch account", value: "switch" }] : []),
+                        { name: "Use a different name", value: "different" }
+                    ];
+
+                    const { action } = await inquirer.prompt<{ action: string }>([
+                        {
+                            type: "list",
+                            name: "action",
+                            message: "What would you like to do?",
+                            loop: false,
+                            choices
+                        }
+                    ]);
+
+                    if (action === "request") {
+                        // TODO: We should actually submit a request to access to the admin.
+                        this.context.stderr.info(
+                            chalk.dim(
+                                `\n  Access requested for "${organization}". Ask an admin to approve, or pick a different name.\n`
+                            )
+                        );
+                    } else if (action === "switch") {
+                        await this.promptAccountSwitch(accounts);
+                    }
+
+                    throw new GoBackSignal();
+                }
+
+                case "unknown-error":
+                    this.context.stderr.info(
+                        chalk.dim("  Could not validate organization. You can create it later.\n")
+                    );
+                    return;
+            }
+        } catch (error) {
+            if (error instanceof GoBackSignal) {
+                throw error;
+            }
+            this.context.stderr.info(chalk.dim("  Could not validate organization. You can create it later.\n"));
+        }
+    }
+
+    private async promptProduct(): Promise<void> {
+        if (this.args.yes) {
+            return;
+        }
+
+        const { product } = await inquirer.prompt<{ product: string }>([
+            {
+                type: "list",
+                name: "product",
+                message: "What would you like to generate?",
+                loop: false,
+                choices: [
+                    { name: "SDKs", value: "sdks" },
+                    { name: "Docs", value: "docs" },
+                    { name: "Both", value: "both" },
+                    BACK_CHOICE,
+                    BACK_OPTION
+                ]
+            }
+        ]);
+
+        if (product === BACK_VALUE) {
+            throw new GoBackSignal();
+        }
+
+        if (product === "docs" || product === "both") {
+            this.context.stderr.info(
+                `\n  ${chalk.yellow("Docs support is coming soon!")} For now, we'll set up SDK generation.`
+            );
+            this.context.stderr.info(chalk.dim("  Learn more: https://buildwithfern.com/learn/docs\n"));
+        }
+    }
+
+    private async promptLanguages(): Promise<Language[]> {
+        if (this.args.yes) {
+            return ["typescript"];
+        }
+
+        const { languages } = await inquirer.prompt<{ languages: Language[] }>([
+            {
+                type: "checkbox",
+                name: "languages",
+                message: "Which SDK languages would you like to generate?",
+                loop: false,
+                choices: LANGUAGE_ORDER.map((lang) => ({
+                    name: LANGUAGE_DISPLAY_NAMES[lang],
+                    value: lang,
+                    checked: lang === "typescript"
+                })),
+                validate: (input: Language[]) => {
+                    if (input.length === 0) {
+                        return "Select at least one language.";
+                    }
+                    return true;
+                }
+            }
+        ]);
+
+        return languages;
+    }
+
+    private async promptOutputs(languages: Language[]): Promise<Map<Language, FernYmlBuilder.OutputConfig>> {
+        const outputs = new Map<Language, FernYmlBuilder.OutputConfig>();
+
+        const group = languages.length > 1 ? "default" : undefined;
+        if (this.args.yes) {
+            for (const lang of languages) {
+                outputs.set(lang, { type: "local", path: `./sdks/${lang}`, group });
+            }
+            return outputs;
+        }
+
+        const firstLang = languages[0];
+        if (languages.length === 1 && firstLang != null) {
+            const output = await this.promptSingleLanguageOutput({ lang: firstLang, group });
+            if (output === BACK_VALUE) {
+                throw new GoBackSignal();
+            }
+            outputs.set(firstLang, output);
+            return outputs;
+        }
+
+        const { strategy } = await inquirer.prompt<{ strategy: string }>([
+            {
+                type: "list",
+                name: "strategy",
+                message: "Where should the generated SDKs be written?",
+                loop: false,
+                choices: [
+                    { name: "All to local directories", value: "all-local" },
+                    { name: "All to GitHub repositories", value: "all-github" },
+                    { name: "Configure each separately", value: "each" },
+                    BACK_CHOICE,
+                    BACK_OPTION
+                ]
+            }
+        ]);
+        if (strategy === BACK_VALUE) {
+            throw new GoBackSignal();
+        }
+        if (strategy === "all-local") {
+            for (const lang of languages) {
+                outputs.set(lang, { type: "local", path: `./sdks/${lang}`, group });
+            }
+            return outputs;
+        }
+        if (strategy === "all-github") {
+            const mode = await this.promptGitMode();
+            for (const lang of languages) {
+                const { repo } = await inquirer.prompt<{ repo: string }>([
+                    {
+                        type: "input",
+                        name: "repo",
+                        message: `GitHub repository for ${LANGUAGE_DISPLAY_NAMES[lang]} (owner/repo):`,
+                        validate: (input: string) => {
+                            if (!/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(input)) {
+                                return "Please enter a valid repository in owner/repo format.";
+                            }
+                            return true;
+                        }
+                    }
+                ]);
+                outputs.set(lang, { type: "git", repository: repo, mode, group });
+            }
+            return outputs;
+        }
+        for (const lang of languages) {
+            const output = await this.promptSingleLanguageOutput({ lang, group });
+            if (output === BACK_VALUE) {
+                throw new GoBackSignal();
+            }
+            outputs.set(lang, output);
+        }
+        return outputs;
+    }
+
+    private async promptSingleLanguageOutput({
+        lang,
+        group
+    }: {
+        lang: Language;
+        group: string | undefined;
+    }): Promise<FernYmlBuilder.OutputConfig | typeof BACK_VALUE> {
+        const { destination } = await inquirer.prompt<{ destination: string }>([
+            {
+                type: "list",
+                name: "destination",
+                message: `Where should the ${LANGUAGE_DISPLAY_NAMES[lang]} SDK be saved?`,
+                loop: false,
+                choices: [
+                    { name: "Local directory", value: "local" },
+                    { name: "GitHub repository", value: "github" },
+                    BACK_CHOICE,
+                    BACK_OPTION
+                ]
+            }
+        ]);
+
+        if (destination === BACK_VALUE) {
+            return BACK_VALUE;
+        }
+        if (destination === "local") {
+            const { outputPath } = await inquirer.prompt<{ outputPath: string }>([
+                {
+                    type: "input",
+                    name: "outputPath",
+                    message: "Output directory:",
+                    default: `./sdks/${lang}`
+                }
+            ]);
+            return { type: "local", path: outputPath, group };
+        }
+
+        const { repo } = await inquirer.prompt<{ repo: string }>([
+            {
+                type: "input",
+                name: "repo",
+                message: "GitHub repository (owner/repo):",
+                validate: (input: string) => {
+                    if (!/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(input)) {
+                        return "Please enter a valid repository in owner/repo format.";
+                    }
+                    return true;
+                }
+            }
+        ]);
+
+        const mode = await this.promptGitMode();
+        return { type: "git", repository: repo, mode, group };
+    }
+
+    private async promptGitMode(): Promise<"pr" | "release" | "push"> {
+        const { mode } = await inquirer.prompt<{ mode: "pr" | "release" | "push" }>([
+            {
+                type: "list",
+                name: "mode",
+                message: "Git publishing mode:",
+                loop: false,
+                choices: [
+                    { name: "Pull Request", value: "pr" },
+                    { name: "Release", value: "release" },
+                    { name: "Push to branch", value: "push" }
+                ]
+            }
+        ]);
+        return mode;
+    }
+
+    private async promptSpecFormat(): Promise<FernYmlBuilder.SpecFormat> {
+        if (this.args.yes) {
+            return "openapi";
+        }
+
+        const { format } = await inquirer.prompt<{ format: FernYmlBuilder.SpecFormat | typeof BACK_VALUE }>([
+            {
+                type: "list",
+                name: "format",
+                message: "What type of API definition do you have?",
+                loop: false,
+                choices: [
+                    { name: "OpenAPI", value: "openapi" },
+                    { name: "AsyncAPI", value: "asyncapi" },
+                    BACK_CHOICE,
+                    BACK_OPTION
+                ]
+            }
+        ]);
+
+        if (format === BACK_VALUE) {
+            throw new GoBackSignal();
+        }
+
+        return format;
+    }
+
+    private async promptApiSource(specFormat: FernYmlBuilder.SpecFormat): Promise<Wizard.ApiSource> {
+        if (this.args.api != null) {
+            const api = this.args.api;
+            if (api.startsWith("http://") || api.startsWith("https://")) {
+                return await this.fetchApiFromUrl(api, specFormat);
+            }
+            return { type: "file", format: specFormat, path: api };
+        }
+
+        if (this.args.yes) {
+            return { type: "sample" };
+        }
+
+        const formatLabel = specFormat === "openapi" ? "OpenAPI" : "AsyncAPI";
+
+        const choices = [
+            ...(specFormat === "openapi" ? [{ name: "Start with the sample Pet Store API", value: "sample" }] : []),
+            { name: `Use an existing ${formatLabel} file`, value: "file" },
+            { name: `Use a URL to an ${formatLabel} file`, value: "url" },
+            BACK_CHOICE,
+            BACK_OPTION
+        ];
+
+        const { source } = await inquirer.prompt<{ source: string }>([
+            {
+                type: "list",
+                name: "source",
+                message: "How would you like to provide your API definition?",
+                loop: false,
+                choices
+            }
+        ]);
+
+        if (source === BACK_VALUE) {
+            throw new GoBackSignal();
+        }
+
+        if (source === "sample") {
+            return { type: "sample" };
+        }
+
+        if (source === "file") {
+            const result = await this.promptApiFile(specFormat);
+            if (result === BACK_VALUE) {
+                return await this.promptApiSource(specFormat);
+            }
+            return result;
+        }
+
+        const result = await this.promptApiUrl(specFormat);
+        if (result === BACK_VALUE) {
+            return await this.promptApiSource(specFormat);
+        }
+        return result;
+    }
+
+    private async promptApiFile(specFormat: FernYmlBuilder.SpecFormat): Promise<Wizard.ApiSource | typeof BACK_VALUE> {
+        const formatLabel = specFormat === "openapi" ? "OpenAPI" : "AsyncAPI";
+
+        // On macOS, offer to open the native Finder file picker.
+        if (process.platform === "darwin") {
+            // Loop so that cancelling Finder returns to this menu.
+            //
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+                const { method } = await inquirer.prompt<{ method: string }>([
+                    {
+                        type: "list",
+                        name: "method",
+                        message: `How would you like to select your ${formatLabel} file?`,
+                        loop: false,
+                        choices: [
+                            { name: "Browse with Finder", value: "finder" },
+                            { name: "Type a file path", value: "manual" },
+                            BACK_CHOICE,
+                            BACK_OPTION
+                        ]
+                    }
+                ]);
+
+                if (method === BACK_VALUE) {
+                    return BACK_VALUE;
+                }
+
+                if (method === "finder") {
+                    const selected = this.openMacOsFinderDialog();
+                    if (selected != null) {
+                        const relativePath = path.relative(this.context.cwd, selected);
+                        const normalizedPath = relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+                        return { type: "file", format: specFormat, path: normalizedPath };
+                    }
+                    this.context.stderr.info(chalk.dim("  No file selected.\n"));
+                    continue;
+                }
+
+                // Fall through to manual input below.
+                break;
+            }
+        }
+
+        const { filePath } = await inquirer.prompt<{ filePath: string }>([
+            {
+                type: "input",
+                name: "filePath",
+                message: `Path to your ${formatLabel} file ${chalk.dim("(empty to go back)")}:`,
+                validate: async (input: string) => {
+                    if (input.trim().length === 0) {
+                        return true;
+                    }
+                    const resolved = path.resolve(this.context.cwd, input);
+                    const exists = await doesPathExist(AbsoluteFilePath.of(resolved));
+                    if (!exists) {
+                        return `File not found: ${input}`;
+                    }
+                    return true;
+                }
+            }
+        ]);
+
+        if (filePath.trim().length === 0) {
+            return BACK_VALUE;
+        }
+
+        const relativePath = path.relative(this.context.cwd, path.resolve(this.context.cwd, filePath));
+        const normalizedPath = relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+        return { type: "file", format: specFormat, path: normalizedPath };
+    }
+
+    private async promptApiUrl(specFormat: FernYmlBuilder.SpecFormat): Promise<Wizard.ApiSource | typeof BACK_VALUE> {
+        const formatLabel = specFormat === "openapi" ? "OpenAPI" : "AsyncAPI";
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const { url } = await inquirer.prompt<{ url: string }>([
+                {
+                    type: "input",
+                    name: "url",
+                    message: `URL to your ${formatLabel} file ${chalk.dim("(empty to go back)")}:`,
+                    validate: (input: string) => {
+                        if (input.trim().length === 0) {
+                            return true;
+                        }
+                        if (!input.startsWith("http://") && !input.startsWith("https://")) {
+                            return "Please enter a valid URL starting with http:// or https://";
+                        }
+                        return true;
+                    }
+                }
+            ]);
+
+            if (url.trim().length === 0) {
+                return BACK_VALUE;
+            }
+
+            try {
+                return await this.fetchApiFromUrl(url, specFormat);
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                this.context.stderr.info(`  ${Icons.error} Could not fetch ${url}: ${message}\n`);
+                // Loop back to re-prompt.
+            }
+        }
+    }
+
+    private async fetchApiFromUrl(url: string, specFormat: FernYmlBuilder.SpecFormat): Promise<Wizard.ApiSource> {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+        }
+        const content = await response.text();
+        const filename = this.resolveFilenameFromUrl({ url, specFormat });
+        return { type: "url", format: specFormat, url, filename, content };
+    }
+
+    private resolveFilenameFromUrl({
+        url,
+        specFormat
+    }: {
+        url: string;
+        specFormat: FernYmlBuilder.SpecFormat;
+    }): string {
+        const defaultFilename = specFormat === "openapi" ? "openapi.yml" : "asyncapi.yml";
+        try {
+            const pathname = new URL(url).pathname;
+            const basename = path.basename(pathname);
+            if (basename.includes(".")) {
+                return basename;
+            }
+            return defaultFilename;
+        } catch {
+            return defaultFilename;
+        }
+    }
+
+    private async promptAccountSwitch(accounts: Array<{ user: string; isActive: boolean }>): Promise<void> {
+        const choices = accounts.map((account) => ({
+            name: account.isActive ? `${account.user} ${chalk.dim("(current)")}` : account.user,
+            value: account.user,
+            disabled: account.isActive ? ("" as const) : false
+        }));
+
+        const { selectedUser } = await inquirer.prompt<{ selectedUser: string }>([
+            {
+                type: "list",
+                name: "selectedUser",
+                message: "Select account:",
+                choices
+            }
+        ]);
+
+        const success = await this.context.tokenService.switchAccount(selectedUser);
+        if (success) {
+            this.context.stderr.info(`  ${Icons.success} Switched to ${chalk.bold(selectedUser)}\n`);
+        }
+    }
+
+    /**
+     * Returns the default organization name for the current working directory.
+     *
+     * @example
+     * /Users/jane/my-project -> my-project
+     */
+    private getDefaultOrgName(): string {
+        const cwdBasename = path.basename(this.context.cwd);
+        return (
+            cwdBasename
+                .toLowerCase()
+                .replace(/[^a-z0-9-]/g, "-")
+                .replace(/^-+|-+$/g, "")
+                .replace(/-+/g, "-") || "my-company"
+        );
+    }
+
+    /**
+     * Opens a native macOS Finder file picker dialog.
+     */
+    private openMacOsFinderDialog(): string | undefined {
+        try {
+            const result = execSync(
+                `osascript -e 'POSIX path of (choose file with prompt "Select your API spec:" of type {"json", "yml", "yaml"})'`,
+                { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+            );
+            return result.trim();
+        } catch {
+            return undefined;
+        }
+    }
+}

--- a/packages/cli/cli-v2/src/init/templates/openapi.yml.ts
+++ b/packages/cli/cli-v2/src/init/templates/openapi.yml.ts
@@ -1,0 +1,130 @@
+export const PETSTORE_OPENAPI_YML = `openapi: 3.0.3
+info:
+  title: Petstore API
+  version: 1.0.0
+  description: A sample API for managing pets.
+
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            maximum: 100
+          description: Maximum number of pets to return.
+      responses:
+        "200":
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPet
+      tags:
+        - pets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePetRequest"
+      responses:
+        "201":
+          description: The created pet.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Get a pet by ID
+      operationId: getPet
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the pet to retrieve.
+      responses:
+        "200":
+          description: The requested pet.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the pet.
+        name:
+          type: string
+          description: Name of the pet.
+        tag:
+          type: string
+          description: Optional tag for the pet.
+    CreatePetRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the pet.
+        tag:
+          type: string
+          description: Optional tag for the pet.
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Error code.
+        message:
+          type: string
+          description: Error message.
+`;

--- a/packages/cli/cli-v2/src/migrator/Migrator.ts
+++ b/packages/cli/cli-v2/src/migrator/Migrator.ts
@@ -10,7 +10,6 @@ import { GeneratorsYmlMigrator } from "./generators-yml/index.js";
 import type { MigratorResult, MigratorWarning } from "./types/index.js";
 
 const FERN_YML_FILENAME = "fern.yml";
-const EDITION = "2026-01-01";
 
 export interface MigratorConfig {
     cwd: AbsoluteFilePath;
@@ -166,7 +165,6 @@ export class Migrator {
         warnings.push(...apiResult.warnings);
 
         const fernYml: schemas.FernYmlSchema = {
-            edition: EDITION,
             org
         };
 
@@ -196,7 +194,7 @@ export class Migrator {
                 type: "conflict",
                 message: "No API directories found in fern/apis/"
             });
-            return { success: false, fernYml: { edition: EDITION, org } };
+            return { success: false, fernYml: { org } };
         }
 
         // Collect generators.yml API configs and SDK results for each API.
@@ -240,7 +238,6 @@ export class Migrator {
         warnings.push(...apisResult.warnings);
 
         const fernYml: schemas.FernYmlSchema = {
-            edition: EDITION,
             org,
             apis: apisResult.apis
         };

--- a/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
+++ b/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
@@ -4,7 +4,6 @@ import { isNullish, type Sourced } from "@fern-api/source";
 import { ValidationIssue } from "@fern-api/yaml-loader";
 import { DEFAULT_API_NAME } from "../../../api/config/converter/ApiDefinitionConverter.js";
 import { FernYmlSchemaLoader } from "../../../config/fern-yml/FernYmlSchemaLoader.js";
-import type { DockerImageReference } from "../DockerImageReference.js";
 import { LANGUAGES, type Language } from "../Language.js";
 import type { SdkConfig } from "../SdkConfig.js";
 import type { Target } from "../Target.js";

--- a/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
+++ b/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
@@ -155,7 +155,7 @@ export class SdkConfigConverter {
         if (lang == null) {
             return undefined;
         }
-        const resolvedDockerImage = this.resolveDockerImage({ name, lang, version: target.version });
+        const resolvedDockerImage = getImageReferenceFromLanguage({ lang, version: target.version });
         return {
             lang,
             image: resolvedDockerImage.image,
@@ -197,21 +197,5 @@ export class SdkConfigConverter {
             })
         );
         return undefined;
-    }
-
-    private resolveDockerImage({
-        name,
-        lang,
-        version
-    }: {
-        name: string;
-        lang: Language;
-        version: string | undefined;
-    }): DockerImageReference {
-        const dockerImage = getImageReferenceFromLanguage({ lang, version });
-        if (version == null) {
-            this.logger.debug(`Target "${name}" has no version specified, using ${dockerImage}`);
-        }
-        return dockerImage;
     }
 }

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -98,7 +98,7 @@ export class LegacyRemoteGenerationRunner {
         const taskContext = new TaskContextAdapter({
             context: this.context,
             task: args.task,
-            logLevel: LogLevel.Info // Capture INFO logs to parse git output URLs
+            logLevel: LogLevel.Info
         });
         try {
             const generatorInvocation = await this.invocationAdapter.adapt(args.target);

--- a/packages/cli/config/src/schemas/FernYmlSchema.ts
+++ b/packages/cli/config/src/schemas/FernYmlSchema.ts
@@ -6,7 +6,7 @@ import { CliSchema } from "./CliSchema.js";
 import { SdksSchema } from "./SdksSchema.js";
 
 export const FernYmlSchema = z.object({
-    edition: z.string(),
+    edition: z.string().optional(),
     org: z.string(),
     ai: AiConfigSchema.optional(),
     cli: CliSchema.optional(),

--- a/packages/cli/ete-tests/src/tests/v2/v2.test.ts
+++ b/packages/cli/ete-tests/src/tests/v2/v2.test.ts
@@ -69,7 +69,6 @@ describe("fern check", () => {
             });
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
-            expect(result.stderr).toContain("fern.yml:1:1: edition is required");
             expect(result.stderr).toContain("fern.yml:1:6: org must be a string");
         } finally {
             await fixture.cleanup();


### PR DESCRIPTION
## Description

This adds a new `init` wizard command which revamps the original `init` experience with an interactive flow that looks like the following:

```sh
$ fern init
  ███████╗███████╗██████╗ ███╗   ██╗
  ██╔════╝██╔════╝██╔══██╗████╗  ██║
  █████╗  █████╗  ██████╔╝██╔██╗ ██║
  ██╔══╝  ██╔══╝  ██╔══██╗██║╚██╗██║
  ██║     ███████╗██║  ██║██║ ╚████║
  ╚═╝     ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝


  🌿 Welcome to Fern!
  Instant Docs and SDKs for your API
  https://buildwithfern.com/learn

? Organization name: amckinney
  ✓ Logged in as alexmckinney01@gmail.com

  ✓ Organization "amckinney" found

? What would you like to generate? SDKs
? Which SDK languages would you like to generate? TypeScript
? Where should the TypeScript SDK be saved? Local directory
? Output directory: ./sdks/typescript
? What type of API definition do you have? OpenAPI
? How would you like to provide your API definition? Start with the sample Pet Store API
organization amckinney

  ✓ Created fern.yml
  ✓ Created openapi/openapi.yml

  ✓ Your Fern project is ready!

  Next steps:
    1. Validate your API definition:
       fern check
    2. Generate your SDK:
       fern sdk generate --target typescript
    3. Learn more:
       https://buildwithfern.com/learn
```

## Changes Made
- Update the `fern check` output to be better suited for first time and long-term users.
- Add organization membership checks for a better interactive experience.
- Improve the `fern sdk generate` UI for simpler output.
- Update the `fern.yml` so that `edition` is no longer required (it's optional to start).
    - This cleans up the generated `fern.yml` to make it as simple as possible.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
