### PR TITLE
feat(swift): add versions.yml entry for global/service-level headers

### DIFF
--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.26.0
+  changelogEntry:
+    - type: feat
+      summary: |
+        Add support for global and service-level headers in generated SDK methods.
+  createdAt: "2026-02-09"
+  irVersion: 61
+
 - version: 0.25.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Adds the missing `versions.yml` entry for the Swift SDK generator changes introduced in #12143, which added support for global and service-level headers but did not include a changelog entry.

Link to Devin run: https://app.devin.ai/sessions/489373a896e5466b85e06fc6d21269ec
Requested by: @tstanmay13

## Changes Made

- Added `versions.yml` entry for version `0.26.0` (minor bump for new feature) with `irVersion: 61`

## Review Checklist

- [ ] Verify version `0.26.0` is the correct next version (bumped from `0.25.4` as a minor/feat)
- [ ] Confirm `irVersion: 61` is appropriate (matches recent Swift entries)
- [ ] Confirm changelog summary accurately reflects #12143 changes

## Testing

- N/A — changelog-only change, no code modifications