### PR TITLE
fix: inline alias types in undiscriminated union oneOf variants

### DIFF
--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/OneOfSchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/OneOfSchemaConverter.ts
@@ -302,11 +302,15 @@ export class OneOfSchemaConverter extends AbstractConverter<
             const convertedSchema = schemaConverter.convert();
             if (convertedSchema != null) {
                 const typeShape = convertedSchema.convertedSchema.typeDeclaration.shape;
-                if (typeShape.type === "alias" && this.typeReferenceIsWrappedPrimitive(typeShape.aliasOf)) {
+                if (typeShape.type === "alias") {
                     unionTypes.push({
                         type: typeShape.aliasOf,
                         docs: subSchema.description
                     });
+                    inlinedTypes = {
+                        ...inlinedTypes,
+                        ...convertedSchema.inlinedTypes
+                    };
                 } else if (
                     typeShape.type === "object" &&
                     typeShape.properties.length === 0 &&

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.74.2
+  changelogEntry:
+    - summary: |
+        Inline alias types in undiscriminated union variants instead of creating unnecessary named types with numeric suffixes. For example, a `oneOf` with `string` and `array` items no longer generates a type like `UserMessageV2Content1` for the array variant.
+      type: fix
+  createdAt: "2026-02-11"
+  irVersion: 65
+
 - version: 3.74.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: [Devin session](https://app.devin.ai/sessions/26842cc2fac4412f812bc82b5f4e1c22)
Requested by: @thesandlord

When an OpenAPI `oneOf` contains inline schemas that resolve to alias types (e.g., `type: array` with `$ref` items), the v3 importer was creating unnecessary named types with numeric index suffixes like `UserMessageV2Content1`. This suffix comes from the schema ID generation at `OneOfSchemaConverter:293` which appends `_${index}` to the parent ID.

Example: Cohere's `UserMessageV2.content` is a `oneOf` of `string` and `array<Content>`. The string variant is correctly inlined as a primitive, but the array variant was wrapped in a named type `UserMessageV2Content1` instead of being inlined as `list<Content>`.

## Changes Made

- Relaxed the alias inlining condition in `OneOfSchemaConverter.convertAsUndiscriminatedUnion` from requiring `typeReferenceIsWrappedPrimitive` to inlining **all** alias types directly as type references
- Added propagation of `convertedSchema.inlinedTypes` in the alias branch to preserve any sub-inlined types from non-primitive aliases
- Added changelog entry (v3.74.2)

## Testing

- [ ] Unit tests added/updated
- [x] Lint passes (`pnpm run check`)
- [ ] Seed test snapshots updated (may require updates in CI)

## Human Review Checklist

- ⚠️ **Broad impact**: The guard `this.typeReferenceIsWrappedPrimitive(typeShape.aliasOf)` was removed entirely, so this now inlines ALL alias types in undiscriminated union variants — not just primitives. This could change generated output for any API with inline `oneOf` schemas that resolve to aliases (arrays, maps, aliases of named types, etc.). Please verify this is the desired behavior.
- ⚠️ **No seed tests included**: CI seed snapshots may need updating. If snapshot diffs appear, they should show named types being replaced with direct type references (which is the intended improvement).
- `typeReferenceIsWrappedPrimitive` and `containerTypeIsWrappedPrimitive` methods are now effectively dead code — consider cleanup.