### PR TITLE
fix(openapi): merge parameters by identity (name + in), not index

### DIFF
--- a/packages/commons/core-utils/src/__tests__/mergeWithOverrides.test.ts
+++ b/packages/commons/core-utils/src/__tests__/mergeWithOverrides.test.ts
@@ -1,6 +1,88 @@
 import { mergeWithOverrides } from "../mergeWithOverrides.js";
 
 describe("mergeWithOverrides", () => {
+    it("should merge OpenAPI parameters by identity (name + in), not by index", () => {
+        // Per OpenAPI spec, parameters are uniquely identified by name + in combination
+        // https://spec.openapis.org/oas/v3.0.3#operation-object
+        const data = {
+            parameters: [
+                { name: "internal", in: "query", description: "Internal param" },
+                { name: "token", in: "header", description: "Auth token" },
+                { name: "visible", in: "query", description: "Visibility param" }
+            ]
+        };
+
+        const overrides = {
+            parameters: [
+                { name: "internal", in: "query", "x-fern-ignore": true },
+                { name: "visible", in: "query", "x-fern-ignore": true }
+            ]
+        };
+
+        const result = mergeWithOverrides({
+            data,
+            overrides
+        });
+
+        // Expected: internal and visible get x-fern-ignore: true
+        // token should remain unchanged (NOT get x-fern-ignore from misaligned index)
+        expect(result).toEqual({
+            parameters: [
+                { name: "internal", in: "query", description: "Internal param", "x-fern-ignore": true },
+                { name: "token", in: "header", description: "Auth token" },
+                { name: "visible", in: "query", description: "Visibility param", "x-fern-ignore": true }
+            ]
+        });
+    });
+
+    it("should add new parameters from overrides", () => {
+        const data = {
+            parameters: [{ name: "existing", in: "query", description: "Existing param" }]
+        };
+
+        const overrides = {
+            parameters: [{ name: "new-param", in: "header", description: "New param from override" }]
+        };
+
+        const result = mergeWithOverrides({
+            data,
+            overrides
+        });
+
+        expect(result).toEqual({
+            parameters: [
+                { name: "existing", in: "query", description: "Existing param" },
+                { name: "new-param", in: "header", description: "New param from override" }
+            ]
+        });
+    });
+
+    it("should distinguish parameters with same name but different location", () => {
+        const data = {
+            parameters: [
+                { name: "id", in: "query", description: "Query ID" },
+                { name: "id", in: "header", description: "Header ID" }
+            ]
+        };
+
+        const overrides = {
+            parameters: [{ name: "id", in: "header", "x-fern-ignore": true }]
+        };
+
+        const result = mergeWithOverrides({
+            data,
+            overrides
+        });
+
+        // Only the header "id" should be ignored, not the query "id"
+        expect(result).toEqual({
+            parameters: [
+                { name: "id", in: "query", description: "Query ID" },
+                { name: "id", in: "header", description: "Header ID", "x-fern-ignore": true }
+            ]
+        });
+    });
+
     it("should handle schema with null examples", () => {
         const schema1 = {
             type: "object",

--- a/packages/commons/core-utils/src/mergeWithOverrides.ts
+++ b/packages/commons/core-utils/src/mergeWithOverrides.ts
@@ -6,6 +6,59 @@ type AncestorOmissionCriteria = {
     allowOmissionCursor: boolean;
 };
 
+/**
+ * Checks if an object looks like an OpenAPI parameter (has both `name` and `in` properties).
+ * Per OpenAPI spec, parameters are uniquely identified by name + in combination.
+ */
+function isOpenApiParameter(obj: unknown): obj is { name: string; in: string } {
+    return (
+        typeof obj === "object" &&
+        obj !== null &&
+        "name" in obj &&
+        "in" in obj &&
+        typeof (obj as Record<string, unknown>).name === "string" &&
+        typeof (obj as Record<string, unknown>).in === "string"
+    );
+}
+
+/**
+ * Gets the unique identity key for an OpenAPI parameter.
+ */
+function getParameterKey(param: { name: string; in: string }): string {
+    return `${param.name}::${param.in}`;
+}
+
+/**
+ * Merges two arrays of OpenAPI parameters by identity (name + in) instead of by index.
+ * Per the OpenAPI spec: "A unique parameter is defined by a combination of a name and location."
+ */
+function mergeParameterArrays<T extends { name: string; in: string }>(base: T[], overrides: T[]): T[] {
+    const result = [...base];
+    const baseIndex = new Map<string, number>();
+
+    // Build index of base parameters by identity
+    base.forEach((param, idx) => {
+        baseIndex.set(getParameterKey(param), idx);
+    });
+
+    // Merge overrides by identity
+    for (const override of overrides) {
+        const key = getParameterKey(override);
+        const existingIdx = baseIndex.get(key);
+
+        if (existingIdx !== undefined) {
+            // Merge with existing parameter at the matching index
+            result[existingIdx] = mergeWith({}, result[existingIdx], override) as T;
+        } else {
+            // Add new parameter
+            result.push(override);
+            baseIndex.set(key, result.length - 1);
+        }
+    }
+
+    return result;
+}
+
 export function mergeWithOverrides<T extends object>({
     data,
     overrides,
@@ -15,15 +68,30 @@ export function mergeWithOverrides<T extends object>({
     overrides: object;
     allowNullKeys?: string[];
 }): T {
-    const merged = mergeWith(data, mergeWith, overrides, (obj, src) =>
-        Array.isArray(obj) && Array.isArray(src)
-            ? src.every((element) => typeof element === "object") && obj.every((element) => typeof element === "object")
-                ? // nested arrays of objects are merged
-                  undefined
-                : // nested arrays of primitives are replaced
-                  [...src]
-            : undefined
-    ) as T;
+    const merged = mergeWith(data, mergeWith, overrides, (obj, src) => {
+        if (Array.isArray(obj) && Array.isArray(src)) {
+            const objIsObjects = obj.every((element) => typeof element === "object");
+            const srcIsObjects = src.every((element) => typeof element === "object");
+
+            if (objIsObjects && srcIsObjects) {
+                // Check if both arrays look like OpenAPI parameter arrays
+                const objIsParams = obj.length > 0 && obj.every(isOpenApiParameter);
+                const srcIsParams = src.length > 0 && src.every(isOpenApiParameter);
+
+                if (objIsParams && srcIsParams) {
+                    // Merge parameters by identity (name + in) instead of by index
+                    return mergeParameterArrays(obj, src);
+                }
+
+                // nested arrays of objects are merged by index (default lodash behavior)
+                return undefined;
+            }
+
+            // nested arrays of primitives are replaced
+            return [...src];
+        }
+        return undefined;
+    }) as T;
     // Remove any nullified values
     const filtered = omitDeepBy(merged, isNull, {
         ancestorKeys: allowNullKeys ?? [],


### PR DESCRIPTION
## Summary

Fixes #12148

Per the [OpenAPI spec](https://spec.openapis.org/oas/v3.0.3#operation-object), parameters are uniquely identified by a combination of `name` and `in` (location). Previously, override arrays were merged by index position using lodash's default `mergeWith` behavior, which caused overrides to be applied to the wrong parameters when the override array didn't exactly mirror the base spec's parameter order.

## Problem

**Base spec:**
```yaml
parameters:
  - name: internal
    in: query
  - name: token
    in: header  
  - name: visible
    in: query
```

**Override:**
```yaml
parameters:
  - name: internal
    in: query
    x-fern-ignore: true
  - name: visible
    in: query
    x-fern-ignore: true
```

**Before (wrong):** `internal` (idx 0) and `token` (idx 1) were modified  
**After (correct):** `internal` and `visible` are modified by matching identity

## Solution

Added special handling in `mergeWithOverrides` for arrays that look like OpenAPI parameter arrays (objects with `name` and `in` properties). These arrays are now merged by identity (`name + in` combination) instead of by index.

## Changes

- `packages/commons/core-utils/src/mergeWithOverrides.ts`: Added `isOpenApiParameter()`, `getParameterKey()`, and `mergeParameterArrays()` functions to handle identity-based merging
- `packages/commons/core-utils/src/__tests__/mergeWithOverrides.test.ts`: Added 3 test cases for parameter merging behavior

## Testing

All existing tests pass, plus 3 new tests:
1. Merge parameters by identity, not index (the bug scenario)
2. Add new parameters from overrides
3. Distinguish parameters with same name but different location