### PR TITLE
fix(java): fix handling of empty or bare `PATCH` requests

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/NoRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/NoRequestEndpointWriter.java
@@ -91,7 +91,8 @@ public final class NoRequestEndpointWriter extends AbstractEndpointWriter {
                 .add(inlineableHttpUrl)
                 .add(")\n");
         if (httpEndpoint.getMethod().equals(HttpMethod.POST)
-                || httpEndpoint.getMethod().equals(HttpMethod.PUT)) {
+                || httpEndpoint.getMethod().equals(HttpMethod.PUT)
+                || httpEndpoint.getMethod().equals(HttpMethod.PATCH)) {
             builder.add(
                     ".method($S, $T.create($S, null))\n",
                     httpEndpoint.getMethod().toString(),

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -151,7 +151,8 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
             }
         } else {
             if (httpEndpoint.getMethod().equals(HttpMethod.POST)
-                    || httpEndpoint.getMethod().equals(HttpMethod.PUT)) {
+                    || httpEndpoint.getMethod().equals(HttpMethod.PUT)
+                    || httpEndpoint.getMethod().equals(HttpMethod.PATCH)) {
                 inlinedRequestBodyBuilder = Optional.of(CodeBlock.of("$T.create($S, null)", RequestBody.class, ""));
             } else {
                 inlinedRequestBodyBuilder = Optional.of(CodeBlock.of("null"));

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.35.2
+  changelogEntry:
+    - summary: |
+        Fix PATCH requests with no explicit body fields failing at runtime with OkHttp's
+        `IllegalArgumentException: method PATCH must have a request body`. The generator now
+        provides a non-null empty request body for PATCH endpoints, matching the existing
+        handling for POST and PUT.
+      type: fix
+  createdAt: "2026-02-12"
+  irVersion: 63
+
 - version: 3.35.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Certain `PATCH` requests were failing when they lacked any explicit body parameters; there was already handling for this for `POST` and `PUT` requests, so this PR just adds `PATCH` to the list.
```
Case 1: Query-only PATCH (no body parameters)

  Before:
  Request okhttpRequest = new Request.Builder()
          .url(httpUrl.build())
          .method("PATCH", null)
          .headers(Headers.of(clientOptions.headers(requestOptions)));

  After:
  Request okhttpRequest = new Request.Builder()
          .url(httpUrl.build())
          .method("PATCH", RequestBody.create("", null))
          .headers(Headers.of(clientOptions.headers(requestOptions)));

  Case 2: Wrapped PATCH request where body has only additionalProperties

  Before:
  RequestBody body = null;
  Request.Builder _requestBuilder = new Request.Builder()
          .url(httpUrl.build())
          .method("PATCH", body)
          .headers(Headers.of(clientOptions.headers(requestOptions)));

  After:
  RequestBody body = RequestBody.create("", null);
  Request.Builder _requestBuilder = new Request.Builder()
          .url(httpUrl.build())
          .method("PATCH", body)
          .headers(Headers.of(clientOptions.headers(requestOptions)));
```

## Testing
Tested on Samsara.
- [X] Unit tests added/updated
- [X] Manual testing completed
