### PR TITLE
chore(internal): remove node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
   ],
   "pnpm": {
     "overrides": {
-      "node-fetch@2.x>whatwg-url": "^14.0.0",
       "qs": "6.14.1",
       "url-join": "^4.0.1",
       "@fern-api/fdr-sdk": "0.145.4-0ea6e08bf",

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -40,7 +40,6 @@
     "execa": "^5.1.1",
     "express": "^4.22.0",
     "js-yaml": "^4.1.1",
-    "node-fetch": "2.7.0",
     "openapi-types": "^12.1.3",
     "strip-ansi": "^7.1.0",
     "tmp-promise": "^3.0.3"
@@ -50,7 +49,6 @@
     "@types/express": "^4.17.21",
     "@types/js-yaml": "^4.0.8",
     "@types/node": "18.15.3",
-    "@types/node-fetch": "2.6.9",
     "depcheck": "^1.4.7",
     "typescript": "5.9.3",
     "vitest": "^4.0.8"

--- a/packages/cli/ete-tests/src/tests/docs-dev/docsDev.test.ts
+++ b/packages/cli/ete-tests/src/tests/docs-dev/docsDev.test.ts
@@ -1,6 +1,5 @@
 import { FdrAPI as FdrCjsSdk } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
-import fetch from "node-fetch";
 
 import { captureFernCli, runFernCli } from "../../utils/runFernCli.js";
 

--- a/packages/cli/ete-tests/src/tests/mock/mock.test.ts
+++ b/packages/cli/ete-tests/src/tests/mock/mock.test.ts
@@ -1,5 +1,4 @@
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
-import fetch from "node-fetch";
 
 import { runFernCli } from "../../utils/runFernCli.js";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,6 @@ overrides:
   micromatch: 4.0.8
   nanoid: 3.3.8
   yaml: 2.3.3
-  node-fetch@2.x>whatwg-url: ^14.0.0
   qs: 6.14.1
   url-join: ^4.0.1
   '@fern-api/fdr-sdk': 0.145.4-0ea6e08bf
@@ -5685,9 +5684,6 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
-      node-fetch:
-        specifier: 2.7.0
-        version: 2.7.0
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -5710,9 +5706,6 @@ importers:
       '@types/node':
         specifier: 18.15.3
         version: 18.15.3
-      '@types/node-fetch':
-        specifier: 2.6.9
-        version: 2.6.9
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -11221,9 +11214,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node-fetch@2.6.9':
-    resolution: {integrity: sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==}
-
   '@types/node@18.15.3':
     resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}
 
@@ -15109,9 +15099,8 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
-  tr46@5.1.1:
-    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
-    engines: {node: '>=18'}
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -15561,17 +15550,15 @@ packages:
   webdriver-bidi-protocol@0.4.0:
     resolution: {integrity: sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==}
 
-  webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
 
-  whatwg-url@14.2.0:
-    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
-    engines: {node: '>=18'}
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
@@ -18553,11 +18540,6 @@ snapshots:
   '@types/minimist@1.2.5': {}
 
   '@types/ms@2.1.0': {}
-
-  '@types/node-fetch@2.6.9':
-    dependencies:
-      '@types/node': 18.15.3
-      form-data: 4.0.5
 
   '@types/node@18.15.3': {}
 
@@ -21794,7 +21776,7 @@ snapshots:
 
   node-fetch@2.7.0:
     dependencies:
-      whatwg-url: 14.2.0
+      whatwg-url: 5.0.0
 
   node-machine-id@1.1.12: {}
 
@@ -23339,9 +23321,7 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  tr46@5.1.1:
-    dependencies:
-      punycode: 2.3.1
+  tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
 
@@ -23897,14 +23877,14 @@ snapshots:
 
   webdriver-bidi-protocol@0.4.0: {}
 
-  webidl-conversions@7.0.0: {}
+  webidl-conversions@3.0.1: {}
 
   whatwg-mimetype@4.0.0: {}
 
-  whatwg-url@14.2.0:
+  whatwg-url@5.0.0:
     dependencies:
-      tr46: 5.1.1
-      webidl-conversions: 7.0.0
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-typed-array@1.1.20:
     dependencies:


### PR DESCRIPTION
## Description

Removes the direct dependency on `node-fetch` in favor of Node.js native `fetch`, which is available globally in Node >= 18 (the repo requires Node >= 20).

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/5414dc9fb5044111a807a4d742a09e71)

## Changes Made

- Removed `node-fetch` and `@types/node-fetch` from `packages/cli/ete-tests/package.json`
- Removed `import fetch from "node-fetch"` from `docsDev.test.ts` and `mock.test.ts`, relying on the global `fetch`
- Removed the `node-fetch@2.x>whatwg-url` pnpm override from root `package.json` (no longer needed)
- Updated `pnpm-lock.yaml` accordingly

## Testing

- [ ] CI passes (lint, type checks, ete-tests)

## Review Checklist

- **`@types/node` version**: The ete-tests package pins `@types/node` to `18.15.3`. Verify that global `fetch` types are available at this version (or via tsconfig `lib` settings). If not, the `@types/node` pin may need to be bumped.
- **Lockfile `whatwg-url` downgrade**: Removing the override causes remaining transitive `node-fetch@2.x` consumers (e.g. in seed fixtures) to resolve `whatwg-url@5.0.0` instead of `14.2.0`. This is the natural/expected resolution for node-fetch v2 and should be fine, but worth a sanity check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
