### PR TITLE
fix(python): add transport-error retry handling for ConnectError and TimeoutException

### DIFF
--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -329,7 +329,11 @@ class HttpClient:
                         {
                             **self.base_headers(),
                             **(headers if headers is not None else {}),
-                            **(request_options.get("additional_headers", {}) or {} if request_options is not None else {}),
+                            **(
+                                request_options.get("additional_headers", {}) or {}
+                                if request_options is not None
+                                else {}
+                            ),
                         }
                     )
                 ),
@@ -593,7 +597,11 @@ class AsyncHttpClient:
                         {
                             **_headers,
                             **(headers if headers is not None else {}),
-                            **(request_options.get("additional_headers", {}) or {} if request_options is not None else {}),
+                            **(
+                                request_options.get("additional_headers", {}) or {}
+                                if request_options is not None
+                                else {}
+                            ),
                         }
                     )
                 ),

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -120,6 +120,11 @@ def _should_retry(response: httpx.Response) -> bool:
     return response.status_code >= 500 or response.status_code in retryable_400s
 
 
+def _retry_timeout_for_transport_error(retries: int) -> float:
+    backoff = min(INITIAL_RETRY_DELAY_SECONDS * pow(2.0, retries), MAX_RETRY_DELAY_SECONDS)
+    return _add_symmetric_jitter(backoff)
+
+
 def _build_url(base_url: str, path: typing.Optional[str]) -> str:
     """
     Build a full URL by joining a base URL with a path.
@@ -313,27 +318,46 @@ class HttpClient:
             )
         )
 
-        response = self.httpx_client.request(
-            method=method,
-            url=_build_url(base_url, path),
-            headers=jsonable_encoder(
-                remove_none_from_dict(
-                    {
-                        **self.base_headers(),
-                        **(headers if headers is not None else {}),
-                        **(request_options.get("additional_headers", {}) or {} if request_options is not None else {}),
-                    }
-                )
-            ),
-            params=_encoded_params if _encoded_params else None,
-            json=json_body,
-            data=data_body,
-            content=content,
-            files=request_files,
-            timeout=timeout,
-        )
-
         max_retries: int = request_options.get("max_retries", 2) if request_options is not None else 2
+
+        try:
+            response = self.httpx_client.request(
+                method=method,
+                url=_build_url(base_url, path),
+                headers=jsonable_encoder(
+                    remove_none_from_dict(
+                        {
+                            **self.base_headers(),
+                            **(headers if headers is not None else {}),
+                            **(request_options.get("additional_headers", {}) or {} if request_options is not None else {}),
+                        }
+                    )
+                ),
+                params=_encoded_params if _encoded_params else None,
+                json=json_body,
+                data=data_body,
+                content=content,
+                files=request_files,
+                timeout=timeout,
+            )
+        except (httpx.ConnectError, httpx.TimeoutException):
+            if retries < max_retries:
+                time.sleep(_retry_timeout_for_transport_error(retries=retries))
+                return self.request(
+                    path=path,
+                    method=method,
+                    base_url=base_url,
+                    params=params,
+                    json=json,
+                    content=content,
+                    files=files,
+                    headers=headers,
+                    request_options=request_options,
+                    retries=retries + 1,
+                    omit=omit,
+                )
+            raise
+
         if _should_retry(response=response):
             if retries < max_retries:
                 time.sleep(_retry_timeout(response=response, retries=retries))
@@ -416,26 +440,51 @@ class HttpClient:
             )
         )
 
-        with self.httpx_client.stream(
-            method=method,
-            url=_build_url(base_url, path),
-            headers=jsonable_encoder(
-                remove_none_from_dict(
-                    {
-                        **self.base_headers(),
-                        **(headers if headers is not None else {}),
-                        **(request_options.get("additional_headers", {}) if request_options is not None else {}),
-                    }
-                )
-            ),
-            params=_encoded_params if _encoded_params else None,
-            json=json_body,
-            data=data_body,
-            content=content,
-            files=request_files,
-            timeout=timeout,
-        ) as stream:
-            yield stream
+        max_retries: int = request_options.get("max_retries", 2) if request_options is not None else 2
+
+        response_started = False
+        try:
+            with self.httpx_client.stream(
+                method=method,
+                url=_build_url(base_url, path),
+                headers=jsonable_encoder(
+                    remove_none_from_dict(
+                        {
+                            **self.base_headers(),
+                            **(headers if headers is not None else {}),
+                            **(request_options.get("additional_headers", {}) if request_options is not None else {}),
+                        }
+                    )
+                ),
+                params=_encoded_params if _encoded_params else None,
+                json=json_body,
+                data=data_body,
+                content=content,
+                files=request_files,
+                timeout=timeout,
+            ) as stream:
+                response_started = True
+                yield stream
+        except (httpx.ConnectError, httpx.TimeoutException):
+            if response_started or retries >= max_retries:
+                raise
+            time.sleep(_retry_timeout_for_transport_error(retries=retries))
+            with self.stream(
+                path=path,
+                method=method,
+                base_url=base_url,
+                params=params,
+                json=json,
+                data=data,
+                content=content,
+                files=files,
+                headers=headers,
+                request_options=request_options,
+                retries=retries + 1,
+                omit=omit,
+                force_multipart=force_multipart,
+            ) as retried_stream:
+                yield retried_stream
 
 
 class AsyncHttpClient:
@@ -533,28 +582,46 @@ class AsyncHttpClient:
             )
         )
 
-        # Add the input to each of these and do None-safety checks
-        response = await self.httpx_client.request(
-            method=method,
-            url=_build_url(base_url, path),
-            headers=jsonable_encoder(
-                remove_none_from_dict(
-                    {
-                        **_headers,
-                        **(headers if headers is not None else {}),
-                        **(request_options.get("additional_headers", {}) or {} if request_options is not None else {}),
-                    }
-                )
-            ),
-            params=_encoded_params if _encoded_params else None,
-            json=json_body,
-            data=data_body,
-            content=content,
-            files=request_files,
-            timeout=timeout,
-        )
-
         max_retries: int = request_options.get("max_retries", 2) if request_options is not None else 2
+
+        try:
+            response = await self.httpx_client.request(
+                method=method,
+                url=_build_url(base_url, path),
+                headers=jsonable_encoder(
+                    remove_none_from_dict(
+                        {
+                            **_headers,
+                            **(headers if headers is not None else {}),
+                            **(request_options.get("additional_headers", {}) or {} if request_options is not None else {}),
+                        }
+                    )
+                ),
+                params=_encoded_params if _encoded_params else None,
+                json=json_body,
+                data=data_body,
+                content=content,
+                files=request_files,
+                timeout=timeout,
+            )
+        except (httpx.ConnectError, httpx.TimeoutException):
+            if retries < max_retries:
+                await asyncio.sleep(_retry_timeout_for_transport_error(retries=retries))
+                return await self.request(
+                    path=path,
+                    method=method,
+                    base_url=base_url,
+                    params=params,
+                    json=json,
+                    content=content,
+                    files=files,
+                    headers=headers,
+                    request_options=request_options,
+                    retries=retries + 1,
+                    omit=omit,
+                )
+            raise
+
         if _should_retry(response=response):
             if retries < max_retries:
                 await asyncio.sleep(_retry_timeout(response=response, retries=retries))
@@ -639,23 +706,48 @@ class AsyncHttpClient:
             )
         )
 
-        async with self.httpx_client.stream(
-            method=method,
-            url=_build_url(base_url, path),
-            headers=jsonable_encoder(
-                remove_none_from_dict(
-                    {
-                        **_headers,
-                        **(headers if headers is not None else {}),
-                        **(request_options.get("additional_headers", {}) if request_options is not None else {}),
-                    }
-                )
-            ),
-            params=_encoded_params if _encoded_params else None,
-            json=json_body,
-            data=data_body,
-            content=content,
-            files=request_files,
-            timeout=timeout,
-        ) as stream:
-            yield stream
+        max_retries: int = request_options.get("max_retries", 2) if request_options is not None else 2
+
+        response_started = False
+        try:
+            async with self.httpx_client.stream(
+                method=method,
+                url=_build_url(base_url, path),
+                headers=jsonable_encoder(
+                    remove_none_from_dict(
+                        {
+                            **_headers,
+                            **(headers if headers is not None else {}),
+                            **(request_options.get("additional_headers", {}) if request_options is not None else {}),
+                        }
+                    )
+                ),
+                params=_encoded_params if _encoded_params else None,
+                json=json_body,
+                data=data_body,
+                content=content,
+                files=request_files,
+                timeout=timeout,
+            ) as stream:
+                response_started = True
+                yield stream
+        except (httpx.ConnectError, httpx.TimeoutException):
+            if response_started or retries >= max_retries:
+                raise
+            await asyncio.sleep(_retry_timeout_for_transport_error(retries=retries))
+            async with self.stream(
+                path=path,
+                method=method,
+                base_url=base_url,
+                params=params,
+                json=json,
+                data=data,
+                content=content,
+                files=files,
+                headers=headers,
+                request_options=request_options,
+                retries=retries + 1,
+                omit=omit,
+                force_multipart=force_multipart,
+            ) as retried_stream:
+                yield retried_stream

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.56.1
+  changelogEntry:
+    - summary: |
+        Add transport-error retry handling for `httpx.ConnectError` and `httpx.TimeoutException`.
+        Both `request()` and `stream()` methods (sync and async) now retry on connection failures
+        and timeouts using exponential backoff, matching the idiomatic pattern used by OpenAI and
+        other major SDKs. Previously, transport-level exceptions bypassed retry logic entirely.
+      type: fix
+  createdAt: "2026-02-11"
+  irVersion: 65
+
 - version: 4.56.0
   changelogEntry:
     - summary: |

--- a/generators/python/tests/utils/test_http_client.py
+++ b/generators/python/tests/utils/test_http_client.py
@@ -1,5 +1,8 @@
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any, Dict
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from core_utilities.shared.http_client import (
@@ -296,3 +299,163 @@ def test_preserves_base_url_path_prefix_trailing_slash() -> None:
     """Test that path prefixes in base URL are preserved."""
     result = _build_url("https://cloud.example.com/org/tenant/api/", "/users")
     assert result == "https://cloud.example.com/org/tenant/api/users"
+
+
+class _ConnectErrorSyncClient:
+    def __init__(self, fail_count: int) -> None:
+        self.fail_count = fail_count
+        self.attempt = 0
+
+    def request(self, **kwargs: Any) -> _DummyResponse:
+        self.attempt += 1
+        if self.attempt <= self.fail_count:
+            raise httpx.ConnectError("All connection attempts failed")
+        return _DummyResponse()
+
+    @contextmanager
+    def stream(self, **kwargs: Any):
+        self.attempt += 1
+        if self.attempt <= self.fail_count:
+            raise httpx.ConnectError("All connection attempts failed")
+        yield _DummyResponse()
+
+
+class _ConnectErrorAsyncClient:
+    def __init__(self, fail_count: int) -> None:
+        self.fail_count = fail_count
+        self.attempt = 0
+
+    async def request(self, **kwargs: Any) -> _DummyResponse:
+        self.attempt += 1
+        if self.attempt <= self.fail_count:
+            raise httpx.ConnectError("All connection attempts failed")
+        return _DummyResponse()
+
+    @asynccontextmanager
+    async def stream(self, **kwargs: Any):
+        self.attempt += 1
+        if self.attempt <= self.fail_count:
+            raise httpx.ConnectError("All connection attempts failed")
+        yield _DummyResponse()
+
+
+@patch("core_utilities.shared.http_client._retry_timeout_for_transport_error", return_value=0.0)
+def test_sync_request_retries_on_connect_error(mock_timeout: MagicMock) -> None:
+    dummy_client = _ConnectErrorSyncClient(fail_count=1)
+    http_client = HttpClient(
+        httpx_client=dummy_client,  # type: ignore[arg-type]
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+    )
+    response = http_client.request(path="/test", method="GET", request_options={"max_retries": 2})
+    assert response.status_code == 200
+    assert dummy_client.attempt == 2
+
+
+@patch("core_utilities.shared.http_client._retry_timeout_for_transport_error", return_value=0.0)
+def test_sync_request_raises_after_max_retries(mock_timeout: MagicMock) -> None:
+    dummy_client = _ConnectErrorSyncClient(fail_count=10)
+    http_client = HttpClient(
+        httpx_client=dummy_client,  # type: ignore[arg-type]
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+    )
+    with pytest.raises(httpx.ConnectError):
+        http_client.request(path="/test", method="GET", request_options={"max_retries": 2})
+    assert dummy_client.attempt == 3
+
+
+@patch("core_utilities.shared.http_client._retry_timeout_for_transport_error", return_value=0.0)
+def test_sync_stream_retries_on_connect_error(mock_timeout: MagicMock) -> None:
+    dummy_client = _ConnectErrorSyncClient(fail_count=1)
+    http_client = HttpClient(
+        httpx_client=dummy_client,  # type: ignore[arg-type]
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+    )
+    with http_client.stream(path="/test", method="GET", request_options={"max_retries": 2}) as response:
+        assert response.status_code == 200
+    assert dummy_client.attempt == 2
+
+
+@patch("core_utilities.shared.http_client._retry_timeout_for_transport_error", return_value=0.0)
+def test_sync_stream_raises_after_max_retries(mock_timeout: MagicMock) -> None:
+    dummy_client = _ConnectErrorSyncClient(fail_count=10)
+    http_client = HttpClient(
+        httpx_client=dummy_client,  # type: ignore[arg-type]
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+    )
+    with pytest.raises(httpx.ConnectError):
+        with http_client.stream(path="/test", method="GET", request_options={"max_retries": 2}) as response:
+            pass
+    assert dummy_client.attempt == 3
+
+
+@pytest.mark.asyncio
+@patch("core_utilities.shared.http_client._retry_timeout_for_transport_error", return_value=0.0)
+async def test_async_request_retries_on_connect_error(mock_timeout: MagicMock) -> None:
+    dummy_client = _ConnectErrorAsyncClient(fail_count=1)
+    http_client = AsyncHttpClient(
+        httpx_client=dummy_client,  # type: ignore[arg-type]
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        async_base_headers=None,
+    )
+    response = await http_client.request(path="/test", method="GET", request_options={"max_retries": 2})
+    assert response.status_code == 200
+    assert dummy_client.attempt == 2
+
+
+@pytest.mark.asyncio
+@patch("core_utilities.shared.http_client._retry_timeout_for_transport_error", return_value=0.0)
+async def test_async_request_raises_after_max_retries(mock_timeout: MagicMock) -> None:
+    dummy_client = _ConnectErrorAsyncClient(fail_count=10)
+    http_client = AsyncHttpClient(
+        httpx_client=dummy_client,  # type: ignore[arg-type]
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        async_base_headers=None,
+    )
+    with pytest.raises(httpx.ConnectError):
+        await http_client.request(path="/test", method="GET", request_options={"max_retries": 2})
+    assert dummy_client.attempt == 3
+
+
+@pytest.mark.asyncio
+@patch("core_utilities.shared.http_client._retry_timeout_for_transport_error", return_value=0.0)
+async def test_async_stream_retries_on_connect_error(mock_timeout: MagicMock) -> None:
+    dummy_client = _ConnectErrorAsyncClient(fail_count=1)
+    http_client = AsyncHttpClient(
+        httpx_client=dummy_client,  # type: ignore[arg-type]
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        async_base_headers=None,
+    )
+    async with http_client.stream(path="/test", method="GET", request_options={"max_retries": 2}) as response:
+        assert response.status_code == 200
+    assert dummy_client.attempt == 2
+
+
+@pytest.mark.asyncio
+@patch("core_utilities.shared.http_client._retry_timeout_for_transport_error", return_value=0.0)
+async def test_async_stream_raises_after_max_retries(mock_timeout: MagicMock) -> None:
+    dummy_client = _ConnectErrorAsyncClient(fail_count=10)
+    http_client = AsyncHttpClient(
+        httpx_client=dummy_client,  # type: ignore[arg-type]
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        async_base_headers=None,
+    )
+    with pytest.raises(httpx.ConnectError):
+        async with http_client.stream(path="/test", method="GET", request_options={"max_retries": 2}) as response:
+            pass
+    assert dummy_client.attempt == 3

--- a/generators/python/tests/utils/test_http_client.py
+++ b/generators/python/tests/utils/test_http_client.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, Dict
+from typing import Any, AsyncIterator, Dict, Iterator
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -313,7 +313,7 @@ class _ConnectErrorSyncClient:
         return _DummyResponse()
 
     @contextmanager
-    def stream(self, **kwargs: Any):
+    def stream(self, **kwargs: Any) -> Iterator[_DummyResponse]:
         self.attempt += 1
         if self.attempt <= self.fail_count:
             raise httpx.ConnectError("All connection attempts failed")
@@ -332,7 +332,7 @@ class _ConnectErrorAsyncClient:
         return _DummyResponse()
 
     @asynccontextmanager
-    async def stream(self, **kwargs: Any):
+    async def stream(self, **kwargs: Any) -> AsyncIterator[_DummyResponse]:
         self.attempt += 1
         if self.attempt <= self.fail_count:
             raise httpx.ConnectError("All connection attempts failed")


### PR DESCRIPTION
## Description

Refs: Reported by Andrew Berneshawi (Cohere SDK user) — `httpx.ConnectError: All connection attempts failed` during streaming calls with zero retry.

Previously, Fern-generated Python SDKs only retried on HTTP status codes (429, 408, 409, 5xx). Transport-level exceptions like `httpx.ConnectError` and `httpx.TimeoutException` — which are thrown *before* a response object exists — bypassed retry logic entirely. This matches the idiomatic pattern used by OpenAI, Anthropic, and other Stainless-generated SDKs.

Link to Devin run: https://app.devin.ai/sessions/90e48004e93a46d48859b6f35a4f8a80
Requested by: @tjb9dc

## Changes Made

- Added `_retry_timeout_for_transport_error()` helper — exponential backoff without response headers (since transport errors have no response)
- Wrapped `httpx_client.request()` calls in try/except for `(httpx.ConnectError, httpx.TimeoutException)` in both `HttpClient.request()` and `AsyncHttpClient.request()`
- Added retry logic to `HttpClient.stream()` and `AsyncHttpClient.stream()` using a `response_started` flag to distinguish connection-establishment failures from mid-stream errors
- Moved `max_retries` computation before the httpx call (was previously after) so it's available in the except block
- Added version `4.56.1` to `generators/python/sdk/versions.yml`
- [x] Unit tests added (8 new tests covering sync/async × request/stream × success-after-retry/exhaust-retries)
- [ ] Updated README.md generator (not applicable)

## Testing

- [x] Unit tests added/updated — 26/26 pass including 8 new transport-error retry tests
- [x] Ruff lint + ruff-format pass
- [x] mypy passes
- [x] All CI checks pass (seed tests for python-sdk, pydantic, fastapi all green)

## ⚠️ Reviewer checklist — key areas to verify

1. **Stream retry with recursive context managers** (`stream()` methods): Uses `response_started` flag + recursive `yield retried_stream` inside `except` of a `@contextmanager`/`@asynccontextmanager`. If the exception occurs *before* `yield stream`, the generator hasn't yielded yet, so `yield retried_stream` in the except block is the first (and only) yield. If the exception occurs *after* yield (mid-stream read), `response_started=True` causes immediate re-raise. Please verify this interaction is sound — this is the riskiest part of the change.

2. **Broad `httpx.TimeoutException` catch**: This catches `ReadTimeout`/`WriteTimeout` in addition to `ConnectTimeout`. For `request()` this is safe (atomic operation). For `stream()`, the `response_started` guard should prevent retrying mid-stream timeouts — worth confirming edge cases.

3. **Tests only exercise `httpx.ConnectError`**: The `httpx.TimeoutException` retry path is not directly tested. The code paths are symmetric, but worth noting.

4. **No `Retry-After` header support for transport errors**: `_retry_timeout_for_transport_error` uses pure exponential backoff since no response exists. This is intentional but differs from `_retry_timeout` which reads `Retry-After`.