### PR TITLE
feat(openapi): include numeric and string validation constraints in generated OpenAPI

### DIFF
--- a/generators/openapi/src/converters/typeConverter.ts
+++ b/generators/openapi/src/converters/typeConverter.ts
@@ -321,16 +321,15 @@ function convertPrimitiveType(primitiveType: FernIr.PrimitiveType): OpenAPIV3.No
                 format: "date-time"
             };
         },
-        double: () => {
-            return {
-                type: "number",
-                format: "double"
-            };
+        double: (val) => {
+            const type: OpenAPIV3.NonArraySchemaObject = { type: "number", format: "double" };
+            applyNumericValidation(type, val.validation);
+            return type;
         },
-        integer: () => {
-            return {
-                type: "integer"
-            };
+        integer: (val) => {
+            const type: OpenAPIV3.NonArraySchemaObject = { type: "integer" };
+            applyNumericValidation(type, val.validation);
+            return type;
         },
         long: () => {
             return {
@@ -345,6 +344,12 @@ function convertPrimitiveType(primitiveType: FernIr.PrimitiveType): OpenAPIV3.No
             }
             if (val.validation?.pattern != null) {
                 type.pattern = val.validation.pattern;
+            }
+            if (val.validation?.minLength != null) {
+                type.minLength = val.validation.minLength;
+            }
+            if (val.validation?.maxLength != null) {
+                type.maxLength = val.validation.maxLength;
             }
             return type;
         },
@@ -394,6 +399,30 @@ function convertPrimitiveType(primitiveType: FernIr.PrimitiveType): OpenAPIV3.No
             throw new Error("Encountered unknown primitiveType: " + primitiveType.v1);
         }
     });
+}
+
+function applyNumericValidation(
+    schema: OpenAPIV3.NonArraySchemaObject,
+    rules: FernIr.IntegerValidationRules | FernIr.DoubleValidationRules | undefined
+): void {
+    if (rules == null) {
+        return;
+    }
+    if (rules.min != null) {
+        schema.minimum = rules.min;
+    }
+    if (rules.max != null) {
+        schema.maximum = rules.max;
+    }
+    if (rules.exclusiveMin != null) {
+        schema.exclusiveMinimum = rules.exclusiveMin;
+    }
+    if (rules.exclusiveMax != null) {
+        schema.exclusiveMaximum = rules.exclusiveMax;
+    }
+    if (rules.multipleOf != null) {
+        schema.multipleOf = rules.multipleOf;
+    }
 }
 
 function convertContainerType(containerType: FernIr.ContainerType): OpenApiComponentSchema {

--- a/generators/openapi/src/converters/typeConverter.ts
+++ b/generators/openapi/src/converters/typeConverter.ts
@@ -414,10 +414,10 @@ function applyNumericValidation(
     if (rules.max != null) {
         schema.maximum = rules.max;
     }
-    if (rules.exclusiveMin != null) {
+    if (rules.exclusiveMin === true) {
         schema.exclusiveMinimum = rules.exclusiveMin;
     }
-    if (rules.exclusiveMax != null) {
+    if (rules.exclusiveMax === true) {
         schema.exclusiveMaximum = rules.exclusiveMax;
     }
     if (rules.multipleOf != null) {

--- a/generators/openapi/versions.yml
+++ b/generators/openapi/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
+- version: 0.1.9
+  createdAt: "2026-02-10"
+  changelogEntry:
+    - type: feat
+      summary: |
+        Add support for numeric validation constraints (minimum/maximum, exclusiveMinimum/exclusiveMaximum, multipleOf)
+        and string length constraints (minLength/maxLength) in the generated OpenAPI schemas, parameters, and request bodies.
+  irVersion: 53
+
 - version: 0.1.8
   createdAt: "2025-11-19"
   changelogEntry:

--- a/generators/openapi/versions.yml
+++ b/generators/openapi/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
-- version: 0.1.9
+- version: 0.2.0
   createdAt: "2026-02-10"
   changelogEntry:
     - type: feat

--- a/seed/openapi/validation/openapi.yml
+++ b/seed/openapi/validation/openapi.yml
@@ -29,13 +29,11 @@ paths:
                   minimum: 1.1
                   maximum: 2.2
                   exclusiveMinimum: true
-                  exclusiveMaximum: false
                   multipleOf: 1.1
                 even:
                   type: integer
                   minimum: 0
                   maximum: 100
-                  exclusiveMinimum: false
                   exclusiveMaximum: true
                   multipleOf: 2
                 name:
@@ -66,7 +64,6 @@ paths:
             minimum: 1.1
             maximum: 2.2
             exclusiveMinimum: true
-            exclusiveMaximum: false
             multipleOf: 1.1
         - name: even
           in: query
@@ -75,7 +72,6 @@ paths:
             type: integer
             minimum: 0
             maximum: 100
-            exclusiveMinimum: false
             exclusiveMaximum: true
             multipleOf: 2
         - name: name
@@ -143,14 +139,12 @@ components:
           minimum: 1.1
           maximum: 2.2
           exclusiveMinimum: true
-          exclusiveMaximum: false
           multipleOf: 1.1
           example: 1.1
         even:
           type: integer
           minimum: 0
           maximum: 100
-          exclusiveMinimum: false
           exclusiveMaximum: true
           multipleOf: 2
           example: 2

--- a/seed/openapi/validation/openapi.yml
+++ b/seed/openapi/validation/openapi.yml
@@ -26,12 +26,24 @@ paths:
                 decimal:
                   type: number
                   format: double
+                  minimum: 1.1
+                  maximum: 2.2
+                  exclusiveMinimum: true
+                  exclusiveMaximum: false
+                  multipleOf: 1.1
                 even:
                   type: integer
+                  minimum: 0
+                  maximum: 100
+                  exclusiveMinimum: false
+                  exclusiveMaximum: true
+                  multipleOf: 2
                 name:
                   type: string
                   format: custom
                   pattern: ^[a-z]+$
+                  minLength: 3
+                  maxLength: 10
                 shape:
                   $ref: '#/components/schemas/Shape'
               required:
@@ -51,11 +63,21 @@ paths:
           schema:
             type: number
             format: double
+            minimum: 1.1
+            maximum: 2.2
+            exclusiveMinimum: true
+            exclusiveMaximum: false
+            multipleOf: 1.1
         - name: even
           in: query
           required: true
           schema:
             type: integer
+            minimum: 0
+            maximum: 100
+            exclusiveMinimum: false
+            exclusiveMaximum: true
+            multipleOf: 2
         - name: name
           in: query
           required: true
@@ -63,6 +85,8 @@ paths:
             type: string
             format: custom
             pattern: ^[a-z]+$
+            minLength: 3
+            maxLength: 10
       responses:
         '200':
           description: ''
@@ -75,19 +99,32 @@ components:
     SmallInteger:
       title: SmallInteger
       type: integer
+      minimum: 0
+      maximum: 10
+      exclusiveMinimum: true
+      exclusiveMaximum: true
+      multipleOf: 1
     LargeInteger:
       title: LargeInteger
       type: integer
+      minimum: 10000
+      maximum: 100000
     Double:
       title: Double
       type: number
       format: double
+      minimum: 256.42
+      maximum: 512.84
     Word:
       title: Word
       type: string
+      minLength: 2
+      maxLength: 26
     Sentence:
       title: Sentence
       type: string
+      minLength: 4
+      maxLength: 256
     Shape:
       title: Shape
       type: string
@@ -103,14 +140,26 @@ components:
         decimal:
           type: number
           format: double
+          minimum: 1.1
+          maximum: 2.2
+          exclusiveMinimum: true
+          exclusiveMaximum: false
+          multipleOf: 1.1
           example: 1.1
         even:
           type: integer
+          minimum: 0
+          maximum: 100
+          exclusiveMinimum: false
+          exclusiveMaximum: true
+          multipleOf: 2
           example: 2
         name:
           type: string
           format: custom
           pattern: ^[a-z]+$
+          minLength: 3
+          maxLength: 10
           example: rules
         shape:
           $ref: '#/components/schemas/Shape'


### PR DESCRIPTION
## Description

Refs: Customer request for `min`/`max` support in the OpenAPI generator ([Slack thread](https://buildwithfern.slack.com/archives/C06SZ08MQGP/p1770739421532499))

Adds support for propagating numeric and string validation constraints from Fern IR into the generated OpenAPI schemas, query parameters, and request bodies.

Requested by: @dannysheridan
Link to Devin run: https://app.devin.ai/sessions/c278b05c05f44d6589dbd7a598fa88d6

## Changes Made

- **Integer & Double types**: Apply `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf` from IR validation rules
- **String type**: Apply `minLength` and `maxLength` from IR validation rules (format/pattern were already supported)
- Added shared `applyNumericValidation` helper to avoid duplication between integer and double handlers
- Bumped generator version to `0.2.0` in `versions.yml`
- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [x] Seed snapshot test updated (`seed/openapi/validation/openapi.yml`) — confirms constraints appear in request bodies, query parameters, component schemas, and type definitions
- [ ] Unit tests added/updated

## Human Review Checklist

- [ ] Verify that `FernIr.IntegerValidationRules` and `FernIr.DoubleValidationRules` share the same field names (`min`, `max`, `exclusiveMin`, `exclusiveMax`, `multipleOf`) used by `applyNumericValidation` — a mismatch would silently produce no output
- [ ] Confirm `exclusiveMinimum`/`exclusiveMaximum` value types (boolean vs numeric) match the target OpenAPI spec version (3.0 uses booleans, 3.1 uses numbers)