### PR TITLE
fix(cli): scope PR update to current generator and fix CI concurrency

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -27,10 +27,10 @@ on:
     branches:
       - main
 
-# Cancel previous workflows when another is triggered
+# Let the current run finish, but cancel any queued (pending) runs in favor of the newest
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.77.1
+  changelogEntry:
+    - summary: |
+        Scope PR update feature for self-hosted GitHub generation to the current generator by
+        including the generator name in the branch prefix (e.g. fern-bot/fernapi-fern-typescript-sdk/).
+        This prevents concurrent generators targeting the same repository from racing on the same PR.
+      type: fix
+  createdAt: "2026-02-13"
+  irVersion: 65
+
 - version: 3.77.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -284,7 +284,8 @@ export async function runLocalGenerationForWorkspace({
                         interactiveTaskContext,
                         selfhostedGithubConfig,
                         absolutePathToLocalOutput,
-                        autoVersioningCommitMessage
+                        autoVersioningCommitMessage,
+                        generatorInvocation.name
                     );
                 }
             });
@@ -361,7 +362,8 @@ async function findExistingUpdatablePR(
     owner: string,
     repo: string,
     baseBranch: string,
-    context: TaskContext
+    context: TaskContext,
+    branchPrefix: string
 ): Promise<ExistingPullRequest | undefined> {
     try {
         const { data: pulls } = await octokit.pulls.list({
@@ -381,8 +383,10 @@ async function findExistingUpdatablePR(
                 continue;
             }
 
-            if (!pr.head.ref.startsWith("fern-bot/")) {
-                context.logger.debug(`PR #${pr.number} skipped: branch ${pr.head.ref} does not start with fern-bot/`);
+            if (!pr.head.ref.startsWith(branchPrefix)) {
+                context.logger.debug(
+                    `PR #${pr.number} skipped: branch ${pr.head.ref} does not start with ${branchPrefix}`
+                );
                 continue;
             }
 
@@ -453,18 +457,25 @@ async function checkPRHasOnlyGenerationCommits(
     }
 }
 
+function sanitizeGeneratorNameForBranch(generatorName: string): string {
+    return generatorName.replace(/\//g, "-");
+}
+
 async function postProcessGithubSelfHosted(
     context: TaskContext,
     selfhostedGithubConfig: SelhostedGithubConfig,
     absolutePathToLocalOutput: AbsoluteFilePath,
-    commitMessage?: string
+    commitMessage?: string,
+    generatorName?: string
 ): Promise<void> {
     try {
         context.logger.debug("Starting GitHub self-hosted flow in directory: " + absolutePathToLocalOutput);
         const repository = ClonedRepository.createAtPath(absolutePathToLocalOutput);
         const now = new Date();
         const formattedDate = now.toISOString().replace("T", "_").replace(/:/g, "-").replace("Z", "").replace(".", "_");
-        const newPrBranch = `fern-bot/${formattedDate}`;
+        const sanitizedName = generatorName != null ? sanitizeGeneratorNameForBranch(generatorName) : undefined;
+        const branchPrefix = sanitizedName != null ? `fern-bot/${sanitizedName}/` : "fern-bot/";
+        const newPrBranch = `${branchPrefix}${formattedDate}`;
         // Ensure git commits are attributed to a bot user so pushes/PRs have a consistent author.
         try {
             // Use repository helper to set git user/email if available
@@ -487,7 +498,14 @@ async function postProcessGithubSelfHosted(
                 const parsedRepo = parseRepository(selfhostedGithubConfig.uri);
                 const { owner, repo } = parsedRepo;
 
-                const existingPR = await findExistingUpdatablePR(octokit, owner, repo, baseBranch, context);
+                const existingPR = await findExistingUpdatablePR(
+                    octokit,
+                    owner,
+                    repo,
+                    baseBranch,
+                    context,
+                    branchPrefix
+                );
 
                 let prBranch: string;
                 let isUpdatingExistingPR = false;


### PR DESCRIPTION
## Description

Refs: [Devin session](https://app.devin.ai/sessions/3e473bbf53e048dbbe0790745ccbbc5f)  
Requested by: @davidkonigsberg

Fixes the `test-remote-vs-local-generation-parity` workflow that has been failing since Feb 9 (when PR #11502 / v3.70.0 introduced the PR update feature for self-hosted GitHub generation).

**Root cause:** When multiple generators (ts-sdk, java-sdk, go-sdk, python-sdk) run concurrently in CI, they all target `fern-api/empty` and `findExistingUpdatablePR` finds the **same** most-recently-updated PR for all of them. They all try to push to the same branch, causing non-fast-forward rejections on all but the first push. Retries don't help because each retry hits the same race.

## Changes Made

- **Generator-scoped branch prefixes**: Branch naming changes from `fern-bot/{date}` to `fern-bot/{generator-name}/{date}` (e.g. `fern-bot/fernapi-fern-typescript-sdk/2026-02-13_...`). `findExistingUpdatablePR` now filters by this generator-specific prefix, so generators only find and update their own PRs.
- **Workflow concurrency**: Changed `cancel-in-progress: true` → `false`. With GitHub Actions, this lets the current run finish while cancelling any intermediate pending runs, so only the newest queued run executes next (instead of constantly cancelling in-progress jobs).
- **CLI versions.yml**: Added v3.77.1 changelog entry.

## Review Checklist

- [ ] **Backward compatibility**: Existing PRs with old `fern-bot/{date}` branches won't be matched by the new prefix filter. First generation after this change will create a new PR instead of updating existing ones — acceptable one-time transition?
- [ ] **`generatorName` is optional**: Falls back to `"fern-bot/"` (old behavior) when undefined. In practice, `generatorInvocation.name` is always defined at the call site — verify this is safe.
- [ ] **Branch name sanitization**: Only replaces `/` with `-`. Are there other characters in generator names that could be invalid in git branch names?
- [ ] **Same-generator race**: This fix prevents cross-generator races but doesn't address two concurrent runs of the *same* generator. Not an issue for the test workflow (one job per generator), but worth considering for production.

## Testing

- [x] Lint passes (`pnpm run check`)
- [ ] CI workflow validation (requires full environment with tokens and `fern-api/empty` repo — will validate post-merge)