### PR TITLE
fix(java): don't escape valid HTML tags in JavaDoc

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/utils/JavaDocUtils.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/utils/JavaDocUtils.java
@@ -2,6 +2,9 @@ package com.fern.java.utils;
 
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Paragraph;
 import org.commonmark.parser.Parser;
@@ -33,6 +36,82 @@ public final class JavaDocUtils {
             })
             .build();
 
+    // HTML tags that are safe to preserve in Javadoc comments.
+    // Reference: Checkstyle JavadocStyle allowed tags + common HTML5 additions.
+    // https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html
+    private static final Set<String> SAFE_JAVADOC_TAGS = Set.of(
+            // Inline formatting
+            "a",
+            "abbr",
+            "acronym",
+            "b",
+            "bdo",
+            "big",
+            "br",
+            "cite",
+            "code",
+            "dfn",
+            "em",
+            "font",
+            "i",
+            "ins",
+            "kbd",
+            "q",
+            "s",
+            "samp",
+            "small",
+            "span",
+            "strong",
+            "sub",
+            "sup",
+            "tt",
+            "u",
+            "var",
+            // Block formatting
+            "address",
+            "blockquote",
+            "del",
+            "div",
+            "fieldset",
+            "hr",
+            "p",
+            "pre",
+            // Lists
+            "dd",
+            "dl",
+            "dt",
+            "li",
+            "ol",
+            "ul",
+            // Tables
+            "area",
+            "caption",
+            "colgroup",
+            "table",
+            "tbody",
+            "td",
+            "tfoot",
+            "th",
+            "thead",
+            "tr",
+            // Headings
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            // Media
+            "img");
+
+    // Matches escaped HTML tags in CommonMark output: &lt;tagName attrs /&gt;
+    // Group 1: full tag opening (optional slash + tag name), e.g. "a" or "/a"
+    // Group 2: tag name only, e.g. "a"
+    // Group 3: attributes (may contain &quot; and other entities)
+    // Group 4: optional self-closing slash
+    private static final Pattern ESCAPED_TAG =
+            Pattern.compile("&lt;(/?([a-zA-Z][a-zA-Z0-9]*))((?:[^&]|&(?!gt;))*?)(/?)&gt;");
+
     public static String render(String docs) {
         return render(docs, false);
     }
@@ -45,7 +124,30 @@ public final class JavaDocUtils {
         String renderedHtml = excludeOuterParagraphTags
                 ? RENDERER_WITHOUT_OUTER_PARAGRAPH_TAGS.render(PARSER.parse(rawDocs))
                 : DEFAULT_RENDERER.render(PARSER.parse(rawDocs));
+        renderedHtml = unescapeSafeHtmlTags(renderedHtml);
         return StringUtils.appendIfMissing(renderedHtml, "\n").replaceAll("<br />", "");
+    }
+
+    /**
+     * After CommonMark renders with escapeHtml(true), all raw HTML from the source is escaped (e.g. &lt;a
+     * href=&quot;...&quot;&gt;). This method selectively un-escapes tags whose tag name is in
+     * {@link #SAFE_JAVADOC_TAGS}, since Javadoc natively supports standard HTML.
+     */
+    private static String unescapeSafeHtmlTags(String html) {
+        Matcher matcher = ESCAPED_TAG.matcher(html);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String tagName = matcher.group(2).toLowerCase();
+            if (SAFE_JAVADOC_TAGS.contains(tagName)) {
+                String attrs = matcher.group(3).replace("&quot;", "\"").replace("&amp;", "&");
+                String replacement = "<" + matcher.group(1) + attrs + matcher.group(4) + ">";
+                matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+            } else {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group(0)));
+            }
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     public static String getParameterJavadoc(String paramName, String docs) {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.35.1
+  changelogEntry:
+    - summary: |
+        Preserve valid HTML tags in Javadoc comments instead of escaping them. Tags like
+        `<a>`, `<code>`, `<p>`, `<pre>`, and other standard HTML tags from API descriptions
+        are now rendered as proper HTML in Javadoc, while standalone angle brackets (e.g.
+        comparisons, generics) remain escaped.
+      type: fix
+  createdAt: "2026-02-12"
+  irVersion: 63
+
 - version: 3.35.0
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/docs/types/ObjectWithDocs.java
@@ -60,8 +60,8 @@ public final class ObjectWithDocs {
    * <li>** /: Block comment end</li>
    * </ul>
    * <p>XMLDoc (C#) (Example of actual XML tags):
-   * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-   * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+   * See <a href="https://example.com/docs">the docs</a> for more info.
+   * Use <code>getValue()</code> to retrieve the value.
    * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
    * <p>Javadoc (Java):</p>
    * <ul>
@@ -167,8 +167,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -266,8 +266,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -336,8 +336,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -55,8 +55,8 @@ public final class ObjectWithDocs {
      * <li>** /: Block comment end</li>
      * </ul>
      * <p>XMLDoc (C#) (Example of actual XML tags):
-     * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-     * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+     * See <a href="https://example.com/docs">the docs</a> for more info.
+     * Use <code>getValue()</code> to retrieve the value.
      * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
      * <p>Javadoc (Java):</p>
      * <ul>
@@ -162,8 +162,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -258,8 +258,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>
@@ -328,8 +328,8 @@ public final class ObjectWithDocs {
          * <li>** /: Block comment end</li>
          * </ul>
          * <p>XMLDoc (C#) (Example of actual XML tags):
-         * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
-         * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
+         * See <a href="https://example.com/docs">the docs</a> for more info.
+         * Use <code>getValue()</code> to retrieve the value.
          * Note: when count &lt; 10 or count &gt; 100, special handling applies.</p>
          * <p>Javadoc (Java):</p>
          * <ul>


### PR DESCRIPTION
## Description
Rough equivalent of https://github.com/fern-api/fern/pull/11830 in Java. Some comments used to get quite mangled by the safe parsing:
```
   * See &lt;a href=&quot;https://example.com/docs&quot;&gt;the docs&lt;/a&gt; for more info.
   * Use &lt;code&gt;getValue()&lt;/code&gt; to retrieve the value.
   * Note: when count &lt; 10 or count &gt; 100, special handling applies.
```
Now they are unmangled specifically when they are valid HTML tags and not otherwise:
```
   * See <a href="https://example.com/docs">the docs</a> for more info.
   * Use <code>getValue()</code> to retrieve the value.
   * Note: when count &lt; 10 or count &gt; 100, special handling applies.
```

## Changes Made
To `JavaDocUtils.java`.

## Testing
Checked on `exhaustive`, which was already tweaked to check this kind of HTML handling for .NET.
- [X] Unit tests added/updated
- [X] Manual testing completed
