### PR TITLE
feat(java): add support for URI and path-based pagination

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/ir/model/http/Pagination.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/ir/model/http/Pagination.java
@@ -1,0 +1,376 @@
+package com.fern.ir.model.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.lang.Object;
+import java.lang.String;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class Pagination {
+    private final Value value;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    private Pagination(Value value) {
+        this.value = value;
+    }
+
+    public <T> T visit(Visitor<T> visitor) {
+        return value.visit(visitor);
+    }
+
+    public static Pagination cursor(CursorPagination value) {
+        return new Pagination(new CursorValue(value));
+    }
+
+    public static Pagination offset(OffsetPagination value) {
+        return new Pagination(new OffsetValue(value));
+    }
+
+    public static Pagination custom(CustomPagination value) {
+        return new Pagination(new CustomValue(value));
+    }
+
+    public static Pagination uri(UriPagination value) {
+        return new Pagination(new UriValue(value));
+    }
+
+    public static Pagination path(PathPagination value) {
+        return new Pagination(new PathValue(value));
+    }
+
+    public boolean isCursor() {
+        return value instanceof CursorValue;
+    }
+
+    public boolean isOffset() {
+        return value instanceof OffsetValue;
+    }
+
+    public boolean isCustom() {
+        return value instanceof CustomValue;
+    }
+
+    public boolean isUri() {
+        return value instanceof UriValue;
+    }
+
+    public boolean isPath() {
+        return value instanceof PathValue;
+    }
+
+    public boolean _isUnknown() {
+        return value instanceof _UnknownValue;
+    }
+
+    public Optional<CursorPagination> getCursor() {
+        if (isCursor()) {
+            return Optional.of(((CursorValue) value).value);
+        }
+        return Optional.empty();
+    }
+
+    public Optional<OffsetPagination> getOffset() {
+        if (isOffset()) {
+            return Optional.of(((OffsetValue) value).value);
+        }
+        return Optional.empty();
+    }
+
+    public Optional<CustomPagination> getCustom() {
+        if (isCustom()) {
+            return Optional.of(((CustomValue) value).value);
+        }
+        return Optional.empty();
+    }
+
+    public Optional<UriPagination> getUri() {
+        if (isUri()) {
+            return Optional.of(((UriValue) value).value);
+        }
+        return Optional.empty();
+    }
+
+    public Optional<PathPagination> getPath() {
+        if (isPath()) {
+            return Optional.of(((PathValue) value).value);
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Object> _getUnknown() {
+        if (_isUnknown()) {
+            return Optional.of(((_UnknownValue) value).value);
+        }
+        return Optional.empty();
+    }
+
+    @JsonValue
+    private Value getValue() {
+        return this.value;
+    }
+
+    public interface Visitor<T> {
+        T visitCursor(CursorPagination cursor);
+
+        T visitOffset(OffsetPagination offset);
+
+        T visitCustom(CustomPagination custom);
+
+        T visitUri(UriPagination uri);
+
+        T visitPath(PathPagination path);
+
+        T _visitUnknown(Object unknownType);
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, defaultImpl = _UnknownValue.class)
+    @JsonSubTypes({
+        @JsonSubTypes.Type(CursorValue.class),
+        @JsonSubTypes.Type(OffsetValue.class),
+        @JsonSubTypes.Type(CustomValue.class),
+        @JsonSubTypes.Type(UriValue.class),
+        @JsonSubTypes.Type(PathValue.class)
+    })
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private interface Value {
+        <T> T visit(Visitor<T> visitor);
+    }
+
+    @JsonTypeName("cursor")
+    @JsonIgnoreProperties("type")
+    private static final class CursorValue implements Value {
+        @JsonUnwrapped
+        private CursorPagination value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private CursorValue() {}
+
+        private CursorValue(CursorPagination value) {
+            this.value = value;
+        }
+
+        @java.lang.Override
+        public <T> T visit(Visitor<T> visitor) {
+            return visitor.visitCursor(value);
+        }
+
+        @java.lang.Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            return other instanceof CursorValue && equalTo((CursorValue) other);
+        }
+
+        private boolean equalTo(CursorValue other) {
+            return value.equals(other.value);
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+            return Objects.hash(this.value);
+        }
+
+        @java.lang.Override
+        public String toString() {
+            return "Pagination{" + "value: " + value + "}";
+        }
+    }
+
+    @JsonTypeName("offset")
+    @JsonIgnoreProperties("type")
+    private static final class OffsetValue implements Value {
+        @JsonUnwrapped
+        private OffsetPagination value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private OffsetValue() {}
+
+        private OffsetValue(OffsetPagination value) {
+            this.value = value;
+        }
+
+        @java.lang.Override
+        public <T> T visit(Visitor<T> visitor) {
+            return visitor.visitOffset(value);
+        }
+
+        @java.lang.Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            return other instanceof OffsetValue && equalTo((OffsetValue) other);
+        }
+
+        private boolean equalTo(OffsetValue other) {
+            return value.equals(other.value);
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+            return Objects.hash(this.value);
+        }
+
+        @java.lang.Override
+        public String toString() {
+            return "Pagination{" + "value: " + value + "}";
+        }
+    }
+
+    @JsonTypeName("custom")
+    @JsonIgnoreProperties("type")
+    private static final class CustomValue implements Value {
+        @JsonUnwrapped
+        private CustomPagination value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private CustomValue() {}
+
+        private CustomValue(CustomPagination value) {
+            this.value = value;
+        }
+
+        @java.lang.Override
+        public <T> T visit(Visitor<T> visitor) {
+            return visitor.visitCustom(value);
+        }
+
+        @java.lang.Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            return other instanceof CustomValue && equalTo((CustomValue) other);
+        }
+
+        private boolean equalTo(CustomValue other) {
+            return value.equals(other.value);
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+            return Objects.hash(this.value);
+        }
+
+        @java.lang.Override
+        public String toString() {
+            return "Pagination{" + "value: " + value + "}";
+        }
+    }
+
+    @JsonTypeName("uri")
+    @JsonIgnoreProperties("type")
+    private static final class UriValue implements Value {
+        @JsonUnwrapped
+        private UriPagination value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private UriValue() {}
+
+        private UriValue(UriPagination value) {
+            this.value = value;
+        }
+
+        @java.lang.Override
+        public <T> T visit(Visitor<T> visitor) {
+            return visitor.visitUri(value);
+        }
+
+        @java.lang.Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            return other instanceof UriValue && equalTo((UriValue) other);
+        }
+
+        private boolean equalTo(UriValue other) {
+            return value.equals(other.value);
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+            return Objects.hash(this.value);
+        }
+
+        @java.lang.Override
+        public String toString() {
+            return "Pagination{" + "value: " + value + "}";
+        }
+    }
+
+    @JsonTypeName("path")
+    @JsonIgnoreProperties("type")
+    private static final class PathValue implements Value {
+        @JsonUnwrapped
+        private PathPagination value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private PathValue() {}
+
+        private PathValue(PathPagination value) {
+            this.value = value;
+        }
+
+        @java.lang.Override
+        public <T> T visit(Visitor<T> visitor) {
+            return visitor.visitPath(value);
+        }
+
+        @java.lang.Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            return other instanceof PathValue && equalTo((PathValue) other);
+        }
+
+        private boolean equalTo(PathValue other) {
+            return value.equals(other.value);
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+            return Objects.hash(this.value);
+        }
+
+        @java.lang.Override
+        public String toString() {
+            return "Pagination{" + "value: " + value + "}";
+        }
+    }
+
+    @JsonIgnoreProperties("type")
+    private static final class _UnknownValue implements Value {
+        private String type;
+
+        @JsonValue
+        private Object value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private _UnknownValue(@JsonProperty("value") Object value) {}
+
+        @java.lang.Override
+        public <T> T visit(Visitor<T> visitor) {
+            return visitor._visitUnknown(value);
+        }
+
+        @java.lang.Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            return other instanceof _UnknownValue && equalTo((_UnknownValue) other);
+        }
+
+        private boolean equalTo(_UnknownValue other) {
+            return type.equals(other.type) && value.equals(other.value);
+        }
+
+        @java.lang.Override
+        public int hashCode() {
+            return Objects.hash(this.type, this.value);
+        }
+
+        @java.lang.Override
+        public String toString() {
+            return "Pagination{" + "type: " + type + ", value: " + value + "}";
+        }
+    }
+}

--- a/generators/java/generator-utils/src/main/java/com/fern/ir/model/http/PathPagination.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/ir/model/http/PathPagination.java
@@ -1,0 +1,105 @@
+package com.fern.ir.model.http;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fern.ir.core.ObjectMappers;
+import java.lang.Object;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+@JsonDeserialize(builder = PathPagination.Builder.class)
+public final class PathPagination {
+    private final ResponseProperty nextPath;
+    private final ResponseProperty results;
+
+    private PathPagination(ResponseProperty nextPath, ResponseProperty results) {
+        this.nextPath = nextPath;
+        this.results = results;
+    }
+
+    @JsonProperty("nextPath")
+    public ResponseProperty getNextPath() {
+        return nextPath;
+    }
+
+    @JsonProperty("results")
+    public ResponseProperty getResults() {
+        return results;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        return other instanceof PathPagination && equalTo((PathPagination) other);
+    }
+
+    private boolean equalTo(PathPagination other) {
+        return nextPath.equals(other.nextPath) && results.equals(other.results);
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return Objects.hash(this.nextPath, this.results);
+    }
+
+    @java.lang.Override
+    public String toString() {
+        return ObjectMappers.stringify(this);
+    }
+
+    public static NextPathStage builder() {
+        return new Builder();
+    }
+
+    public interface NextPathStage {
+        ResultsStage nextPath(ResponseProperty nextPath);
+
+        Builder from(PathPagination other);
+    }
+
+    public interface ResultsStage {
+        _FinalStage results(ResponseProperty results);
+    }
+
+    public interface _FinalStage {
+        PathPagination build();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder implements NextPathStage, ResultsStage, _FinalStage {
+        private ResponseProperty nextPath;
+        private ResponseProperty results;
+
+        private Builder() {}
+
+        @java.lang.Override
+        public Builder from(PathPagination other) {
+            nextPath(other.getNextPath());
+            results(other.getResults());
+            return this;
+        }
+
+        @java.lang.Override
+        @JsonSetter("nextPath")
+        public ResultsStage nextPath(ResponseProperty nextPath) {
+            this.nextPath = Objects.requireNonNull(nextPath, "nextPath must not be null");
+            return this;
+        }
+
+        @java.lang.Override
+        @JsonSetter("results")
+        public _FinalStage results(ResponseProperty results) {
+            this.results = Objects.requireNonNull(results, "results must not be null");
+            return this;
+        }
+
+        @java.lang.Override
+        public PathPagination build() {
+            return new PathPagination(nextPath, results);
+        }
+    }
+}

--- a/generators/java/generator-utils/src/main/java/com/fern/ir/model/http/UriPagination.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/ir/model/http/UriPagination.java
@@ -1,0 +1,105 @@
+package com.fern.ir.model.http;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fern.ir.core.ObjectMappers;
+import java.lang.Object;
+import java.lang.String;
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+@JsonDeserialize(builder = UriPagination.Builder.class)
+public final class UriPagination {
+    private final ResponseProperty nextUri;
+    private final ResponseProperty results;
+
+    private UriPagination(ResponseProperty nextUri, ResponseProperty results) {
+        this.nextUri = nextUri;
+        this.results = results;
+    }
+
+    @JsonProperty("nextUri")
+    public ResponseProperty getNextUri() {
+        return nextUri;
+    }
+
+    @JsonProperty("results")
+    public ResponseProperty getResults() {
+        return results;
+    }
+
+    @java.lang.Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        return other instanceof UriPagination && equalTo((UriPagination) other);
+    }
+
+    private boolean equalTo(UriPagination other) {
+        return nextUri.equals(other.nextUri) && results.equals(other.results);
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+        return Objects.hash(this.nextUri, this.results);
+    }
+
+    @java.lang.Override
+    public String toString() {
+        return ObjectMappers.stringify(this);
+    }
+
+    public static NextUriStage builder() {
+        return new Builder();
+    }
+
+    public interface NextUriStage {
+        ResultsStage nextUri(ResponseProperty nextUri);
+
+        Builder from(UriPagination other);
+    }
+
+    public interface ResultsStage {
+        _FinalStage results(ResponseProperty results);
+    }
+
+    public interface _FinalStage {
+        UriPagination build();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder implements NextUriStage, ResultsStage, _FinalStage {
+        private ResponseProperty nextUri;
+        private ResponseProperty results;
+
+        private Builder() {}
+
+        @java.lang.Override
+        public Builder from(UriPagination other) {
+            nextUri(other.getNextUri());
+            results(other.getResults());
+            return this;
+        }
+
+        @java.lang.Override
+        @JsonSetter("nextUri")
+        public ResultsStage nextUri(ResponseProperty nextUri) {
+            this.nextUri = Objects.requireNonNull(nextUri, "nextUri must not be null");
+            return this;
+        }
+
+        @java.lang.Override
+        @JsonSetter("results")
+        public _FinalStage results(ResponseProperty results) {
+            this.results = Objects.requireNonNull(results, "results must not be null");
+            return this;
+        }
+
+        @java.lang.Override
+        public UriPagination build() {
+            return new UriPagination(nextUri, results);
+        }
+    }
+}

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
@@ -293,6 +293,20 @@ public abstract class AbstractHttpResponseParserGenerator {
                                     }
 
                                     @Override
+                                    public ClassName visitUri(UriPagination uri) {
+                                        return clientGeneratorContext
+                                                .getPoetClassNameFactory()
+                                                .getPaginationClassName("SyncPagingIterable");
+                                    }
+
+                                    @Override
+                                    public ClassName visitPath(PathPagination path) {
+                                        return clientGeneratorContext
+                                                .getPoetClassNameFactory()
+                                                .getPaginationClassName("SyncPagingIterable");
+                                    }
+
+                                    @Override
                                     public ClassName _visitUnknown(Object unknownType) {
                                         return clientGeneratorContext
                                                 .getPoetClassNameFactory()
@@ -388,6 +402,50 @@ public abstract class AbstractHttpResponseParserGenerator {
                                                         .map(PropertyPathItem::getName)
                                                         .collect(Collectors.toList())),
                                         customPagination.getResults().getProperty(),
+                                        body.getResponseBodyType());
+                                com.fern.ir.model.types.ContainerType resultContainerType = resultSnippet
+                                        .typeReference
+                                        .getContainer()
+                                        .orElseThrow(() -> new RuntimeException(
+                                                "Unexpected non-container pagination result type"));
+                                com.fern.ir.model.types.TypeReference resultUnderlyingType = resultContainerType.visit(
+                                        new TypeReferenceUtils.ContainerTypeToUnderlyingType());
+                                return ParameterizedTypeName.get(
+                                        pagerClassName,
+                                        clientGeneratorContext
+                                                .getPoetTypeNameMapper()
+                                                .convertToTypeName(true, resultUnderlyingType));
+                            }
+
+                            @Override
+                            public TypeName visitUri(UriPagination uri) {
+                                SnippetAndResultType resultSnippet = getNestedPropertySnippet(
+                                        uri.getResults().getPropertyPath().map(path -> path.stream()
+                                                .map(PropertyPathItem::getName)
+                                                .collect(Collectors.toList())),
+                                        uri.getResults().getProperty(),
+                                        body.getResponseBodyType());
+                                com.fern.ir.model.types.ContainerType resultContainerType = resultSnippet
+                                        .typeReference
+                                        .getContainer()
+                                        .orElseThrow(() -> new RuntimeException(
+                                                "Unexpected non-container pagination result type"));
+                                com.fern.ir.model.types.TypeReference resultUnderlyingType = resultContainerType.visit(
+                                        new TypeReferenceUtils.ContainerTypeToUnderlyingType());
+                                return ParameterizedTypeName.get(
+                                        pagerClassName,
+                                        clientGeneratorContext
+                                                .getPoetTypeNameMapper()
+                                                .convertToTypeName(true, resultUnderlyingType));
+                            }
+
+                            @Override
+                            public TypeName visitPath(PathPagination path) {
+                                SnippetAndResultType resultSnippet = getNestedPropertySnippet(
+                                        path.getResults().getPropertyPath().map(p -> p.stream()
+                                                .map(PropertyPathItem::getName)
+                                                .collect(Collectors.toList())),
+                                        path.getResults().getProperty(),
                                         body.getResponseBodyType());
                                 com.fern.ir.model.types.ContainerType resultContainerType = resultSnippet
                                         .typeReference
@@ -1767,6 +1825,245 @@ public abstract class AbstractHttpResponseParserGenerator {
                     .build();
 
             handleSuccessfulResult(httpResponseBuilder, customPagerCreation);
+            endpointMethodBuilder.returns(responseType);
+            return null;
+        }
+
+        @Override
+        public Void visitUri(UriPagination uri) {
+            return visitUrlBasedPagination(
+                    uri.getNextUri(), uri.getResults(), true);
+        }
+
+        @Override
+        public Void visitPath(PathPagination path) {
+            return visitUrlBasedPagination(
+                    path.getNextPath(), path.getResults(), false);
+        }
+
+        private Void visitUrlBasedPagination(
+                ResponseProperty nextProperty, ResponseProperty resultsProperty, boolean isUri) {
+            SnippetAndResultType nextSnippet = getNestedPropertySnippet(
+                    nextProperty.getPropertyPath().map(path -> path.stream()
+                            .map(PropertyPathItem::getName)
+                            .collect(Collectors.toList())),
+                    nextProperty.getProperty(),
+                    body.getResponseBodyType());
+            CodeBlock nextBlock = CodeBlock.builder()
+                    .add(
+                            "$T $L = $L",
+                            nextSnippet.typeName,
+                            variables.getStartingAfterVariableName(),
+                            variables.getParsedResponseVariableName())
+                    .add(nextSnippet.codeBlock)
+                    .build();
+            httpResponseBuilder.addStatement(nextBlock);
+
+            SnippetAndResultType resultSnippet = getNestedPropertySnippet(
+                    resultsProperty.getPropertyPath().map(path -> path.stream()
+                            .map(PropertyPathItem::getName)
+                            .collect(Collectors.toList())),
+                    resultsProperty.getProperty(),
+                    body.getResponseBodyType());
+            CodeBlock resultBlock = CodeBlock.builder()
+                    .add(
+                            "$T $L = $L",
+                            resultSnippet.typeName,
+                            variables.getResultVariableName(),
+                            variables.getParsedResponseVariableName())
+                    .add(resultSnippet.codeBlock)
+                    .build();
+            httpResponseBuilder.addStatement(resultBlock);
+
+            CodeBlock hasNextPageBlock;
+            if (nextSnippet.typeReference.getContainer().isPresent()) {
+                com.fern.ir.model.types.ContainerType containerType =
+                        nextSnippet.typeReference.getContainer().get();
+                if (containerType.isOptional()) {
+                    hasNextPageBlock = CodeBlock.of(
+                            "$L.isPresent() && !$L.get().isEmpty()",
+                            variables.getStartingAfterVariableName(),
+                            variables.getStartingAfterVariableName());
+                } else if (containerType.isNullable()) {
+                    hasNextPageBlock = CodeBlock.of(
+                            "$L != null && !$L.isEmpty()",
+                            variables.getStartingAfterVariableName(),
+                            variables.getStartingAfterVariableName());
+                } else {
+                    throw new IllegalStateException(
+                            "Found non-optional, non-nullable container as next page token. "
+                                    + getContainerDiagnosticString(containerType));
+                }
+            } else {
+                hasNextPageBlock = CodeBlock.of(
+                        "$L != null && !$L.isEmpty()",
+                        variables.getStartingAfterVariableName(),
+                        variables.getStartingAfterVariableName());
+            }
+
+            TypeName responseType = getResponseType(httpEndpoint, clientGeneratorContext);
+            TypeName responseBodyTypeName = clientGeneratorContext
+                    .getPoetTypeNameMapper()
+                    .convertToTypeName(true, body.getResponseBodyType());
+
+            String httpMethodStr = httpEndpoint.getMethod().toString();
+
+            com.fern.ir.model.types.ContainerType resultContainerType = resultSnippet
+                    .typeReference
+                    .getContainer()
+                    .orElseThrow(() -> new RuntimeException("Unexpected non-container pagination result type"));
+            com.fern.ir.model.types.TypeReference resultUnderlyingTypeRef =
+                    resultContainerType.visit(new TypeReferenceUtils.ContainerTypeToUnderlyingType());
+            TypeName resultElementType = clientGeneratorContext
+                    .getPoetTypeNameMapper()
+                    .convertToTypeName(true, resultUnderlyingTypeRef);
+
+            ClassName syncPagingIterableClass = clientGeneratorContext
+                    .getPoetClassNameFactory()
+                    .getPaginationClassName("SyncPagingIterable");
+            TypeName pagerReturnType = ParameterizedTypeName.get(syncPagingIterableClass, resultElementType);
+            ClassName functionClass = ClassName.get("java.util.function", "Function");
+            TypeName pageFetcherType =
+                    ParameterizedTypeName.get(functionClass, ClassName.get(String.class), pagerReturnType);
+
+            ObjectMapperUtils objectMapperUtils = new ObjectMapperUtils(clientGeneratorContext, generatedObjectMapper);
+
+            CodeBlock urlExpression;
+            if (isUri) {
+                urlExpression = CodeBlock.of("$T.parse(_url)", ClassName.get("okhttp3", "HttpUrl"));
+            } else {
+                urlExpression = CodeBlock.of(
+                        "$T.parse($L.environment().getUrl() + _url)",
+                        ClassName.get("okhttp3", "HttpUrl"),
+                        clientOptionsField.name);
+            }
+
+            CodeBlock.Builder pageFetcherBuilder = CodeBlock.builder();
+            pageFetcherBuilder.add("$T _pageFetcher = new $T() {\n", pageFetcherType, pageFetcherType);
+            pageFetcherBuilder.indent();
+            pageFetcherBuilder.add("@$T\n", ClassName.get(Override.class));
+            pageFetcherBuilder.add("public $T apply($T _url) {\n", pagerReturnType, ClassName.get(String.class));
+            pageFetcherBuilder.indent();
+
+            pageFetcherBuilder.addStatement(
+                    "$T _pageRequest = new $T.Builder()\n.url($L)\n.method($S, null)\n"
+                            + ".headers($T.of($L.headers($L)))\n.addHeader($S, $S)\n.build()",
+                    ClassName.get("okhttp3", "Request"),
+                    ClassName.get("okhttp3", "Request"),
+                    urlExpression,
+                    httpMethodStr,
+                    ClassName.get("okhttp3", "Headers"),
+                    clientOptionsField.name,
+                    AbstractEndpointWriterVariableNameContext.REQUEST_OPTIONS_PARAMETER_NAME,
+                    "Accept",
+                    "application/json");
+
+            pageFetcherBuilder.addStatement(
+                    "$T _pageClient = $L.httpClient()",
+                    OkHttpClient.class,
+                    clientOptionsField.name);
+            pageFetcherBuilder.beginControlFlow(
+                    "if ($L != null && $L.getTimeout().isPresent())",
+                    AbstractEndpointWriterVariableNameContext.REQUEST_OPTIONS_PARAMETER_NAME,
+                    AbstractEndpointWriterVariableNameContext.REQUEST_OPTIONS_PARAMETER_NAME);
+            pageFetcherBuilder.addStatement(
+                    "_pageClient = $L.httpClientWithTimeout($L)",
+                    clientOptionsField.name,
+                    AbstractEndpointWriterVariableNameContext.REQUEST_OPTIONS_PARAMETER_NAME);
+            pageFetcherBuilder.endControlFlow();
+
+            pageFetcherBuilder.beginControlFlow(
+                    "try ($T _pageResponse = _pageClient.newCall(_pageRequest).execute())",
+                    ClassName.get("okhttp3", "Response"));
+            pageFetcherBuilder.addStatement(
+                    "$T _pageBody = _pageResponse.body()", ClassName.get("okhttp3", "ResponseBody"));
+            pageFetcherBuilder.addStatement(
+                    "$T _pageBodyString = _pageBody != null ? _pageBody.string() : $S", String.class, "{}");
+
+            pageFetcherBuilder.beginControlFlow("if (_pageResponse.isSuccessful())");
+
+            pageFetcherBuilder.add("$T _parsed = ", responseBodyTypeName);
+            pageFetcherBuilder.addStatement(objectMapperUtils.readValueCall(
+                    CodeBlock.of("_pageBodyString"), Optional.of(body.getResponseBodyType())));
+
+            pageFetcherBuilder.add("$T _nextUrl = _parsed", nextSnippet.typeName);
+            pageFetcherBuilder.add(nextSnippet.codeBlock);
+            pageFetcherBuilder.add(";\n");
+
+            pageFetcherBuilder.add("$T _items = _parsed", resultSnippet.typeName);
+            pageFetcherBuilder.add(resultSnippet.codeBlock);
+            pageFetcherBuilder.add(";\n");
+
+            CodeBlock innerHasNextBlock;
+            if (nextSnippet.typeReference.getContainer().isPresent()) {
+                com.fern.ir.model.types.ContainerType ct =
+                        nextSnippet.typeReference.getContainer().get();
+                if (ct.isOptional()) {
+                    innerHasNextBlock =
+                            CodeBlock.of("_nextUrl.isPresent() && !_nextUrl.get().isEmpty()");
+                } else if (ct.isNullable()) {
+                    innerHasNextBlock = CodeBlock.of("_nextUrl != null && !_nextUrl.isEmpty()");
+                } else {
+                    innerHasNextBlock = CodeBlock.of("_nextUrl != null && !_nextUrl.isEmpty()");
+                }
+            } else {
+                innerHasNextBlock = CodeBlock.of("_nextUrl != null && !_nextUrl.isEmpty()");
+            }
+
+            CodeBlock nextUrlGet;
+            if (nextSnippet.typeReference.getContainer().isPresent()
+                    && nextSnippet.typeReference.getContainer().get().isOptional()) {
+                nextUrlGet = CodeBlock.of("_nextUrl.get()");
+            } else {
+                nextUrlGet = CodeBlock.of("_nextUrl");
+            }
+
+            pageFetcherBuilder.addStatement(
+                    "return new $T($L, _items, _parsed, () -> this.apply($L))",
+                    pagerReturnType,
+                    innerHasNextBlock,
+                    nextUrlGet);
+
+            pageFetcherBuilder.endControlFlow();
+
+            pageFetcherBuilder.addStatement(
+                    "$T errorBody = $T.parseErrorBody(_pageBodyString)",
+                    Object.class,
+                    clientGeneratorContext.getPoetClassNameFactory().getObjectMapperClassName());
+            pageFetcherBuilder.addStatement(
+                    "throw new $T($S + _pageResponse.code(), _pageResponse.code(), errorBody, _pageResponse)",
+                    apiErrorClassName,
+                    "Error with status code ");
+
+            pageFetcherBuilder.nextControlFlow("catch ($T e)", ClassName.get("java.io", "IOException"));
+            pageFetcherBuilder.addStatement(
+                    "throw new $T($S, e)", baseErrorClassName, "Network error executing HTTP request");
+            pageFetcherBuilder.endControlFlow();
+
+            pageFetcherBuilder.unindent();
+            pageFetcherBuilder.add("}\n");
+            pageFetcherBuilder.unindent();
+            pageFetcherBuilder.add("}");
+
+            httpResponseBuilder.addStatement(pageFetcherBuilder.build());
+
+            CodeBlock startingAfterGet;
+            if (nextSnippet.typeReference.getContainer().isPresent()
+                    && nextSnippet.typeReference.getContainer().get().isOptional()) {
+                startingAfterGet = CodeBlock.of("$L.get()", variables.getStartingAfterVariableName());
+            } else {
+                startingAfterGet = CodeBlock.of("$L", variables.getStartingAfterVariableName());
+            }
+
+            CodeBlock paginationConstructor = CodeBlock.of(
+                    "new $T($L, $L, $L, () -> _pageFetcher.apply($L))",
+                    responseType,
+                    hasNextPageBlock,
+                    variables.getResultVariableName(),
+                    variables.getParsedResponseVariableName(),
+                    startingAfterGet);
+
+            handleSuccessfulResult(httpResponseBuilder, paginationConstructor);
             endpointMethodBuilder.returns(responseType);
             return null;
         }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.36.0
+  changelogEntry:
+    - summary: |
+        Add support for URI and path-based pagination. URI pagination follows full URIs from
+        response for next page requests, while path pagination combines response paths with
+        the default base URL.
+      type: feat
+  createdAt: "2026-02-12"
+  irVersion: 65
+
 - version: 3.35.1
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/ir-migrations/src/migrations/v65-to-v63/migrateFromV65ToV63.ts
+++ b/packages/cli/generation/ir-migrations/src/migrations/v65-to-v63/migrateFromV65ToV63.ts
@@ -19,7 +19,7 @@ export const V65_TO_V63_MIGRATION: IrMigration<
         [GeneratorName.TYPESCRIPT_EXPRESS]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.JAVA]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.JAVA_MODEL]: GeneratorWasNeverUpdatedToConsumeNewIR,
-        [GeneratorName.JAVA_SDK]: GeneratorWasNeverUpdatedToConsumeNewIR,
+        [GeneratorName.JAVA_SDK]: "3.36.0",
         [GeneratorName.JAVA_SPRING]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.OPENAPI_PYTHON_CLIENT]: GeneratorWasNeverUpdatedToConsumeNewIR,
         [GeneratorName.OPENAPI]: GeneratorWasNeverUpdatedToConsumeNewIR,


### PR DESCRIPTION
## Description

Refs #12238

Ports URI and path-based pagination support from the Python SDK generator to the Java SDK generator. URI pagination follows full URIs from the response for next page requests, while path pagination combines response paths with the default base URL.

Link to Devin run: https://app.devin.ai/sessions/62317080c0744ddaa120d4f6599449c4
Requested by: @tjb9dc

## Changes Made

- Added `UriPagination.java` and `PathPagination.java` IR model types in `generator-utils` as source-level overrides of the irV63 JAR (which doesn't include these types)
- Added a new `Pagination.java` in `generator-utils` that extends the union with `uri` and `path` variants (shadows the irV63 JAR version)
- Implemented `visitUri()` and `visitPath()` in three visitor sites within `AbstractHttpResponseParserGenerator.java`:
  - Pager class name resolution (returns `SyncPagingIterable`)
  - Return type resolution (extracts result element type from container)
  - `JsonResponsePaginationVisitor` — generates OkHttp-based page fetching code via a shared `visitUrlBasedPagination()` helper
- Updated `v65-to-v63` IR migration to mark `JAVA_SDK >= 3.36.0` as consuming IR v65
- Added `3.36.0` entry to `generators/java/sdk/versions.yml`
- [ ] Updated README.md generator (if applicable) — N/A

## ⚠️ Important Review Notes

1. **IR model source override approach**: Rather than upgrading the Maven `irV63` dependency to v65, new source files are placed in `generator-utils` to shadow compiled JAR classes at compile time. This avoids waiting for a new IR JAR to be published but means `build.gradle` still declares `irV63`. Reviewers should confirm this approach is acceptable long-term or if an IR dependency bump is preferred.

2. **Missing seed test output**: The `pagination-uri-path` seed fixture output for `java-sdk` has **not** been generated/committed yet (shell timeout during seed run). CI will likely fail until this is added.


3. **HTTP method handling**: The `visitUrlBasedPagination()` helper passes `null` as the request body (`.method($S, null)`). This works for GET but may fail for POST-based paginated endpoints since OkHttp requires a body for POST.

## Testing

- [x] Java generator compiles successfully (`./gradlew compileJava`)
- [ ] Seed tests for `pagination-uri-path` fixture — **not yet run/committed**
- [ ] Manual testing completed