### PR TITLE
feat(cli): Add self-hosted git output mode

### DIFF
--- a/packages/cli/auth/src/orgs/checkOrganizationMembership.ts
+++ b/packages/cli/auth/src/orgs/checkOrganizationMembership.ts
@@ -20,17 +20,15 @@ export async function checkOrganizationMembership({
 
     // First check if the user is a member of the organization.
     const isMemberResponse = await venus.organization.isMember(FernVenusApi.OrganizationId(organization));
-    if (isMemberResponse.ok) {
-        if (isMemberResponse.body) {
-            return { type: "member" };
-        }
-        return { type: "no-access" };
+    if (isMemberResponse.ok && isMemberResponse.body) {
+        return { type: "member" };
     }
 
-    // If the isMember call failed, check whether the org exists at all.
+    // Either the isMember call failed or the user is not a member.
+    // Check whether the org exists at all.
     const getResponse = await venus.organization.get(FernVenusApi.OrganizationId(organization));
     if (getResponse.ok) {
-        // Org exists but isMember failed; treat as no access.
+        // Org exists but user is not a member.
         return { type: "no-access" };
     }
 
@@ -41,6 +39,8 @@ export async function checkOrganizationMembership({
             result = { type: "no-access" };
         },
         _other: () => {
+            // TODO: We should actually send a 404 to more clearly communicate a not-found error.
+            // Otherwise, internal server errors would be mistaken for not-found errors.
             result = { type: "not-found" };
         }
     });

--- a/packages/cli/cli-v2/src/__test__/SdkConfigConverter.test.ts
+++ b/packages/cli/cli-v2/src/__test__/SdkConfigConverter.test.ts
@@ -1,3 +1,4 @@
+import { schemas } from "@fern-api/config";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { NOOP_LOGGER } from "@fern-api/logger";
 import { randomUUID } from "crypto";
@@ -403,7 +404,12 @@ sdks:
 
             expect(result.success).toBe(true);
             if (result.success) {
-                expect(result.config.targets[0]?.output.git?.repository).toBe("acme/python-sdk");
+                const git = result.config.targets[0]?.output.git;
+                expect(git).toBeDefined();
+                expect(git != null && schemas.isGitOutputGitHubRepository(git)).toBe(true);
+                if (git != null && schemas.isGitOutputGitHubRepository(git)) {
+                    expect(git.repository).toBe("acme/python-sdk");
+                }
             }
         });
     });
@@ -525,9 +531,13 @@ sdks:
 
             expect(result.success).toBe(true);
             if (result.success) {
-                const reviewers = result.config.targets[0]?.output.git?.reviewers;
-                expect(reviewers?.teams).toEqual(["sdk-team", "backend-team"]);
-                expect(reviewers?.users).toEqual(["alice", "bob"]);
+                const git = result.config.targets[0]?.output.git;
+                expect(git).toBeDefined();
+                expect(git != null && schemas.isGitOutputGitHubRepository(git)).toBe(true);
+                if (git != null && schemas.isGitOutputGitHubRepository(git)) {
+                    expect(git.reviewers?.teams).toEqual(["sdk-team", "backend-team"]);
+                    expect(git.reviewers?.users).toEqual(["alice", "bob"]);
+                }
             }
         });
     });

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -1,13 +1,16 @@
-import type { schemas } from "@fern-api/config";
+import { schemas } from "@fern-api/config";
 import type { Audiences } from "@fern-api/configuration";
 import type { ContainerRunner } from "@fern-api/core-utils";
 import { assertNever } from "@fern-api/core-utils";
 import { resolve } from "@fern-api/fs-utils";
+import { ValidationIssue } from "@fern-api/yaml-loader";
+import yaml from "js-yaml";
 import type { Argv } from "yargs";
 import { ApiChecker } from "../../../api/checker/ApiChecker.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
+import { ValidationError } from "../../../errors/ValidationError.js";
 import type { Target } from "../../../sdk/config/Target.js";
 import { GeneratorPipeline } from "../../../sdk/generator/GeneratorPipeline.js";
 import { SdkStageOverrides, SdkTaskGroup } from "../../../sdk/task/SdkTaskGroup.js";
@@ -56,13 +59,13 @@ export class GenerateCommand {
             throw new Error("No SDKs configured in fern.yml");
         }
 
-        this.validateArgs({ workspace, args });
-
         const targets = this.getTargets({
             workspace,
             groupName: args.group ?? workspace.sdks.defaultGroup,
             targetName: args.target
         });
+
+        this.validateArgs({ workspace, args, targets });
 
         const apisToCheck = [...new Set(targets.map((t) => t.api))];
         const checker = new ApiChecker({
@@ -85,7 +88,7 @@ export class GenerateCommand {
             cliVersion: workspace.cliVersion
         });
 
-        const token = args.local ? undefined : await context.getTokenOrPrompt();
+        const token = this.isTokenRequired({ targets, args }) ? await context.getTokenOrPrompt() : undefined;
         const runtime = args.local ? "local" : "remote";
 
         const taskGroup = new SdkTaskGroup({ context });
@@ -169,7 +172,15 @@ export class GenerateCommand {
         }
     }
 
-    private validateArgs({ workspace, args }: { workspace: Workspace; args: GenerateCommand.Args }): void {
+    private validateArgs({
+        workspace,
+        args,
+        targets
+    }: {
+        workspace: Workspace;
+        args: GenerateCommand.Args;
+        targets: Target[];
+    }): void {
         if (args.output != null && !args.preview) {
             throw new Error("The --output flag can only be used with --preview");
         }
@@ -183,6 +194,62 @@ export class GenerateCommand {
         if (defaultGroup == null && args.group == null && args.target == null) {
             throw new Error("A --target or --group must be specified");
         }
+        const issues: ValidationIssue[] = [];
+        if (args.local) {
+            for (const target of targets) {
+                const git = target.output.git;
+                if (git != null && !schemas.isGitOutputSelfHosted(git) && target.output.path == null) {
+                    issues.push(this.suggestGitHubRepositoryOutput({ target, git }));
+                }
+            }
+        }
+        if (issues.length > 0) {
+            throw new ValidationError(issues);
+        }
+    }
+
+    private suggestGitHubRepositoryOutput({
+        target,
+        git
+    }: {
+        target: Target;
+        git: schemas.GitHubRepositoryOutputSchema;
+    }): ValidationIssue {
+        const { repository, reviewers: _reviewers, ...rest } = git;
+        const uri =
+            repository.startsWith("https://") || repository.startsWith("http://")
+                ? repository
+                : `https://github.com/${repository}`;
+        const suggestedTarget = {
+            [target.name]: {
+                output: {
+                    git: {
+                        ...rest,
+                        uri,
+                        token: "${GIT_TOKEN}"
+                    }
+                }
+            }
+        };
+        return new ValidationIssue({
+            message: `Target '${target.name}' is incompatible with --local mode.`,
+            suggestion:
+                `Use remote generation (without --local) or configure the target with 'uri' and 'token' instead of 'repository'.\n\n` +
+                `Example:\n` +
+                this.indentBlock(yaml.dump(suggestedTarget, { lineWidth: -1 })),
+            location: target.sourceLocation
+        });
+    }
+
+    /**
+     * Determines if a Fern token is required for the given targets and arguments.
+     *
+     * A Fern token is required if:
+     *  - The user is relying on remote generation.
+     *  - The target is using Fern's self-hosted git output mode.
+     */
+    private isTokenRequired({ targets, args }: { targets: Target[]; args: GenerateCommand.Args }): boolean {
+        return !args.local || targets.some((t) => t.output.git != null && schemas.isGitOutputSelfHosted(t.output.git));
     }
 
     private getTargets({
@@ -232,7 +299,7 @@ export class GenerateCommand {
         return targets.length === 1 ? "SDK" : "SDKs";
     }
 
-    private getGitOutputStageLabels(mode: schemas.GitOutputModeSchema): Partial<TaskStageLabels> {
+    private getGitOutputStageLabels(mode: schemas.GitHubOutputModeSchema): Partial<TaskStageLabels> {
         switch (mode) {
             case "push":
                 return {
@@ -255,6 +322,14 @@ export class GenerateCommand {
             default:
                 assertNever(mode);
         }
+    }
+
+    private indentBlock(text: string): string {
+        return text
+            .trimEnd()
+            .split("\n")
+            .map((line) => (line.length > 0 ? `  ${line}` : line))
+            .join("\n");
     }
 }
 

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -1,5 +1,6 @@
 import { FernToken, FernUserToken, getAccessToken, verifyAndDecodeJwt } from "@fern-api/auth";
 import { Log, TtyAwareLogger } from "@fern-api/cli-logger";
+import { schemas } from "@fern-api/config";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { createLogger, LOG_LEVELS, Logger, LogLevel } from "@fern-api/logger";
 import { getTokenFromAuth0 } from "@fern-api/login";
@@ -136,7 +137,8 @@ export class Context {
             }
         }
         if (target.output.git != null && target.output.path == null) {
-            outputs.push(target.output.git.repository);
+            const git = target.output.git;
+            outputs.push(schemas.isGitOutputSelfHosted(git) ? git.uri : git.repository);
         }
         return outputs;
     }

--- a/packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts
+++ b/packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts
@@ -24,6 +24,7 @@ export class LegacyGeneratorInvocationAdapter {
 
     public async adapt(target: Target): Promise<generatorsYml.GeneratorInvocation> {
         return {
+            raw: this.buildRaw(target),
             name: target.image,
             version: target.version,
             config: target.config,
@@ -43,54 +44,136 @@ export class LegacyGeneratorInvocationAdapter {
         };
     }
 
+    private buildRaw(target: Target): generatorsYml.GeneratorInvocationSchema | undefined {
+        const git = target.output.git;
+        if (git == null || !schemas.isGitOutputSelfHosted(git)) {
+            return undefined;
+        }
+        return {
+            name: target.image,
+            version: target.version,
+            github: {
+                uri: git.uri,
+                token: git.token,
+                mode: this.mapSelfHostedMode(git.mode),
+                branch: git.branch
+            }
+        };
+    }
+
+    private mapSelfHostedMode(
+        mode: schemas.GitSelfHostedOutputModeSchema | undefined
+    ): generatorsYml.GithubSelfhostedMode | undefined {
+        if (mode == null) {
+            return generatorsYml.GithubSelfhostedMode.PullRequest;
+        }
+        switch (mode) {
+            case "pr":
+                return generatorsYml.GithubSelfhostedMode.PullRequest;
+            case "push":
+                return generatorsYml.GithubSelfhostedMode.Push;
+            default:
+                assertNever(mode);
+        }
+    }
+
     private async buildOutputMode(target: Target): Promise<FernFiddle.remoteGen.OutputMode> {
         if (target.output.git != null) {
             const git = target.output.git;
-            const repository = parseRepository(git.repository);
-            const license = git.license != null ? await this.convertLicense(git.license) : undefined;
-            const publishInfo = target.publish != null ? this.buildPublishInfo(target.publish) : undefined;
-            const reviewers = this.buildReviewers(git.reviewers);
-            const mode = git.mode ?? "pr";
-
-            switch (mode) {
-                case "pr":
-                    return FernFiddle.remoteGen.OutputMode.githubV2(
-                        FernFiddle.GithubOutputModeV2.pullRequest({
-                            owner: repository.owner,
-                            repo: repository.repo,
-                            license,
-                            publishInfo,
-                            reviewers,
-                            downloadSnippets: undefined
-                        })
-                    );
-                case "release":
-                    return FernFiddle.remoteGen.OutputMode.githubV2(
-                        FernFiddle.GithubOutputModeV2.commitAndRelease({
-                            owner: repository.owner,
-                            repo: repository.repo,
-                            license,
-                            publishInfo,
-                            downloadSnippets: undefined
-                        })
-                    );
-                case "push":
-                    return FernFiddle.remoteGen.OutputMode.githubV2(
-                        FernFiddle.GithubOutputModeV2.push({
-                            owner: repository.owner,
-                            repo: repository.repo,
-                            branch: git.branch,
-                            license,
-                            publishInfo,
-                            downloadSnippets: undefined
-                        })
-                    );
-                default:
-                    assertNever(mode);
+            if (schemas.isGitOutputSelfHosted(git)) {
+                return await this.buildGitSelfHostedOutputMode({ target, git });
             }
+            return await this.buildGitHubRepositoryOutputMode({ target, git });
         }
         // Default to downloadFiles for local output.
         return FernFiddle.remoteGen.OutputMode.downloadFiles({});
+    }
+
+    private async buildGitHubRepositoryOutputMode({
+        target,
+        git
+    }: {
+        target: Target;
+        git: schemas.GitHubRepositoryOutputSchema;
+    }): Promise<FernFiddle.OutputMode.GithubV2> {
+        const repository = parseRepository(git.repository);
+        const license = git.license != null ? await this.convertLicense(git.license) : undefined;
+        const publishInfo = target.publish != null ? this.buildPublishInfo(target.publish) : undefined;
+        const reviewers = this.buildReviewers(git.reviewers);
+        const mode = git.mode ?? "pr";
+        switch (mode) {
+            case "pr":
+                return FernFiddle.remoteGen.OutputMode.githubV2(
+                    FernFiddle.GithubOutputModeV2.pullRequest({
+                        owner: repository.owner,
+                        repo: repository.repo,
+                        license,
+                        publishInfo,
+                        reviewers,
+                        downloadSnippets: undefined
+                    })
+                );
+            case "release":
+                return FernFiddle.remoteGen.OutputMode.githubV2(
+                    FernFiddle.GithubOutputModeV2.commitAndRelease({
+                        owner: repository.owner,
+                        repo: repository.repo,
+                        license,
+                        publishInfo,
+                        downloadSnippets: undefined
+                    })
+                );
+            case "push":
+                return FernFiddle.remoteGen.OutputMode.githubV2(
+                    FernFiddle.GithubOutputModeV2.push({
+                        owner: repository.owner,
+                        repo: repository.repo,
+                        branch: git.branch,
+                        license,
+                        publishInfo,
+                        downloadSnippets: undefined
+                    })
+                );
+            default:
+                assertNever(mode);
+        }
+    }
+
+    private async buildGitSelfHostedOutputMode({
+        target,
+        git
+    }: {
+        target: Target;
+        git: schemas.GitSelfHostedOutputSchema;
+    }): Promise<FernFiddle.OutputMode.GithubV2> {
+        const repository = parseRepository(git.uri);
+        const license = git.license != null ? await this.convertLicense(git.license) : undefined;
+        const publishInfo = target.publish != null ? this.buildPublishInfo(target.publish) : undefined;
+        const mode = git.mode ?? "pr";
+        switch (mode) {
+            case "pr":
+                return FernFiddle.remoteGen.OutputMode.githubV2(
+                    FernFiddle.GithubOutputModeV2.pullRequest({
+                        owner: repository.owner,
+                        repo: repository.repo,
+                        branch: git.branch,
+                        license,
+                        publishInfo
+                    })
+                );
+            case "push":
+                return FernFiddle.remoteGen.OutputMode.githubV2(
+                    FernFiddle.GithubOutputModeV2.push({
+                        owner: repository.owner,
+                        repo: repository.repo,
+                        branch: git.branch,
+                        license,
+                        publishInfo
+                    })
+                );
+            default:
+                assertNever(mode);
+        }
     }
 
     private buildPublishInfo(publish: schemas.PublishSchema): FernFiddle.GithubPublishInfo | undefined {

--- a/packages/cli/cli-v2/src/sdk/config/Target.ts
+++ b/packages/cli/cli-v2/src/sdk/config/Target.ts
@@ -1,4 +1,5 @@
 import { schemas } from "@fern-api/config";
+import type { SourceLocation } from "@fern-api/source";
 import type { Language } from "./Language.js";
 
 export interface Target {
@@ -12,6 +13,8 @@ export interface Target {
     lang: Language;
     /** SDK version to generate */
     version: string;
+    /** Source location of this target in fern.yml (for error reporting) */
+    sourceLocation: SourceLocation;
     /** Output configuration for local/git publishing */
     output: schemas.OutputSchema;
     /** Target-specific configuration */

--- a/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
+++ b/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
@@ -129,6 +129,7 @@ export class SdkConfigConverter {
             image: generatorInfo.image,
             version: generatorInfo.version,
             api: this.resolveApi({ api: target.api }),
+            sourceLocation: sourced.$loc,
             config: target.config != null ? this.convertConfig(target.config) : undefined,
             output: target.output,
             publish: target.publish,

--- a/packages/cli/cli-v2/src/sdk/generator/GeneratorPipeline.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/GeneratorPipeline.ts
@@ -1,4 +1,5 @@
 import type { FernToken } from "@fern-api/auth";
+import { schemas } from "@fern-api/config";
 import type { Audiences } from "@fern-api/configuration";
 import type { ContainerRunner } from "@fern-api/core-utils";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
@@ -107,7 +108,7 @@ export class GeneratorPipeline {
      */
     public async run(args: GeneratorPipeline.RunArgs): Promise<GeneratorPipeline.Result> {
         try {
-            if (args.runtime === "local") {
+            if (this.isLocalGeneration(args)) {
                 return await this.runLocalGeneration(args);
             }
             return await this.runRemoteGeneration(args);
@@ -137,7 +138,8 @@ export class GeneratorPipeline {
             keepContainer: args.keepContainer,
             preview: args.preview,
             outputPath: args.outputPath,
-            containerEngine: args.containerEngine
+            containerEngine: args.containerEngine,
+            token: args.token
         });
         if (!result.success) {
             return {
@@ -187,5 +189,12 @@ export class GeneratorPipeline {
             target: args.target,
             output: result.output
         };
+    }
+
+    private isLocalGeneration(args: GeneratorPipeline.RunArgs): boolean {
+        return (
+            args.runtime === "local" ||
+            (args.target.output.git != null && schemas.isGitOutputSelfHosted(args.target.output.git))
+        );
     }
 }

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyGenerationRunner.ts
@@ -1,9 +1,16 @@
+import type { FernWorkspace } from "@fern-api/api-workspace-commons";
+import type { FernToken } from "@fern-api/auth";
+import { schemas } from "@fern-api/config";
 import type { Audiences } from "@fern-api/configuration";
-import { generatorsYml, SNIPPET_JSON_FILENAME } from "@fern-api/configuration";
+import { fernConfigJson, generatorsYml, SNIPPET_JSON_FILENAME } from "@fern-api/configuration";
 import type { ContainerRunner } from "@fern-api/core-utils";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
-import { ContainerExecutionEnvironment, GenerationRunner } from "@fern-api/local-workspace-runner";
+import {
+    ContainerExecutionEnvironment,
+    GenerationRunner,
+    runLocalGenerationForWorkspace
+} from "@fern-api/local-workspace-runner";
 import { TaskResult } from "@fern-api/task-context";
 import { rm } from "fs/promises";
 import type { AiConfig } from "../../ai/config/AiConfig.js";
@@ -60,6 +67,9 @@ export namespace LegacyGenerationRunner {
 
         /** Version override for the generated SDK */
         version?: string;
+
+        /** Authentication token (required for self-hosted git generation) */
+        token?: FernToken;
     }
 
     export interface Result {
@@ -95,14 +105,6 @@ export class LegacyGenerationRunner {
                 generators: [generatorInvocation],
                 reviewers: undefined
             };
-
-            const containerImage = `${args.target.image}:${args.target.version}`;
-            const executionEnvironment = new ContainerExecutionEnvironment({
-                containerImage,
-                keepContainer: args.keepContainer ?? false,
-                runner: args.containerEngine
-            });
-
             const workspaceAdapter = new LegacyFernWorkspaceAdapter({
                 context: this.context,
                 cliVersion: this.cliVersion,
@@ -110,50 +112,135 @@ export class LegacyGenerationRunner {
             });
             const fernWorkspace = await workspaceAdapter.adapt(args.apiDefinition);
 
-            const runner = new GenerationRunner(executionEnvironment);
-            await runner.run({
-                organization: args.organization,
-                workspace: fernWorkspace,
+            if (args.target.output.git != null && schemas.isGitOutputSelfHosted(args.target.output.git)) {
+                return await this.runSelfHostedGeneration({
+                    args,
+                    taskContext,
+                    fernWorkspace,
+                    generatorGroup
+                });
+            }
+
+            return await this.runLocalGeneration({
+                args,
+                taskContext,
+                fernWorkspace,
                 generatorGroup,
-                context: taskContext,
-                outputVersionOverride: args.version,
-                ai: args.ai,
-                absolutePathToFernConfig: undefined,
-                irVersionOverride: undefined,
-                shouldGenerateDynamicSnippetTests: false,
-                skipUnstableDynamicSnippetTests: true,
-                inspect: false
+                generatorInvocation
             });
-
-            if (args.target.output.path != null && generatorInvocation.absolutePathToLocalOutput != null) {
-                // The local generator runner always writes snippet.json to the
-                // output directory. Remove it so that the user receives a clean
-                // full-project repository.
-                //
-                // TODO: Is this a bug in the local generator? Can we patch this
-                // in the @fern-api/local-generation package?
-                const snippetPath = join(
-                    generatorInvocation.absolutePathToLocalOutput,
-                    RelativeFilePath.of(SNIPPET_JSON_FILENAME)
-                );
-                await rm(snippetPath, { force: true });
-            }
-
-            if (taskContext.getResult() === TaskResult.Failure) {
-                return {
-                    success: false
-                };
-            }
-
-            return {
-                success: true,
-                output: this.context.resolveTargetOutputs(args.target)
-            };
         } catch (error) {
             return {
                 success: false,
                 error: error instanceof Error ? error.message : String(error)
             };
         }
+    }
+
+    private async runSelfHostedGeneration({
+        args,
+        taskContext,
+        fernWorkspace,
+        generatorGroup
+    }: {
+        args: LegacyGenerationRunner.RunArgs;
+        taskContext: TaskContextAdapter;
+        fernWorkspace: FernWorkspace;
+        generatorGroup: generatorsYml.GeneratorGroup;
+    }): Promise<LegacyGenerationRunner.Result> {
+        const projectConfig: fernConfigJson.ProjectConfig = {
+            _absolutePath: join(this.context.cwd, RelativeFilePath.of("fern.config.json")),
+            rawConfig: {
+                organization: args.organization,
+                version: this.cliVersion
+            },
+            organization: args.organization,
+            version: this.cliVersion
+        };
+
+        await runLocalGenerationForWorkspace({
+            token: args.token,
+            projectConfig,
+            workspace: fernWorkspace,
+            generatorGroup,
+            version: args.version,
+            keepDocker: args.keepContainer ?? false,
+            context: taskContext,
+            runner: args.containerEngine,
+            absolutePathToPreview: undefined,
+            inspect: false,
+            ai: undefined
+        });
+
+        if (taskContext.getResult() === TaskResult.Failure) {
+            return {
+                success: false
+            };
+        }
+
+        return {
+            success: true,
+            output: this.context.resolveTargetOutputs(args.target)
+        };
+    }
+
+    private async runLocalGeneration({
+        args,
+        taskContext,
+        fernWorkspace,
+        generatorGroup,
+        generatorInvocation
+    }: {
+        args: LegacyGenerationRunner.RunArgs;
+        taskContext: TaskContextAdapter;
+        fernWorkspace: FernWorkspace;
+        generatorGroup: generatorsYml.GeneratorGroup;
+        generatorInvocation: generatorsYml.GeneratorInvocation;
+    }): Promise<LegacyGenerationRunner.Result> {
+        const containerImage = `${args.target.image}:${args.target.version}`;
+        const executionEnvironment = new ContainerExecutionEnvironment({
+            containerImage,
+            keepContainer: args.keepContainer ?? false,
+            runner: args.containerEngine
+        });
+
+        const runner = new GenerationRunner(executionEnvironment);
+        await runner.run({
+            organization: args.organization,
+            workspace: fernWorkspace,
+            generatorGroup,
+            context: taskContext,
+            outputVersionOverride: args.version,
+            ai: args.ai,
+            absolutePathToFernConfig: undefined,
+            irVersionOverride: undefined,
+            shouldGenerateDynamicSnippetTests: false,
+            skipUnstableDynamicSnippetTests: true,
+            inspect: false
+        });
+
+        if (args.target.output.path != null && generatorInvocation.absolutePathToLocalOutput != null) {
+            // The local generator runner always writes snippet.json to the
+            // output directory. Remove it so that the user receives a clean
+            // full-project repository.
+            //
+            // TODO: Is this a bug in the local generator? Can we patch this
+            // in the @fern-api/local-generation package?
+            const snippetPath = join(
+                generatorInvocation.absolutePathToLocalOutput,
+                RelativeFilePath.of(SNIPPET_JSON_FILENAME)
+            );
+            await rm(snippetPath, { force: true });
+        }
+
+        if (taskContext.getResult() === TaskResult.Failure) {
+            return {
+                success: false
+            };
+        }
+
+        return {
+            success: true,
+            output: this.context.resolveTargetOutputs(args.target)
+        };
     }
 }

--- a/packages/cli/config/src/schemas/GitHubOutputModeSchema.ts
+++ b/packages/cli/config/src/schemas/GitHubOutputModeSchema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const GitHubOutputModeSchema = z.enum(["pr", "release", "push"]);
+
+export type GitHubOutputModeSchema = z.infer<typeof GitHubOutputModeSchema>;

--- a/packages/cli/config/src/schemas/GitHubRepositoryOutputModeSchema.ts
+++ b/packages/cli/config/src/schemas/GitHubRepositoryOutputModeSchema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const GitHubRepositoryOutputModeSchema = z.enum(["pr", "release", "push"]);
+
+export type GitHubRepositoryOutputModeSchema = z.infer<typeof GitHubRepositoryOutputModeSchema>;

--- a/packages/cli/config/src/schemas/GitHubRepositoryOutputSchema.ts
+++ b/packages/cli/config/src/schemas/GitHubRepositoryOutputSchema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { GitHubRepositoryOutputModeSchema } from "./GitHubRepositoryOutputModeSchema.js";
+import { LicenseSchema } from "./LicenseSchema.js";
+import { ReviewersSchema } from "./ReviewersSchema.js";
+
+export const GitHubRepositoryOutputSchema = z
+    .object({
+        repository: z.string(),
+        mode: GitHubRepositoryOutputModeSchema.optional(),
+        branch: z.string().optional(),
+        license: LicenseSchema.optional(),
+        reviewers: ReviewersSchema.optional()
+    })
+    .strict();
+
+export type GitHubRepositoryOutputSchema = z.infer<typeof GitHubRepositoryOutputSchema>;

--- a/packages/cli/config/src/schemas/GitOutputModeSchema.ts
+++ b/packages/cli/config/src/schemas/GitOutputModeSchema.ts
@@ -1,5 +1,0 @@
-import { z } from "zod";
-
-export const GitOutputModeSchema = z.enum(["pr", "release", "push"]);
-
-export type GitOutputModeSchema = z.infer<typeof GitOutputModeSchema>;

--- a/packages/cli/config/src/schemas/GitOutputSchema.ts
+++ b/packages/cli/config/src/schemas/GitOutputSchema.ts
@@ -1,14 +1,15 @@
 import { z } from "zod";
-import { GitOutputModeSchema } from "./GitOutputModeSchema.js";
-import { LicenseSchema } from "./LicenseSchema.js";
-import { ReviewersSchema } from "./ReviewersSchema.js";
+import { GitHubRepositoryOutputSchema } from "./GitHubRepositoryOutputSchema.js";
+import { GitSelfHostedOutputSchema } from "./GitSelfHostedOutputSchema.js";
 
-export const GitOutputSchema = z.object({
-    repository: z.string(),
-    mode: GitOutputModeSchema.optional(),
-    branch: z.string().optional(),
-    license: LicenseSchema.optional(),
-    reviewers: ReviewersSchema.optional()
-});
+export const GitOutputSchema = z.union([GitSelfHostedOutputSchema, GitHubRepositoryOutputSchema]);
 
 export type GitOutputSchema = z.infer<typeof GitOutputSchema>;
+
+export function isGitOutputSelfHosted(git: GitOutputSchema): git is GitSelfHostedOutputSchema {
+    return "uri" in git;
+}
+
+export function isGitOutputGitHubRepository(git: GitOutputSchema): git is GitHubRepositoryOutputSchema {
+    return "repository" in git;
+}

--- a/packages/cli/config/src/schemas/GitSelfHostedOutputModeSchema.ts
+++ b/packages/cli/config/src/schemas/GitSelfHostedOutputModeSchema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const GitSelfHostedOutputModeSchema = z.enum(["pr", "push"]);
+
+export type GitSelfHostedOutputModeSchema = z.infer<typeof GitSelfHostedOutputModeSchema>;

--- a/packages/cli/config/src/schemas/GitSelfHostedOutputSchema.ts
+++ b/packages/cli/config/src/schemas/GitSelfHostedOutputSchema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { GitSelfHostedOutputModeSchema } from "./GitSelfHostedOutputModeSchema.js";
+import { LicenseSchema } from "./LicenseSchema.js";
+
+export const GitSelfHostedOutputSchema = z
+    .object({
+        uri: z.string(),
+        token: z.string(),
+        mode: GitSelfHostedOutputModeSchema.optional(),
+        branch: z.string().optional(),
+        license: LicenseSchema.optional()
+    })
+    .strict();
+
+export type GitSelfHostedOutputSchema = z.infer<typeof GitSelfHostedOutputSchema>;

--- a/packages/cli/config/src/schemas/index.ts
+++ b/packages/cli/config/src/schemas/index.ts
@@ -15,8 +15,12 @@ export {
     FernRcCacheSchema,
     FernRcSchema
 } from "./fernrc/index.js";
-export { GitOutputModeSchema } from "./GitOutputModeSchema.js";
-export { GitOutputSchema } from "./GitOutputSchema.js";
+export { GitHubOutputModeSchema } from "./GitHubOutputModeSchema.js";
+export { GitHubRepositoryOutputModeSchema } from "./GitHubRepositoryOutputModeSchema.js";
+export { GitHubRepositoryOutputSchema } from "./GitHubRepositoryOutputSchema.js";
+export { GitOutputSchema, isGitOutputGitHubRepository, isGitOutputSelfHosted } from "./GitOutputSchema.js";
+export { GitSelfHostedOutputModeSchema } from "./GitSelfHostedOutputModeSchema.js";
+export { GitSelfHostedOutputSchema } from "./GitSelfHostedOutputSchema.js";
 export { HeaderConfigSchema } from "./HeaderConfigSchema.js";
 export { HeaderSchema } from "./HeaderSchema.js";
 export { isWellKnownLicense, LicenseSchema } from "./LicenseSchema.js";

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -99,7 +99,7 @@ export async function runLocalGenerationForWorkspace({
                 const venus = createVenusService({ token: token?.value });
 
                 if (generatorInvocation.absolutePathToLocalOutput == null) {
-                    token = await getAccessToken();
+                    token ??= await getAccessToken();
                     if (token == null) {
                         interactiveTaskContext.failWithoutThrowing("Please provide a FERN_TOKEN in your environment.");
                         return;

--- a/packages/cli/yaml/loader/src/ValidationIssue.ts
+++ b/packages/cli/yaml/loader/src/ValidationIssue.ts
@@ -12,19 +12,24 @@ export class ValidationIssue {
     public readonly location: SourceLocation;
     /** The path to the value in the YAML document (e.g., ["cli", "version"]) */
     public readonly yamlPath?: ReadonlyArray<string | number>;
+    /** The suggestion to remediate the issue, if any */
+    public readonly suggestion?: string;
 
     constructor({
         message,
         location,
-        yamlPath
+        yamlPath,
+        suggestion
     }: {
         message: string;
         location: SourceLocation;
         yamlPath?: ReadonlyArray<string | number>;
+        suggestion?: string;
     }) {
         this.message = message;
         this.location = location;
         this.yamlPath = yamlPath;
+        this.suggestion = suggestion;
     }
 
     /**
@@ -36,6 +41,16 @@ export class ValidationIssue {
      * ```
      */
     public toString(): string {
-        return `${this.location}: ${this.message}`;
+        if (this.suggestion == null) {
+            return `${this.location}: ${this.message}`;
+        }
+        return `${this.location}: ${this.message}\n${this.indentBlock(this.suggestion)}`;
+    }
+
+    private indentBlock(text: string, indent: string = "  "): string {
+        return text
+            .split("\n")
+            .map((line) => (line.length > 0 ? `${indent}${line}` : line))
+            .join("\n");
     }
 }


### PR DESCRIPTION
## Description

This ports over the self-hosted `git` output mode to `@fern-api/cli-v2`. With this, users can now specify a `fern.yml` like the following:

```yaml
org: amckinney
api:
  specs:
    - openapi: ./openapi/openapi.yml
sdks:
  targets:
    go:
      output:
        git:
          uri: https://github.com/amckinney/web
          token: ${GITHUB_TOKEN}
      group:
        - prod

    python:
      output:
        git:
          repository: fern-demo/imdb-typescript
      group:
        - prod

    php:
      output:
        path: ./sdks/php
        git:
          repository: acme/acme-php
      group:
        - prod
```

```sh
$ GITHUB_TOKEN=<redacted> fern sdk generate --group prod

◆ Generating SDKs
  org: amckinney

┌─
│ ✓ go 6.7s
│     ✓ Validated API
│     ✓ Generator completed
│     ✓ Created pull request
│     → https://github.com/amckinney/web
│ ✓ python 20.1s
│     ✓ Validated API
│     ✓ Generator completed
│     ✓ Created pull request
│     → https://github.com/fern-demo/imdb-typescript/pull/44
│ ✓ php 12.3s
│     ✓ Validated API
│     ✓ Generator completed
│     ✓ Wrote output
│     → /Users/alex/code/playground/sdks/php
└─

✓ Successfully generated SDKs in 20.1s

Logs written to: /Users/alex/.cache/fern/v1/logs/2026-02-11T22-22-32-820Z.log
```

This also improves our error reporting so that we actually provide the user with actionable remediation steps. For example, if `--local` is specified for a remote generation configuration like the one specified for `python` above:

```sh
$ GITHUB_TOKEN=<redacted> fern sdk generate --group prod
fern.yml:17:7: Target 'python' is incompatible with --local mode.
  Use remote generation (without --local) or configure the target with 'uri' and 'token' instead of 'repository'.

  Example:
    python:
      output:
        git:
          uri: https://github.com/fern-demo/imdb-typescript
          token: ${GIT_TOKEN}
```

## Changes Made
- Fix a small organization membership check used to confirm when a new organization needs to be created.
- Add the `GitSelfHostedOutputSchema.ts`, which is largely based on the original.
- Add a new `suggestion` field to the `ValidationIssue` type to encourage better error messages (shown above).

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
