### PR TITLE
feat(cli): replace deprecated generator aliases during `fern generator upgrade`

### DIFF
--- a/packages/cli/cli/src/commands/upgrade/__test__/upgradeGenerator.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/__test__/upgradeGenerator.test.ts
@@ -8,11 +8,20 @@ import YAML from "yaml";
 
 import { loadAndUpdateGenerators } from "../upgradeGenerator.js";
 
+const GENERATOR_NAME_ALIASES: Record<string, string> = {
+    "fernapi/java-model": "fernapi/fern-java-model",
+    "fernapi/fern-typescript-node-sdk": "fernapi/fern-typescript-sdk"
+};
+
 vi.mock("@fern-api/configuration-loader", () => ({
     getPathToGeneratorsConfiguration: vi.fn(),
     normalizeGeneratorName: vi.fn((name: string) => {
         if (!name.includes("/")) {
             name = `fernapi/${name}`;
+        }
+        const aliased = GENERATOR_NAME_ALIASES[name];
+        if (aliased != null) {
+            name = aliased;
         }
         const knownGenerators = [
             "fernapi/fern-typescript-sdk",
@@ -31,6 +40,13 @@ vi.mock("@fern-api/configuration-loader", () => ({
     addDefaultDockerOrgIfNotPresent: vi.fn((name: string) => {
         if (!name.includes("/")) {
             return `fernapi/${name}`;
+        }
+        return name;
+    }),
+    removeDefaultDockerOrgIfPresent: vi.fn((name: string) => {
+        const prefix = "fernapi/";
+        if (name.startsWith(prefix)) {
+            return name.slice(prefix.length);
         }
         return name;
     }),
@@ -334,5 +350,140 @@ groups:
         expect(nameIndex).toBeLessThan(versionIndex);
         expect(versionIndex).toBeLessThan(outputIndex);
         expect(outputIndex).toBeLessThan(configIndex);
+    });
+
+    it("should replace deprecated alias with canonical name when upgrading version", async () => {
+        const yamlContent = `groups:
+  production:
+    generators:
+      - name: fernapi/fern-typescript-node-sdk
+        version: 1.0.0
+        config:
+          packageName: my-sdk
+`;
+
+        const { getPathToGeneratorsConfiguration } = await import("@fern-api/configuration-loader");
+        vi.mocked(getPathToGeneratorsConfiguration).mockResolvedValue(testYamlPath as AbsoluteFilePath);
+        vi.mocked(readFile).mockResolvedValue(yamlContent);
+
+        const { getLatestGeneratorVersion } = await import("@fern-api/configuration-loader");
+        vi.mocked(getLatestGeneratorVersion).mockResolvedValue("1.5.0");
+
+        const { loadAndRunMigrations } = await import("../migrations");
+        vi.mocked(loadAndRunMigrations).mockResolvedValue(null);
+
+        const result = await loadAndUpdateGenerators({
+            absolutePathToWorkspace: "/test" as AbsoluteFilePath,
+            context: mockContext,
+            generatorFilter: undefined,
+            groupFilter: undefined,
+            includeMajor: false,
+            channel: undefined,
+            cliVersion: "1.0.0"
+        });
+
+        expect(result.updatedConfiguration).toBeDefined();
+
+        const parsedDoc = YAML.parseDocument(result.updatedConfiguration as string);
+        const groups = parsedDoc.get("groups") as YAML.YAMLMap;
+        const production = groups.get("production") as YAML.YAMLMap;
+        const generators = production.get("generators") as YAML.YAMLSeq;
+        const generator = generators.items[0] as YAML.YAMLMap;
+
+        expect(generator.get("name")).toBe("fernapi/fern-typescript-sdk");
+        expect(generator.get("version")).toBe("1.5.0");
+
+        expect(result.appliedUpgrades).toHaveLength(1);
+        expect(result.appliedUpgrades[0]?.previousName).toBe("fernapi/fern-typescript-node-sdk");
+        expect(result.appliedUpgrades[0]?.generatorName).toBe("fernapi/fern-typescript-sdk");
+    });
+
+    it("should replace deprecated alias preserving shorthand format", async () => {
+        const yamlContent = `groups:
+  production:
+    generators:
+      - name: fern-typescript-node-sdk
+        version: 1.0.0
+`;
+
+        const { getPathToGeneratorsConfiguration } = await import("@fern-api/configuration-loader");
+        vi.mocked(getPathToGeneratorsConfiguration).mockResolvedValue(testYamlPath as AbsoluteFilePath);
+        vi.mocked(readFile).mockResolvedValue(yamlContent);
+
+        const { getLatestGeneratorVersion } = await import("@fern-api/configuration-loader");
+        vi.mocked(getLatestGeneratorVersion).mockResolvedValue("2.0.0");
+
+        const { loadAndRunMigrations } = await import("../migrations");
+        vi.mocked(loadAndRunMigrations).mockResolvedValue(null);
+
+        const result = await loadAndUpdateGenerators({
+            absolutePathToWorkspace: "/test" as AbsoluteFilePath,
+            context: mockContext,
+            generatorFilter: undefined,
+            groupFilter: undefined,
+            includeMajor: false,
+            channel: undefined,
+            cliVersion: "1.0.0"
+        });
+
+        expect(result.updatedConfiguration).toBeDefined();
+
+        const parsedDoc = YAML.parseDocument(result.updatedConfiguration as string);
+        const groups = parsedDoc.get("groups") as YAML.YAMLMap;
+        const production = groups.get("production") as YAML.YAMLMap;
+        const generators = production.get("generators") as YAML.YAMLSeq;
+        const generator = generators.items[0] as YAML.YAMLMap;
+
+        expect(generator.get("name")).toBe("fern-typescript-sdk");
+        expect(generator.get("version")).toBe("2.0.0");
+
+        expect(result.appliedUpgrades[0]?.previousName).toBe("fern-typescript-node-sdk");
+        expect(result.appliedUpgrades[0]?.generatorName).toBe("fern-typescript-sdk");
+    });
+
+    it("should replace deprecated alias even when version is already latest", async () => {
+        const yamlContent = `groups:
+  production:
+    generators:
+      - name: fernapi/fern-typescript-node-sdk
+        version: 2.0.0
+`;
+
+        const { getPathToGeneratorsConfiguration } = await import("@fern-api/configuration-loader");
+        vi.mocked(getPathToGeneratorsConfiguration).mockResolvedValue(testYamlPath as AbsoluteFilePath);
+        vi.mocked(readFile).mockResolvedValue(yamlContent);
+
+        const { getLatestGeneratorVersion } = await import("@fern-api/configuration-loader");
+        vi.mocked(getLatestGeneratorVersion).mockResolvedValue("2.0.0");
+
+        const { loadAndRunMigrations } = await import("../migrations");
+        vi.mocked(loadAndRunMigrations).mockResolvedValue(null);
+
+        const result = await loadAndUpdateGenerators({
+            absolutePathToWorkspace: "/test" as AbsoluteFilePath,
+            context: mockContext,
+            generatorFilter: undefined,
+            groupFilter: undefined,
+            includeMajor: false,
+            channel: undefined,
+            cliVersion: "1.0.0"
+        });
+
+        expect(result.updatedConfiguration).toBeDefined();
+
+        const parsedDoc = YAML.parseDocument(result.updatedConfiguration as string);
+        const groups = parsedDoc.get("groups") as YAML.YAMLMap;
+        const production = groups.get("production") as YAML.YAMLMap;
+        const generators = production.get("generators") as YAML.YAMLSeq;
+        const generator = generators.items[0] as YAML.YAMLMap;
+
+        expect(generator.get("name")).toBe("fernapi/fern-typescript-sdk");
+
+        expect(result.appliedUpgrades).toHaveLength(1);
+        expect(result.appliedUpgrades[0]?.previousName).toBe("fernapi/fern-typescript-node-sdk");
+        expect(result.appliedUpgrades[0]?.previousVersion).toBe("2.0.0");
+        expect(result.appliedUpgrades[0]?.newVersion).toBe("2.0.0");
+
+        expect(result.alreadyUpToDate).toHaveLength(0);
     });
 });

--- a/packages/cli/cli/src/commands/upgrade/__test__/upgradeGenerator.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/__test__/upgradeGenerator.test.ts
@@ -370,7 +370,7 @@ groups:
         vi.mocked(getLatestGeneratorVersion).mockResolvedValue("1.5.0");
 
         const { loadAndRunMigrations } = await import("../migrations");
-        vi.mocked(loadAndRunMigrations).mockResolvedValue(null);
+        vi.mocked(loadAndRunMigrations).mockResolvedValue(undefined);
 
         const result = await loadAndUpdateGenerators({
             absolutePathToWorkspace: "/test" as AbsoluteFilePath,
@@ -414,7 +414,7 @@ groups:
         vi.mocked(getLatestGeneratorVersion).mockResolvedValue("2.0.0");
 
         const { loadAndRunMigrations } = await import("../migrations");
-        vi.mocked(loadAndRunMigrations).mockResolvedValue(null);
+        vi.mocked(loadAndRunMigrations).mockResolvedValue(undefined);
 
         const result = await loadAndUpdateGenerators({
             absolutePathToWorkspace: "/test" as AbsoluteFilePath,
@@ -457,7 +457,7 @@ groups:
         vi.mocked(getLatestGeneratorVersion).mockResolvedValue("2.0.0");
 
         const { loadAndRunMigrations } = await import("../migrations");
-        vi.mocked(loadAndRunMigrations).mockResolvedValue(null);
+        vi.mocked(loadAndRunMigrations).mockResolvedValue(undefined);
 
         const result = await loadAndUpdateGenerators({
             absolutePathToWorkspace: "/test" as AbsoluteFilePath,

--- a/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
@@ -3,7 +3,8 @@ import {
     getLatestGeneratorVersion,
     getPathToGeneratorsConfiguration,
     loadRawGeneratorsConfiguration,
-    normalizeGeneratorName
+    normalizeGeneratorName,
+    removeDefaultDockerOrgIfPresent
 } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
@@ -29,6 +30,7 @@ interface AppliedUpgrade {
     groupName: string;
     previousVersion: string;
     newVersion: string;
+    previousName?: string;
     migrationsApplied?: number;
     migrationVersions?: string[];
 }
@@ -149,6 +151,18 @@ export async function loadAndUpdateGenerators({
                 continue;
             }
 
+            const fullOriginalName = addDefaultDockerOrgIfNotPresent(generatorName);
+            const isAlias = fullOriginalName !== normalizedGeneratorName;
+            let replacedName: string | undefined;
+            if (isAlias) {
+                const originalHadOrg = generatorName.includes("/");
+                replacedName = originalHadOrg
+                    ? normalizedGeneratorName
+                    : removeDefaultDockerOrgIfPresent(normalizedGeneratorName);
+                generator.set("name", replacedName);
+                context.logger.debug(chalk.green(`Replacing deprecated alias ${generatorName} with ${replacedName}`));
+            }
+
             // Normalize the generator filter to add default Docker org prefix if not present
             const normalizedGeneratorFilter =
                 generatorFilter != null ? addDefaultDockerOrgIfNotPresent(generatorFilter) : undefined;
@@ -226,10 +240,11 @@ export async function loadAndUpdateGenerators({
                     }
 
                     appliedUpgrades.push({
-                        generatorName,
+                        generatorName: replacedName ?? generatorName,
                         groupName,
                         previousVersion: currentGeneratorVersion,
                         newVersion: latestVersion,
+                        previousName: isAlias ? generatorName : undefined,
                         migrationsApplied: migrationsApplied > 0 ? migrationsApplied : undefined,
                         migrationVersions: migrationVersions.length > 0 ? migrationVersions : undefined
                     });
@@ -238,11 +253,21 @@ export async function loadAndUpdateGenerators({
                     context.logger.debug(
                         chalk.gray(`${generatorName} is already on the latest version: ${currentGeneratorVersion}`)
                     );
-                    alreadyUpToDate.push({
-                        generatorName,
-                        groupName,
-                        version: currentGeneratorVersion
-                    });
+                    if (isAlias) {
+                        appliedUpgrades.push({
+                            generatorName: replacedName ?? generatorName,
+                            groupName,
+                            previousVersion: currentGeneratorVersion,
+                            newVersion: currentGeneratorVersion,
+                            previousName: generatorName
+                        });
+                    } else {
+                        alreadyUpToDate.push({
+                            generatorName,
+                            groupName,
+                            version: currentGeneratorVersion
+                        });
+                    }
                 }
             }
 
@@ -367,11 +392,15 @@ export async function upgradeGenerator({
                 cliContext.logger.info(chalk.green(`${workspacePrefix}Group ${groupName}:`));
 
                 for (const upgrade of groupUpgrades) {
-                    cliContext.logger.info(
-                        chalk.green(
-                            `  - ${upgrade.generatorName}: ${chalk.dim(upgrade.previousVersion)} → ${upgrade.newVersion}`
-                        )
-                    );
+                    const nameChange =
+                        upgrade.previousName != null
+                            ? `${upgrade.previousName} → ${upgrade.generatorName}`
+                            : upgrade.generatorName;
+                    const versionChange =
+                        upgrade.previousVersion !== upgrade.newVersion
+                            ? `: ${chalk.dim(upgrade.previousVersion)} → ${upgrade.newVersion}`
+                            : `: ${upgrade.newVersion} (alias updated)`;
+                    cliContext.logger.info(chalk.green(`  - ${nameChange}${versionChange}`));
                     // Show migration info if migrations were applied
                     if (upgrade.migrationsApplied != null && upgrade.migrationsApplied > 0) {
                         cliContext.logger.info(

--- a/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
@@ -287,7 +287,7 @@ export async function loadAndUpdateGenerators({
 
                     if (currentParsed != null && latestParsed != null && latestParsed.major > currentParsed.major) {
                         skippedMajorUpgrades.push({
-                            generatorName,
+                            generatorName: replacedName ?? generatorName,
                             currentVersion: versionToUse,
                             latestMajorVersion
                         });

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.77.0
+  changelogEntry:
+    - summary: |
+        `fern generator upgrade` now replaces deprecated generator aliases with their canonical names
+        in generators.yml. For example, `fern-typescript-node-sdk` is automatically replaced with
+        `fern-typescript-sdk`. The alias is updated even if the generator is already on the latest version.
+      type: feat
+  createdAt: "2026-02-13"
+  irVersion: 65
+
 - version: 3.76.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: User request from @iamnamananand996

`fern generator upgrade` now automatically replaces deprecated generator aliases (e.g. `fern-typescript-node-sdk`) with their canonical names (e.g. `fern-typescript-sdk`) in `generators.yml`. Previously, `normalizeGeneratorName` resolved aliases internally for version lookups but never wrote the canonical name back to the YAML file.

[Link to Devin run](https://app.devin.ai/sessions/dfbb268cf48e4b12b364b48680840983)

## Changes Made

- **`upgradeGenerator.ts`**: After normalizing a generator name, compare the original (with org prefix) to the normalized result. If they differ (i.e. it's a deprecated alias), update the `name` field in the YAML. Preserves the user's format convention — if they used shorthand (`fern-typescript-node-sdk`), the replacement is also shorthand (`fern-typescript-sdk`); if they used the full form (`fernapi/...`), the replacement uses the full form.
- When the version is already latest but the name is a deprecated alias, the alias replacement is still applied and reported as an upgrade (rather than silently skipped as "already up to date").
- Updated CLI output to show alias renames: `fern-typescript-node-sdk → fern-typescript-sdk: 1.0.0 → 1.5.0` or `fern-typescript-node-sdk → fern-typescript-sdk: 2.0.0 (alias updated)` when only the name changed.
- `skippedMajorUpgrades` messages also use the replaced canonical name for consistency.
- Added `previousName` optional field to `AppliedUpgrade` interface to track renames.
- Added new `3.77.0` entry to CLI `versions.yml`.

## Testing

- [x] Unit tests added — 3 new cases: alias replacement with version upgrade, shorthand format preservation, alias-only update when version is already latest
- [x] All 7 existing + new tests pass
- [x] Biome lint passes
- [x] Local CLI build + manual test against a fixture with `fern-typescript-node-sdk` confirmed the alias is replaced in `generators.yml` and output shows `fern-typescript-node-sdk → fern-typescript-sdk: 0.39.3 → 0.51.7`

## Review Checklist

- [ ] When `latestVersion` is `null` (e.g. API lookup fails), the alias name replacement is still written to the YAML (`generator.set("name", ...)` on L162) but no `appliedUpgrade` entry is recorded — verify this silent-rename-on-failure behavior is acceptable
- [ ] Confirm the new output formatting looks correct for all combinations (alias+version change, alias-only, version-only, no change)