### PR TITLE
feat(cli): Add support for 'latest' in IR migrator

### DIFF
--- a/packages/cli/semver-utils/src/__test__/isVersionAhead.test.ts
+++ b/packages/cli/semver-utils/src/__test__/isVersionAhead.test.ts
@@ -43,6 +43,17 @@ describe("isVersionAhead", () => {
         ${"0.0.190-beta.1"}         | ${"0.0.190-beta.0"}         | ${true}
         ${"0.0.190-beta.0"}         | ${"0.0.190-alpha.0"}        | ${true}
         ${"0.0.190-alpha.0"}        | ${"0.0.190-beta.0"}         | ${false}
+        ${"latest"}                 | ${"0.0.191"}                | ${true}
+        ${"latest"}                 | ${"0.0.191-rc0"}            | ${true}
+        ${"latest"}                 | ${"0.0.191-4-abc"}          | ${true}
+        ${"latest"}                 | ${"0.0.191-beta.0"}         | ${true}
+        ${"latest"}                 | ${"0.0.191-alpha.0"}        | ${true}
+        ${"0.0.191"}                | ${"latest"}                 | ${false}
+        ${"0.0.191-rc0"}            | ${"latest"}                 | ${false}
+        ${"0.0.191-4-abc"}          | ${"latest"}                 | ${false}
+        ${"0.0.191-beta.0"}         | ${"latest"}                 | ${false}
+        ${"0.0.191-alpha.0"}        | ${"latest"}                 | ${false}
+        ${"latest"}                 | ${"latest"}                 | ${false}
     `("$a vs. $b", ({ a, b, expected }) => {
         expect(isVersionAhead(a, b)).toBe(expected);
     });

--- a/packages/cli/semver-utils/src/isVersionAhead.ts
+++ b/packages/cli/semver-utils/src/isVersionAhead.ts
@@ -10,6 +10,14 @@ export function isVersionAhead(a: string, b: string): boolean {
         return false;
     }
 
+    // "latest" is treated as always being the most recent version.
+    if (b === "latest") {
+        return false;
+    }
+    if (a === "latest") {
+        return true;
+    }
+
     const aVersion = parseVersion(a);
     const bVersion = parseVersion(b);
 


### PR DESCRIPTION
## Description

This updates the IR migrator so that it treats `latest` as the latest version, which allows the generator version to receive the corresponding IR version (i.e. if the latest Go generator uses `v61`, the `latest` key will now resolve to `v61`).

## Changes Made
- Update `isVersionAhead` to support `latest` for the IR migration process.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
