### PR TITLE
feat(java): add server URL templating support

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -31,6 +31,14 @@ import com.fern.ir.model.commons.EndpointReference;
 import com.fern.ir.model.commons.ErrorId;
 import com.fern.ir.model.commons.TypeId;
 import com.fern.ir.model.commons.WebSocketChannelId;
+import com.fern.ir.model.environment.EnvironmentBaseUrlWithId;
+import com.fern.ir.model.environment.Environments;
+import com.fern.ir.model.environment.EnvironmentsConfig;
+import com.fern.ir.model.environment.MultipleBaseUrlsEnvironment;
+import com.fern.ir.model.environment.MultipleBaseUrlsEnvironments;
+import com.fern.ir.model.environment.ServerVariable;
+import com.fern.ir.model.environment.SingleBaseUrlEnvironment;
+import com.fern.ir.model.environment.SingleBaseUrlEnvironments;
 import com.fern.ir.model.http.HttpEndpoint;
 import com.fern.ir.model.http.HttpService;
 import com.fern.ir.model.http.QueryParameter;
@@ -44,6 +52,7 @@ import com.fern.java.AbstractGeneratorContext;
 import com.fern.java.client.ClientGeneratorContext;
 import com.fern.java.client.GeneratedClientOptions;
 import com.fern.java.client.GeneratedEnvironmentsClass;
+import com.fern.java.client.GeneratedEnvironmentsClass.MultiUrlEnvironmentsClass;
 import com.fern.java.client.GeneratedEnvironmentsClass.SingleUrlEnvironmentClass;
 import com.fern.java.client.GeneratedRootClient;
 import com.fern.java.client.generators.AbstractClientGeneratorUtils.Result;
@@ -661,7 +670,25 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                 })
                 .forEach(clientBuilder::addMethod);
 
-        MethodSpec.Builder buildClientOptionsMethodBuilder = MethodSpec.methodBuilder("buildClientOptions")
+        List<ServerVariable> serverVariables = getServerVariables();
+        for (ServerVariable serverVar : serverVariables) {
+            String paramName = getServerVariableParamName(serverVar);
+            clientBuilder.addField(FieldSpec.builder(String.class, paramName)
+                    .addModifiers(Modifier.PRIVATE)
+                    .build());
+        }
+        for (ServerVariable serverVar : serverVariables) {
+            String paramName = getServerVariableParamName(serverVar);
+            clientBuilder.addMethod(MethodSpec.methodBuilder(paramName)
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(isExtensible ? TypeVariableName.get("T") : builderName)
+                    .addParameter(String.class, paramName)
+                    .addStatement("this.$L = $L", paramName, paramName)
+                    .addStatement(isExtensible ? "return self()" : "return this")
+                    .build());
+        }
+
+        MethodSpec.Builder buildClientOptionsMethodBuilder= MethodSpec.methodBuilder("buildClientOptions")
                 .addModifiers(Modifier.PROTECTED)
                 .returns(generatedClientOptions.getClassName())
                 .addStatement(
@@ -700,16 +727,114 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
 
         clientBuilder.addMethod(buildClientOptionsMethodBuilder.build());
 
-        MethodSpec setEnvironmentMethod = MethodSpec.methodBuilder("setEnvironment")
+        MethodSpec.Builder setEnvironmentMethodBuilder = MethodSpec.methodBuilder("setEnvironment")
                 .addModifiers(Modifier.PROTECTED)
                 .addParameter(generatedClientOptions.builderClassName(), "builder")
                 .addJavadoc("Sets the environment configuration for the client.\n"
                         + "Override this method to modify URLs or add environment-specific logic.\n"
                         + "\n"
-                        + "@param builder The ClientOptions.Builder to configure")
-                .addStatement("builder.$N(this.$N)", generatedClientOptions.environment(), environmentField)
-                .build();
-        clientBuilder.addMethod(setEnvironmentMethod);
+                        + "@param builder The ClientOptions.Builder to configure");
+
+        if (!serverVariables.isEmpty()) {
+            Optional<EnvironmentsConfig> envConfig = generatorContext.getIr().getEnvironments();
+            if (envConfig.isPresent()) {
+                StringBuilder conditionBuilder = new StringBuilder();
+                for (int i = 0; i < serverVariables.size(); i++) {
+                    if (i > 0) conditionBuilder.append(" || ");
+                    conditionBuilder
+                            .append("this.")
+                            .append(getServerVariableParamName(serverVariables.get(i)))
+                            .append(" != null");
+                }
+                setEnvironmentMethodBuilder.beginControlFlow("if ($L)", conditionBuilder.toString());
+
+                for (ServerVariable serverVar : serverVariables) {
+                    String paramName = getServerVariableParamName(serverVar);
+                    String defaultValue = serverVar.getDefault().orElse("");
+                    setEnvironmentMethodBuilder.addStatement(
+                            "$T _$L = this.$L != null ? this.$L : $S",
+                            String.class,
+                            paramName,
+                            paramName,
+                            paramName,
+                            defaultValue);
+                }
+
+                Environments envs = envConfig.get().getEnvironments();
+                if (generatedEnvironmentsClass.info() instanceof SingleUrlEnvironmentClass) {
+                    envs.getSingleBaseUrl().ifPresent(singleBaseUrl -> {
+                        if (!singleBaseUrl.getEnvironments().isEmpty()) {
+                            SingleBaseUrlEnvironment firstEnv =
+                                    singleBaseUrl.getEnvironments().get(0);
+                            String urlTemplate =
+                                    firstEnv.getUrlTemplate().orElse(firstEnv.getUrl().get());
+
+                            CodeBlock.Builder replaceChain = CodeBlock.builder().add("$S", urlTemplate);
+                            for (ServerVariable sv : serverVariables) {
+                                replaceChain.add(
+                                        ".replace($S, _$L)",
+                                        "{" + sv.getId() + "}",
+                                        getServerVariableParamName(sv));
+                            }
+                            setEnvironmentMethodBuilder.addStatement(
+                                    "this.$N = $T.custom($L)",
+                                    environmentField,
+                                    generatedEnvironmentsClass.getClassName(),
+                                    replaceChain.build());
+                        }
+                    });
+                } else if (generatedEnvironmentsClass.info() instanceof MultiUrlEnvironmentsClass) {
+                    envs.getMultipleBaseUrls().ifPresent(multiBase -> {
+                        if (!multiBase.getEnvironments().isEmpty()) {
+                            MultipleBaseUrlsEnvironment firstEnv =
+                                    multiBase.getEnvironments().get(0);
+
+                            CodeBlock.Builder envCode = CodeBlock.builder();
+                            envCode.add(
+                                    "this.$N = $T.custom()",
+                                    environmentField,
+                                    generatedEnvironmentsClass.getClassName());
+
+                            for (EnvironmentBaseUrlWithId baseUrl : multiBase.getBaseUrls()) {
+                                String urlName =
+                                        baseUrl.getName().getCamelCase().getSafeName();
+                                String template;
+                                if (firstEnv.getUrlTemplates().isPresent()
+                                        && firstEnv.getUrlTemplates()
+                                                .get()
+                                                .containsKey(baseUrl.getId())) {
+                                    template = firstEnv.getUrlTemplates()
+                                            .get()
+                                            .get(baseUrl.getId());
+                                } else {
+                                    template = firstEnv.getUrls()
+                                            .get(baseUrl.getId())
+                                            .get();
+                                }
+
+                                CodeBlock.Builder replaceChain =
+                                        CodeBlock.builder().add("$S", template);
+                                for (ServerVariable sv : serverVariables) {
+                                    replaceChain.add(
+                                            ".replace($S, _$L)",
+                                            "{" + sv.getId() + "}",
+                                            getServerVariableParamName(sv));
+                                }
+                                envCode.add("\n.$L($L)", urlName, replaceChain.build());
+                            }
+                            envCode.add("\n.build()");
+                            setEnvironmentMethodBuilder.addStatement("$L", envCode.build());
+                        }
+                    });
+                }
+
+                setEnvironmentMethodBuilder.endControlFlow();
+            }
+        }
+
+        setEnvironmentMethodBuilder.addStatement(
+                "builder.$N(this.$N)", generatedClientOptions.environment(), environmentField);
+        clientBuilder.addMethod(setEnvironmentMethodBuilder.build());
 
         if (hasAuth) {
             clientBuilder.addMethod(configureAuthBuilder.build());
@@ -882,6 +1007,71 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                         generatorContext.getGeneratorConfig().getOrganization())
                 + CasingUtils.convertKebabCaseToUpperCamelCase(
                         generatorContext.getGeneratorConfig().getWorkspaceName());
+    }
+
+    private static final Set<String> RESERVED_BUILDER_PARAM_NAMES =
+            Set.of("environment", "url", "timeout", "maxRetries", "httpClient");
+
+    private List<ServerVariable> getServerVariables() {
+        Optional<EnvironmentsConfig> envConfig = generatorContext.getIr().getEnvironments();
+        if (!envConfig.isPresent()) {
+            return new ArrayList<>();
+        }
+
+        Environments environments = envConfig.get().getEnvironments();
+        Set<String> seenIds = new HashSet<>();
+        List<ServerVariable> variables = new ArrayList<>();
+
+        environments.visit(new Environments.Visitor<Void>() {
+            @Override
+            public Void visitSingleBaseUrl(SingleBaseUrlEnvironments singleBaseUrl) {
+                if (!singleBaseUrl.getEnvironments().isEmpty()) {
+                    SingleBaseUrlEnvironment firstEnv =
+                            singleBaseUrl.getEnvironments().get(0);
+                    firstEnv.getUrlVariables().ifPresent(vars -> {
+                        for (ServerVariable var : vars) {
+                            if (seenIds.add(var.getId())) {
+                                variables.add(var);
+                            }
+                        }
+                    });
+                }
+                return null;
+            }
+
+            @Override
+            public Void visitMultipleBaseUrls(MultipleBaseUrlsEnvironments multipleBaseUrls) {
+                if (!multipleBaseUrls.getEnvironments().isEmpty()) {
+                    MultipleBaseUrlsEnvironment firstEnv =
+                            multipleBaseUrls.getEnvironments().get(0);
+                    firstEnv.getUrlVariables().ifPresent(urlVarsMap -> {
+                        for (List<ServerVariable> vars : urlVarsMap.values()) {
+                            for (ServerVariable var : vars) {
+                                if (seenIds.add(var.getId())) {
+                                    variables.add(var);
+                                }
+                            }
+                        }
+                    });
+                }
+                return null;
+            }
+
+            @Override
+            public Void _visitUnknown(Object unknown) {
+                return null;
+            }
+        });
+
+        return variables;
+    }
+
+    private String getServerVariableParamName(ServerVariable var) {
+        String name = var.getName().getCamelCase().getSafeName();
+        if (RESERVED_BUILDER_PARAM_NAMES.contains(name)) {
+            return "serverUrl" + var.getName().getPascalCase().getSafeName();
+        }
+        return name;
     }
 
     private final class AuthSchemeHandler implements AuthScheme.Visitor<Void> {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/AbstractRootClientGenerator.java
@@ -688,7 +688,7 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                     .build());
         }
 
-        MethodSpec.Builder buildClientOptionsMethodBuilder= MethodSpec.methodBuilder("buildClientOptions")
+        MethodSpec.Builder buildClientOptionsMethodBuilder = MethodSpec.methodBuilder("buildClientOptions")
                 .addModifiers(Modifier.PROTECTED)
                 .returns(generatedClientOptions.getClassName())
                 .addStatement(
@@ -766,15 +766,13 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                         if (!singleBaseUrl.getEnvironments().isEmpty()) {
                             SingleBaseUrlEnvironment firstEnv =
                                     singleBaseUrl.getEnvironments().get(0);
-                            String urlTemplate =
-                                    firstEnv.getUrlTemplate().orElse(firstEnv.getUrl().get());
+                            String urlTemplate = firstEnv.getUrlTemplate()
+                                    .orElse(firstEnv.getUrl().get());
 
                             CodeBlock.Builder replaceChain = CodeBlock.builder().add("$S", urlTemplate);
                             for (ServerVariable sv : serverVariables) {
                                 replaceChain.add(
-                                        ".replace($S, _$L)",
-                                        "{" + sv.getId() + "}",
-                                        getServerVariableParamName(sv));
+                                        ".replace($S, _$L)", "{" + sv.getId() + "}", getServerVariableParamName(sv));
                             }
                             setEnvironmentMethodBuilder.addStatement(
                                     "this.$N = $T.custom($L)",
@@ -800,12 +798,8 @@ public abstract class AbstractRootClientGenerator extends AbstractFileGenerator 
                                         baseUrl.getName().getCamelCase().getSafeName();
                                 String template;
                                 if (firstEnv.getUrlTemplates().isPresent()
-                                        && firstEnv.getUrlTemplates()
-                                                .get()
-                                                .containsKey(baseUrl.getId())) {
-                                    template = firstEnv.getUrlTemplates()
-                                            .get()
-                                            .get(baseUrl.getId());
+                                        && firstEnv.getUrlTemplates().get().containsKey(baseUrl.getId())) {
+                                    template = firstEnv.getUrlTemplates().get().get(baseUrl.getId());
                                 } else {
                                     template = firstEnv.getUrls()
                                             .get(baseUrl.getId())

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/EnvironmentGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/EnvironmentGenerator.java
@@ -2,7 +2,6 @@ package com.fern.java.client.generators;
 
 import com.fern.ir.model.environment.EnvironmentBaseUrlId;
 import com.fern.ir.model.environment.EnvironmentId;
-import com.fern.ir.model.environment.EnvironmentUrl;
 import com.fern.ir.model.environment.Environments;
 import com.fern.ir.model.environment.EnvironmentsConfig;
 import com.fern.ir.model.environment.MultipleBaseUrlsEnvironment;
@@ -96,7 +95,8 @@ public final class EnvironmentGenerator extends AbstractFileGenerator {
             for (SingleBaseUrlEnvironment environment : singleBaseUrl.getEnvironments()) {
                 optionsPresent = true;
                 String constant = environment.getName().getScreamingSnakeCase().getSafeName();
-                String envUrl = environment.getDefaultUrl().orElse(environment.getUrl().get());
+                String envUrl =
+                        environment.getDefaultUrl().orElse(environment.getUrl().get());
                 environmentsBuilder.addField(
                         FieldSpec.builder(className, constant, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
                                 .initializer("new $T($S)", className, envUrl)
@@ -150,14 +150,11 @@ public final class EnvironmentGenerator extends AbstractFileGenerator {
                 String args = multipleBaseUrls.getBaseUrls().stream()
                         .map(baseUrlWithId -> {
                             if (environment.getDefaultUrls().isPresent()
-                                    && environment.getDefaultUrls()
-                                            .get()
-                                            .containsKey(baseUrlWithId.getId())) {
-                                return environment.getDefaultUrls()
-                                        .get()
-                                        .get(baseUrlWithId.getId());
+                                    && environment.getDefaultUrls().get().containsKey(baseUrlWithId.getId())) {
+                                return environment.getDefaultUrls().get().get(baseUrlWithId.getId());
                             }
-                            return environment.getUrls()
+                            return environment
+                                    .getUrls()
                                     .get(baseUrlWithId.getId())
                                     .get();
                         })

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/EnvironmentGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/EnvironmentGenerator.java
@@ -96,9 +96,10 @@ public final class EnvironmentGenerator extends AbstractFileGenerator {
             for (SingleBaseUrlEnvironment environment : singleBaseUrl.getEnvironments()) {
                 optionsPresent = true;
                 String constant = environment.getName().getScreamingSnakeCase().getSafeName();
+                String envUrl = environment.getDefaultUrl().orElse(environment.getUrl().get());
                 environmentsBuilder.addField(
                         FieldSpec.builder(className, constant, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                                .initializer("new $T($S)", className, environment.getUrl())
+                                .initializer("new $T($S)", className, envUrl)
                                 .build());
                 if (defaultEnvironmentId.isPresent()
                         && defaultEnvironmentId.get().equals(environment.getId())) {
@@ -147,8 +148,19 @@ public final class EnvironmentGenerator extends AbstractFileGenerator {
             for (MultipleBaseUrlsEnvironment environment : multipleBaseUrls.getEnvironments()) {
                 optionsPresent = true;
                 String args = multipleBaseUrls.getBaseUrls().stream()
-                        .map(baseUrlWithId -> environment.getUrls().get(baseUrlWithId.getId()))
-                        .map(EnvironmentUrl::get)
+                        .map(baseUrlWithId -> {
+                            if (environment.getDefaultUrls().isPresent()
+                                    && environment.getDefaultUrls()
+                                            .get()
+                                            .containsKey(baseUrlWithId.getId())) {
+                                return environment.getDefaultUrls()
+                                        .get()
+                                        .get(baseUrlWithId.getId());
+                            }
+                            return environment.getUrls()
+                                    .get(baseUrlWithId.getId())
+                                    .get();
+                        })
                         .map(url -> "\"" + url + "\"")
                         .collect(Collectors.joining(","));
                 String constant = environment.getName().getScreamingSnakeCase().getSafeName();

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.36.0
+  changelogEntry:
+    - summary: |
+        Add server URL templating support. When an OpenAPI spec uses server variables
+        (e.g., `https://api.{region}.{environment}.example.com`), the generated SDK now
+        exposes those variables as builder methods (e.g., `.region("us-east-1")`). The
+        `x-fern-default-url` extension provides a clean fallback URL when no variables
+        are provided. Supports both single and multiple base URL environments.
+      type: feat
+  createdAt: "2026-02-13"
+  irVersion: 63
+
 - version: 3.35.2
   changelogEntry:
     - summary: |

--- a/generators/java/versions.lock
+++ b/generators/java/versions.lock
@@ -10,7 +10,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2 (8 constraints: 0866
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2 (3 constraints: 941c125b)
 com.fern.fern:generator-exec-client:0.0.806 (1 constraints: 70059d40)
 com.fern.fern:generator-exec-model:0.0.806 (1 constraints: 760ff78e)
-com.fern.fern:irV63:63.1.0 (1 constraints: 3c05573b)
+com.fern.fern:irV63:63.2.0 (1 constraints: 3d055a3b)
 com.google.code.findbugs:annotations:3.0.1 (5 constraints: 0b486b6a)
 com.google.code.findbugs:jsr305:3.0.2 (6 constraints: 3e53d684)
 com.google.errorprone:error_prone_annotations:2.18.0 (5 constraints: 824496e2)

--- a/generators/java/versions.props
+++ b/generators/java/versions.props
@@ -8,7 +8,7 @@ org.immutables:* = 2.8.8
 org.apache.commons:commons-lang3 = 3.18.0
 
 # fern
-com.fern.fern:irV63 = 63.1.0
+com.fern.fern:irV63 = 63.2.0
 com.fern.fern:generator-exec-client = 0.0.806
 
 # testing

--- a/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/AsyncSeedApiClientBuilder.java
+++ b/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/AsyncSeedApiClientBuilder.java
@@ -21,6 +21,10 @@ public class AsyncSeedApiClientBuilder {
 
     private OkHttpClient httpClient;
 
+    private String region;
+
+    private String serverUrlEnvironment;
+
     public AsyncSeedApiClientBuilder environment(Environment environment) {
         this.environment = environment;
         return this;
@@ -63,6 +67,16 @@ public class AsyncSeedApiClientBuilder {
         return this;
     }
 
+    public AsyncSeedApiClientBuilder region(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public AsyncSeedApiClientBuilder serverUrlEnvironment(String serverUrlEnvironment) {
+        this.serverUrlEnvironment = serverUrlEnvironment;
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -83,6 +97,18 @@ public class AsyncSeedApiClientBuilder {
      * @param builder The ClientOptions.Builder to configure
      */
     protected void setEnvironment(ClientOptions.Builder builder) {
+        if (this.region != null || this.serverUrlEnvironment != null) {
+            String _region = this.region != null ? this.region : "us-east-1";
+            String _serverUrlEnvironment = this.serverUrlEnvironment != null ? this.serverUrlEnvironment : "prod";
+            this.environment = Environment.custom()
+                    .base("https://api.{region}.{environment}.example.com/v1"
+                            .replace("{region}", _region)
+                            .replace("{environment}", _serverUrlEnvironment))
+                    .auth("https://auth.{region}.example.com"
+                            .replace("{region}", _region)
+                            .replace("{environment}", _serverUrlEnvironment))
+                    .build();
+        }
         builder.environment(this.environment);
     }
 

--- a/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/SeedApiClientBuilder.java
+++ b/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/SeedApiClientBuilder.java
@@ -21,6 +21,10 @@ public class SeedApiClientBuilder {
 
     private OkHttpClient httpClient;
 
+    private String region;
+
+    private String serverUrlEnvironment;
+
     public SeedApiClientBuilder environment(Environment environment) {
         this.environment = environment;
         return this;
@@ -63,6 +67,16 @@ public class SeedApiClientBuilder {
         return this;
     }
 
+    public SeedApiClientBuilder region(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public SeedApiClientBuilder serverUrlEnvironment(String serverUrlEnvironment) {
+        this.serverUrlEnvironment = serverUrlEnvironment;
+        return this;
+    }
+
     protected ClientOptions buildClientOptions() {
         ClientOptions.Builder builder = ClientOptions.builder();
         setEnvironment(builder);
@@ -83,6 +97,18 @@ public class SeedApiClientBuilder {
      * @param builder The ClientOptions.Builder to configure
      */
     protected void setEnvironment(ClientOptions.Builder builder) {
+        if (this.region != null || this.serverUrlEnvironment != null) {
+            String _region = this.region != null ? this.region : "us-east-1";
+            String _serverUrlEnvironment = this.serverUrlEnvironment != null ? this.serverUrlEnvironment : "prod";
+            this.environment = Environment.custom()
+                    .base("https://api.{region}.{environment}.example.com/v1"
+                            .replace("{region}", _region)
+                            .replace("{environment}", _serverUrlEnvironment))
+                    .auth("https://auth.{region}.example.com"
+                            .replace("{region}", _region)
+                            .replace("{environment}", _serverUrlEnvironment))
+                    .build();
+        }
         builder.environment(this.environment);
     }
 


### PR DESCRIPTION
## Description

Refs PRs #12041, #12114, #12131

Adds OpenAPI server URL templating support to the Java SDK generator, matching the existing Python SDK implementation. When an OpenAPI spec uses server variables (e.g., `https://api.{region}.{environment}.example.com`), the generated Java SDK now exposes those variables as builder methods.

**Link to Devin run:** https://app.devin.ai/sessions/2498db176c6c464ab519160e73b53b2f
**Requested by:** @iamnamananand996

## Changes Made

- **`EnvironmentGenerator.java`**: Prefer `defaultUrl`/`defaultUrls` (from `x-fern-default-url` extension) over raw `url`/`urls` when generating environment constants. Falls back to original URL when `defaultUrl` is not present.
- **`AbstractRootClientGenerator.java`**:
  - `getServerVariables()`: Extracts unique `ServerVariable` objects from the IR environments config (first environment only, matching Python behavior). Handles both single and multiple base URL environments via the visitor pattern.
  - `getServerVariableParamName()`: Handles name collisions — a server variable named `environment` becomes `serverUrlEnvironment` to avoid conflicting with the existing builder method.
  - Generates `private String` fields and `public` setter methods on the builder for each server variable.
  - Extends `setEnvironment()` to conditionally reconstruct the `Environment` from URL templates using `.replace()` chains when any server variable is set. Defaults are applied from the IR when a variable is not provided.
- **IR dependency**: Bumped `com.fern.fern:irV63` from `63.1.0` → `63.2.0` to get `ServerVariable`, `defaultUrl`, `urlTemplate`, `urlVariables` fields.
- **`versions.yml`**: Added version `3.36.0` changelog entry.
- **Seed snapshots**: Regenerated `server-url-templating` fixture showing the new `region()` and `serverUrlEnvironment()` builder methods and the interpolation logic in `setEnvironment()`.

### Generated SDK usage (from seed output):
```java
// Default (uses x-fern-default-url: https://api.example.com/v1)
SeedApiClient client = SeedApiClient.builder().build();

// With server variables
SeedApiClient client = SeedApiClient.builder()
    .region("eu-west-1")
    .serverUrlEnvironment("staging")
    .build();
// → https://api.eu-west-1.staging.example.com/v1
```

## Testing

- [x] Seed test passed for `server-url-templating` fixture
- [x] Java generator compiles successfully
- [x] All required CI checks pass (java-sdk, java-model seed tests pass)
- [ ] Unit tests added/updated (no new unit tests — relies on seed snapshot testing)

**CI Note:** The `java-spring` seed tests fail due to a pre-existing `@fern-api/rust-base#compile` failure unrelated to this PR. All Java SDK/model tests pass.

## Human Review Checklist

- [ ] **Single-URL environment code path**: The `server-url-templating` fixture uses multiple base URLs. The single-URL code path (`SingleUrlEnvironmentClass`) is not covered by seed snapshots — please verify the logic in `setEnvironmentMethodBuilder` for this case.
- [ ] **Default value handling**: When a server variable has no default and the user doesn't provide a value, an empty string is substituted (`serverVar.getDefault().orElse("")`). This could produce malformed URLs like `https://api..staging.example.com`. Verify this matches expected behavior.
- [ ] **Other fixtures**: Verify no other seed fixtures are affected by the `EnvironmentGenerator` change (should be safe since `defaultUrl` only exists when `x-fern-default-url` is used).
- [ ] **Reserved name set**: `RESERVED_BUILDER_PARAM_NAMES` covers `environment`, `url`, `timeout`, `maxRetries`, `httpClient`. Confirm this is sufficient or if other builder method names should be added.