### PR TITLE
fix(internal): skip nop results when matching undiscriminated union types in dynamic snippets

### DIFF
--- a/generators/csharp/dynamic-snippets/src/context/DynamicLiteralMapper.ts
+++ b/generators/csharp/dynamic-snippets/src/context/DynamicLiteralMapper.ts
@@ -502,6 +502,9 @@ export class DynamicLiteralMapper extends WithGeneration {
         for (const typeReference of undiscriminatedUnion.types) {
             try {
                 const typeLiteral = this.convert({ typeReference, value });
+                if (typeLiteral instanceof ast.Literal.Nop) {
+                    continue;
+                }
                 return { valueTypeReference: typeReference, typeLiteral };
             } catch (e) {
                 continue;

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.20.4
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippets for undiscriminated unions with array variants. Previously, array
+        values like `["test1", "test2"]` would render as empty output because the first union
+        variant (e.g., string) returned a nop result that was incorrectly treated as a match.
+      type: fix
+  createdAt: "2026-02-10"
+  irVersion: 62
+
 - version: 2.20.3
   changelogEntry:
     - summary: |

--- a/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -507,6 +507,9 @@ export class DynamicTypeLiteralMapper {
                     inUndiscriminatedUnion: true
                 });
 
+                if (java.TypeLiteral.isNop(typeInstantiation)) {
+                    continue;
+                }
                 return { valueTypeReference: typeReference, typeInstantiation };
             } catch (e) {
                 variantErrors.push(

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.34.10
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippets for undiscriminated unions with array variants. Previously, array
+        values like `["test1", "test2"]` would render as empty output because the first union
+        variant (e.g., string) returned a nop result that was incorrectly treated as a match.
+      type: fix
+  createdAt: "2026-02-10"
+  irVersion: 63
+
 - version: 3.34.9
   changelogEntry:
     - summary: |

--- a/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -431,7 +431,11 @@ export class DynamicTypeLiteralMapper {
     }): php.TypeLiteral | undefined {
         for (const typeReference of undiscriminatedUnion.types) {
             try {
-                return this.convert({ typeReference, value });
+                const result = this.convert({ typeReference, value });
+                if (php.TypeLiteral.isNop(result)) {
+                    continue;
+                }
+                return result;
             } catch (e) {
                 continue;
             }

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.27.1
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippets for undiscriminated unions with array variants. Previously, array
+        values like `["test1", "test2"]` would render as empty output because the first union
+        variant (e.g., string) returned a nop result that was incorrectly treated as a match.
+      type: fix
+  createdAt: "2026-02-10"
+  irVersion: 62
+
 - version: 1.27.0
   changelogEntry:
     - summary: |

--- a/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -469,6 +469,9 @@ export class DynamicTypeLiteralMapper {
         for (const typeReference of undiscriminatedUnion.types) {
             try {
                 const converted = this.convert({ fromSymbol, typeReference, value });
+                if (converted.isNop()) {
+                    continue;
+                }
                 const swiftType = this.context.getSwiftTypeReferenceFromScope(typeReference, fromSymbol);
                 const matchingVariant = variants.find((v) => v.swiftType.equals(swiftType));
                 if (matchingVariant == null) {

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.26.1
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippets for undiscriminated unions with array variants. Previously, array
+        values like `["test1", "test2"]` would render as empty output because the first union
+        variant (e.g., string) returned a nop result that was incorrectly treated as a match.
+      type: fix
+  createdAt: "2026-02-10"
+  irVersion: 61
+
 - version: 0.26.0
   changelogEntry:
     - type: feat

--- a/generators/typescript-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -564,7 +564,11 @@ export class DynamicTypeLiteralMapper {
     }): ts.TypeLiteral | undefined {
         for (const typeReference of undiscriminatedUnion.types) {
             try {
-                return this.convert({ typeReference, value, convertOpts });
+                const result = this.convert({ typeReference, value, convertOpts });
+                if (ts.TypeLiteral.isNop(result)) {
+                    continue;
+                }
+                return result;
             } catch (e) {
                 continue;
             }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.47.2
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippets for undiscriminated unions with array variants. Previously, array
+        values like `["test1", "test2"]` would render as empty output because the first union
+        variant (e.g., string) returned a nop result that was incorrectly treated as a match.
+      type: fix
+  createdAt: "2026-02-10"
+  irVersion: 63
+
 - version: 3.47.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes a bug where the API explorer's dynamic snippet generator produced empty/missing values for undiscriminated union types (e.g., `string | list<string>`). When users selected the array variant and entered values like `["test1", "test2"]`, the generated TypeScript and Java code showed empty output (`filter: {}` and `ModelObjectFilterGroupIds.of()` respectively).

Reported in: https://buildwithfern.slack.com/archives/C089J72VA3T/p1770740154531669

Link to Devin run: https://app.devin.ai/sessions/e3fa2c1f6c4d49888898c5c1cdeef1b3
Requested by: @tjb9dc

## Root Cause

In `findMatchingUndiscriminatedUnionType`, the method iterates through union variant types and calls `convert()` for each. When a value doesn't match a type (e.g., an array value against a `string` primitive), `convert()` returns `nop()` instead of throwing. Since `nop()` doesn't throw, the first variant was always treated as a successful match — even though it produced no output.

Python, Go, and Ruby generators already had nop checks. TypeScript, Java, PHP, C#, and Swift did not.

## Changes Made

- Added nop check after `convert()` in `findMatchingUndiscriminatedUnionType` for 5 generators:
  - **TypeScript** (`generators/typescript-v2/dynamic-snippets/`) — `ts.TypeLiteral.isNop()`
  - **Java** (`generators/java-v2/dynamic-snippets/`) — `java.TypeLiteral.isNop()`
  - **PHP** (`generators/php/dynamic-snippets/`) — `php.TypeLiteral.isNop()`
  - **C#** (`generators/csharp/dynamic-snippets/`) — `instanceof ast.Literal.Nop`
  - **Swift** (`generators/swift/dynamic-snippets/`) — `.isNop()` instance method
- Updated `versions.yml` for all 5 affected generators:
  - TypeScript SDK: 3.47.1 → 3.48.1
  - Java SDK: 3.34.9 → 3.34.10
  - PHP SDK: 1.27.0 → 1.27.1
  - C# SDK: 2.20.3 → 2.20.4
  - Swift SDK: 0.26.0 → 0.26.1
- [ ] Updated README.md generator (not applicable)

Each uses the nop detection pattern already established in that generator's AST.

## Testing

- [x] `pnpm run check` (biome lint) passes
- [x] All generators compile locally (`pnpm --filter @fern-api/java-dynamic-snippets run compile`, etc.)
- [ ] No new unit tests added — existing dynamic snippet snapshot tests should cover regression, but a dedicated test for undiscriminated unions with array values would strengthen coverage

> **CI note:** The `ts-sdk` and `ts-express` seed-test-results failures are caused by a pre-existing `core-utils` build dependency issue (`core-utils/lib/index.d.ts is not a module`) unrelated to this PR. All affected generators compile successfully locally.

## Human Review Checklist

- [ ] Verify each nop detection API matches the convention used in that generator's AST — each has a slightly different pattern (`isNop()` static, `instanceof Nop`, `.isNop()` instance). A mismatch would fail silently at runtime.
- [ ] Confirm the behavioral change is safe: previously, mismatched values silently produced empty snippets; now they fall through to try the correct variant (or error if none match)
- [ ] Spot-check that `convert()` does in fact return nop (not throw) for type mismatches in each generator — the fix assumes this based on Python/Go/Ruby precedent
- [x] `versions.yml` updates added for all affected generators