### PR TITLE
fix(csharp): include QueryString in custom pagination endpoint requests

### DIFF
--- a/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -1473,6 +1473,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             bodyReference: requestBodyCodeBlock?.requestBodyReference,
             pathParameterReferences: endpointSignatureInfo.pathParameterReferences,
             headerBagReference: headerParameterCodeBlock.headerParameterBagReference,
+            queryString: queryParameterCodeBlock?.queryStringReference,
             endpointRequest: endpointSignatureInfo.request
         });
         if (apiRequestCodeBlock.code) {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.20.4
+  changelogEntry:
+    - summary: |
+        Fix query string parameters not being included in HTTP requests for custom pagination endpoints.
+      type: fix
+  createdAt: "2026-02-10"
+  irVersion: 62
+
 - version: 2.20.3
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Users/UsersClient.cs
@@ -38,6 +38,7 @@ public partial class UsersClient : IUsersClient
                 BaseUrl = _client.Options.BaseUrl,
                 Method = HttpMethod.Get,
                 Path = "/users",
+                QueryString = _queryString,
                 Headers = _headers,
                 Options = options,
             }


### PR DESCRIPTION
## Description

Refs [SDK - C# - Query string parameters not sent #145](https://github.com/fern-api/fern/issues/145)

The `generateCustomPagerMethodBody` in `HttpEndpointGenerator.ts` was building the query string variable (`_queryString`) but never passing it to the `createHttpRequestWrapper` call. This caused query parameters to be silently dropped from HTTP requests for endpoints using custom pagination.

## Changes Made

- Added the missing `queryString: queryParameterCodeBlock?.queryStringReference` parameter to `createHttpRequestWrapper` in `generateCustomPagerMethodBody`
- Added version `2.20.4` changelog entry
- Updated `pagination-custom` seed snapshot (now includes `QueryString = _queryString` in the generated `JsonRequest`)

## Key Review Points

The other two call sites of `createHttpRequestWrapper` in the same file (`writeUnpagedMethodBody` at ~L213 and `addWithRawResponseTaskCoreMethod` at ~L276) already include the `queryString` parameter — this was simply missed for the custom pager path.

### Human Review Checklist

- [ ] Confirm no other call sites of `createHttpRequestWrapper` are missing `queryString`
- [ ] Verify CI seed tests pass for all `csharp-sdk` fixtures (not just `pagination-custom`)
- [ ] Consider whether the reporter's endpoint (`ach-deposit-fees`, a GET with no pagination) might indicate a separate issue beyond custom pagination — the non-paginated path already includes `queryString`, so the reporter's case may involve custom pagination or a different root cause

## Testing

- [x] Seed test snapshots updated for `csharp-sdk` (`pagination-custom` fixture confirmed changed)
- [ ] CI seed tests passing

[Link to Devin run](https://app.devin.ai/sessions/7b99208feea64443b0b8cf8a6bf5c469) | Requested by: @Swimburger