### PR TITLE
fix(python): use path= instead of url= for path-based pagination

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -4,8 +4,7 @@
   changelogEntry:
     - summary: |
         Fix path-based pagination to pass the next page path as `path=` instead of `url=`
-        in the generated HTTP client request call, so it is correctly combined with the
-        default base URL.
+        in the generated HTTP client request call.
       type: fix
   createdAt: "2026-02-13"
   irVersion: 65

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.57.2
+  changelogEntry:
+    - summary: |
+        Fix path-based pagination to pass the next page path as `path=` instead of `url=`
+        in the generated HTTP client request call, so it is correctly combined with the
+        default base URL.
+      type: fix
+  createdAt: "2026-02-13"
+  irVersion: 65
+
 - version: 4.57.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/pagination/path.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/pagination/path.py
@@ -98,7 +98,7 @@ class PathPagination(Paginator):
                 writer.write(f"{PathPagination.NEXT_RESPONSE_VAR} = await {client_ref}.request(")
             else:
                 writer.write(f"{PathPagination.NEXT_RESPONSE_VAR} = {client_ref}.request(")
-            writer.write(f'method="{self._http_method}", url=_next_path')
+            writer.write(f'method="{self._http_method}", path=_next_path')
             writer.write_line(")")
 
             # Parse response

--- a/seed/python-sdk/pagination-uri-path/src/seed/users/raw_client.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/users/raw_client.py
@@ -106,7 +106,7 @@ class RawUsersClient:
                 _has_next = _parsed_next is not None and _parsed_next != ""
 
                 def _fetch_next_page(_next_path):
-                    _next_response = self._client_wrapper.httpx_client.request(method="GET", url=_next_path)
+                    _next_response = self._client_wrapper.httpx_client.request(method="GET", path=_next_path)
                     _next_parsed = typing.cast(
                         ListUsersPathPaginationResponse,
                         parse_obj_as(
@@ -225,7 +225,7 @@ class AsyncRawUsersClient:
                 _has_next = _parsed_next is not None and _parsed_next != ""
 
                 async def _fetch_next_page(_next_path):
-                    _next_response = await self._client_wrapper.httpx_client.request(method="GET", url=_next_path)
+                    _next_response = await self._client_wrapper.httpx_client.request(method="GET", path=_next_path)
                     _next_parsed = typing.cast(
                         ListUsersPathPaginationResponse,
                         parse_obj_as(


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/pull/12238

Fixes a bug introduced in #12238 where path-based pagination passes the next page path as `url=` instead of `path=` in the generated `_fetch_next_page` function. The wrapper's `HttpClient.request()` method has no `url` parameter — its signature is `request(path=None, *, method, base_url=None, ...)` — so `url=_next_path` would raise a `TypeError` at runtime.

## Changes Made

- Changed `url=_next_path` → `path=_next_path` in `PathPagination.init_get_next()` so the generated code correctly calls `self._client_wrapper.httpx_client.request(method="GET", path=_next_path)`, which combines the path with the default base URL via `_build_url()`
- Updated the `pagination-uri-path` seed snapshot (both sync and async clients)
- Bumped Python SDK version to 4.57.2

Note: URI pagination (`uri.py`) correctly uses `base_url=_next_url` and is not affected.

## Testing

- [x] Seed snapshot updated for `pagination-uri-path` fixture
- [ ] Unit tests added/updated

## Review Checklist

- [ ] Verify `path=` matches the `HttpClient.request()` / `AsyncHttpClient.request()` signature in `generators/python/core_utilities/shared/http_client.py`
- [ ] Confirm no other generated files reference `url=_next_path` (only the one fixture was affected)

Link to Devin run: https://app.devin.ai/sessions/4d78e393305e45d3b89d8cb8535aa00b
Requested by: @aditya-arolkar-swe