### PR TITLE
fix(python): handle empty response bodies

### DIFF
--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -233,6 +233,7 @@ by pytest's normal test collection rules.
 """
 
 import os
+import re
 import subprocess
 
 import pytest
@@ -254,11 +255,10 @@ def _project_name() -> str:
     """Returns a unique project name for this test fixture to avoid container name conflicts."""
     tests_dir = os.path.dirname(__file__)
     project_root = os.path.abspath(os.path.join(tests_dir, ".."))
-    # Use the last two directory names to create a unique project name
-    # e.g., "python-streaming-parameter-openapi-with-wire-tests"
     parent = os.path.basename(os.path.dirname(project_root))
     current = os.path.basename(project_root)
-    return f"{parent}-{current}".replace("_", "-").lower()
+    name = re.sub(r"[^a-z0-9_-]", "", f"{parent}-{current}".replace("_", "-").lower()).lstrip("-_")
+    return name or "wiremock-tests"
 
 
 def _get_wiremock_port() -> str:

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.55.2
+  changelogEntry:
+    - summary: |
+        Add empty response handling for HTTP responses without body content (e.g., 204 No Content).
+      type: fix
+    - summary: |
+        Improve wiremock container name sanitization in wire tests (fixes testing on seed-generated SDKs).
+      type: fix
+  createdAt: "2026-02-06"
+  irVersion: 63
+
 - version: 4.55.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -338,6 +338,7 @@ class EndpointResponseCodeWriter:
                 )
                 writer.write("return ")
                 writer.write_node(empty_pager_expr)
+                writer.write("  # type: ignore")
                 writer.write_newline_if_last_line_not()
             elif self._is_raw_client:
                 writer.write("return ")

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -325,6 +325,28 @@ class EndpointResponseCodeWriter:
     def _handle_success_json(
         self, *, writer: AST.NodeWriter, json_response: ir_types.JsonResponse, use_response_json: bool
     ) -> None:
+        # Guard against empty response bodies (e.g. 204 No Content)
+        writer.write_line(f"if not {RESPONSE_VARIABLE}.text:")
+        with writer.indent():
+            if self._pagination is not None:
+                empty_pager_expr = self._context.core_utilities.instantiate_paginator(
+                    is_async=self._is_async,
+                    has_next=AST.Expression("False"),
+                    items=AST.Expression("[]"),
+                    get_next=AST.Expression("None"),
+                    response=AST.Expression("None"),
+                )
+                writer.write("return ")
+                writer.write_node(empty_pager_expr)
+                writer.write_newline_if_last_line_not()
+            elif self._is_raw_client:
+                writer.write("return ")
+                writer.write_node(self._instantiate_http_response(data=AST.Expression("None")))
+                writer.write("  # type: ignore")
+                writer.write_newline_if_last_line_not()
+            else:
+                writer.write_line("return")
+
         pydantic_parse_expression = self._context.core_utilities.get_construct(
             self._get_json_response_body_type(json_response),
             AST.Expression(


### PR DESCRIPTION
## Description
Similarly to TypeScript, this PR adds a `if not _response.text` check to check for empty response bodies, so None or an empty type can be returned early before the endpoint crashes when trying to execute `_response_json = _response.json()`.

## Changes Made
Small change to Python client generator.

## Testing
Seed - unblocks Samsara Python wire tests.
- [X] Unit tests added/updated
- [X] Manual testing completed
