### PR TITLE
chore(deps): remove `qs` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
   "pnpm": {
     "overrides": {
       "node-fetch@2.x>whatwg-url": "^14.0.0",
-      "qs": "6.14.1",
       "url-join": "^4.0.1",
       "@fern-api/fdr-sdk": "0.145.4-0ea6e08bf",
       "es-toolkit": "^1.39.10",
@@ -152,7 +151,6 @@
   },
   "catalog": {
     "es-toolkit": "^1.39.10",
-    "qs": "^6.14.1",
     "ts-essentials": "^10.1.1",
     "url-join": "^4.0.1"
   },

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.70.1
+  changelogEntry:
+    - summary: |
+        Remove dependency on `qs` package in the login module, replacing it with native `URLSearchParams`.
+      type: chore
+  createdAt: "2026-02-09"
+  irVersion: 63
+
 - version: 3.70.0
   changelogEntry:
     - summary: |

--- a/packages/cli/login/package.json
+++ b/packages/cli/login/package.json
@@ -40,15 +40,13 @@
     "boxen": "^7.1.1",
     "chalk": "^5.3.0",
     "inquirer": "^9.2.23",
-    "open": "^8.4.0",
-    "qs": "6.14.1"
+    "open": "^8.4.0"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
     "@types/boxen": "^3.0.1",
     "@types/inquirer": "^9.0.7",
     "@types/node": "18.15.3",
-    "@types/qs": "6.9.15",
     "depcheck": "^1.4.7",
     "typescript": "5.9.3",
     "vitest": "^4.0.8"

--- a/packages/cli/login/src/auth0-login/doAuth0DeviceAuthorizationFlow.ts
+++ b/packages/cli/login/src/auth0-login/doAuth0DeviceAuthorizationFlow.ts
@@ -3,7 +3,6 @@ import { TaskContext } from "@fern-api/task-context";
 import axios from "axios";
 import boxen from "boxen";
 import open from "open";
-import qs from "qs";
 
 import type { Auth0TokenResponse } from "./doAuth0LoginFlow.js";
 
@@ -31,11 +30,11 @@ export async function doAuth0DeviceAuthorizationFlow({
         method: "POST",
         url: `https://${auth0Domain}/oauth/device/code`,
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        data: qs.stringify({
+        data: new URLSearchParams({
             client_id: auth0ClientId,
             audience,
             scope: "openid profile email offline_access"
-        }),
+        }).toString(),
         validateStatus: () => true
     });
 
@@ -96,11 +95,11 @@ async function pollForToken({
         method: "POST",
         url: `https://${auth0Domain}/oauth/token`,
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        data: qs.stringify({
+        data: new URLSearchParams({
             grant_type: "urn:ietf:params:oauth:grant-type:device_code",
             device_code: deviceCode,
             client_id: auth0ClientId
-        }),
+        }).toString(),
         validateStatus: () => true
     });
 

--- a/packages/cli/login/src/auth0-login/doAuth0DeviceAuthorizationFlow.ts
+++ b/packages/cli/login/src/auth0-login/doAuth0DeviceAuthorizationFlow.ts
@@ -6,6 +6,10 @@ import open from "open";
 
 import type { Auth0TokenResponse } from "./doAuth0LoginFlow.js";
 
+function encodeFormData(params: Record<string, string>): string {
+    return new URLSearchParams(params).toString().replaceAll("+", "%20");
+}
+
 interface DeviceCodeResponse {
     device_code: string;
     user_code: string;
@@ -30,11 +34,11 @@ export async function doAuth0DeviceAuthorizationFlow({
         method: "POST",
         url: `https://${auth0Domain}/oauth/device/code`,
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        data: new URLSearchParams({
+        data: encodeFormData({
             client_id: auth0ClientId,
             audience,
             scope: "openid profile email offline_access"
-        }).toString(),
+        }),
         validateStatus: () => true
     });
 
@@ -95,11 +99,11 @@ async function pollForToken({
         method: "POST",
         url: `https://${auth0Domain}/oauth/token`,
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        data: new URLSearchParams({
+        data: encodeFormData({
             grant_type: "urn:ietf:params:oauth:grant-type:device_code",
             device_code: deviceCode,
             client_id: auth0ClientId
-        }).toString(),
+        }),
         validateStatus: () => true
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,6 @@ overrides:
   nanoid: 3.3.8
   yaml: 2.3.3
   node-fetch@2.x>whatwg-url: ^14.0.0
-  qs: 6.14.1
   url-join: ^4.0.1
   '@fern-api/fdr-sdk': 0.145.4-0ea6e08bf
   es-toolkit: ^1.39.10
@@ -6790,9 +6789,6 @@ importers:
       open:
         specifier: ^8.4.0
         version: 8.4.2
-      qs:
-        specifier: 6.14.1
-        version: 6.14.1
     devDependencies:
       '@fern-api/configs':
         specifier: workspace:*
@@ -6806,9 +6802,6 @@ importers:
       '@types/node':
         specifier: 18.15.3
         version: 18.15.3
-      '@types/qs':
-        specifier: 6.9.15
-        version: 6.9.15
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -14404,6 +14397,10 @@ packages:
     resolution: {integrity: sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==}
     engines: {node: '>=20'}
 
+  qs@6.11.2:
+    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
+    engines: {node: '>=0.6'}
+
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
@@ -17196,7 +17193,7 @@ snapshots:
       form-data: 4.0.5
       js-base64: 3.7.2
       node-fetch: 2.7.0
-      qs: 6.14.1
+      qs: 6.11.2
       url-join: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -17206,7 +17203,7 @@ snapshots:
       form-data: 4.0.5
       js-base64: 3.7.2
       node-fetch: 2.7.0
-      qs: 6.14.1
+      qs: 6.11.2
       url-join: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -17235,7 +17232,7 @@ snapshots:
     dependencies:
       form-data: 4.0.5
       node-fetch: 2.7.0
-      qs: 6.14.1
+      qs: 6.11.2
       url-join: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -17246,7 +17243,7 @@ snapshots:
       formdata-node: 6.0.3
       js-base64: 3.7.2
       node-fetch: 2.7.0
-      qs: 6.14.1
+      qs: 6.11.2
       readable-stream: 4.7.0
       url-join: 4.0.1
     transitivePeerDependencies:
@@ -17431,7 +17428,7 @@ snapshots:
       form-data: 4.0.5
       formdata-node: 6.0.3
       node-fetch: 2.7.0
-      qs: 6.14.1
+      qs: 6.11.2
       url-join: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -22356,6 +22353,10 @@ snapshots:
   qified@0.6.0:
     dependencies:
       hookified: 1.15.0
+
+  qs@6.11.2:
+    dependencies:
+      side-channel: 1.1.0
 
   qs@6.14.1:
     dependencies:


### PR DESCRIPTION
## Description

Removes the direct dependency on the `qs` package from the CLI login module, replacing it with native `URLSearchParams` and an `encodeFormData` helper that preserves `qs.stringify()` encoding behavior.

Refs https://app.devin.ai/sessions/44f154a940594ba4a3ed7e858e7696fa
Requested by: @Swimburger

## Changes Made

- Replaced `qs.stringify()` with a local `encodeFormData()` helper in `doAuth0DeviceAuthorizationFlow.ts` (two call sites: device code request and token polling)
- `encodeFormData` uses `new URLSearchParams().toString().replaceAll("+", "%20")` to match `qs.stringify()` space encoding (`%20` instead of `+`)
- Removed `qs` and `@types/qs` from `packages/cli/login/package.json`
- Removed `qs` from root `pnpm.overrides` and `catalog`
- Added `v3.70.1` changelog entry in `packages/cli/cli/versions.yml`

## Review Checklist

- [ ] **Transitive `qs` downgrade**: Removing the `qs: "6.14.1"` override causes several `@fern-api/*` transitive dependencies to resolve `qs@6.11.2` instead of `6.14.1` (visible in lockfile diff). Verify this is acceptable — the override may have been added for a security or compatibility reason.
- [ ] **Encoding equivalence**: The `encodeFormData` helper was verified to produce byte-identical output to `qs.stringify()` for both payloads used here. Worth confirming the `.replaceAll("+", "%20")` approach is sufficient for all values that could appear in these OAuth params.

## Testing

- [x] Biome lint/check passes
- [x] Encoding equivalence verified locally against `qs.stringify()` for both payload shapes
- [ ] No unit tests added — login flow is an interactive OAuth device flow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
