### PR TITLE
fix(python): only copy custom_pagination.py when custom pagination is used

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.57.1
+  changelogEntry:
+    - summary: |
+        Only copy `custom_pagination.py` into generated SDKs when custom pagination endpoints
+        are present, and only copy `pagination.py` when standard pagination endpoints are present.
+      type: fix
+  createdAt: "2026-02-12"
+  irVersion: 65
+
 - version: 4.57.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/context/sdk_generator_context.py
+++ b/generators/python/src/fern_python/generators/sdk/context/sdk_generator_context.py
@@ -51,15 +51,19 @@ class SdkGeneratorContext(ABC):
             pydantic_compatibility=custom_config.pydantic_config.version,
         )
 
-        # This should be replaced with `hasPaginatedEndpoints` in the IR, but that's on IR44, not 39, which is what Python's on
-        _has_paginated_endpoints = any(
-            map(
-                lambda service: any(map(lambda ep: ep.pagination is not None, service.endpoints)),
-                ir.services.values(),
-            )
+        _has_standard_paginated_endpoints = any(
+            ep.pagination is not None and ep.pagination.get_as_union().type != "custom"
+            for service in ir.services.values()
+            for ep in service.endpoints
+        )
+        _has_custom_paginated_endpoints = any(
+            ep.pagination is not None and ep.pagination.get_as_union().type == "custom"
+            for service in ir.services.values()
+            for ep in service.endpoints
         )
         self.core_utilities = CoreUtilities(
-            has_paginated_endpoints=_has_paginated_endpoints,
+            has_standard_paginated_endpoints=_has_standard_paginated_endpoints,
+            has_custom_paginated_endpoints=_has_custom_paginated_endpoints,
             project_module_path=project_module_path,
             custom_config=custom_config,
         )

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -25,7 +25,8 @@ class CoreUtilities:
 
     def __init__(
         self,
-        has_paginated_endpoints: bool,
+        has_standard_paginated_endpoints: bool,
+        has_custom_paginated_endpoints: bool,
         project_module_path: AST.ModulePath,
         custom_config: SDKCustomConfig,
     ) -> None:
@@ -35,7 +36,8 @@ class CoreUtilities:
         self._module_path_unnamed = tuple(part.module_name for part in self.filepath[:-1])  # type: ignore
         self._allow_skipping_validation = custom_config.pydantic_config.skip_validation
         self._use_typeddict_requests = custom_config.pydantic_config.use_typeddict_requests
-        self._has_paginated_endpoints = has_paginated_endpoints
+        self._has_standard_paginated_endpoints = has_standard_paginated_endpoints
+        self._has_custom_paginated_endpoints = has_custom_paginated_endpoints
         self._version = custom_config.pydantic_config.version
         self._project_module_path = project_module_path
         self._use_pydantic_field_aliases = custom_config.pydantic_config.use_pydantic_field_aliases
@@ -215,7 +217,7 @@ class CoreUtilities:
             else set(),
         )
 
-        if self._has_paginated_endpoints:
+        if self._has_standard_paginated_endpoints:
             self._copy_file_to_project(
                 project=project,
                 relative_filepath_on_disk="pagination.py",
@@ -225,7 +227,8 @@ class CoreUtilities:
                 ),
                 exports={"SyncPager", "AsyncPager"} if not self._exclude_types_from_init_exports else set(),
             )
-            # Copy custom pagination file (for user customization)
+
+        if self._has_custom_paginated_endpoints:
             self._copy_file_to_project(
                 project=project,
                 relative_filepath_on_disk="custom_pagination.py",


### PR DESCRIPTION
## Summary
- `custom_pagination.py` was being copied into every generated SDK with any paginated endpoints, even when no endpoints use custom pagination
- Split the single `has_paginated_endpoints` flag into `has_standard_paginated_endpoints` and `has_custom_paginated_endpoints`
- `pagination.py` is now only copied for standard (offset/cursor/nextUri) endpoints; `custom_pagination.py` only for custom pagination endpoints

## Test plan
- [ ] Run `pnpm seed test --generator python-sdk --fixture pagination --skip-scripts` to verify standard pagination still works
- [ ] Verify `custom_pagination.py` is not present in seed output for non-custom pagination fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)