### PR TITLE
fix(python): use name mangling for _raw_client to prevent multiple inheritance collision

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.55.4
+  changelogEntry:
+    - summary: |
+        Use Python name mangling for the internal `_raw_client` attribute (now `__raw_client`) on
+        generated wrapped clients. This prevents attribute collisions when combining root and
+        subpackage clients via multiple inheritance (e.g. `class ClientV2(V2Client, Client)`),
+        which previously caused wrapper methods to reference the wrong raw client instance.
+      type: fix
+  createdAt: "2026-02-10"
+  irVersion: 63
+
 - version: 4.55.3
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/base_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/base_client_generator.py
@@ -158,7 +158,7 @@ class BaseClientGenerator(ABC, typing.Generic[ConstructorParameterT]):
         )
 
     def _get_raw_client_member_name(self) -> str:
-        return "_raw_client"
+        return "__raw_client"
 
     def _get_client_wrapper_member_name(self) -> str:
         return "_client_wrapper"

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
@@ -1684,12 +1684,14 @@ class EndpointFunctionGenerator:
             [f"{param.name}={param.name}" for param in function.signature.named_parameters if param.name != "self"]
         )
 
+        raw_client_member = self._client_wrapper_member_name.rsplit(".", 1)[0]
+
         def write_method_body(writer: AST.NodeWriter) -> None:
             raw_client_method_name = get_endpoint_name(self._endpoint)
             func_invocation_expr = AST.Expression(
                 AST.FunctionInvocation(
                     function_definition=AST.Reference(
-                        qualified_name_excluding_import=(f"self._raw_client.{raw_client_method_name}",),
+                        qualified_name_excluding_import=(f"self.{raw_client_member}.{raw_client_method_name}",),
                     ),
                     args=[AST.Expression(param) for param in parameters],
                 )

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/client.py
@@ -16,7 +16,7 @@ from .urls.client import AsyncUrlsClient, UrlsClient
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self.container = ContainerClient(client_wrapper=self._client_wrapper)
         self.content_type = ContentTypeClient(client_wrapper=self._client_wrapper)
@@ -38,12 +38,12 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self.container = AsyncContainerClient(client_wrapper=self._client_wrapper)
         self.content_type = AsyncContentTypeClient(client_wrapper=self._client_wrapper)
@@ -65,4 +65,4 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, *, id: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id=id, request_options=request_options)
+        _response = self.__raw_client.test_get(id=id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id=id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id=id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id=id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id=id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id=id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, *, id: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id=id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id=id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id=id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id=id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id=id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id=id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id=id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_=string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_=string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, *, param: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param=param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param=param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, *, param: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param=param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param=param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param=param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param=param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(
+        _response = self.__raw_client.get_with_inline_path_and_query(
             param=param, query=query, request_options=request_options
         )
         return _response.data
@@ -265,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param=param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param=param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -300,7 +300,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(
+        _response = self.__raw_client.modify_with_inline_path(
             param=param, request=request, request_options=request_options
         )
         return _response.data
@@ -308,7 +308,7 @@ class ParamsClient:
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -319,7 +319,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, *, param: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -356,7 +356,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param=param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param=param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, *, param: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -394,7 +394,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param=param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param=param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -437,7 +437,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -484,7 +484,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -529,7 +529,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(
+        _response = await self.__raw_client.get_with_path_and_query(
             param=param, query=query, request_options=request_options
         )
         return _response.data
@@ -574,7 +574,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param=param, query=query, request_options=request_options
         )
         return _response.data
@@ -619,7 +619,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(
+        _response = await self.__raw_client.modify_with_path(
             param=param, request=request, request_options=request_options
         )
         return _response.data
@@ -664,7 +664,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param=param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, *, id: str, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id=id, request_options=request_options)
+        _response = self.__raw_client.add(id=id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, *, id: str, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id=id, request_options=request_options)
+        _response = await self.__raw_client.add(id=id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/test_lazy_loading.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/test_lazy_loading.py
@@ -127,7 +127,7 @@ def test_lazy_loading_preserves_client_wrapper(client: Union[SeedExhaustive, Asy
     endpoints = client.endpoints
 
     assert endpoints._client_wrapper is client._client_wrapper
-    assert endpoints._raw_client._client_wrapper is client._client_wrapper
+    assert endpoints.with_raw_response._client_wrapper is client._client_wrapper
 
     container = client.endpoints.container
-    assert container._raw_client._client_wrapper is endpoints._client_wrapper
+    assert container.with_raw_response._client_wrapper is endpoints._client_wrapper

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/client.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 
 class EndpointsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[ContainerClient] = None
         self._content_type: typing.Optional[ContentTypeClient] = None
@@ -44,7 +44,7 @@ class EndpointsClient:
         -------
         RawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):
@@ -129,7 +129,7 @@ class EndpointsClient:
 
 class AsyncEndpointsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEndpointsClient(client_wrapper=client_wrapper)
         self._client_wrapper = client_wrapper
         self._container: typing.Optional[AsyncContainerClient] = None
         self._content_type: typing.Optional[AsyncContentTypeClient] = None
@@ -151,7 +151,7 @@ class AsyncEndpointsClient:
         -------
         AsyncRawEndpointsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     @property
     def container(self):

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/container/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/container/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContainerClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContainerClient:
@@ -24,7 +24,7 @@ class ContainerClient:
         -------
         RawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -53,7 +53,9 @@ class ContainerClient:
             request=["string", "string"],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_primitives(
+            request=request, request_options=request_options
+        )
         return _response.data
 
     def get_and_return_list_of_objects(
@@ -94,7 +96,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_list_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_primitives(
@@ -124,7 +126,7 @@ class ContainerClient:
             request={"string"},
         )
         """
-        _response = self._raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_primitives(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_set_of_objects(
@@ -162,7 +164,7 @@ class ContainerClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_set_of_objects(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_prim_to_prim(
@@ -192,7 +194,7 @@ class ContainerClient:
             request={"string": "string"},
         )
         """
-        _response = self._raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_map_prim_to_prim(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_map_of_prim_to_object(
@@ -230,7 +232,7 @@ class ContainerClient:
             },
         )
         """
-        _response = self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -268,13 +270,13 @@ class ContainerClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncContainerClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContainerClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContainerClient:
@@ -285,7 +287,7 @@ class AsyncContainerClient:
         -------
         AsyncRawContainerClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_list_of_primitives(
         self, *, request: typing.Sequence[str], request_options: typing.Optional[RequestOptions] = None
@@ -322,7 +324,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_primitives(
+        _response = await self.__raw_client.get_and_return_list_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -373,7 +375,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_list_of_objects(
+        _response = await self.__raw_client.get_and_return_list_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -413,7 +415,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_primitives(
+        _response = await self.__raw_client.get_and_return_set_of_primitives(
             request=request, request_options=request_options
         )
         return _response.data
@@ -461,7 +463,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_set_of_objects(
+        _response = await self.__raw_client.get_and_return_set_of_objects(
             request=request, request_options=request_options
         )
         return _response.data
@@ -501,7 +503,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_prim_to_prim(
+        _response = await self.__raw_client.get_and_return_map_prim_to_prim(
             request=request, request_options=request_options
         )
         return _response.data
@@ -549,7 +551,7 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_map_of_prim_to_object(
+        _response = await self.__raw_client.get_and_return_map_of_prim_to_object(
             request=request, request_options=request_options
         )
         return _response.data
@@ -595,5 +597,5 @@ class AsyncContainerClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_optional(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_optional(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/content_type/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/content_type/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ContentTypeClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawContentTypeClient:
@@ -25,7 +25,7 @@ class ContentTypeClient:
         -------
         RawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_json_patch_content_type(
         self,
@@ -115,7 +115,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_type(
+        _response = self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -221,7 +221,7 @@ class ContentTypeClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.post_json_patch_content_with_charset_type(
+        _response = self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -242,7 +242,7 @@ class ContentTypeClient:
 
 class AsyncContentTypeClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawContentTypeClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawContentTypeClient:
@@ -253,7 +253,7 @@ class AsyncContentTypeClient:
         -------
         AsyncRawContentTypeClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_json_patch_content_type(
         self,
@@ -350,7 +350,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_type(
+        _response = await self.__raw_client.post_json_patch_content_type(
             string=string,
             integer=integer,
             long_=long_,
@@ -463,7 +463,7 @@ class AsyncContentTypeClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_json_patch_content_with_charset_type(
+        _response = await self.__raw_client.post_json_patch_content_with_charset_type(
             string=string,
             integer=integer,
             long_=long_,

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/enum/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/enum/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class EnumClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawEnumClient:
@@ -24,7 +24,7 @@ class EnumClient:
         -------
         RawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -53,13 +53,13 @@ class EnumClient:
             request="SUNNY",
         )
         """
-        _response = self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncEnumClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawEnumClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawEnumClient:
@@ -70,7 +70,7 @@ class AsyncEnumClient:
         -------
         AsyncRawEnumClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_enum(
         self, *, request: WeatherReport, request_options: typing.Optional[RequestOptions] = None
@@ -107,5 +107,5 @@ class AsyncEnumClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_enum(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_enum(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/http_methods/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/http_methods/client.py
@@ -15,7 +15,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class HttpMethodsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawHttpMethodsClient:
@@ -26,7 +26,7 @@ class HttpMethodsClient:
         -------
         RawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -53,7 +53,7 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_get(id, request_options=request_options)
+        _response = self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     def test_post(
@@ -83,7 +83,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_post(string=string, request_options=request_options)
+        _response = self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     def test_put(
@@ -116,7 +116,7 @@ class HttpMethodsClient:
             string="string",
         )
         """
-        _response = self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     def test_patch(
@@ -211,7 +211,7 @@ class HttpMethodsClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.test_patch(
+        _response = self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -255,13 +255,13 @@ class HttpMethodsClient:
             id="id",
         )
         """
-        _response = self._raw_client.test_delete(id, request_options=request_options)
+        _response = self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data
 
 
 class AsyncHttpMethodsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawHttpMethodsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawHttpMethodsClient:
@@ -272,7 +272,7 @@ class AsyncHttpMethodsClient:
         -------
         AsyncRawHttpMethodsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def test_get(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -307,7 +307,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_get(id, request_options=request_options)
+        _response = await self.__raw_client.test_get(id, request_options=request_options)
         return _response.data
 
     async def test_post(
@@ -345,7 +345,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_post(string=string, request_options=request_options)
+        _response = await self.__raw_client.test_post(string=string, request_options=request_options)
         return _response.data
 
     async def test_put(
@@ -386,7 +386,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_put(id, string=string, request_options=request_options)
+        _response = await self.__raw_client.test_put(id, string=string, request_options=request_options)
         return _response.data
 
     async def test_patch(
@@ -488,7 +488,7 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_patch(
+        _response = await self.__raw_client.test_patch(
             id,
             string=string,
             integer=integer,
@@ -540,5 +540,5 @@ class AsyncHttpMethodsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.test_delete(id, request_options=request_options)
+        _response = await self.__raw_client.test_delete(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/object/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/object/client.py
@@ -20,7 +20,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ObjectClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawObjectClient:
@@ -31,7 +31,7 @@ class ObjectClient:
         -------
         RawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_with_optional_field(
         self,
@@ -121,7 +121,7 @@ class ObjectClient:
             bigint=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_with_optional_field(
+        _response = self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -166,7 +166,7 @@ class ObjectClient:
             string="string",
         )
         """
-        _response = self._raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_required_field(string=string, request_options=request_options)
         return _response.data
 
     def get_and_return_with_map_of_map(
@@ -196,7 +196,7 @@ class ObjectClient:
             map_={"map": {"map": "map"}},
         )
         """
-        _response = self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     def get_and_return_nested_with_optional_field(
@@ -257,7 +257,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_optional_field(
+        _response = self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -324,7 +324,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field(
+        _response = self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -415,7 +415,7 @@ class ObjectClient:
             ],
         )
         """
-        _response = self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -464,7 +464,7 @@ class ObjectClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_with_datetime_like_string(
+        _response = self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data
@@ -472,7 +472,7 @@ class ObjectClient:
 
 class AsyncObjectClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawObjectClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawObjectClient:
@@ -483,7 +483,7 @@ class AsyncObjectClient:
         -------
         AsyncRawObjectClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_with_optional_field(
         self,
@@ -580,7 +580,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_optional_field(
+        _response = await self.__raw_client.get_and_return_with_optional_field(
             string=string,
             integer=integer,
             long_=long_,
@@ -633,7 +633,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_required_field(
+        _response = await self.__raw_client.get_and_return_with_required_field(
             string=string, request_options=request_options
         )
         return _response.data
@@ -673,7 +673,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_with_map_of_map(map_=map_, request_options=request_options)
         return _response.data
 
     async def get_and_return_nested_with_optional_field(
@@ -741,7 +741,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_optional_field(
+        _response = await self.__raw_client.get_and_return_nested_with_optional_field(
             string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -815,7 +815,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field(
             string_, string=string, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -913,7 +913,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_nested_with_required_field_as_list(
+        _response = await self.__raw_client.get_and_return_nested_with_required_field_as_list(
             request=request, request_options=request_options
         )
         return _response.data
@@ -969,7 +969,7 @@ class AsyncObjectClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_with_datetime_like_string(
+        _response = await self.__raw_client.get_and_return_with_datetime_like_string(
             datetime_like_string=datetime_like_string, actual_datetime=actual_datetime, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/params/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/params/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ParamsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawParamsClient:
@@ -23,7 +23,7 @@ class ParamsClient:
         -------
         RawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -82,7 +82,7 @@ class ParamsClient:
             param="param",
         )
         """
-        _response = self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     def get_with_query(
@@ -117,7 +117,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     def get_with_allow_multiple_query(
@@ -156,7 +156,7 @@ class ParamsClient:
             number=1,
         )
         """
-        _response = self._raw_client.get_with_allow_multiple_query(
+        _response = self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -193,7 +193,7 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     def get_with_inline_path_and_query(
@@ -228,7 +228,9 @@ class ParamsClient:
             query="query",
         )
         """
-        _response = self._raw_client.get_with_inline_path_and_query(param, query=query, request_options=request_options)
+        _response = self.__raw_client.get_with_inline_path_and_query(
+            param, query=query, request_options=request_options
+        )
         return _response.data
 
     def modify_with_path(
@@ -263,7 +265,7 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     def modify_with_inline_path(
@@ -298,13 +300,13 @@ class ParamsClient:
             request="string",
         )
         """
-        _response = self._raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
+        _response = self.__raw_client.modify_with_inline_path(param, request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncParamsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawParamsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawParamsClient:
@@ -315,7 +317,7 @@ class AsyncParamsClient:
         -------
         AsyncRawParamsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -352,7 +354,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path(self, param: str, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -390,7 +392,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path(param, request_options=request_options)
+        _response = await self.__raw_client.get_with_inline_path(param, request_options=request_options)
         return _response.data
 
     async def get_with_query(
@@ -433,7 +435,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_query(query=query, number=number, request_options=request_options)
+        _response = await self.__raw_client.get_with_query(query=query, number=number, request_options=request_options)
         return _response.data
 
     async def get_with_allow_multiple_query(
@@ -480,7 +482,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_allow_multiple_query(
+        _response = await self.__raw_client.get_with_allow_multiple_query(
             query=query, number=number, request_options=request_options
         )
         return _response.data
@@ -525,7 +527,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
+        _response = await self.__raw_client.get_with_path_and_query(param, query=query, request_options=request_options)
         return _response.data
 
     async def get_with_inline_path_and_query(
@@ -568,7 +570,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_inline_path_and_query(
+        _response = await self.__raw_client.get_with_inline_path_and_query(
             param, query=query, request_options=request_options
         )
         return _response.data
@@ -613,7 +615,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_path(param, request=request, request_options=request_options)
+        _response = await self.__raw_client.modify_with_path(param, request=request, request_options=request_options)
         return _response.data
 
     async def modify_with_inline_path(
@@ -656,7 +658,7 @@ class AsyncParamsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.modify_with_inline_path(
+        _response = await self.__raw_client.modify_with_inline_path(
             param, request=request, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/primitive/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/primitive/client.py
@@ -14,7 +14,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class PrimitiveClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPrimitiveClient:
@@ -25,7 +25,7 @@ class PrimitiveClient:
         -------
         RawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_string(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -52,7 +52,7 @@ class PrimitiveClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -80,7 +80,7 @@ class PrimitiveClient:
             request=1,
         )
         """
-        _response = self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_long(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -108,7 +108,7 @@ class PrimitiveClient:
             request=1000000,
         )
         """
-        _response = self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_double(
@@ -138,7 +138,7 @@ class PrimitiveClient:
             request=1.1,
         )
         """
-        _response = self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_bool(self, *, request: bool, request_options: typing.Optional[RequestOptions] = None) -> bool:
@@ -166,7 +166,7 @@ class PrimitiveClient:
             request=True,
         )
         """
-        _response = self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_datetime(
@@ -200,7 +200,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_date(
@@ -234,7 +234,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_uuid(
@@ -268,7 +268,7 @@ class PrimitiveClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     def get_and_return_base_64(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -296,13 +296,13 @@ class PrimitiveClient:
             request="SGVsbG8gd29ybGQh",
         )
         """
-        _response = self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncPrimitiveClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPrimitiveClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPrimitiveClient:
@@ -313,7 +313,7 @@ class AsyncPrimitiveClient:
         -------
         AsyncRawPrimitiveClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_string(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
@@ -350,7 +350,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_string(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_string(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_int(self, *, request: int, request_options: typing.Optional[RequestOptions] = None) -> int:
@@ -386,7 +386,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_int(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_int(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_long(
@@ -424,7 +424,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_long(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_long(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_double(
@@ -462,7 +462,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_double(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_double(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_bool(
@@ -500,7 +500,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_bool(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_bool(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_datetime(
@@ -541,7 +541,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_datetime(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_datetime(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_date(
@@ -582,7 +582,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_date(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_date(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_uuid(
@@ -623,7 +623,7 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_uuid(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_uuid(request=request, request_options=request_options)
         return _response.data
 
     async def get_and_return_base_64(
@@ -661,5 +661,5 @@ class AsyncPrimitiveClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_base_64(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_base_64(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/put/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/put/client.py
@@ -10,7 +10,7 @@ from .types.put_response import PutResponse
 
 class PutClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawPutClient:
@@ -21,7 +21,7 @@ class PutClient:
         -------
         RawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -48,13 +48,13 @@ class PutClient:
             id="id",
         )
         """
-        _response = self._raw_client.add(id, request_options=request_options)
+        _response = self.__raw_client.add(id, request_options=request_options)
         return _response.data
 
 
 class AsyncPutClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawPutClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawPutClient:
@@ -65,7 +65,7 @@ class AsyncPutClient:
         -------
         AsyncRawPutClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def add(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> PutResponse:
         """
@@ -100,5 +100,5 @@ class AsyncPutClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.add(id, request_options=request_options)
+        _response = await self.__raw_client.add(id, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/union/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/union/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class UnionClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUnionClient:
@@ -24,7 +24,7 @@ class UnionClient:
         -------
         RawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -57,13 +57,13 @@ class UnionClient:
             ),
         )
         """
-        _response = self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncUnionClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUnionClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUnionClient:
@@ -74,7 +74,7 @@ class AsyncUnionClient:
         -------
         AsyncRawUnionClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_and_return_union(
         self, *, request: Animal, request_options: typing.Optional[RequestOptions] = None
@@ -115,5 +115,5 @@ class AsyncUnionClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_and_return_union(request=request, request_options=request_options)
+        _response = await self.__raw_client.get_and_return_union(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/urls/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/endpoints/urls/client.py
@@ -9,7 +9,7 @@ from .raw_client import AsyncRawUrlsClient, RawUrlsClient
 
 class UrlsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawUrlsClient:
@@ -20,7 +20,7 @@ class UrlsClient:
         -------
         RawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -43,7 +43,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_mixed_case()
         """
-        _response = self._raw_client.with_mixed_case(request_options=request_options)
+        _response = self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -67,7 +67,7 @@ class UrlsClient:
         )
         client.endpoints.urls.no_ending_slash()
         """
-        _response = self._raw_client.no_ending_slash(request_options=request_options)
+        _response = self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -91,7 +91,7 @@ class UrlsClient:
         )
         client.endpoints.urls.with_ending_slash()
         """
-        _response = self._raw_client.with_ending_slash(request_options=request_options)
+        _response = self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -115,13 +115,13 @@ class UrlsClient:
         )
         client.endpoints.urls.with_underscores()
         """
-        _response = self._raw_client.with_underscores(request_options=request_options)
+        _response = self.__raw_client.with_underscores(request_options=request_options)
         return _response.data
 
 
 class AsyncUrlsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawUrlsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawUrlsClient:
@@ -132,7 +132,7 @@ class AsyncUrlsClient:
         -------
         AsyncRawUrlsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def with_mixed_case(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
         """
@@ -163,7 +163,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_mixed_case(request_options=request_options)
+        _response = await self.__raw_client.with_mixed_case(request_options=request_options)
         return _response.data
 
     async def no_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -195,7 +195,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.no_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.no_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_ending_slash(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -227,7 +227,7 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_ending_slash(request_options=request_options)
+        _response = await self.__raw_client.with_ending_slash(request_options=request_options)
         return _response.data
 
     async def with_underscores(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -259,5 +259,5 @@ class AsyncUrlsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.with_underscores(request_options=request_options)
+        _response = await self.__raw_client.with_underscores(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/inlined_requests/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/inlined_requests/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class InlinedRequestsClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawInlinedRequestsClient:
@@ -24,7 +24,7 @@ class InlinedRequestsClient:
         -------
         RawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_object_bodyand_response(
         self,
@@ -90,7 +90,7 @@ class InlinedRequestsClient:
             ),
         )
         """
-        _response = self._raw_client.post_with_object_bodyand_response(
+        _response = self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data
@@ -98,7 +98,7 @@ class InlinedRequestsClient:
 
 class AsyncInlinedRequestsClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawInlinedRequestsClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawInlinedRequestsClient:
@@ -109,7 +109,7 @@ class AsyncInlinedRequestsClient:
         -------
         AsyncRawInlinedRequestsClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_object_bodyand_response(
         self,
@@ -182,7 +182,7 @@ class AsyncInlinedRequestsClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_object_bodyand_response(
+        _response = await self.__raw_client.post_with_object_bodyand_response(
             string=string, integer=integer, nested_object=nested_object, request_options=request_options
         )
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/no_auth/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/no_auth/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class NoAuthClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoAuthClient:
@@ -23,7 +23,7 @@ class NoAuthClient:
         -------
         RawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -54,13 +54,13 @@ class NoAuthClient:
             request={"key": "value"},
         )
         """
-        _response = self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data
 
 
 class AsyncNoAuthClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoAuthClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoAuthClient:
@@ -71,7 +71,7 @@ class AsyncNoAuthClient:
         -------
         AsyncRawNoAuthClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def post_with_no_auth(
         self, *, request: typing.Any, request_options: typing.Optional[RequestOptions] = None
@@ -110,5 +110,5 @@ class AsyncNoAuthClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_auth(request=request, request_options=request_options)
+        _response = await self.__raw_client.post_with_no_auth(request=request, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/no_req_body/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/no_req_body/client.py
@@ -10,7 +10,7 @@ from .raw_client import AsyncRawNoReqBodyClient, RawNoReqBodyClient
 
 class NoReqBodyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawNoReqBodyClient:
@@ -21,7 +21,7 @@ class NoReqBodyClient:
         -------
         RawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -46,7 +46,7 @@ class NoReqBodyClient:
         )
         client.no_req_body.get_with_no_request_body()
         """
-        _response = self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -70,13 +70,13 @@ class NoReqBodyClient:
         )
         client.no_req_body.post_with_no_request_body()
         """
-        _response = self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data
 
 
 class AsyncNoReqBodyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawNoReqBodyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawNoReqBodyClient:
@@ -87,7 +87,7 @@ class AsyncNoReqBodyClient:
         -------
         AsyncRawNoReqBodyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_no_request_body(
         self, *, request_options: typing.Optional[RequestOptions] = None
@@ -120,7 +120,7 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.get_with_no_request_body(request_options=request_options)
         return _response.data
 
     async def post_with_no_request_body(self, *, request_options: typing.Optional[RequestOptions] = None) -> str:
@@ -152,5 +152,5 @@ class AsyncNoReqBodyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.post_with_no_request_body(request_options=request_options)
+        _response = await self.__raw_client.post_with_no_request_body(request_options=request_options)
         return _response.data

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/req_with_headers/client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/req_with_headers/client.py
@@ -12,7 +12,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class ReqWithHeadersClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawReqWithHeadersClient:
@@ -23,7 +23,7 @@ class ReqWithHeadersClient:
         -------
         RawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def get_with_custom_header(
         self,
@@ -63,7 +63,7 @@ class ReqWithHeadersClient:
             request="string",
         )
         """
-        _response = self._raw_client.get_with_custom_header(
+        _response = self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,
@@ -74,7 +74,7 @@ class ReqWithHeadersClient:
 
 class AsyncReqWithHeadersClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawReqWithHeadersClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawReqWithHeadersClient:
@@ -85,7 +85,7 @@ class AsyncReqWithHeadersClient:
         -------
         AsyncRawReqWithHeadersClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def get_with_custom_header(
         self,
@@ -133,7 +133,7 @@ class AsyncReqWithHeadersClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.get_with_custom_header(
+        _response = await self.__raw_client.get_with_custom_header(
             x_test_service_header=x_test_service_header,
             x_test_endpoint_header=x_test_endpoint_header,
             request=request,

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/dummy/client.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/dummy/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class DummyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawDummyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawDummyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawDummyClient:
@@ -24,7 +24,7 @@ class DummyClient:
         -------
         RawDummyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def generate_stream(
         self, *, num_events: int, request_options: typing.Optional[RequestOptions] = None
@@ -54,7 +54,7 @@ class DummyClient:
         for chunk in response:
             yield chunk
         """
-        with self._raw_client.generate_stream(num_events=num_events, request_options=request_options) as r:
+        with self.__raw_client.generate_stream(num_events=num_events, request_options=request_options) as r:
             yield from r.data
 
     def generate(self, *, num_events: int, request_options: typing.Optional[RequestOptions] = None) -> StreamResponse:
@@ -81,13 +81,13 @@ class DummyClient:
             num_events=5,
         )
         """
-        _response = self._raw_client.generate(num_events=num_events, request_options=request_options)
+        _response = self.__raw_client.generate(num_events=num_events, request_options=request_options)
         return _response.data
 
 
 class AsyncDummyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawDummyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawDummyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawDummyClient:
@@ -98,7 +98,7 @@ class AsyncDummyClient:
         -------
         AsyncRawDummyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def generate_stream(
         self, *, num_events: int, request_options: typing.Optional[RequestOptions] = None
@@ -136,7 +136,7 @@ class AsyncDummyClient:
 
         asyncio.run(main())
         """
-        async with self._raw_client.generate_stream(num_events=num_events, request_options=request_options) as r:
+        async with self.__raw_client.generate_stream(num_events=num_events, request_options=request_options) as r:
             async for _chunk in r.data:
                 yield _chunk
 
@@ -174,5 +174,5 @@ class AsyncDummyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.generate(num_events=num_events, request_options=request_options)
+        _response = await self.__raw_client.generate(num_events=num_events, request_options=request_options)
         return _response.data

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/dummy/client.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/dummy/client.py
@@ -13,7 +13,7 @@ OMIT = typing.cast(typing.Any, ...)
 
 class DummyClient:
     def __init__(self, *, client_wrapper: SyncClientWrapper):
-        self._raw_client = RawDummyClient(client_wrapper=client_wrapper)
+        self.__raw_client = RawDummyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> RawDummyClient:
@@ -24,7 +24,7 @@ class DummyClient:
         -------
         RawDummyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     def generate_stream(
         self, *, num_events: int, request_options: typing.Optional[RequestOptions] = None
@@ -54,7 +54,7 @@ class DummyClient:
         for chunk in response:
             yield chunk
         """
-        with self._raw_client.generate_stream(num_events=num_events, request_options=request_options) as r:
+        with self.__raw_client.generate_stream(num_events=num_events, request_options=request_options) as r:
             yield from r.data
 
     def generate(self, *, num_events: int, request_options: typing.Optional[RequestOptions] = None) -> StreamResponse:
@@ -81,13 +81,13 @@ class DummyClient:
             num_events=5,
         )
         """
-        _response = self._raw_client.generate(num_events=num_events, request_options=request_options)
+        _response = self.__raw_client.generate(num_events=num_events, request_options=request_options)
         return _response.data
 
 
 class AsyncDummyClient:
     def __init__(self, *, client_wrapper: AsyncClientWrapper):
-        self._raw_client = AsyncRawDummyClient(client_wrapper=client_wrapper)
+        self.__raw_client = AsyncRawDummyClient(client_wrapper=client_wrapper)
 
     @property
     def with_raw_response(self) -> AsyncRawDummyClient:
@@ -98,7 +98,7 @@ class AsyncDummyClient:
         -------
         AsyncRawDummyClient
         """
-        return self._raw_client
+        return self.__raw_client
 
     async def generate_stream(
         self, *, num_events: int, request_options: typing.Optional[RequestOptions] = None
@@ -136,7 +136,7 @@ class AsyncDummyClient:
 
         asyncio.run(main())
         """
-        async with self._raw_client.generate_stream(num_events=num_events, request_options=request_options) as r:
+        async with self.__raw_client.generate_stream(num_events=num_events, request_options=request_options) as r:
             async for _chunk in r.data:
                 yield _chunk
 
@@ -174,5 +174,5 @@ class AsyncDummyClient:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.generate(num_events=num_events, request_options=request_options)
+        _response = await self.__raw_client.generate(num_events=num_events, request_options=request_options)
         return _response.data


### PR DESCRIPTION
## Description

Refs: [Customer report (Cohere)](https://buildwithfern.slack.com/archives/C05KKD1P8BG/p1770299642501849)

Fixes a regression where wrapped client methods (e.g. `generate_stream`) break when SDKs combine root and subpackage clients via multiple inheritance (e.g. Cohere's `class ClientV2(V2Client, BaseCohere)`). Both parent classes were setting `self._raw_client` in `__init__`, so the last call would overwrite the first — causing inherited wrapper methods to dispatch against the wrong raw client instance.

The fix uses Python name mangling (`__raw_client` instead of `_raw_client`), which makes each class's attribute scope to `_ClassName__raw_client` at runtime, preventing collisions.

## Changes Made

- **`base_client_generator.py`**: `_get_raw_client_member_name()` now returns `"__raw_client"` instead of `"_raw_client"`
- **`endpoint_function_generator.py`**: `generate_wrapper_function()` derives the raw client member name from `self._client_wrapper_member_name` instead of hardcoding `"_raw_client"`
- **`versions.yml`**: Added `4.55.4` changelog entry
- **`test_lazy_loading.py`** (exhaustive seed fixture): Updated assertions to use `with_raw_response` property instead of directly accessing `_raw_client` (which is no longer accessible externally due to name mangling)
- Regenerated `streaming` and `exhaustive` seed fixtures

## Testing

- [x] `pnpm seed test --generator python-sdk --fixture exhaustive:no-custom-config` — passed (includes test scripts)
- [x] `pnpm seed test --generator python-sdk --fixture streaming --skip-scripts` — 2/2 passed
- [x] `pnpm seed test --generator python-sdk --fixture exhaustive --skip-scripts` — 26/26 passed
- [x] `pnpm run check` (biome lint) — passed
- [x] CI — all 92 checks pass

## Human Review Checklist

- [ ] Verify that `self._client_wrapper_member_name.rsplit(".", 1)[0]` in `endpoint_function_generator.py:1687` correctly extracts the raw client member name for all possible values of `_client_wrapper_member_name` (expected format: `"__raw_client._client_wrapper"`)
- [ ] Confirm Python name mangling (`__raw_client` → `_ClassName__raw_client`) works correctly with the `with_raw_response` property pattern, where access is always within the defining class
- [ ] **Breaking change for internal access**: Any hand-written code that directly accesses `client._raw_client` will break (must use `client.with_raw_response` instead). Verify this is acceptable for existing SDK consumers
- [ ] Note: there is no seed fixture that tests the multiple inheritance composition pattern itself (e.g. `ClientV2(V2Client, Client)`) — the fix is based on Python language semantics

---

Link to Devin run: https://app.devin.ai/sessions/3ddeec557a1a45b1baaefa2a8a6119be
Requested by: @tjb9dc