### PR TITLE
Scaffolding for telemetry system in cli-v2

### DIFF
--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -21,7 +21,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
     "compile": "tsc --build",
@@ -76,8 +78,10 @@
     "inquirer": "^9.2.15",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.2",
+    "posthog-node": "^5.14.0",
     "tsup": "^8.5.0",
     "typescript": "5.9.3",
+    "uuid": "^13.0.0",
     "vitest": "^4.0.8",
     "yargs": "^17.4.1"
   }

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -5,6 +5,7 @@ import { createLogger, LOG_LEVELS, Logger, LogLevel } from "@fern-api/logger";
 import { getTokenFromAuth0 } from "@fern-api/login";
 import chalk from "chalk";
 import inquirer from "inquirer";
+import { v4 as uuidv4 } from "uuid";
 import { CredentialStore, TokenService } from "../auth/index.js";
 import { Cache } from "../cache/index.js";
 import { loadFernYml } from "../config/fern-yml/loadFernYml.js";
@@ -16,6 +17,8 @@ import type { Workspace } from "../workspace/Workspace.js";
 import { WorkspaceLoader } from "../workspace/WorkspaceLoader.js";
 import { TaskContextAdapter } from "./adapter/TaskContextAdapter.js";
 import { LogFileWriter } from "./LogFileWriter.js";
+import { getPosthogManager } from "../telemetry";
+import type { PosthogEvent } from "../telemetry";
 
 export class Context {
     private ttyAwareLogger: TtyAwareLogger;
@@ -27,7 +30,8 @@ export class Context {
     public readonly cache: Cache;
     public readonly logFileWriter: LogFileWriter;
     public readonly tokenService: TokenService;
-
+    public readonly isLocal: boolean;
+    public readonly tags: Record<string, string | number | boolean>;
     constructor({
         stdout,
         stderr,
@@ -47,6 +51,12 @@ export class Context {
         this.cache = new Cache({ logger: this.stderr });
         this.logFileWriter = new LogFileWriter(this.cache.logs.absoluteFilePath);
         this.tokenService = new TokenService({ credential: new CredentialStore() });
+        this.isLocal = false; // TODO: make this configurable
+        this.tags = {
+            invocationId: uuidv4(),
+            version: process.env.CLI_VERSION || '',
+            source: 'CLI',
+        };
     }
 
     /**
@@ -173,6 +183,24 @@ export class Context {
      */
     public finish(): void {
         this.ttyAwareLogger.finish();
+    }
+
+    public async tag(key: string, value: string | number): Promise<void> {
+        this.tags[key] = value
+    }
+
+    public async sendEventToPosthog(event: PosthogEvent): Promise<void> {
+        if (!this.isLocal) {
+            const mergedEvent: PosthogEvent = {
+                event: event.event,
+                properties: {
+                    ...(event.properties ?? {}),
+                    ...this.tags
+                }
+            };
+            const manager = await getPosthogManager();
+            (await getPosthogManager()).sendEvent(mergedEvent);
+        }
     }
 
     private async promptAndLogin(): Promise<FernUserToken> {

--- a/packages/cli/cli-v2/src/context/GlobalArgs.ts
+++ b/packages/cli/cli-v2/src/context/GlobalArgs.ts
@@ -1,3 +1,4 @@
 export interface GlobalArgs {
     "log-level": string;
+    _: (string | number)[];
 }

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -18,14 +18,23 @@ export function withContext<T extends GlobalArgs>(
 ): (args: T) => Promise<void> {
     return async (args: T) => {
         const context = createContext(args);
+        context.tag("command", args._.join(' '));
+        const startTime = performance.now();
+        let exitCode = 0;
         try {
             await handler(context, args);
-            context.finish();
-            process.exit(0);
         } catch (error) {
             handleError(context, error);
+            exitCode = 1;
+        } finally {
+            const endTime = performance.now();
+            const durationMs = endTime - startTime;
+            context.sendEventToPosthog({
+                event: "command finished",
+                properties: { durationMs }
+            });
             context.finish();
-            process.exit(1);
+            process.exit(exitCode);
         }
     };
 }

--- a/packages/cli/cli-v2/src/telemetry/NoopPosthogManager.ts
+++ b/packages/cli/cli-v2/src/telemetry/NoopPosthogManager.ts
@@ -1,0 +1,14 @@
+import { PosthogManager } from "./PosthogManager.js";
+
+export class NoopPosthogManager implements PosthogManager {
+    async sendEvent(): Promise<void> {
+        // no-op
+    }
+    async identify(): Promise<void> {
+        // no-op
+    }
+
+    async flush(): Promise<void> {
+        // no-op
+    }
+}

--- a/packages/cli/cli-v2/src/telemetry/PosthogEvent.ts
+++ b/packages/cli/cli-v2/src/telemetry/PosthogEvent.ts
@@ -1,0 +1,4 @@
+export interface PosthogEvent {
+    event: string;
+    properties?: Record<string, string | number | boolean>;
+}

--- a/packages/cli/cli-v2/src/telemetry/PosthogManager.ts
+++ b/packages/cli/cli-v2/src/telemetry/PosthogManager.ts
@@ -1,0 +1,7 @@
+import { PosthogEvent } from "./PosthogEvent.js";
+
+export interface PosthogManager {
+    sendEvent(event: PosthogEvent): void;
+    identify(): void;
+    flush(): Promise<void>;
+}

--- a/packages/cli/cli-v2/src/telemetry/PosthogManagerImpl.ts
+++ b/packages/cli/cli-v2/src/telemetry/PosthogManagerImpl.ts
@@ -1,0 +1,24 @@
+import { PosthogEvent } from "./PosthogEvent.js";
+import { PostHog } from "posthog-node";
+
+import { PosthogManager } from "./PosthogManager.js";
+
+export class PosthogManagerImpl implements PosthogManager {
+    private posthog: PostHog;
+
+    constructor({ posthogApiKey }: { posthogApiKey: string }) {
+        this.posthog = new PostHog(posthogApiKey);
+    }
+
+    public async identify(): Promise<void> {
+        // no-op
+    }
+
+    public async sendEvent(event: PosthogEvent): Promise<void> {
+        this.posthog.capture(event);
+    }
+
+    public async flush(): Promise<void> {
+        await this.posthog.flush();
+    }
+}

--- a/packages/cli/cli-v2/src/telemetry/getPosthogManager.ts
+++ b/packages/cli/cli-v2/src/telemetry/getPosthogManager.ts
@@ -1,0 +1,30 @@
+import { getAccessToken, getUserToken } from "@fern-api/auth";
+
+import { PosthogManagerImpl } from "./PosthogManagerImpl.js";
+import { NoopPosthogManager } from "./NoopPosthogManager.js";
+import { PosthogManager } from "./PosthogManager.js";
+
+let posthogManager: PosthogManager | undefined;
+
+export async function getPosthogManager(): Promise<PosthogManager> {
+    if (posthogManager == null) {
+        posthogManager = await createPosthogManager();
+    }
+    return posthogManager;
+}
+
+async function createPosthogManager(): Promise<PosthogManager> {
+    try {
+        const posthogApiKey = process.env.POSTHOG_API_KEY;
+        const disableTelemetry = process.env.FERN_DISABLE_TELEMETRY === "true";
+        if (disableTelemetry) {
+            return new NoopPosthogManager();
+        } else if (!posthogApiKey) {
+            // TODO: fetch an API key from Fern if one is not found.
+            throw new Error('No Posthog API key found')
+        }
+        return new PosthogManagerImpl({ posthogApiKey });
+    } catch (err) {
+        return new NoopPosthogManager();
+    }
+}

--- a/packages/cli/cli-v2/src/telemetry/index.ts
+++ b/packages/cli/cli-v2/src/telemetry/index.ts
@@ -1,0 +1,3 @@
+export { getPosthogManager } from "./getPosthogManager.js";
+export { type PosthogManager } from "./PosthogManager.js";
+export { type PosthogEvent } from "./PosthogEvent.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5053,12 +5053,18 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
+      posthog-node:
+        specifier: ^5.14.0
+        version: 5.24.7
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.3.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
       vitest:
         specifier: ^4.0.8
         version: 4.0.18(@types/node@18.15.3)(tsx@4.21.0)(yaml@2.3.3)
@@ -15235,6 +15241,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
@@ -23255,6 +23265,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@13.0.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
## Description
Linear ticket: Refs FERN-8399 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Adds the beginnings of a telemetry system for cli-v2 connected to the Context object. With this, we can do:
* `context.sendEventToPosthog` to send a metric
* `context.tag` to add a tag to all future metrics for this CLI run.

To keep the data anonymized, I've set up a random uuid to represent each CLI run. This will help link all metrics outputted by a single run, while keeping all user data anonymous.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updates cli-v2 context to include Posthog objects
- Moves Posthog logic from cli v1 to cli-v2 and simplifies it
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
