### PR TITLE
feat(cli): Add local file cache

### DIFF
--- a/packages/cli/cli-v2/src/cache/Cache.ts
+++ b/packages/cli/cli-v2/src/cache/Cache.ts
@@ -1,0 +1,181 @@
+import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import type { Logger } from "@fern-api/logger";
+import os from "os";
+import { FernRcSchemaLoader } from "../config/fern-rc/FernRcSchemaLoader.js";
+import { IrCache } from "./ir/index.js";
+import { LogsCache } from "./logs/index.js";
+
+const CACHE_VERSION = "v1";
+
+/**
+ * CLI cache providing access to all cache subsystems.
+ *
+ * Directory structure:
+ * ```
+ * ~/.cache/fern               # Linux and macOS (XDG_CACHE_HOME/fern)
+ * %LOCALAPPDATA%/fern/cache   # Windows
+ *
+ * ├── v1/                     # Cache schema version
+ * │   ├── ir/
+ * │   │   ├── v63/
+ * │   │   │   └── sha256/
+ * │   │   │       └── 0a/
+ * │   │   │           └── 0a3f9c2e4a7d1b...json
+ * │   │   └── v62/
+ * │   └── logs/
+ * └── tmp/                    # Atomic write staging
+ * ```
+ */
+export declare namespace Cache {
+    /** Combined statistics for the entire cache */
+    interface Stats {
+        /** Total size in bytes across all cache types */
+        totalSize: number;
+        /** IR cache statistics */
+        ir: IrCache.Stats;
+        /** Logs statistics */
+        logs: LogsCache.Stats;
+    }
+
+    /** Options for clearing cache entries */
+    interface ClearOptions {
+        /** Clear IR cache entries */
+        ir?: boolean;
+        /** Clear log files */
+        logs?: boolean;
+        /** Preview what would be cleared without actually deleting */
+        dryRun?: boolean;
+    }
+
+    /** Result of a cache clear operation */
+    interface ClearResult {
+        /** Number of entries that were (or would be) deleted */
+        deletedCount: number;
+        /** Total size that was (or would be) freed in bytes */
+        freedSize: number;
+        /** Whether this was a dry run */
+        dryRun: boolean;
+    }
+}
+
+export class Cache {
+    public readonly absoluteFilePath: AbsoluteFilePath;
+    public readonly ir: IrCache;
+    public readonly logs: LogsCache;
+
+    constructor({ logger }: { logger?: Logger } = {}) {
+        this.absoluteFilePath = this.resolveAbsoluteFilePath();
+        this.ir = new IrCache({
+            absoluteFilePath: join(this.getVersionedPath(), RelativeFilePath.of("ir")),
+            tempPath: this.getTempPath(),
+            logger
+        });
+        this.logs = new LogsCache({ absoluteFilePath: join(this.getVersionedPath(), RelativeFilePath.of("logs")) });
+    }
+
+    /**
+     * Get the versioned cache directory path.
+     * This includes the cache schema version prefix.
+     */
+    public getVersionedPath(): AbsoluteFilePath {
+        return join(this.absoluteFilePath, RelativeFilePath.of(CACHE_VERSION));
+    }
+
+    /**
+     * Get the temporary directory for atomic writes.
+     */
+    public getTempPath(): AbsoluteFilePath {
+        return join(this.absoluteFilePath, RelativeFilePath.of("tmp"));
+    }
+
+    /**
+     * Get statistics for the entire cache.
+     */
+    public async getStats(): Promise<Cache.Stats> {
+        const irStats = await this.ir.getStats();
+        const logsStats = await this.logs.getStats();
+
+        return {
+            totalSize: irStats.totalSize + logsStats.totalSize,
+            ir: irStats,
+            logs: logsStats
+        };
+    }
+
+    /**
+     * Clear cache entries. If no specific subsystem is specified, clears everything.
+     */
+    public async clear(options?: Cache.ClearOptions): Promise<Cache.ClearResult> {
+        const dryRun = options?.dryRun ?? false;
+
+        let deletedCount = 0;
+        let freedSize = 0;
+
+        const clearIr = options?.ir ?? options?.logs == null;
+        if (clearIr) {
+            const irResult = await this.ir.clear({ dryRun });
+            deletedCount += irResult.deletedCount;
+            freedSize += irResult.freedSize;
+        }
+
+        const clearLogs = options?.logs ?? options?.ir == null;
+        if (clearLogs) {
+            const logsResult = await this.logs.clear(dryRun);
+            deletedCount += logsResult.deletedCount;
+            freedSize += logsResult.freedSize;
+        }
+
+        return { deletedCount, freedSize, dryRun };
+    }
+
+    /**
+     * Resolve the absolute file path for the cache directory based on environment,
+     * ~/.fernrc configuration, and platform defaults.
+     *
+     * Priority order:
+     *  1. FERN_CACHE_DIR environment variable
+     *  2. The configured cache path in ~/.fernrc
+     *  3. Platform defaults (XDG on macOS/Linux, LOCALAPPDATA on Windows)
+     */
+    private resolveAbsoluteFilePath(): AbsoluteFilePath {
+        const envCacheDir = process.env.FERN_CACHE_DIR;
+        if (envCacheDir != null && envCacheDir.length > 0) {
+            return AbsoluteFilePath.of(this.expandPath(envCacheDir));
+        }
+
+        const fernRcCachePath = new FernRcSchemaLoader().loadCachePathSync();
+        if (fernRcCachePath != null && fernRcCachePath.length > 0) {
+            return AbsoluteFilePath.of(this.expandPath(fernRcCachePath));
+        }
+
+        const homeDir = AbsoluteFilePath.of(os.homedir());
+
+        const platform = process.platform;
+        if (platform === "win32") {
+            // Windows: %LOCALAPPDATA%/fern/cache
+            const localAppData =
+                process.env.LOCALAPPDATA != null
+                    ? AbsoluteFilePath.of(process.env.LOCALAPPDATA)
+                    : join(homeDir, RelativeFilePath.of("AppData/Local"));
+            return join(localAppData, RelativeFilePath.of("fern/cache"));
+        }
+
+        // For macOS and Linux, follow the XDG Base Directory Specification.
+        // For details, see: https://specifications.freedesktop.org/basedir/latest
+        const xdgCacheHome =
+            process.env.XDG_CACHE_HOME != null
+                ? AbsoluteFilePath.of(process.env.XDG_CACHE_HOME)
+                : join(homeDir, RelativeFilePath.of(".cache"));
+        return join(xdgCacheHome, RelativeFilePath.of("fern"));
+    }
+
+    /**
+     * Expand `~` prefix to the user's home directory.
+     */
+    private expandPath(path: string): string {
+        if (path.startsWith("~/") || path === "~") {
+            return path.replace("~", os.homedir());
+        }
+        return path;
+    }
+}

--- a/packages/cli/cli-v2/src/cache/index.ts
+++ b/packages/cli/cli-v2/src/cache/index.ts
@@ -1,0 +1,2 @@
+export { Cache } from "./Cache.js";
+export { IrCache, IrHasher } from "./ir/index.js";

--- a/packages/cli/cli-v2/src/cache/ir/IrCache.ts
+++ b/packages/cli/cli-v2/src/cache/ir/IrCache.ts
@@ -1,0 +1,344 @@
+import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import type { Logger } from "@fern-api/logger";
+import crypto from "crypto";
+import fs from "fs/promises";
+import { formatBytes } from "../../ui/format.js";
+
+/**
+ * Content-addressable cache for IR files.
+ *
+ * Stores IR files organized by version and content hash:
+ * ```
+ * ~/.cache/fern/v1/ir/
+ * ├── v63/
+ * │   └── sha256/
+ * │       ├── 0a/
+ * │       │   └── 0a3f9c2e4a7d1b...json
+ * │       └── ff/
+ * │           └── ff02a1d998c11d...json
+ * └── v62/
+ *     └── sha256/...
+ * ```
+ *
+ * TODO: The given 'hash' needs to account for everything that can influence the IR content, such as:
+ *  - Any distinctions between a specific version of the CLI and the same IR version.
+ *  - Whether or not the user specified smart-casing (which affects the safe and unsafe names in the IR).
+ *  - etc.
+ */
+export declare namespace IrCache {
+    /** A cached IR entry */
+    interface Entry {
+        /** SHA-256 hash of the content */
+        hash: string;
+        /** IR version (e.g., "v63", "v62") */
+        irVersion: string;
+        /** Full path to the cached file */
+        absoluteFilePath: AbsoluteFilePath;
+        /** Size in bytes */
+        size: number;
+        /** Timestamp when the entry was created */
+        createdAt: Date;
+    }
+
+    /** Statistics for the IR cache */
+    interface Stats {
+        /** Total number of cached IR entries */
+        entryCount: number;
+        /** Total size in bytes */
+        totalSize: number;
+        /** Breakdown by IR version */
+        byVersion: Record<string, VersionStats>;
+    }
+
+    /** Statistics for a specific IR version */
+    interface VersionStats {
+        /** Number of entries for this version */
+        entryCount: number;
+        /** Total size in bytes for this version */
+        totalSize: number;
+    }
+
+    interface ClearResult {
+        /** Number of entries that were (or would be) deleted */
+        deletedCount: number;
+        /** Total size that was (or would be) freed in bytes */
+        freedSize: number;
+    }
+}
+
+export class IrCache {
+    /** Absolute file path to the IR cache directory (e.g. ~/.cache/fern/v1/ir) */
+    public readonly absoluteFilePath: AbsoluteFilePath;
+
+    private readonly tempPath: AbsoluteFilePath;
+    private readonly logger: Logger | undefined;
+
+    constructor({
+        absoluteFilePath,
+        tempPath,
+        logger
+    }: {
+        absoluteFilePath: AbsoluteFilePath;
+        tempPath: AbsoluteFilePath;
+        logger?: Logger;
+    }) {
+        this.absoluteFilePath = absoluteFilePath;
+        this.tempPath = tempPath;
+        this.logger = logger;
+    }
+
+    /**
+     * Get the path for a specific IR version directory.
+     */
+    public getVersionPath(irVersion: string): AbsoluteFilePath {
+        return join(this.absoluteFilePath, RelativeFilePath.of(irVersion));
+    }
+
+    /**
+     * Get the path for a specific IR cache entry.
+     */
+    public getEntryPath({ irVersion, hash }: { irVersion: string; hash: string }): AbsoluteFilePath {
+        const prefix = hash.substring(0, 2);
+        return join(
+            this.getVersionPath(irVersion),
+            RelativeFilePath.of("sha256"),
+            RelativeFilePath.of(prefix),
+            RelativeFilePath.of(`${hash}.json`)
+        );
+    }
+
+    /**
+     * Look up a cached IR entry by hash and version.
+     */
+    public async lookup({ hash, irVersion }: { hash: string; irVersion: string }): Promise<IrCache.Entry | undefined> {
+        const entryPath = this.getEntryPath({ irVersion, hash });
+        try {
+            const stats = await fs.stat(entryPath);
+            if (!stats.isFile()) {
+                return undefined;
+            }
+            const entry: IrCache.Entry = {
+                hash,
+                irVersion,
+                absoluteFilePath: entryPath,
+                size: stats.size,
+                createdAt: stats.birthtime
+            };
+            this.logger?.debug(`Cache hit: ${irVersion}/${hash.substring(0, 8)}... (${formatBytes(stats.size)})`);
+            return entry;
+        } catch {
+            // File doesn't exist or isn't accessible.
+            return undefined;
+        }
+    }
+
+    /**
+     * Read the content of a cached IR entry.
+     */
+    public async read(entry: IrCache.Entry): Promise<string> {
+        return await fs.readFile(entry.absoluteFilePath, "utf-8");
+    }
+
+    /**
+     * Store IR content in the cache with an atomic write.
+     */
+    public async store({
+        hash,
+        irVersion,
+        content
+    }: {
+        hash: string;
+        irVersion: string;
+        content: string;
+    }): Promise<IrCache.Entry> {
+        const entryPath = this.getEntryPath({ irVersion, hash });
+        const entryDir = dirname(entryPath);
+        const tempFile = join(this.tempPath, RelativeFilePath.of(`${crypto.randomUUID()}.json`));
+
+        // Create the directory structure if it doesn't exist.
+        await fs.mkdir(entryDir, { recursive: true });
+        await fs.mkdir(this.tempPath, { recursive: true });
+
+        try {
+            await fs.writeFile(tempFile, content, "utf-8");
+            await fs.rename(tempFile, entryPath);
+        } catch (error) {
+            // Clean up temp file if rename fails.
+            try {
+                await fs.unlink(tempFile);
+            } catch {
+                // Ignore cleanup errors.
+            }
+            throw error;
+        }
+
+        const stats = await fs.stat(entryPath);
+        return {
+            hash,
+            irVersion,
+            absoluteFilePath: entryPath,
+            size: stats.size,
+            createdAt: stats.birthtime
+        };
+    }
+
+    /**
+     * Clear all IR cache entries.
+     */
+    public async clear(options?: { dryRun?: boolean }): Promise<IrCache.ClearResult> {
+        if (!(await doesPathExist(this.absoluteFilePath))) {
+            return { deletedCount: 0, freedSize: 0 };
+        }
+
+        const dryRun = options?.dryRun ?? false;
+
+        let deletedCount = 0;
+        let freedSize = 0;
+
+        const versions = await this.listVersionDirectories();
+        for (const version of versions) {
+            const versionPath = this.getVersionPath(version);
+            const result = await this.clearDirectory(versionPath, dryRun);
+            deletedCount += result.deletedCount;
+            freedSize += result.freedSize;
+        }
+
+        return { deletedCount, freedSize };
+    }
+
+    /**
+     * Get statistics about the IR cache.
+     */
+    public async getStats(): Promise<IrCache.Stats> {
+        const byVersion: Record<string, IrCache.VersionStats> = {};
+
+        if (!(await doesPathExist(this.absoluteFilePath))) {
+            return { entryCount: 0, totalSize: 0, byVersion };
+        }
+
+        let entryCount = 0;
+        let totalSize = 0;
+
+        const versions = await this.listVersionDirectories();
+        for (const version of versions) {
+            const versionPath = this.getVersionPath(version);
+            const stats = await this.getDirectoryStats(versionPath);
+            byVersion[version] = stats;
+            entryCount += stats.entryCount;
+            totalSize += stats.totalSize;
+        }
+
+        return { entryCount, totalSize, byVersion };
+    }
+
+    /**
+     * List all IR version directories.
+     */
+    private async listVersionDirectories(): Promise<string[]> {
+        try {
+            const entries = await fs.readdir(this.absoluteFilePath, { withFileTypes: true });
+            return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+        } catch {
+            return [];
+        }
+    }
+
+    /**
+     * Get statistics for a directory.
+     */
+    private async getDirectoryStats(dirPath: AbsoluteFilePath): Promise<IrCache.VersionStats> {
+        let entryCount = 0;
+        let totalSize = 0;
+
+        const walk = async (dir: string): Promise<void> => {
+            try {
+                const entries = await fs.readdir(dir, { withFileTypes: true });
+                for (const entry of entries) {
+                    const fullPath = `${dir}/${entry.name}`;
+                    if (entry.isDirectory()) {
+                        await walk(fullPath);
+                        continue;
+                    }
+                    if (entry.isFile() && entry.name.endsWith(".json")) {
+                        entryCount++;
+                        try {
+                            const stats = await fs.stat(fullPath);
+                            totalSize += stats.size;
+                        } catch {
+                            // Ignore stat errors.
+                        }
+                    }
+                }
+            } catch {
+                // Ignore read errors.
+            }
+        };
+
+        await walk(dirPath);
+
+        return { entryCount, totalSize };
+    }
+
+    /**
+     * Clear a directory and return statistics.
+     */
+    private async clearDirectory(
+        dirPath: AbsoluteFilePath,
+        dryRun: boolean
+    ): Promise<{ deletedCount: number; freedSize: number }> {
+        if (!(await doesPathExist(dirPath))) {
+            return { deletedCount: 0, freedSize: 0 };
+        }
+
+        let deletedCount = 0;
+        let freedSize = 0;
+
+        const walk = async (dir: string): Promise<void> => {
+            try {
+                const entries = await fs.readdir(dir, { withFileTypes: true });
+                for (const entry of entries) {
+                    const fullPath = `${dir}/${entry.name}`;
+                    if (entry.isDirectory()) {
+                        await walk(fullPath);
+                        // Remove empty directories (unless dry run).
+                        if (!dryRun) {
+                            try {
+                                await fs.rmdir(fullPath);
+                            } catch {
+                                // Directory not empty or other error.
+                            }
+                        }
+                        continue;
+                    }
+                    if (entry.isFile() && entry.name.endsWith(".json")) {
+                        try {
+                            const stats = await fs.stat(fullPath);
+                            deletedCount++;
+                            freedSize += stats.size;
+                            if (!dryRun) {
+                                await fs.unlink(fullPath);
+                            }
+                        } catch {
+                            // Ignore errors.
+                        }
+                    }
+                }
+            } catch {
+                // Ignore read errors.
+            }
+        };
+
+        await walk(dirPath);
+
+        // Try to remove the version directory itself.
+        if (!dryRun) {
+            try {
+                await fs.rmdir(dirPath);
+            } catch {
+                // Directory not empty or other error.
+            }
+        }
+
+        return { deletedCount, freedSize };
+    }
+}

--- a/packages/cli/cli-v2/src/cache/ir/IrHasher.ts
+++ b/packages/cli/cli-v2/src/cache/ir/IrHasher.ts
@@ -1,0 +1,68 @@
+import crypto from "crypto";
+
+/**
+ * Fields to exclude from IR hashing for deterministic results.
+ * These fields contain metadata that doesn't affect the semantic content.
+ */
+const EXCLUDED_FIELDS = new Set(["fdrApiDefinitionId"]);
+
+/**
+ * Computes deterministic SHA-256 hashes of IR content.
+ *
+ * The hasher excludes certain metadata fields to ensure that
+ * semantically identical IRs produce the same hash, even if
+ * they have different generation timestamps or other metadata.
+ */
+export class IrHasher {
+    /**
+     * Compute a SHA-256 hash of IR content.
+     */
+    public hash(content: unknown): string {
+        const normalized = this.normalize(content);
+        const json = JSON.stringify(normalized);
+        return crypto.createHash("sha256").update(json, "utf8").digest("hex");
+    }
+
+    /**
+     * Compute a SHA-256 hash from a JSON string.
+     * Parses the JSON, normalizes it, and returns the hash.
+     */
+    public hashFromJSON(json: string): string {
+        const content = JSON.parse(json) as unknown;
+        return this.hash(content);
+    }
+
+    /**
+     * Normalize content for deterministic hashing.
+     *  - Sorts object keys alphabetically
+     *  - Removes excluded metadata fields
+     *  - Recursively processes nested objects and arrays
+     */
+    private normalize(value: unknown): unknown {
+        if (value == null) {
+            return value;
+        }
+
+        if (Array.isArray(value)) {
+            return value.map((item) => this.normalize(item));
+        }
+
+        if (typeof value === "object") {
+            const normalized: Record<string, unknown> = {};
+
+            const obj = value as Record<string, unknown>;
+            for (const key of Object.keys(obj).sort()) {
+                // Skip excluded metadata fields.
+                if (EXCLUDED_FIELDS.has(key)) {
+                    continue;
+                }
+                normalized[key] = this.normalize(obj[key]);
+            }
+
+            return normalized;
+        }
+
+        // All other values (i.e. string, number, boolean) pass through unchanged.
+        return value;
+    }
+}

--- a/packages/cli/cli-v2/src/cache/ir/__test__/IrCache.test.ts
+++ b/packages/cli/cli-v2/src/cache/ir/__test__/IrCache.test.ts
@@ -1,0 +1,213 @@
+import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { randomUUID } from "crypto";
+import { mkdir, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join as pathJoin } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { IrCache } from "../IrCache.js";
+
+describe("IrCache", () => {
+    let testDir: AbsoluteFilePath;
+    let cache: IrCache;
+
+    beforeEach(async () => {
+        testDir = AbsoluteFilePath.of(pathJoin(tmpdir(), `fern-ir-cache-test-${randomUUID()}`));
+        await mkdir(testDir, { recursive: true });
+
+        const irDir = join(testDir, RelativeFilePath.of("ir"));
+        const tmpDir = join(testDir, RelativeFilePath.of("tmp"));
+        cache = new IrCache({
+            absoluteFilePath: irDir,
+            tempPath: tmpDir
+        });
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    describe("store + lookup", () => {
+        it("stores content and looks it up by same hash and version", async () => {
+            const hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+            const irVersion = "v63";
+            const content = JSON.stringify({ types: {}, services: {} });
+
+            await cache.store({ hash, irVersion, content });
+            const entry = await cache.lookup({ hash, irVersion });
+
+            expect(entry).toBeDefined();
+            expect(entry?.hash).toBe(hash);
+            expect(entry?.irVersion).toBe(irVersion);
+            expect(entry?.size).toBeGreaterThan(0);
+            expect(entry?.createdAt).toBeInstanceOf(Date);
+        });
+    });
+
+    describe("store + read", () => {
+        it("stores content and reads it back exactly", async () => {
+            const hash = "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3";
+            const irVersion = "v63";
+            const content = JSON.stringify({ types: { User: { name: "User" } } });
+
+            const entry = await cache.store({ hash, irVersion, content });
+            const readContent = await cache.read(entry);
+
+            expect(readContent).toBe(content);
+        });
+    });
+
+    describe("cache miss", () => {
+        it("returns undefined for a non-existent hash", async () => {
+            const entry = await cache.lookup({
+                hash: "0000000000000000000000000000000000000000000000000000000000000000",
+                irVersion: "v63"
+            });
+            expect(entry).toBeUndefined();
+        });
+    });
+
+    describe("multiple IR versions", () => {
+        it("stores and looks up entries independently per version", async () => {
+            const hash = "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4";
+            const contentV63 = JSON.stringify({ version: "v63", types: {} });
+            const contentV62 = JSON.stringify({ version: "v62", types: {} });
+
+            await cache.store({ hash, irVersion: "v63", content: contentV63 });
+            await cache.store({ hash, irVersion: "v62", content: contentV62 });
+
+            const entryV63 = await cache.lookup({ hash, irVersion: "v63" });
+            const entryV62 = await cache.lookup({ hash, irVersion: "v62" });
+
+            expect(entryV63).toBeDefined();
+            expect(entryV62).toBeDefined();
+
+            if (entryV63 == null || entryV62 == null) {
+                return;
+            }
+
+            const readV63 = await cache.read(entryV63);
+            const readV62 = await cache.read(entryV62);
+
+            expect(readV63).toBe(contentV63);
+            expect(readV62).toBe(contentV62);
+        });
+    });
+
+    describe("content-addressable", () => {
+        it("stores same hash and version twice without errors", async () => {
+            const hash = "d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5";
+            const irVersion = "v63";
+            const content = JSON.stringify({ types: {} });
+
+            const entry1 = await cache.store({ hash, irVersion, content });
+            const entry2 = await cache.store({ hash, irVersion, content });
+
+            expect(entry1.absoluteFilePath).toBe(entry2.absoluteFilePath);
+        });
+    });
+
+    describe("getStats", () => {
+        it("returns correct stats across versions", async () => {
+            const content1 = JSON.stringify({ id: 1 });
+            const content2 = JSON.stringify({ id: 2 });
+            const content3 = JSON.stringify({ id: 3 });
+
+            await cache.store({
+                hash: "1111111111111111111111111111111111111111111111111111111111111111",
+                irVersion: "v63",
+                content: content1
+            });
+            await cache.store({
+                hash: "2222222222222222222222222222222222222222222222222222222222222222",
+                irVersion: "v63",
+                content: content2
+            });
+            await cache.store({
+                hash: "3333333333333333333333333333333333333333333333333333333333333333",
+                irVersion: "v62",
+                content: content3
+            });
+
+            const stats = await cache.getStats();
+
+            expect(stats.entryCount).toBe(3);
+            expect(stats.totalSize).toBeGreaterThan(0);
+            expect(stats.byVersion["v63"]?.entryCount).toBe(2);
+            expect(stats.byVersion["v62"]?.entryCount).toBe(1);
+        });
+
+        it("returns zero counts on empty cache", async () => {
+            const stats = await cache.getStats();
+            expect(stats.entryCount).toBe(0);
+            expect(stats.totalSize).toBe(0);
+            expect(Object.keys(stats.byVersion)).toHaveLength(0);
+        });
+    });
+
+    describe("clear", () => {
+        it("clears all entries and reports correct counts", async () => {
+            const content = JSON.stringify({ data: "test" });
+
+            await cache.store({
+                hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                irVersion: "v63",
+                content
+            });
+            await cache.store({
+                hash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                irVersion: "v62",
+                content
+            });
+
+            const result = await cache.clear();
+            expect(result.deletedCount).toBe(2);
+            expect(result.freedSize).toBeGreaterThan(0);
+
+            // Verify entries are gone
+            const entry = await cache.lookup({
+                hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                irVersion: "v63"
+            });
+            expect(entry).toBeUndefined();
+        });
+
+        it("does not delete entries on dry run", async () => {
+            const content = JSON.stringify({ data: "test" });
+            const hash = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+            const irVersion = "v63";
+
+            await cache.store({ hash, irVersion, content });
+
+            const result = await cache.clear({ dryRun: true });
+            expect(result.deletedCount).toBe(1);
+            expect(result.freedSize).toBeGreaterThan(0);
+
+            // Entry should still exist
+            const entry = await cache.lookup({ hash, irVersion });
+            expect(entry).toBeDefined();
+        });
+
+        it("returns zero counts on empty cache", async () => {
+            const result = await cache.clear();
+            expect(result.deletedCount).toBe(0);
+            expect(result.freedSize).toBe(0);
+        });
+    });
+
+    describe("entry path structure", () => {
+        it("returns path in expected format: {base}/{version}/sha256/{first2chars}/{hash}.json", () => {
+            const hash = "e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6";
+            const irVersion = "v63";
+            const entryPath = cache.getEntryPath({ irVersion, hash });
+
+            const expected = join(
+                cache.absoluteFilePath,
+                RelativeFilePath.of("v63"),
+                RelativeFilePath.of("sha256"),
+                RelativeFilePath.of("e5"),
+                RelativeFilePath.of(`${hash}.json`)
+            );
+            expect(entryPath).toBe(expected);
+        });
+    });
+});

--- a/packages/cli/cli-v2/src/cache/ir/__test__/IrHasher.test.ts
+++ b/packages/cli/cli-v2/src/cache/ir/__test__/IrHasher.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { IrHasher } from "../IrHasher.js";
+
+describe("IrHasher", () => {
+    const hasher = new IrHasher();
+
+    it("produces deterministic hashes", () => {
+        const content = { name: "test", version: "1.0" };
+        const hash1 = hasher.hash(content);
+        const hash2 = hasher.hash(content);
+        expect(hash1).toBe(hash2);
+    });
+
+    it("produces different hashes for different content", () => {
+        const hash1 = hasher.hash({ name: "alpha" });
+        const hash2 = hasher.hash({ name: "beta" });
+        expect(hash1).not.toBe(hash2);
+    });
+
+    it("is independent of key order", () => {
+        const hash1 = hasher.hash({ b: 1, a: 2 });
+        const hash2 = hasher.hash({ a: 2, b: 1 });
+        expect(hash1).toBe(hash2);
+    });
+
+    it("excludes fdrApiDefinitionId from hash computation", () => {
+        const hash1 = hasher.hash({ name: "test", fdrApiDefinitionId: "abc-123" });
+        const hash2 = hasher.hash({ name: "test", fdrApiDefinitionId: "xyz-789" });
+        const hash3 = hasher.hash({ name: "test" });
+        expect(hash1).toBe(hash2);
+        expect(hash1).toBe(hash3);
+    });
+
+    it("hashFromJSON produces same hash as hash(JSON.parse(json))", () => {
+        const json = JSON.stringify({ name: "test", version: "2.0" });
+        const hashFromJSON = hasher.hashFromJSON(json);
+        const hashFromParsed = hasher.hash(JSON.parse(json));
+        expect(hashFromJSON).toBe(hashFromParsed);
+    });
+
+    it("sorts keys in nested objects", () => {
+        const hash1 = hasher.hash({ outer: { z: 1, a: 2 } });
+        const hash2 = hasher.hash({ outer: { a: 2, z: 1 } });
+        expect(hash1).toBe(hash2);
+    });
+
+    it("preserves array order but sorts element keys", () => {
+        const hash1 = hasher.hash({
+            items: [
+                { b: 1, a: 2 },
+                { d: 3, c: 4 }
+            ]
+        });
+        const hash2 = hasher.hash({
+            items: [
+                { a: 2, b: 1 },
+                { c: 4, d: 3 }
+            ]
+        });
+        expect(hash1).toBe(hash2);
+
+        // Different array order should produce different hash
+        const hash3 = hasher.hash({
+            items: [
+                { c: 4, d: 3 },
+                { a: 2, b: 1 }
+            ]
+        });
+        expect(hash1).not.toBe(hash3);
+    });
+
+    it("handles null values", () => {
+        const hash = hasher.hash({ a: null });
+        expect(hash).toBeDefined();
+        expect(hash).toHaveLength(64);
+    });
+
+    it("produces a 64-character lowercase hex string", () => {
+        const hash = hasher.hash({ anything: "value" });
+        expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+});

--- a/packages/cli/cli-v2/src/cache/ir/index.ts
+++ b/packages/cli/cli-v2/src/cache/ir/index.ts
@@ -1,0 +1,2 @@
+export { IrCache } from "./IrCache.js";
+export { IrHasher } from "./IrHasher.js";

--- a/packages/cli/cli-v2/src/cache/logs/LogsCache.ts
+++ b/packages/cli/cli-v2/src/cache/logs/LogsCache.ts
@@ -1,0 +1,89 @@
+import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import fs from "fs/promises";
+
+/**
+ * Provides access to the logs directory within the cache.
+ */
+export declare namespace LogsCache {
+    /** Statistics for the logs directory */
+    interface Stats {
+        /** Number of log files */
+        fileCount: number;
+        /** Total size in bytes */
+        totalSize: number;
+    }
+
+    interface ClearResult {
+        /** Number of log files that were (or would be) deleted */
+        deletedCount: number;
+        /** Total size that was (or would be) freed in bytes */
+        freedSize: number;
+    }
+}
+
+export class LogsCache {
+    /** Absolute file path to the log cache directory (e.g. ~/.cache/fern/v1/logs) */
+    public readonly absoluteFilePath: AbsoluteFilePath;
+
+    constructor({ absoluteFilePath }: { absoluteFilePath: AbsoluteFilePath }) {
+        this.absoluteFilePath = absoluteFilePath;
+    }
+
+    /**
+     * Get statistics about the logs cache.
+     */
+    public async getStats(): Promise<LogsCache.Stats> {
+        let fileCount = 0;
+        let totalSize = 0;
+
+        try {
+            const entries = await fs.readdir(this.absoluteFilePath, { withFileTypes: true });
+            for (const entry of entries) {
+                if (entry.isFile() && entry.name.endsWith(".log")) {
+                    fileCount++;
+                    try {
+                        const stats = await fs.stat(`${this.absoluteFilePath}/${entry.name}`);
+                        totalSize += stats.size;
+                    } catch {
+                        // Ignore stat errors.
+                    }
+                }
+            }
+        } catch {
+            // Directory doesn't exist or isn't readable.
+        }
+
+        return { fileCount, totalSize };
+    }
+
+    /**
+     * Clear log files from the cache.
+     */
+    public async clear(dryRun: boolean): Promise<LogsCache.ClearResult> {
+        let deletedCount = 0;
+        let freedSize = 0;
+
+        try {
+            const entries = await fs.readdir(this.absoluteFilePath, { withFileTypes: true });
+            for (const entry of entries) {
+                if (entry.isFile() && entry.name.endsWith(".log")) {
+                    const fullPath = `${this.absoluteFilePath}/${entry.name}`;
+                    try {
+                        const stats = await fs.stat(fullPath);
+                        deletedCount++;
+                        freedSize += stats.size;
+                        if (!dryRun) {
+                            await fs.unlink(fullPath);
+                        }
+                    } catch {
+                        // Ignore errors.
+                    }
+                }
+            }
+        } catch {
+            // Directory doesn't exist or isn't readable.
+        }
+
+        return { deletedCount, freedSize };
+    }
+}

--- a/packages/cli/cli-v2/src/cache/logs/index.ts
+++ b/packages/cli/cli-v2/src/cache/logs/index.ts
@@ -1,0 +1,1 @@
+export { LogsCache } from "./LogsCache.js";

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -3,6 +3,7 @@ import type { Argv } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { addAuthCommand } from "./commands/auth/index.js";
+import { addCacheCommand } from "./commands/cache/index.js";
 import { addCheckCommand } from "./commands/check/index.js";
 import { addConfigCommand } from "./commands/config/index.js";
 import { addInitCommand } from "./commands/init/index.js";
@@ -53,6 +54,7 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
         });
 
     addAuthCommand(cli);
+    addCacheCommand(cli);
     addCheckCommand(cli);
     addConfigCommand(cli);
     addInitCommand(cli);

--- a/packages/cli/cli-v2/src/commands/cache/clear/command.ts
+++ b/packages/cli/cli-v2/src/commands/cache/clear/command.ts
@@ -1,0 +1,81 @@
+import type { Argv } from "yargs";
+import type { Context } from "../../../context/Context.js";
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { formatBytes } from "../../../ui/format.js";
+import { command } from "../../_internal/command.js";
+
+export declare namespace ClearCommand {
+    export interface Args extends GlobalArgs {
+        all?: boolean;
+        ir?: boolean;
+        logs?: boolean;
+        "dry-run"?: boolean;
+    }
+}
+
+export class ClearCommand {
+    public async handle(context: Context, args: ClearCommand.Args): Promise<void> {
+        const { cache } = context;
+
+        const dryRun = args["dry-run"] ?? false;
+
+        // If --all is specified or neither --ir nor --logs is specified, clear everything.
+        const clearAll = args.all || (!args.ir && !args.logs);
+        const clearOptions = {
+            ir: clearAll || args.ir,
+            logs: clearAll || args.logs,
+            dryRun
+        };
+
+        const result = await cache.clear(clearOptions);
+
+        if (dryRun) {
+            if (result.deletedCount === 0) {
+                context.stdout.info("Cache is already empty, nothing to clear.");
+                return;
+            }
+            context.stdout.info(`Would delete ${result.deletedCount} entries (${formatBytes(result.freedSize)})`);
+            context.stdout.info("Run without --dry-run to actually delete these entries.");
+            return;
+        }
+
+        if (result.deletedCount === 0) {
+            context.stdout.info("Cache is already empty, nothing to clear.");
+            return;
+        }
+
+        context.stdout.info(`Cleared ${result.deletedCount} entries (${formatBytes(result.freedSize)} freed)`);
+    }
+}
+
+export function addClearCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new ClearCommand();
+    command(
+        cli,
+        "clear",
+        "Clear cache entries",
+        (context, args) => cmd.handle(context, args as ClearCommand.Args),
+        (yargs) =>
+            yargs
+                .option("all", {
+                    type: "boolean",
+                    description: "Clear all cache entries (default behavior)",
+                    default: false
+                })
+                .option("ir", {
+                    type: "boolean",
+                    description: "Clear only IR cache entries",
+                    default: false
+                })
+                .option("logs", {
+                    type: "boolean",
+                    description: "Clear only log files",
+                    default: false
+                })
+                .option("dry-run", {
+                    type: "boolean",
+                    description: "Preview what would be cleared without deleting",
+                    default: false
+                })
+    );
+}

--- a/packages/cli/cli-v2/src/commands/cache/clear/index.ts
+++ b/packages/cli/cli-v2/src/commands/cache/clear/index.ts
@@ -1,0 +1,1 @@
+export { addClearCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/cache/command.ts
+++ b/packages/cli/cli-v2/src/commands/cache/command.ts
@@ -1,0 +1,9 @@
+import type { Argv } from "yargs";
+import type { GlobalArgs } from "../../context/GlobalArgs.js";
+import { commandGroup } from "../_internal/commandGroup.js";
+import { addClearCommand } from "./clear/index.js";
+import { addShowCommand } from "./show/index.js";
+
+export function addCacheCommand(cli: Argv<GlobalArgs>): void {
+    commandGroup(cli, "cache <command>", "Manage the local cache", [addShowCommand, addClearCommand]);
+}

--- a/packages/cli/cli-v2/src/commands/cache/index.ts
+++ b/packages/cli/cli-v2/src/commands/cache/index.ts
@@ -1,0 +1,1 @@
+export { addCacheCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/cache/show/command.ts
+++ b/packages/cli/cli-v2/src/commands/cache/show/command.ts
@@ -1,0 +1,116 @@
+import type { Argv } from "yargs";
+import type { Context } from "../../../context/Context.js";
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { formatBytes } from "../../../ui/format.js";
+import { command } from "../../_internal/command.js";
+
+export declare namespace ShowCommand {
+    export interface Args extends GlobalArgs {
+        json?: boolean;
+    }
+}
+
+export class ShowCommand {
+    public async handle(context: Context, args: ShowCommand.Args): Promise<void> {
+        const { cache } = context;
+
+        const stats = await cache.getStats();
+
+        if (args.json) {
+            const output = {
+                paths: {
+                    base: cache.absoluteFilePath,
+                    ir: cache.ir.absoluteFilePath,
+                    logs: cache.logs.absoluteFilePath
+                },
+                stats: {
+                    totalSize: stats.totalSize,
+                    totalSizeFormatted: formatBytes(stats.totalSize),
+                    ir: {
+                        entryCount: stats.ir.entryCount,
+                        totalSize: stats.ir.totalSize,
+                        totalSizeFormatted: formatBytes(stats.ir.totalSize),
+                        byVersion: Object.entries(stats.ir.byVersion).map(([version, versionStats]) => ({
+                            version,
+                            entries: versionStats.entryCount,
+                            size: versionStats.totalSize,
+                            sizeFormatted: formatBytes(versionStats.totalSize)
+                        }))
+                    },
+                    logs: {
+                        fileCount: stats.logs.fileCount,
+                        totalSize: stats.logs.totalSize,
+                        totalSizeFormatted: formatBytes(stats.logs.totalSize)
+                    }
+                }
+            };
+            context.stdout.info(JSON.stringify(output, null, 2));
+            return;
+        }
+
+        context.stdout.info("Cache Location");
+        context.stdout.info("==============");
+        context.stdout.info(`Base:  ${cache.absoluteFilePath}`);
+        context.stdout.info(`IR:    ${cache.ir.absoluteFilePath}`);
+        context.stdout.info(`Logs:  ${cache.logs.absoluteFilePath}`);
+        context.stdout.info("");
+
+        context.stdout.info("Cache Statistics");
+        context.stdout.info("================");
+
+        const isEmpty = stats.ir.entryCount === 0 && stats.logs.fileCount === 0;
+        if (isEmpty) {
+            context.stdout.info("Cache is empty");
+            return;
+        }
+
+        context.stdout.info(`Total size: ${formatBytes(stats.totalSize)}`);
+        context.stdout.info("");
+
+        context.stdout.info("IR Cache:");
+        if (stats.ir.entryCount === 0) {
+            context.stdout.info("  (empty)");
+        } else {
+            context.stdout.info(`  ${stats.ir.entryCount} entries (${formatBytes(stats.ir.totalSize)})`);
+
+            if (Object.keys(stats.ir.byVersion).length > 0) {
+                // Sort versions in descending order (newest first).
+                const sortedVersions = Object.entries(stats.ir.byVersion).sort(([a], [b]) => {
+                    const numA = parseInt(a.replace("v", ""), 10);
+                    const numB = parseInt(b.replace("v", ""), 10);
+                    return numB - numA;
+                });
+
+                for (const [version, versionStats] of sortedVersions) {
+                    context.stdout.info(
+                        `    ${version}: ${versionStats.entryCount} entries (${formatBytes(versionStats.totalSize)})`
+                    );
+                }
+            }
+        }
+        context.stdout.info("");
+
+        context.stdout.info("Logs:");
+        if (stats.logs.fileCount === 0) {
+            context.stdout.info("  (empty)");
+        } else {
+            context.stdout.info(`  ${stats.logs.fileCount} files (${formatBytes(stats.logs.totalSize)})`);
+        }
+    }
+}
+
+export function addShowCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new ShowCommand();
+    command(
+        cli,
+        "show",
+        "Show cache location and statistics",
+        (context, args) => cmd.handle(context, args as ShowCommand.Args),
+        (yargs) =>
+            yargs.option("json", {
+                type: "boolean",
+                description: "Output in JSON format",
+                default: false
+            })
+    );
+}

--- a/packages/cli/cli-v2/src/commands/cache/show/index.ts
+++ b/packages/cli/cli-v2/src/commands/cache/show/index.ts
@@ -1,0 +1,1 @@
+export { addShowCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/config/fern-rc/FernRcSchemaLoader.ts
+++ b/packages/cli/cli-v2/src/config/fern-rc/FernRcSchemaLoader.ts
@@ -1,5 +1,6 @@
 import { createEmptyFernRcSchema, FernRcSchema } from "@fern-api/config";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { existsSync, readFileSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import { homedir } from "os";
@@ -62,6 +63,30 @@ export class FernRcSchemaLoader {
     }
 
     /**
+     * Synchronously loads only the cache path from ~/.fernrc.
+     *
+     * @returns The cache path string if configured, or undefined.
+     */
+    public loadCachePathSync(): string | undefined {
+        try {
+            if (!existsSync(this.absoluteFilePath)) {
+                return undefined;
+            }
+            const contents = readFileSync(this.absoluteFilePath, "utf-8");
+            if (contents.trim().length === 0) {
+                return undefined;
+            }
+            const result = FernRcSchema.safeParse(yaml.load(contents));
+            if (!result.success) {
+                return undefined;
+            }
+            return result.data.cache?.path;
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
      * Saves the configuration to ~/.fernrc.
      */
     public async save(config: FernRcSchema): Promise<void> {
@@ -76,6 +101,9 @@ export class FernRcSchemaLoader {
         };
         if (config.auth.active == null) {
             delete (toSerialize.auth as Record<string, unknown>).active;
+        }
+        if (config.cache != null) {
+            toSerialize.cache = config.cache;
         }
         const yamlContent = yaml.dump(toSerialize, {
             indent: 2,

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -6,6 +6,7 @@ import { getTokenFromAuth0 } from "@fern-api/login";
 import chalk from "chalk";
 import inquirer from "inquirer";
 import { CredentialStore, TokenService } from "../auth/index.js";
+import { Cache } from "../cache/index.js";
 import { loadFernYml } from "../config/fern-yml/loadFernYml.js";
 import { CliError } from "../errors/CliError.js";
 import { ValidationError } from "../errors/ValidationError.js";
@@ -23,6 +24,7 @@ export class Context {
     public readonly logLevel: LogLevel;
     public readonly stdout: Logger;
     public readonly stderr: Logger;
+    public readonly cache: Cache;
     public readonly logFileWriter: LogFileWriter;
     public readonly tokenService: TokenService;
 
@@ -40,10 +42,18 @@ export class Context {
         this.cwd = cwd ?? AbsoluteFilePath.of(process.cwd());
         this.logLevel = logLevel ?? LogLevel.Info;
         this.ttyAwareLogger = new TtyAwareLogger(stdout, stderr);
-        this.logFileWriter = new LogFileWriter();
         this.stdout = createLogger((level: LogLevel, ...args: string[]) => this.log(level, ...args));
         this.stderr = createLogger((level: LogLevel, ...args: string[]) => this.logStderr(level, ...args));
+        this.cache = new Cache({ logger: this.stderr });
+        this.logFileWriter = new LogFileWriter(this.cache.logs.absoluteFilePath);
         this.tokenService = new TokenService({ credential: new CredentialStore() });
+    }
+
+    /**
+     * Returns true if running in an interactive TTY environment (not CI).
+     */
+    public get isTTY(): boolean {
+        return this.ttyAwareLogger.isTTY;
     }
 
     public async loadWorkspaceOrThrow(): Promise<Workspace> {
@@ -108,14 +118,6 @@ export class Context {
     }
 
     /**
-     * Returns true if running in an interactive TTY environment (not CI).
-     * Delegates to TtyAwareLogger which handles the is-ci check.
-     */
-    public get isTTY(): boolean {
-        return this.ttyAwareLogger.isTTY;
-    }
-
-    /**
      * Get the log file path if logs have been written.
      */
     public getLogFilePath(): AbsoluteFilePath | undefined {
@@ -134,7 +136,6 @@ export class Context {
             }
         }
         if (target.output.git != null) {
-            // TODO: Include a link to the branch, commit, or release that was created.
             outputs.push(target.output.git.repository);
         }
         return outputs;

--- a/packages/cli/cli-v2/src/context/LogFileWriter.ts
+++ b/packages/cli/cli-v2/src/context/LogFileWriter.ts
@@ -1,7 +1,6 @@
-import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, dirname, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { appendFileSync, mkdirSync, writeFileSync } from "fs";
-import { homedir } from "os";
 
 /**
  * Writes logs to a file for later inspection.
@@ -10,11 +9,9 @@ export class LogFileWriter {
     public readonly logFilePath: AbsoluteFilePath;
     private initialized = false;
 
-    constructor() {
+    constructor(logsDirectory: AbsoluteFilePath) {
         const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-
-        const logsDir = join(AbsoluteFilePath.of(homedir()), RelativeFilePath.of(".cache/fern/v1/logs"));
-        this.logFilePath = join(logsDir, RelativeFilePath.of(`${timestamp}.log`));
+        this.logFilePath = join(logsDirectory, RelativeFilePath.of(`${timestamp}.log`));
     }
 
     /**
@@ -39,8 +36,7 @@ export class LogFileWriter {
             return;
         }
         // Create the logs directory and file.
-        const logsDir = join(this.logFilePath, RelativeFilePath.of(".."));
-        mkdirSync(logsDir, { recursive: true });
+        mkdirSync(dirname(this.logFilePath), { recursive: true });
         writeFileSync(this.logFilePath, `Fern Debug Log - ${new Date().toISOString()}\n${"=".repeat(60)}\n\n`);
         this.initialized = true;
     }

--- a/packages/cli/cli-v2/src/ui/format.ts
+++ b/packages/cli/cli-v2/src/ui/format.ts
@@ -109,3 +109,17 @@ export const Colors = {
     info: chalk.cyan.bind(chalk),
     dim: chalk.dim.bind(chalk)
 } as const;
+
+/**
+ * Format bytes as a human-readable string.
+ */
+export function formatBytes(bytes: number): string {
+    if (bytes === 0) {
+        return "0 B";
+    }
+    const units = ["B", "KB", "MB", "GB"];
+    const base = 1024;
+    const index = Math.min(Math.floor(Math.log(bytes) / Math.log(base)), units.length - 1);
+    const value = bytes / Math.pow(base, index);
+    return `${value.toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+}

--- a/packages/cli/config/src/schemas/fernrc/FernRcCacheSchema.ts
+++ b/packages/cli/config/src/schemas/fernrc/FernRcCacheSchema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const FernRcCacheSchema = z.object({
+    /** Custom cache directory path */
+    path: z.string().optional()
+});
+
+export type FernRcCacheSchema = z.infer<typeof FernRcCacheSchema>;

--- a/packages/cli/config/src/schemas/fernrc/FernRcSchema.ts
+++ b/packages/cli/config/src/schemas/fernrc/FernRcSchema.ts
@@ -1,11 +1,14 @@
 import { z } from "zod";
 import { FernRcAuthSchema } from "./FernRcAuthSchema.js";
+import { FernRcCacheSchema } from "./FernRcCacheSchema.js";
 
 export const FernRcSchema = z.object({
     /** Config file version for migrations */
     version: z.literal("v1").default("v1"),
     /** Authentication settings */
-    auth: FernRcAuthSchema.default({ accounts: [] })
+    auth: FernRcAuthSchema.default({ accounts: [] }),
+    /** Cache settings */
+    cache: FernRcCacheSchema.optional()
 });
 
 export type FernRcSchema = z.infer<typeof FernRcSchema>;

--- a/packages/cli/config/src/schemas/fernrc/index.ts
+++ b/packages/cli/config/src/schemas/fernrc/index.ts
@@ -1,3 +1,4 @@
 export { FernRcAccountSchema } from "./FernRcAccountSchema.js";
 export { FernRcAuthSchema } from "./FernRcAuthSchema.js";
+export { FernRcCacheSchema } from "./FernRcCacheSchema.js";
 export { createEmptyFernRcSchema, FernRcSchema } from "./FernRcSchema.js";

--- a/packages/cli/config/src/schemas/index.ts
+++ b/packages/cli/config/src/schemas/index.ts
@@ -8,7 +8,13 @@ export { CliSchema } from "./CliSchema.js";
 export { CratesPublishSchema } from "./CratesPublishSchema.js";
 export { EnvironmentSchema } from "./EnvironmentSchema.js";
 export { FernYmlSchema } from "./FernYmlSchema.js";
-export { createEmptyFernRcSchema, FernRcAccountSchema, FernRcAuthSchema, FernRcSchema } from "./fernrc/index.js";
+export {
+    createEmptyFernRcSchema,
+    FernRcAccountSchema,
+    FernRcAuthSchema,
+    FernRcCacheSchema,
+    FernRcSchema
+} from "./fernrc/index.js";
 export { GitOutputModeSchema } from "./GitOutputModeSchema.js";
 export { GitOutputSchema } from "./GitOutputSchema.js";
 export { HeaderConfigSchema } from "./HeaderConfigSchema.js";


### PR DESCRIPTION
## Description

This adds a local file cache for the CLI, which consolidates all of our caching needs. For now, this is primarily used to cache logs, but this sets us up to start caching the IR, too. Given that we still delegate to the legacy infrastructure for SDK generation, the IR cache is unused in its current state.

This also introduces a couple new commands which allows users to introspect and interact with their cache:

```sh
$ fern cache show
Cache Location
==============
Base:  /Users/alex/.cache/fern
IR:    /Users/alex/.cache/fern/v1/ir
Logs:  /Users/alex/.cache/fern/v1/logs

Cache Statistics
================
Total size: 71.1 KB

IR Cache:
  (empty)

Logs:
  16 files (71.1 KB)
```

```sh
$ fern cache show --json
{
  "paths": {
    "base": "/Users/alex/.cache/fern",
    "ir": "/Users/alex/.cache/fern/v1/ir",
    "logs": "/Users/alex/.cache/fern/v1/logs"
  },
  "stats": {
    "totalSize": 72835,
    "totalSizeFormatted": "71.1 KB",
    "ir": {
      "entryCount": 0,
      "totalSize": 0,
      "totalSizeFormatted": "0 B",
      "byVersion": []
    },
    "logs": {
      "fileCount": 16,
      "totalSize": 72835,
      "totalSizeFormatted": "71.1 KB"
    }
  }
}
```

```sh
$ fern cache clear --dry-run
Would delete 16 entries (71.1 KB)
Run without --dry-run to actually delete these entries.
```

```sh
$ fern cache clear
Cleared 16 entries (71.1 KB freed)
```

```sh
$ fern cache show --json
{
  "paths": {
    "base": "/Users/alex/.cache/fern",
    "ir": "/Users/alex/.cache/fern/v1/ir",
    "logs": "/Users/alex/.cache/fern/v1/logs"
  },
  "stats": {
    "totalSize": 0,
    "totalSizeFormatted": "0 B",
    "ir": {
      "entryCount": 0,
      "totalSize": 0,
      "totalSizeFormatted": "0 B",
      "byVersion": []
    },
    "logs": {
      "fileCount": 0,
      "totalSize": 0,
      "totalSizeFormatted": "0 B"
    }
  }
}
```

## Changes Made
- Add `Cache` abstraction, which is accessible from the CLI `Context`.
- Add `fern cache` sub-commands to `show` and `clear` content.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
