### PR TITLE
fix(openapi): use schema title for discriminated union variant displayName

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/discriminated-union-value-title.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/discriminated-union-value-title.json
@@ -82,9 +82,11 @@
             },
             "union": {
               "request": {
+                "display-name": "A simple request title",
                 "type": "Request",
               },
               "response": {
+                "display-name": "A simple response title",
                 "type": "Response",
               },
             },
@@ -137,8 +139,10 @@ types:
     union:
       request:
         type: Request
+        display-name: A simple request title
       response:
         type: Response
+        display-name: A simple response title
     source:
       openapi: ../openapi.yml
 ",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/switchboard.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/switchboard.json
@@ -2376,9 +2376,11 @@ service:
             },
             "union": {
               "error": {
+                "display-name": "Event error",
                 "type": "SessionsEventsResponseError",
               },
               "status": {
+                "display-name": "Event status",
                 "type": "SessionsEventsResponseStatus",
               },
             },
@@ -2478,8 +2480,10 @@ service:
     union:
       status:
         type: SessionsEventsResponseStatus
+        display-name: Event status
       error:
         type: SessionsEventsResponseError
+        display-name: Event error
     source:
       openapi: ../openapi.yml
 imports:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeDeclaration.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeDeclaration.ts
@@ -26,7 +26,8 @@ import {
     buildPrimitiveTypeReference,
     buildReferenceTypeReference,
     buildTypeReference,
-    buildUnknownTypeReference
+    buildUnknownTypeReference,
+    getDisplayName
 } from "./buildTypeReference.js";
 import { OpenApiIrConverterContext } from "./OpenApiIrConverterContext.js";
 import { State } from "./State.js";
@@ -661,13 +662,28 @@ export function buildOneOfTypeDeclaration({
         }
         const union: Record<string, RawSchemas.SingleUnionTypeSchema> = {};
         for (const [discriminantValue, subSchema] of Object.entries(schema.schemas)) {
-            union[discriminantValue] = buildTypeReference({
+            const typeRef = buildTypeReference({
                 schema: subSchema,
                 context,
                 fileContainingReference: declarationFile,
                 namespace,
                 declarationDepth: declarationDepth + 1
             });
+            let variantTitle: string | undefined = getDisplayName(subSchema);
+            if (variantTitle == null && subSchema.type === "reference") {
+                const resolvedSchema = context.getSchema(subSchema.schema, subSchema.namespace);
+                if (resolvedSchema != null) {
+                    variantTitle = getDisplayName(resolvedSchema);
+                }
+            }
+            if (variantTitle != null) {
+                union[discriminantValue] =
+                    typeof typeRef === "string"
+                        ? { type: typeRef, "display-name": variantTitle }
+                        : { ...typeRef, "display-name": variantTitle };
+            } else {
+                union[discriminantValue] = typeRef;
+            }
         }
         return {
             name: schema.nameOverride ?? schema.generatedName,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
@@ -886,7 +886,7 @@ function getSchemaName(schema: Schema): string | undefined {
     });
 }
 
-function getDisplayName(schema: Schema): string | undefined {
+export function getDisplayName(schema: Schema): string | undefined {
     return Schema._visit(schema, {
         primitive: (s) => s.title,
         object: (s) => s.title,

--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/OneOfSchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/OneOfSchemaConverter.ts
@@ -147,11 +147,14 @@ export class OneOfSchemaConverter extends AbstractConverter<
                     wireValue: discriminant
                 });
 
+                const variantDisplayName =
+                    (resolvedSchema.resolved ? resolvedSchema.value.title : undefined) ?? discriminant;
+
                 unionTypes.push({
                     docs: undefined,
                     discriminantValue: nameAndWireValue,
                     availability: convertedSchema.availability,
-                    displayName: discriminant,
+                    displayName: variantDisplayName,
                     shape: SingleUnionTypeProperties.samePropertiesAsObject({
                         typeId,
                         name: this.context.casingsGenerator.generateName(typeId),
@@ -160,7 +163,7 @@ export class OneOfSchemaConverter extends AbstractConverter<
                             packagePath: [],
                             file: undefined
                         },
-                        displayName: discriminant
+                        displayName: variantDisplayName
                     })
                 });
                 inlinedTypes = {

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/discriminated-union-mapping.json
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/discriminated-union-mapping.json
@@ -267,7 +267,7 @@
               },
               "wireValue": "request"
             },
-            "displayName": "request",
+            "displayName": "A simple request title",
             "shape": {
               "typeId": "RequestOne",
               "name": {
@@ -293,7 +293,7 @@
                 "allParts": [],
                 "packagePath": []
               },
-              "displayName": "request",
+              "displayName": "A simple request title",
               "propertiesType": "samePropertiesAsObject"
             }
           },
@@ -320,7 +320,7 @@
               },
               "wireValue": "response"
             },
-            "displayName": "response",
+            "displayName": "A simple response title",
             "shape": {
               "typeId": "RequestTwo",
               "name": {
@@ -346,7 +346,7 @@
                 "allParts": [],
                 "packagePath": []
               },
-              "displayName": "response",
+              "displayName": "A simple response title",
               "propertiesType": "samePropertiesAsObject"
             }
           }

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/discriminated-union-value-title.json
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/discriminated-union-value-title.json
@@ -281,7 +281,7 @@
               },
               "wireValue": "request"
             },
-            "displayName": "request",
+            "displayName": "A simple request title",
             "shape": {
               "typeId": "Request",
               "name": {
@@ -307,7 +307,7 @@
                 "allParts": [],
                 "packagePath": []
               },
-              "displayName": "request",
+              "displayName": "A simple request title",
               "propertiesType": "samePropertiesAsObject"
             }
           },
@@ -334,7 +334,7 @@
               },
               "wireValue": "response"
             },
-            "displayName": "response",
+            "displayName": "A simple response title",
             "shape": {
               "typeId": "Response",
               "name": {
@@ -360,7 +360,7 @@
                 "allParts": [],
                 "packagePath": []
               },
-              "displayName": "response",
+              "displayName": "A simple response title",
               "propertiesType": "samePropertiesAsObject"
             }
           }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.74.1
+  changelogEntry:
+    - summary: |
+        Fix discriminated union variant displayName to use the schema `title` field from
+        the OpenAPI spec when available, falling back to the discriminator mapping key.
+        Previously, variant display names always used the raw discriminator key (e.g. "user")
+        instead of the human-readable title (e.g. "User Message").
+      type: fix
+  createdAt: "2026-02-11"
+  irVersion: 65
+
 - version: 3.74.0
   changelogEntry:
     - summary: |

--- a/packages/cli/ete-tests/src/tests/write-definition/__snapshots__/writeDefinition.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/write-definition/__snapshots__/writeDefinition.test.ts.snap
@@ -953,11 +953,13 @@ channel:
       openapi: openapi/trains/openapi.yml
     union:
       bank_account:
+        display-name: Bank Account
         docs: >-
           A bank account to take payment from. Must be able to make payments in
           the currency specified in the payment.
         type: BookingPaymentSourceBankAccount
       card:
+        display-name: Card
         docs: A card (debit or credit) to take payment from.
         type: BookingPaymentSourceCard
   BookingPaymentSourceBankAccount:

--- a/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced/fern/.definition/trains/__package__.yml
+++ b/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced/fern/.definition/trains/__package__.yml
@@ -83,11 +83,13 @@ types:
       openapi: openapi/trains/openapi.yml
     union:
       bank_account:
+        display-name: Bank Account
         docs: >-
           A bank account to take payment from. Must be able to make payments in
           the currency specified in the payment.
         type: BookingPaymentSourceBankAccount
       card:
+        display-name: Card
         docs: A card (debit or credit) to take payment from.
         type: BookingPaymentSourceCard
   BookingPaymentSourceBankAccount:


### PR DESCRIPTION
## Description

Refs: Reported by @alecharmon — [Devin run](https://app.devin.ai/sessions/0b14610f4cef43f1b723837023873bc0)

When bumping the Fern CLI past ~3.50.1, discriminated union variants in generated docs lost their human-readable display names (e.g. "User Message") and instead showed the raw discriminator mapping key (e.g. "user"). This affected **both** OpenAPI import paths:

1. **v3 importer** (`OneOfSchemaConverter.convertAsDiscriminatedUnion()`) — always used the discriminator key as `displayName`, ignoring the schema's `title` field.
2. **Old importer** (`openapi-ir-to-fern` → `buildOneOfTypeDeclaration()`) — never set `display-name` on discriminated union variants in the generated Fern definition, so the title was lost before reaching the IR generator.

The old importer path is used by docs generation (`toFernWorkspace()`), which is why the initial v3-only fix did not resolve the issue on the [preview site](https://cohere-preview-fc661a5f-7844-4136-8694-8d9c30d7de64.docs.buildwithfern.com/reference/chat).

## Changes Made

### v3 importer (`v3-importer-commons`)
- In `OneOfSchemaConverter.convertAsDiscriminatedUnion()`, the variant `displayName` now prefers the resolved schema's `title` field, falling back to the discriminator mapping key when no title is present

### Old importer (`openapi-ir-to-fern`)
- Exported `getDisplayName` from `buildTypeReference.ts` (was previously a private helper)
- In `buildOneOfTypeDeclaration()`, each discriminated union variant now resolves its schema title (including through `$ref` references) and sets `display-name` on the Fern definition output
- Updated two old-importer-test snapshots (`discriminated-union-value-title`, `switchboard`) to reflect the new `display-name` values

### Other
- Updated two v3-importer-test snapshots (`discriminated-union-value-title`, `discriminated-union-mapping`)
- Updated ETE test snapshot and generated fixture output for `namespaced` write-definition fixture (`BookingPaymentSource` union now includes `display-name: Card` / `display-name: Bank Account`)
- Added CLI changelog entry (3.74.1)

## Testing

- [x] v3-importer-tests pass (219/219)
- [x] openapi-ir-to-fern-tests pass (253/253)
- [x] ETE write-definition tests pass (namespaced snapshot updated)
- [x] Lint passes (`biome check`)

## Review Checklist

- [ ] In the old importer path, verify that `context.getSchema(subSchema.schema, subSchema.namespace)` correctly resolves the reference's target namespace (matches the pattern used in `buildReferenceTypeReference`)
- [ ] Confirm no downstream consumers rely on `displayName` matching the raw discriminator key rather than the schema title
- [ ] Verify that deeply-chained `$ref` references (ref → ref → object with title) are handled — the current fix resolves one level, which may miss chained refs
- [ ] Validate on a real Cohere OAS preview deployment that "User Message" / "Assistant Message" now display correctly