### PR TITLE
feat(cli): Add support for local git output mode

### DIFF
--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -91,7 +91,7 @@ export class GenerateCommand {
         const taskGroup = new SdkTaskGroup({ context });
         for (const target of targets) {
             const stageOverrides: SdkStageOverrides | undefined =
-                target.output.git != null
+                target.output.git != null && target.output.path == null
                     ? {
                           output: this.getGitOutputStageLabels(target.output.git.mode ?? "pr")
                       }

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -135,7 +135,7 @@ export class Context {
                 outputs.push(outputPath.toString());
             }
         }
-        if (target.output.git != null) {
+        if (target.output.git != null && target.output.path == null) {
             outputs.push(target.output.git.repository);
         }
         return outputs;

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyGenerationRunner.ts
@@ -1,9 +1,11 @@
 import type { Audiences } from "@fern-api/configuration";
-import { generatorsYml } from "@fern-api/configuration";
+import { generatorsYml, SNIPPET_JSON_FILENAME } from "@fern-api/configuration";
 import type { ContainerRunner } from "@fern-api/core-utils";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { join, RelativeFilePath } from "@fern-api/fs-utils";
 import { ContainerExecutionEnvironment, GenerationRunner } from "@fern-api/local-workspace-runner";
 import { TaskResult } from "@fern-api/task-context";
+import { rm } from "fs/promises";
 import type { AiConfig } from "../../ai/config/AiConfig.js";
 import { LegacyFernWorkspaceAdapter } from "../../api/adapter/LegacyFernWorkspaceAdapter.js";
 import type { ApiDefinition } from "../../api/config/ApiDefinition.js";
@@ -122,6 +124,20 @@ export class LegacyGenerationRunner {
                 skipUnstableDynamicSnippetTests: true,
                 inspect: false
             });
+
+            if (args.target.output.path != null && generatorInvocation.absolutePathToLocalOutput != null) {
+                // The local generator runner always writes snippet.json to the
+                // output directory. Remove it so that the user receives a clean
+                // full-project repository.
+                //
+                // TODO: Is this a bug in the local generator? Can we patch this
+                // in the @fern-api/local-generation package?
+                const snippetPath = join(
+                    generatorInvocation.absolutePathToLocalOutput,
+                    RelativeFilePath.of(SNIPPET_JSON_FILENAME)
+                );
+                await rm(snippetPath, { force: true });
+            }
 
             if (taskContext.getResult() === TaskResult.Failure) {
                 return {

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -1,11 +1,12 @@
 import type { FernToken } from "@fern-api/auth";
 import type { Audiences } from "@fern-api/configuration";
 import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
-import type { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, basename, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { runRemoteGenerationForAPIWorkspace } from "@fern-api/remote-workspace-runner";
 import { TaskResult } from "@fern-api/task-context";
+import { cp, mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
 import type { AiConfig } from "../../ai/config/AiConfig.js";
 import { LegacyFernWorkspaceAdapter } from "../../api/adapter/LegacyFernWorkspaceAdapter.js";
 import type { ApiDefinition } from "../../api/config/ApiDefinition.js";
@@ -116,7 +117,7 @@ export class LegacyRemoteGenerationRunner {
             });
             const fernWorkspace = await workspaceAdapter.adapt(args.apiDefinition);
 
-            const absolutePathToPreview = this.getAbsolutePathToPreview(args);
+            const absolutePathToPreview = await this.getAbsolutePathToPreview(args);
             await runRemoteGenerationForAPIWorkspace({
                 projectConfig: this.getProjectConfig(args),
                 organization: args.organization,
@@ -132,6 +133,25 @@ export class LegacyRemoteGenerationRunner {
                 whitelabel: undefined,
                 dynamicIrOnly: false
             });
+
+            if (this.isLocalGitCombo(args) && absolutePathToPreview != null) {
+                // Copy preview output to the configured output.path, then clean up the
+                // temp directory.
+                const generatorName = basename(generatorInvocation.name);
+                const previewOutputDirectory = join(absolutePathToPreview, RelativeFilePath.of(generatorName));
+                const targetOutputDirectory = generatorInvocation.absolutePathToLocalOutput;
+                if (targetOutputDirectory != null) {
+                    await cp(previewOutputDirectory, targetOutputDirectory, { recursive: true });
+
+                    // The preview output includes .git from the repository setup —- remove it
+                    // so the output is represented as plain files, not a separate repository.
+                    await rm(join(targetOutputDirectory, RelativeFilePath.of(".git")), {
+                        recursive: true,
+                        force: true
+                    });
+                }
+                await rm(absolutePathToPreview, { recursive: true, force: true });
+            }
 
             if (taskContext.getResult() === TaskResult.Failure) {
                 return {
@@ -152,7 +172,15 @@ export class LegacyRemoteGenerationRunner {
         }
     }
 
-    private getAbsolutePathToPreview(args: LegacyRemoteGenerationRunner.RunArgs): AbsoluteFilePath | undefined {
+    private async getAbsolutePathToPreview(
+        args: LegacyRemoteGenerationRunner.RunArgs
+    ): Promise<AbsoluteFilePath | undefined> {
+        if (this.isLocalGitCombo(args)) {
+            const tmpPreviewDirectory = await mkdtemp(
+                join(AbsoluteFilePath.of(tmpdir()), RelativeFilePath.of("fern-preview-"))
+            );
+            return AbsoluteFilePath.of(tmpPreviewDirectory);
+        }
         if (!args.preview) {
             return undefined;
         }
@@ -185,6 +213,18 @@ export class LegacyRemoteGenerationRunner {
             }
         }
         return undefined;
+    }
+
+    /**
+     * When both `path` and `git` are configured (and not already in preview mode),
+     * we force preview mode so that the remote generation service produces a full
+     * project (i.e. CI workflows, repo URLs in package metadata, etc) without
+     * actually pushing to GitHub.
+     *
+     * The output is downloaded to a temp directory and then copied to `output.path`.
+     */
+    private isLocalGitCombo(args: LegacyRemoteGenerationRunner.RunArgs): boolean {
+        return args.target.output.path != null && args.target.output.git != null && !args.preview;
     }
 
     /**
@@ -229,9 +269,13 @@ export class LegacyRemoteGenerationRunner {
         args: LegacyRemoteGenerationRunner.RunArgs,
         gitOutput: GitOutput | undefined
     ): string[] | undefined {
-        const absolutePathToPreview = this.getAbsolutePathToPreview(args);
-        if (absolutePathToPreview != null) {
-            return [absolutePathToPreview.toString()];
+        // For explicit preview mode, report the user-facing preview path.
+        if (args.preview) {
+            const previewPath =
+                args.outputPath != null
+                    ? resolve(this.context.cwd, args.outputPath)
+                    : join(this.context.cwd, RelativeFilePath.of(`.fern/preview`));
+            return [previewPath.toString()];
         }
         if (gitOutput != null) {
             if (gitOutput.pullRequestUrl != null) {

--- a/packages/commons/fs-utils/src/basename.ts
+++ b/packages/commons/fs-utils/src/basename.ts
@@ -1,0 +1,3 @@
+// For convenience, we re-export the basename function for any caller
+// that requires fs-utils.
+export { basename } from "@fern-api/path-utils";

--- a/packages/commons/fs-utils/src/index.ts
+++ b/packages/commons/fs-utils/src/index.ts
@@ -1,4 +1,5 @@
 export { AbsoluteFilePath } from "./AbsoluteFilePath.js";
+export { basename } from "./basename.js";
 export { cwd } from "./cwd.js";
 export { dirname } from "./dirname.js";
 export { doesPathExist, doesPathExistSync, isPathEmpty } from "./doesPathExist.js";


### PR DESCRIPTION
## Description

This explores and implements a new generator output mode: `git` in combination with a local `path`. With this, we now provide users a simple UX to generate a full SDK locally (i.e. it contains the respective GitHub metadata like the repository URL in package metadata, GitHub workflow files, license, etc).

```yaml
org: amckinney
api:
  specs:
    - openapi: ./openapi/openapi.yml
sdks:
  targets:
    go:
      version: 1.23.4
      output:
        # This tells Fern to generate an SDK for acme/acme-go but deposit
        # the SDK locally (not directly in acme/acme-go).
        path: ./sdks/go
        git:
          repository: acme/acme-go
```

With this, both local and remote generation produces the same artifact:

```sh
./sdks/go
├── .github
│   └── workflows
│       └── ...
├── client
│   └── ...
├── ...
├── README.md
├── reference.md
└── types.go
```

## Implementation

For this to work there's a few things that were changed:
1. The local generator _always_ produces a `snippet.json` file in its current state. This file is now removed for locally generated SDKs in `@fern-api/cli-v2`.
    * **Follow-up**: Should this fix actually be moved to the original CLI, too? When is this used in its current state?
2. For remote generation, we leverage a `--preview` build, and move the output to the configured output `path`. We remove the `.git` folder contained within the preview so that the users can receive the full GitHub repository as ordinary text files rather than as a separate repository.

In both the `local` and `remote` environment, a `git` artifact is not produced on the target when a `path` is configured -- it's purely treated as a local output operation (as desired).

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
