### PR TITLE
feat(cli): improve library docs generation with clean spinner UI

### DIFF
--- a/packages/cli/cli/src/commands/docs-md-generate/__test__/generateLibraryDocs.test.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/__test__/generateLibraryDocs.test.ts
@@ -32,13 +32,33 @@ function makeMockCliContext() {
         runTask: vi.fn(
             async (
                 fn: (ctx: {
-                    logger: { info: (m: string) => void };
+                    logger: { info: (m: string) => void; debug: (m: string) => void };
                     failAndThrow: (...args: unknown[]) => never;
+                    runInteractiveTask: (
+                        { name }: { name: string },
+                        taskFn: (interactiveCtx: {
+                            logger: { debug: (m: string) => void };
+                            setSubtitle: (subtitle: string) => void;
+                            failAndThrow: (...args: unknown[]) => never;
+                        }) => Promise<unknown>
+                    ) => Promise<boolean>;
                 }) => unknown
             ) => {
                 return fn({
-                    logger: { info: (m: string) => logs.push(m) },
-                    failAndThrow: fail
+                    logger: {
+                        info: (m: string) => logs.push(m),
+                        debug: (m: string) => logs.push(`[DEBUG] ${m}`)
+                    },
+                    failAndThrow: fail,
+                    runInteractiveTask: vi.fn(async ({ name }, taskFn) => {
+                        logs.push(`Starting task: ${name}`);
+                        await taskFn({
+                            logger: { debug: (m: string) => logs.push(`[DEBUG] ${m}`) },
+                            setSubtitle: (subtitle: string) => logs.push(`[SUBTITLE] ${subtitle}`),
+                            failAndThrow: fail
+                        });
+                        return true;
+                    })
                 });
             }
         ),
@@ -238,7 +258,7 @@ describe("generateLibraryDocs", () => {
             })
         );
 
-        expect(ctx.logs.some((l: string) => l.includes("Generated 1 pages"))).toBe(true);
+        expect(ctx.logs.some((l: string) => l.includes("Generated library documentation for 1 libraries"))).toBe(true);
     });
 
     it("reports failure when generation status is FAILED", async () => {

--- a/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
@@ -6,7 +6,7 @@ import { resolve } from "@fern-api/fs-utils";
 import { generate } from "@fern-api/library-docs-generator";
 import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
-import { TaskContext } from "@fern-api/task-context";
+import { InteractiveTaskContext, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 
 import { CliContext } from "../../cli-context/CliContext.js";
@@ -74,56 +74,68 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
 
     const orgId = project.config.organization;
 
-    for (const [name, config] of Object.entries(librariesToGenerate)) {
-        if (config == null) {
-            continue;
-        }
-        if (!isGitLibraryInput(config.input)) {
-            cliContext.failAndThrow(
-                `Library '${name}' uses 'path' input which is not yet supported. Please use 'git' input.`
-            );
-            return;
-        }
+    await cliContext.runTask(async (context) => {
+        context.logger.info("Initiating Library Generation");
+        let successful = 0;
 
-        const resolvedOutputPath = resolve(docsWorkspace.absoluteFilePath, config.output.path);
-        const gitInput = config.input as docsYml.RawSchemas.GitLibraryInputSchema;
+        for (const [name, config] of Object.entries(librariesToGenerate)) {
+            if (config == null) {
+                continue;
+            }
+            if (!isGitLibraryInput(config.input)) {
+                context.failAndThrow(
+                    `Library '${name}' uses 'path' input which is not yet supported. Please use 'git' input.`
+                );
+                return;
+            }
 
-        await cliContext.runTask(async (context) => {
-            const fdr = createFdrService({ token: token.value });
+            const resolvedOutputPath = resolve(docsWorkspace.absoluteFilePath, config.output.path);
+            const gitInput = config.input as docsYml.RawSchemas.GitLibraryInputSchema;
 
-            context.logger.info(`Starting generation for library '${name}'...`);
+            const result = await context.runInteractiveTask({ name }, async (interactiveTaskContext) => {
+                const fdr = createFdrService({ token: token.value });
 
-            const jobId = await startGeneration(fdr, context, {
-                orgId,
-                githubUrl: gitInput.git,
-                language: config.lang === "python" ? "PYTHON" : "CPP",
-                packagePath: gitInput.subpath,
-                name
+                interactiveTaskContext.logger.debug(`Starting generation for library '${name}' from ${gitInput.git}`);
+
+                const jobId = await startGeneration(fdr, interactiveTaskContext, {
+                    orgId,
+                    githubUrl: gitInput.git,
+                    language: config.lang === "python" ? "PYTHON" : "CPP",
+                    packagePath: gitInput.subpath,
+                    name
+                });
+
+                await pollForCompletion(fdr, jobId, name, interactiveTaskContext);
+
+                const ir = await downloadIr(fdr, jobId, name, interactiveTaskContext);
+
+                const generateResult = generate({
+                    ir,
+                    outputDir: resolvedOutputPath,
+                    slug: name,
+                    title: name
+                });
+
+                interactiveTaskContext.logger.debug(
+                    `Generated ${generateResult.pageCount} pages at ${resolvedOutputPath}`
+                );
             });
 
-            await pollForCompletion(fdr, jobId, name, context);
+            if (result) {
+                successful++;
+            }
+        }
 
-            const ir = await downloadIr(fdr, jobId, name, context);
-
-            context.logger.info("Generating MDX files...");
-
-            const generateResult = generate({
-                ir,
-                outputDir: resolvedOutputPath,
-                slug: name,
-                title: name
-            });
-
-            context.logger.info(
-                chalk.green(`Generated ${generateResult.pageCount} pages for '${name}' at ${resolvedOutputPath}`)
-            );
-        });
-    }
+        // Log summary of successful generations
+        if (successful > 0) {
+            context.logger.info(chalk.green(`✓ Generated library documentation for ${successful} libraries`));
+        }
+    });
 }
 
 async function startGeneration(
     fdr: FdrService,
-    context: TaskContext,
+    context: InteractiveTaskContext,
     opts: { orgId: string; githubUrl: string; language: "PYTHON" | "CPP"; packagePath?: string; name: string }
 ): Promise<FdrAPI.docs.v2.write.LibraryDocsJobId> {
     const startResponse = await fdr.docs.v2.write.startLibraryDocsGeneration({
@@ -145,7 +157,7 @@ async function startGeneration(
     }
 
     const jobId = startResponse.body.jobId;
-    context.logger.info(`Generation job started (${jobId}). Polling for completion...`);
+    context.logger.debug(`Generation job started with ID: ${jobId}`);
     return jobId;
 }
 
@@ -153,7 +165,7 @@ async function pollForCompletion(
     fdr: FdrService,
     jobId: FdrAPI.docs.v2.write.LibraryDocsJobId,
     libraryName: string,
-    context: TaskContext
+    context: InteractiveTaskContext
 ): Promise<void> {
     const deadline = Date.now() + POLL_TIMEOUT_MS;
 
@@ -172,9 +184,12 @@ async function pollForCompletion(
 
         switch (status.status) {
             case "PENDING":
-            case "PARSING":
-                context.logger.info(`Status: ${status.status}${status.progress ? ` — ${status.progress}` : ""}`);
+                context.logger.debug(`Status: PENDING`);
                 break;
+            case "PARSING": {
+                context.logger.debug(`Status: PARSING${status.progress ? ` — ${status.progress}` : ""}`);
+                break;
+            }
             case "COMPLETED":
                 return;
             case "FAILED":
@@ -195,10 +210,8 @@ async function downloadIr(
     fdr: FdrService,
     jobId: FdrAPI.docs.v2.write.LibraryDocsJobId,
     libraryName: string,
-    context: TaskContext
+    context: InteractiveTaskContext
 ): Promise<FdrAPI.libraryDocs.PythonLibraryDocsIr> {
-    context.logger.info("Downloading generated IR...");
-
     const resultResponse = await fdr.docs.v2.write.getLibraryDocsResult(jobId);
 
     if (!resultResponse.ok) {
@@ -207,6 +220,7 @@ async function downloadIr(
         );
     }
 
+    context.logger.debug(`Fetching IR from ${resultResponse.body.resultUrl}`);
     const irFetchResponse = await fetch(resultResponse.body.resultUrl);
     if (!irFetchResponse.ok) {
         return context.failAndThrow(
@@ -224,5 +238,6 @@ async function downloadIr(
         return context.failAndThrow(`IR has no rootModule for library '${libraryName}'`);
     }
 
+    context.logger.debug(`Downloaded IR with ${Object.keys(ir.rootModule.submodules).length} submodules`);
     return ir;
 }

--- a/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
@@ -2,7 +2,7 @@ import { FernToken } from "@fern-api/auth";
 import { docsYml } from "@fern-api/configuration";
 import { createFdrService } from "@fern-api/core";
 import { FdrAPI } from "@fern-api/fdr-sdk";
-import { resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, resolve } from "@fern-api/fs-utils";
 import { generate } from "@fern-api/library-docs-generator";
 import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
@@ -89,36 +89,13 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
                 return;
             }
 
-            const resolvedOutputPath = resolve(docsWorkspace.absoluteFilePath, config.output.path);
-            const gitInput = config.input as docsYml.RawSchemas.GitLibraryInputSchema;
-
-            const result = await context.runInteractiveTask({ name }, async (interactiveTaskContext) => {
-                const fdr = createFdrService({ token: token.value });
-
-                interactiveTaskContext.logger.debug(`Starting generation for library '${name}' from ${gitInput.git}`);
-
-                const jobId = await startGeneration(fdr, interactiveTaskContext, {
-                    orgId,
-                    githubUrl: gitInput.git,
-                    language: config.lang === "python" ? "PYTHON" : "CPP",
-                    packagePath: gitInput.subpath,
-                    name
-                });
-
-                await pollForCompletion(fdr, jobId, name, interactiveTaskContext);
-
-                const ir = await downloadIr(fdr, jobId, name, interactiveTaskContext);
-
-                const generateResult = generate({
-                    ir,
-                    outputDir: resolvedOutputPath,
-                    slug: name,
-                    title: name
-                });
-
-                interactiveTaskContext.logger.debug(
-                    `Generated ${generateResult.pageCount} pages at ${resolvedOutputPath}`
-                );
+            const result = await generateSingleLibrary({
+                name,
+                config,
+                docsWorkspace,
+                orgId,
+                token,
+                context
             });
 
             if (result) {
@@ -130,6 +107,52 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
         if (successful > 0) {
             context.logger.info(chalk.green(`✓ Generated library documentation for ${successful} libraries`));
         }
+    });
+}
+
+async function generateSingleLibrary({
+    name,
+    config,
+    docsWorkspace,
+    orgId,
+    token,
+    context
+}: {
+    name: string;
+    config: docsYml.RawSchemas.LibraryConfiguration;
+    docsWorkspace: { absoluteFilePath: AbsoluteFilePath };
+    orgId: string;
+    token: FernToken;
+    context: TaskContext;
+}): Promise<boolean> {
+    const resolvedOutputPath = resolve(docsWorkspace.absoluteFilePath, config.output.path);
+    const gitInput = config.input as docsYml.RawSchemas.GitLibraryInputSchema;
+
+    return context.runInteractiveTask({ name }, async (interactiveTaskContext) => {
+        const fdr = createFdrService({ token: token.value });
+
+        interactiveTaskContext.logger.debug(`Starting generation for library '${name}' from ${gitInput.git}`);
+
+        const jobId = await startGeneration(fdr, interactiveTaskContext, {
+            orgId,
+            githubUrl: gitInput.git,
+            language: config.lang === "python" ? "PYTHON" : "CPP",
+            packagePath: gitInput.subpath,
+            name
+        });
+
+        await pollForCompletion(fdr, jobId, name, interactiveTaskContext);
+
+        const ir = await downloadIr(fdr, jobId, name, interactiveTaskContext);
+
+        const generateResult = generate({
+            ir,
+            outputDir: resolvedOutputPath,
+            slug: name,
+            title: name
+        });
+
+        interactiveTaskContext.logger.debug(`Generated ${generateResult.pageCount} pages at ${resolvedOutputPath}`);
     });
 }
 

--- a/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
@@ -75,35 +75,31 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
     const orgId = project.config.organization;
 
     await cliContext.runTask(async (context) => {
-        context.logger.info("Initiating Library Generation");
-        let successful = 0;
+        const results = await Promise.all(
+            Object.entries(librariesToGenerate).map(async ([name, config]) => {
+                if (config == null) {
+                    return false;
+                }
+                if (!isGitLibraryInput(config.input)) {
+                    context.failAndThrow(
+                        `Library '${name}' uses 'path' input which is not yet supported. Please use 'git' input.`
+                    );
+                    return false;
+                }
 
-        for (const [name, config] of Object.entries(librariesToGenerate)) {
-            if (config == null) {
-                continue;
-            }
-            if (!isGitLibraryInput(config.input)) {
-                context.failAndThrow(
-                    `Library '${name}' uses 'path' input which is not yet supported. Please use 'git' input.`
-                );
-                return;
-            }
-
-            const result = await generateSingleLibrary({
-                name,
-                config,
-                docsWorkspace,
-                orgId,
-                token,
-                context
-            });
-
-            if (result) {
-                successful++;
-            }
-        }
+                return generateSingleLibrary({
+                    name,
+                    config,
+                    docsWorkspace,
+                    orgId,
+                    token,
+                    context
+                });
+            })
+        );
 
         // Log summary of successful generations
+        const successful = results.filter(Boolean).length;
         if (successful > 0) {
             context.logger.info(chalk.green(`✓ Generated library documentation for ${successful} libraries`));
         }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -7,6 +7,8 @@
         Show "Initiating Library Generation" message and clean library name spinners
         with sequential processing. Verbose logs moved to debug level only.
       type: feat
+  createdAt: "2026-02-13"
+  irVersion: 65
 - version: 3.77.1
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.78.0
+  changelogEntry:
+    - summary: |
+        Improve library docs generation UI with clean spinner interface.
+        Replace verbose polling logs with interactive task spinners for better UX.
+        Show "Initiating Library Generation" message and clean library name spinners
+        with sequential processing. Verbose logs moved to debug level only.
+      type: feat
 - version: 3.77.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -4,8 +4,8 @@
     - summary: |
         Improve library docs generation UI with clean spinner interface.
         Replace verbose polling logs with interactive task spinners for better UX.
-        Show "Initiating Library Generation" message and clean library name spinners
-        with sequential processing. Verbose logs moved to debug level only.
+        Enable parallel processing of multiple libraries with concurrent spinners.
+        Verbose logs moved to debug level only for cleaner output.
       type: feat
   createdAt: "2026-02-13"
   irVersion: 65


### PR DESCRIPTION
Replace verbose polling logs with interactive task spinners for better UX:
- Use clean library name spinners
- Process libraries parallely with individual spinners
- Move verbose logs to debug level only
- Update tests to support new interactive task pattern

Provides cleaner, professional UI similar to `fern generate` command.

