### PR TITLE
feat(cli): add bytes type support in fern export command

### DIFF
--- a/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
+++ b/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
@@ -342,8 +342,20 @@ function convertRequestBody({
                 }
             };
         },
-        bytes: () => {
-            throw new Error("bytes is not supported");
+        bytes: (bytesRequest) => {
+            const contentType = bytesRequest.contentType ?? "application/octet-stream";
+            return {
+                required: !bytesRequest.isOptional,
+                description: bytesRequest.docs ?? undefined,
+                content: {
+                    [contentType]: {
+                        schema: {
+                            type: "string",
+                            format: "binary"
+                        }
+                    }
+                }
+            };
         },
         _other: () => {
             throw new Error("Unknown HttpRequestBody type: " + httpRequest.type);
@@ -396,6 +408,41 @@ function convertResponse({
             description: httpResponse.body.value.docs ?? "",
             content: {
                 "application/json": convertedResponse
+            }
+        };
+    } else if (httpResponse?.body?.type === "fileDownload" || httpResponse?.body?.type === "bytes") {
+        responseByStatusCode[String(httpResponse.statusCode ?? 200)] = {
+            description: httpResponse.body.docs ?? "",
+            content: {
+                "application/octet-stream": {
+                    schema: {
+                        type: "string",
+                        format: "binary"
+                    }
+                }
+            }
+        };
+    } else if (httpResponse?.body?.type === "text") {
+        responseByStatusCode[String(httpResponse.statusCode ?? 200)] = {
+            description: httpResponse.body.docs ?? "",
+            content: {
+                "text/plain": {
+                    schema: {
+                        type: "string"
+                    }
+                }
+            }
+        };
+    } else if (httpResponse?.body?.type === "streaming") {
+        responseByStatusCode[String(httpResponse.statusCode ?? 200)] = {
+            description: httpResponse.body.value.docs ?? "",
+            content: {
+                "application/octet-stream": {
+                    schema: {
+                        type: "string",
+                        format: "binary"
+                    }
+                }
             }
         };
     } else {

--- a/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
+++ b/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
@@ -434,10 +434,26 @@ function convertResponse({
             }
         };
     } else if (httpResponse?.body?.type === "streaming") {
+        const streamingValue = httpResponse.body.value;
+        let streamingContentType: string;
+        switch (streamingValue.type) {
+            case "sse":
+                streamingContentType = "text/event-stream";
+                break;
+            case "json":
+                streamingContentType = "application/jsonl";
+                break;
+            case "text":
+                streamingContentType = "text/plain";
+                break;
+            default:
+                streamingContentType = "application/octet-stream";
+                break;
+        }
         responseByStatusCode[String(httpResponse.statusCode ?? 200)] = {
-            description: httpResponse.body.value.docs ?? "",
+            description: streamingValue.docs ?? "",
             content: {
-                "application/octet-stream": {
+                [streamingContentType]: {
                     schema: {
                         type: "string",
                         format: "binary"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.76.1
+  changelogEntry:
+    - summary: |
+        Add support for bytes request and response body types in the `fern export` command.
+        Previously, exporting APIs with bytes endpoints would fail with "bytes is not supported".
+        Now bytes request bodies are exported as `application/octet-stream` with `format: binary`,
+        and bytes/fileDownload/text/streaming response bodies are properly converted to their
+        corresponding OpenAPI content types.
+      type: feat
+  createdAt: "2026-02-12"
+  irVersion: 65
+
 - version: 3.76.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.76.1
+- version: 3.77.0
   changelogEntry:
     - summary: |
         Add support for bytes request and response body types in the `fern export` command.


### PR DESCRIPTION
## Description

Refs: Requested by @jsklan
[Link to Devin run](https://app.devin.ai/sessions/65f271d0998b4435a2a2c9662da7ef1c)

The `fern export` command crashed with `"bytes is not supported"` when exporting API specs containing bytes request bodies (e.g., the Anduril Lattice object store API with `application/octet-stream` upload endpoints). This PR adds proper handling for bytes types in the IR→OpenAPI export converter.

## Changes Made

- **Bytes request body**: Replaced the `throw new Error("bytes is not supported")` handler with a proper conversion that emits `type: string, format: binary` under the appropriate content type (uses `contentType` from the IR's `BytesRequest` if set, otherwise defaults to `application/octet-stream`). Respects `isOptional` and `docs` fields.
- **Non-JSON response bodies**: The response converter previously only handled `json` bodies; everything else silently fell through to `204 No Content`. Added explicit handling for:
  - `fileDownload` / `bytes` → `application/octet-stream` with `format: binary`
  - `text` → `text/plain` with `type: string`
  - `streaming` → content type derived from the `StreamingResponse` variant:
    - `sse` → `text/event-stream`
    - `json` → `application/jsonl`
    - `text` → `text/plain`
    - unknown/fallback → `application/octet-stream`
- Added CLI changelog entry (v3.77.0)

### Known limitations

- **`bytes` / `fileDownload` response types always use `application/octet-stream`**: The IR types `BytesResponse` and `FileDownloadResponse` do not carry a `contentType` field (they only extend `WithDocs` and `WithV2Examples`), so there is no content type information available from the IR to use. An IR change would be needed to support custom content types for these response body types.
- **`BytesRequest` (request body) is flexible**: Unlike the response types, `BytesRequest` extends `WithContentType` so we use the IR-provided `contentType` when available, falling back to `application/octet-stream`.

## Human Review Checklist

- [ ] **`application/jsonl` for JSON streaming**: Verify `application/jsonl` is the preferred content type for JSON streaming responses (vs. `application/x-ndjson` or `application/json`).
- [ ] **`streamParameter` response type** is not handled (falls through to `204`). This is pre-existing behavior, but worth considering if it should also be addressed.
- [ ] **No automated tests added**: There are no unit/snapshot tests covering the export converter for bytes bodies.

## Testing

- [x] `pnpm run check` (biome lint) passes
- [x] Manual testing completed — built CLI locally and ran `fern export` against the attached Anduril object store OpenAPI spec. Export succeeded and output correctly contains `application/octet-stream` with `format: binary` for both the upload request body and the get-object response.
- [ ] No automated tests added for the new bytes export behavior