### PR TITLE
fix(ruby): various changes for RuboCop compliance

### DIFF
--- a/generators/ruby-v2/ast/src/ast/ClassInstantiation.ts
+++ b/generators/ruby-v2/ast/src/ast/ClassInstantiation.ts
@@ -26,6 +26,11 @@ export class ClassInstantiation extends AstNode {
         writer.writeNode(this.classReference);
         writer.write(".");
         writer.write("new");
+
+        if (this.arguments_.length === 0) {
+            return;
+        }
+
         writer.write("(");
         // If there is more than one argument, write each argument on its own line,
         // separated by commas, for better readability in the generated Ruby code.

--- a/generators/ruby-v2/ast/src/ast/MethodInvocation.ts
+++ b/generators/ruby-v2/ast/src/ast/MethodInvocation.ts
@@ -40,10 +40,6 @@ export class MethodInvocation extends AstNode {
         this.on.write(writer);
         writer.write(".");
         writer.write(this.method);
-        // If there is more than one argument, write each argument on its own line,
-        // separated by commas, for better readability in the generated Ruby code.
-        // Otherwise, write the arguments inline (on the same line).
-        writer.write("(");
 
         const allArguments: PositionalOrKeywordArgument[] = [];
         for (const node of this.arguments_) {
@@ -53,6 +49,15 @@ export class MethodInvocation extends AstNode {
             allArguments.push({ kind: "keyword", arg });
         }
 
+        // In Ruby, omit parentheses on method calls with no arguments and no block.
+        if (allArguments.length === 0 && this.block == null) {
+            return;
+        }
+
+        // If there is more than one argument, write each argument on its own line,
+        // separated by commas, for better readability in the generated Ruby code.
+        // Otherwise, write the arguments inline (on the same line).
+        writer.write("(");
         if (allArguments.length > 1) {
             writer.indent();
             writer.newLine();

--- a/generators/ruby-v2/ast/src/ast/TypeLiteral.ts
+++ b/generators/ruby-v2/ast/src/ast/TypeLiteral.ts
@@ -113,11 +113,11 @@ export class TypeLiteral extends AstNode {
     public write(writer: Writer): void {
         switch (this.internalType.type) {
             case "str": {
-                // For now, just write the string as a Ruby string literal
-                if (this.internalType.value.includes("'") || this.internalType.value.includes("#")) {
-                    writer.write(`"${this.internalType.value.replaceAll('"', '\\"')}"`);
+                const value = this.internalType.value.replaceAll("\r\n", "\n");
+                if (value.includes('"') && !value.includes("'") && !value.includes("#")) {
+                    writer.write(`'${value}'`);
                 } else {
-                    writer.write(`'${this.internalType.value}'`);
+                    writer.write(`"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`);
                 }
                 break;
             }
@@ -188,6 +188,24 @@ export class TypeLiteral extends AstNode {
                 const values = this.internalType.values.filter((v) => !TypeLiteral.isNop(v));
                 if (values.length === 0) {
                     writer.write("[]");
+                    break;
+                }
+                // Use %w[] for arrays where every element is a simple string with no
+                // spaces, backslashes, or brackets that would break the syntax.
+                if (
+                    values.length >= 2 &&
+                    values.every(
+                        (v) =>
+                            v instanceof TypeLiteral &&
+                            v.internalType.type === "str" &&
+                            !/[\s\\\[\]]/.test(v.internalType.value)
+                    )
+                ) {
+                    const words = (values as TypeLiteral[]).map((v) => {
+                        const str = v.internalType as { type: "str"; value: string };
+                        return str.value;
+                    });
+                    writer.write(`%w[${words.join(" ")}]`);
                     break;
                 }
                 writer.write("[");

--- a/generators/ruby-v2/ast/src/ast/TypeLiteral.ts
+++ b/generators/ruby-v2/ast/src/ast/TypeLiteral.ts
@@ -198,7 +198,7 @@ export class TypeLiteral extends AstNode {
                         (v) =>
                             v instanceof TypeLiteral &&
                             v.internalType.type === "str" &&
-                            !/[\s\\\[\]]/.test(v.internalType.value)
+                            !/[\s\\[\]]/.test(v.internalType.value)
                     )
                 ) {
                     const words = (values as TypeLiteral[]).map((v) => {

--- a/generators/ruby-v2/ast/src/ast/__test__/__snapshots__/MethodInvocation.test.ts.snap
+++ b/generators/ruby-v2/ast/src/ast/__test__/__snapshots__/MethodInvocation.test.ts.snap
@@ -60,7 +60,7 @@ exports[`MethodInvocation > writes method invocation with a mix of positional an
 )"
 `;
 
-exports[`MethodInvocation > writes method invocation with no arguments 1`] = `"2.my_method()"`;
+exports[`MethodInvocation > writes method invocation with no arguments 1`] = `"2.my_method"`;
 
 exports[`MethodInvocation > writes method invocation with no arguments but a block 1`] = `
 "2.my_method() do

--- a/generators/ruby-v2/ast/src/ast/core/Writer.ts
+++ b/generators/ruby-v2/ast/src/ast/core/Writer.ts
@@ -1,4 +1,9 @@
-import { AbstractFormatter, AbstractWriter, NopFormatter } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractAstNode,
+    AbstractFormatter,
+    AbstractWriter,
+    NopFormatter
+} from "@fern-api/browser-compatible-base-generator";
 
 import { BaseRubyCustomConfigSchema } from "../../custom-config/BaseRubyCustomConfigSchema.js";
 
@@ -54,6 +59,15 @@ export class Writer extends AbstractWriter {
     public override dedent(): void {
         this._indentLevel--;
         super.dedent();
+    }
+
+    /**
+     * Override to omit the trailing semicolon. Ruby does not use semicolons
+     * as statement terminators.
+     */
+    public override writeNodeStatement(node: AbstractAstNode): void {
+        this.writeNode(node);
+        this.writeNewLineIfLastLineNot();
     }
 
     // override abstract method

--- a/generators/ruby-v2/base/src/project/RubocopFile.ts
+++ b/generators/ruby-v2/base/src/project/RubocopFile.ts
@@ -61,7 +61,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: snake_case
+  EnforcedStyle: normalcase
 
 Style/Documentation:
   Enabled: false
@@ -74,6 +74,15 @@ Minitest/MultipleAssertions:
 
 Minitest/UselessAssertion:
   Enabled: false
+
+# Dynamic snippets are code samples for documentation, not standalone Ruby files.
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - "dynamic-snippets/**/*"
+
+Layout/FirstHashElementIndentation:
+  Exclude:
+    - "dynamic-snippets/**/*"
 `;
     }
 }

--- a/generators/ruby-v2/base/src/project/RubyProject.ts
+++ b/generators/ruby-v2/base/src/project/RubyProject.ts
@@ -275,7 +275,7 @@ class GemspecFile {
             require_relative "lib/${moduleFolderName}/version"
             require_relative "${CUSTOM_GEMSPEC_FILENAME}"
 
-            # Note: A handful of these fields are required as part of the Ruby specification. 
+            # Note: A handful of these fields are required as part of the Ruby specification.
             #       You can change them here or overwrite them in the custom gemspec file.
             Gem::Specification.new do |spec|
             spec.name = "${gemName}"

--- a/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`snippets (default) > examples > 'GET /metadata (allow-multiple)' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(token: '<YOUR_API_KEY>');
+client = Acme::Client.new(token: "<YOUR_API_KEY>")
 
 client.service.get_metadata(
   shallow: false,
-  tag: ['development', 'public'],
-  x_api_version: '0.0.1'
-);
+  tag: %w[development public],
+  x_api_version: "0.0.1"
+)
 "
 `;
 
@@ -28,29 +28,29 @@ exports[`snippets (default) > examples > 'GET /metadata (simple)' 1`] = `
 exports[`snippets (default) > examples > 'POST /big-entity (simple)' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(token: '<YOUR_API_KEY>');
+client = Acme::Client.new(token: "<YOUR_API_KEY>")
 
 client.service.create_big_entity(
   cast_member: {
-    id: 'john.doe',
-    name: 'John Doe'
+    id: "john.doe",
+    name: "John Doe"
   },
   extended_movie: {
-    cast: ['John Travolta', 'Samuel L. Jackson', 'Uma Thurman', 'Bruce Willis'],
-    id: 'movie-sda231x',
-    title: 'Pulp Fiction',
-    from: 'Quentin Tarantino',
+    cast: ["John Travolta", "Samuel L. Jackson", "Uma Thurman", "Bruce Willis"],
+    id: "movie-sda231x",
+    title: "Pulp Fiction",
+    from: "Quentin Tarantino",
     rating: 8.5,
-    type: 'movie',
-    tag: 'tag-12efs9dv',
+    type: "movie",
+    tag: "tag-12efs9dv",
     metadata: {},
     revenue: 1000000
   },
   migration: {
-    name: 'Migration 31 Aug',
-    status: 'RUNNING'
+    name: "Migration 31 Aug",
+    status: "RUNNING"
   }
-);
+)
 "
 `;
 
@@ -69,44 +69,44 @@ exports[`snippets (default) > examples > 'POST /movie (invalid request body)' 1`
 exports[`snippets (default) > examples > 'POST /movie (simple)' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(token: '<YOUR_API_KEY>');
+client = Acme::Client.new(token: "<YOUR_API_KEY>")
 
 client.service.create_movie(
-  id: 'movie-c06a4ad7',
-  prequel: 'movie-cv9b914f',
-  title: 'The Boy and the Heron',
-  from: 'Hayao Miyazaki',
+  id: "movie-c06a4ad7",
+  prequel: "movie-cv9b914f",
+  title: "The Boy and the Heron",
+  from: "Hayao Miyazaki",
   rating: 8,
-  type: 'movie',
-  tag: 'development',
+  type: "movie",
+  tag: "development",
   metadata: {},
   revenue: 1000000
-);
+)
 "
 `;
 
 exports[`snippets (default) > exhaustive > 'GET /object/get-and-return-with-optio…' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(token: '<YOUR_API_KEY>');
+client = Acme::Client.new(token: "<YOUR_API_KEY>")
 
 client.endpoints.object.get_and_return_with_optional_field(
-  string: 'string',
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base64: "SGVsbG8gd29ybGQh",
+  list: %w[list list],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)
 "
 `;
 
@@ -132,75 +132,75 @@ exports[`snippets (default) > exhaustive > 'POST /container/list-of-objects (inv
 exports[`snippets (default) > exhaustive > 'POST /container/list-of-objects (simp…' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(token: '<YOUR_API_KEY>');
+client = Acme::Client.new(token: "<YOUR_API_KEY>")
 
 client.endpoints.container.get_and_return_list_of_objects(request: [{
-  string: 'one'
+  string: "one"
 }, {
-  string: 'two'
+  string: "two"
 }, {
-  string: 'three'
-}]);
+  string: "three"
+}])
 "
 `;
 
 exports[`snippets (default) > exhaustive > 'POST /container/list-of-primitives (s…' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(token: '<YOUR_API_KEY>');
+client = Acme::Client.new(token: "<YOUR_API_KEY>")
 
-client.endpoints.container.get_and_return_list_of_primitives(request: ['one', 'two', 'three']);
+client.endpoints.container.get_and_return_list_of_primitives(request: %w[one two three])
 "
 `;
 
 exports[`snippets (default) > file-upload > 'POST /' 1`] = `
 "require "acme"
 
-client = Acme::Client.new();
+client = Acme::Client.new
 
-client.service.post();
+client.service.post
 "
 `;
 
 exports[`snippets (default) > file-upload > 'POST /just-file' 1`] = `
 "require "acme"
 
-client = Acme::Client.new();
+client = Acme::Client.new
 
-client.service.just_file();
+client.service.just_file
 "
 `;
 
 exports[`snippets (default) > file-upload > 'POST /just-file-with-query-params' 1`] = `
 "require "acme"
 
-client = Acme::Client.new();
+client = Acme::Client.new
 
 client.service.just_file_with_query_params(
   integer: 42,
-  maybe_string: 'exists'
-);
+  maybe_string: "exists"
+)
 "
 `;
 
 exports[`snippets (default) > imdb > 'GET /movies/{movieId} (simple)' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(token: '<YOUR_API_KEY>');
+client = Acme::Client.new(token: "<YOUR_API_KEY>")
 
-client.imdb.get_movie(movie_id: 'movie_xyz');
+client.imdb.get_movie(movie_id: "movie_xyz")
 "
 `;
 
 exports[`snippets (default) > imdb > 'POST /movies/create-movie (simple)' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(token: '<YOUR_API_KEY>');
+client = Acme::Client.new(token: "<YOUR_API_KEY>")
 
 client.imdb.create_movie(
-  title: 'The Matrix',
+  title: "The Matrix",
   rating: 8.2
-);
+)
 "
 `;
 
@@ -228,11 +228,11 @@ exports[`snippets (default) > multi-url-environment > 'Production environment' 1
 "require "acme"
 
 client = Acme::Client.new(
-  token: '<YOUR_API_KEY>',
+  token: "<YOUR_API_KEY>",
   environment: Acme::Environment::PRODUCTION
-);
+)
 
-client.s3.get_presigned_url(s3key: 'xyz');
+client.s3.get_presigned_url(s3key: "xyz")
 "
 `;
 
@@ -240,11 +240,11 @@ exports[`snippets (default) > multi-url-environment > 'Staging environment' 1`] 
 "require "acme"
 
 client = Acme::Client.new(
-  token: '<YOUR_API_KEY>',
+  token: "<YOUR_API_KEY>",
   environment: Acme::Environment::STAGING
-);
+)
 
-client.s3.get_presigned_url(s3key: 'xyz');
+client.s3.get_presigned_url(s3key: "xyz")
 "
 `;
 
@@ -261,19 +261,19 @@ exports[`snippets (default) > multi-url-environment > 'Unrecognized environment'
 exports[`snippets (default) > nullable > 'Body properties' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(base_url: 'https://api.example.com');
+client = Acme::Client.new(base_url: "https://api.example.com")
 
 client.nullable.create_user(
-  username: 'john.doe',
-  tags: ['admin'],
+  username: "john.doe",
+  tags: ["admin"],
   metadata: {
-    created_at: '1980-01-01T00:00:00Z',
-    updated_at: '1980-01-01T00:00:00Z',
+    created_at: "1980-01-01T00:00:00Z",
+    updated_at: "1980-01-01T00:00:00Z",
     avatar: nil,
     activated: nil
   },
   avatar: nil
-);
+)
 "
 `;
 
@@ -290,46 +290,46 @@ exports[`snippets (default) > nullable > 'Invalid null value' 1`] = `
 exports[`snippets (default) > nullable > 'Query parameters' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(base_url: 'https://api.example.com');
+client = Acme::Client.new(base_url: "https://api.example.com")
 
 client.nullable.get_users(
-  usernames: ['john.doe', 'jane.doe'],
+  usernames: %w[john.doe jane.doe],
   tags: [nil],
   extra: nil
-);
+)
 "
 `;
 
 exports[`snippets (default) > read-write-only > 'Body properties' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(base_url: 'https://api.example.com');
+client = Acme::Client.new(base_url: "https://api.example.com")
 
 client.create_user(
-  password: 'password',
+  password: "password",
   profile: {
-    name: 'name',
+    name: "name",
     verification: {},
-    ssn: 'ssn'
+    ssn: "ssn"
   }
-);
+)
 "
 `;
 
 exports[`snippets (default) > read-write-only > 'Readonly value in request' 1`] = `
 "require "acme"
 
-client = Acme::Client.new(base_url: 'https://api.example.com');
+client = Acme::Client.new(base_url: "https://api.example.com")
 
 client.create_user(
-  id: 'id',
-  password: 'password',
+  id: "id",
+  password: "password",
   profile: {
-    name: 'name',
+    name: "name",
     verification: {},
-    ssn: 'ssn'
+    ssn: "ssn"
   }
-);
+)
 "
 `;
 
@@ -337,11 +337,11 @@ exports[`snippets (default) > single-url-environment-default > 'Production envir
 "require "acme"
 
 client = Acme::Client.new(
-  token: '<YOUR_API_KEY>',
+  token: "<YOUR_API_KEY>",
   environment: Acme::Environment::PRODUCTION
-);
+)
 
-client.dummy.get_dummy();
+client.dummy.get_dummy
 "
 `;
 
@@ -349,11 +349,11 @@ exports[`snippets (default) > single-url-environment-default > 'Staging environm
 "require "acme"
 
 client = Acme::Client.new(
-  token: '<YOUR_API_KEY>',
+  token: "<YOUR_API_KEY>",
   environment: Acme::Environment::STAGING
-);
+)
 
-client.dummy.get_dummy();
+client.dummy.get_dummy
 "
 `;
 
@@ -361,11 +361,11 @@ exports[`snippets (default) > single-url-environment-default > 'custom baseURL' 
 "require "acme"
 
 client = Acme::Client.new(
-  token: '<YOUR_API_KEY>',
-  base_url: 'http://localhost:8080'
-);
+  token: "<YOUR_API_KEY>",
+  base_url: "http://localhost:8080"
+)
 
-client.dummy.get_dummy();
+client.dummy.get_dummy
 "
 `;
 

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,31 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc86
+  changelogEntry:
+    - summary: |
+        Fix RuboCop style offenses in generated dynamic snippets. Generated Ruby snippets now use
+        double-quoted strings, omit trailing semicolons, and drop empty parentheses on no-arg
+        method calls. Also normalizes CRLF line endings to LF and adds RuboCop exclusions for
+        snippet-only cops (FrozenStringLiteralComment, FirstHashElementIndentation) in the
+        generated .rubocop.yml.
+      type: fix
+    - summary: |
+        Change RuboCop Naming/VariableNumber enforced style from snake_case to normalcase in the
+        generated .rubocop.yml. This eliminates false positives on API-derived identifiers that
+        contain numbers (e.g., :recaptcha_v2, :sha256, :line1, :pkcs7) without requiring
+        underscores before digit sequences.
+      type: fix
+    - summary: |
+        Fix seed.yml Docker build command using incorrect package filter (@fern-api/fern-ruby-sdk
+        instead of @fern-api/ruby-sdk).
+      type: fix
+    - summary: |
+        Use %w[] syntax for arrays of simple strings in generated snippets, eliminating
+        Style/WordArray RuboCop offenses.
+      type: fix
+  createdAt: "2026-02-13"
+  irVersion: 61
+
 - version: 1.0.0-rc85
   changelogEntry:
     - summary: |
@@ -840,7 +866,7 @@
   changelogEntry:
     - type: feat
       summary: >-
-        Introduce a revamped Ruby SDK generator with several improvements 
+        Introduce a revamped Ruby SDK generator with several improvements
         to be detailed in a larger post.
   irVersion: 39
 

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: snake_case
+  EnforcedStyle: normalcase
 
 Style/Documentation:
   Enabled: false
@@ -58,3 +58,12 @@ Minitest/MultipleAssertions:
 
 Minitest/UselessAssertion:
   Enabled: false
+
+# Dynamic snippets are code samples for documentation, not standalone Ruby files.
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - "dynamic-snippets/**/*"
+
+Layout/FirstHashElementIndentation:
+  Exclude:
+    - "dynamic-snippets/**/*"

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/README.md
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/README.md
@@ -28,9 +28,9 @@ Instantiate and use the client with the following:
 ```ruby
 require "seed"
 
-client = Seed::Client.new(token: '<token>');
+client = Seed::Client.new(token: "<token>")
 
-client.endpoints.container.get_and_return_list_of_primitives(request: ['string', 'string']);
+client.endpoints.container.get_and_return_list_of_primitives(request: ["string", "string"])
 ```
 
 ## Environments

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example0/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example0/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.container.get_and_return_list_of_primitives(request: ['string', 'string']);
+client.endpoints.container.get_and_return_list_of_primitives(request: ["string", "string"])

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example1/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example1/snippet.rb
@@ -1,12 +1,12 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.container.get_and_return_list_of_objects(request: [{
-  string: 'string'
+  string: "string"
 }, {
-  string: 'string'
-}]);
+  string: "string"
+}])

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example10/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example10/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.http_methods.test_get(id: 'id');
+client.endpoints.http_methods.test_get(id: "id")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example11/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example11/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.http_methods.test_post(string: 'string');
+client.endpoints.http_methods.test_post(string: "string")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example12/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example12/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.http_methods.test_put(
-  id: 'id',
-  string: 'string'
-);
+  id: "id",
+  string: "string"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example13/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example13/snippet.rb
@@ -1,25 +1,25 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.http_methods.test_patch(
-  id: 'id',
-  string: 'string',
+  id: "id",
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base_64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base_64: "SGVsbG8gd29ybGQh",
+  list: ["list", "list"],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example14/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example14/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.http_methods.test_delete(id: 'id');
+client.endpoints.http_methods.test_delete(id: "id")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example15/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example15/snippet.rb
@@ -1,24 +1,24 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.object.get_and_return_with_optional_field(
-  string: 'string',
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base_64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base_64: "SGVsbG8gd29ybGQh",
+  list: ["list", "list"],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example16/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example16/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.object.get_and_return_with_required_field(string: 'string');
+client.endpoints.object.get_and_return_with_required_field(string: "string")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example17/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example17/snippet.rb
@@ -1,12 +1,12 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.object.get_and_return_with_map_of_map(map: {
   map: {
-    map: 'map'
+    map: "map"
   }
-});
+})

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example18/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example18/snippet.rb
@@ -1,27 +1,27 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.object.get_and_return_nested_with_optional_field(
-  string: 'string',
+  string: "string",
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-);
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example19/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example19/snippet.rb
@@ -1,28 +1,28 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.object.get_and_return_nested_with_required_field(
-  string: 'string',
-  string: 'string',
+  string: "string",
+  string: "string",
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-);
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example2/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example2/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.container.get_and_return_set_of_primitives(request: Set.new(['string']));
+client.endpoints.container.get_and_return_set_of_primitives(request: Set.new(["string"]))

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example20/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example20/snippet.rb
@@ -1,46 +1,46 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(request: [{
-  string: 'string',
+  string: "string",
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
 }, {
-  string: 'string',
+  string: "string",
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-}]);
+}])

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example21/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example21/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
-  datetime_like_string: '2023-08-31T14:15:22Z',
-  actual_datetime: '2023-08-31T14:15:22Z'
-);
+  datetime_like_string: "2023-08-31T14:15:22Z",
+  actual_datetime: "2023-08-31T14:15:22Z"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example22/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example22/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.object.get_and_return_with_datetime_like_string(
-  datetime_like_string: 'datetimeLikeString',
-  actual_datetime: '2024-01-15T09:30:00Z'
-);
+  datetime_like_string: "datetimeLikeString",
+  actual_datetime: "2024-01-15T09:30:00Z"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example23/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example23/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.pagination.list_items(
-  cursor: 'cursor',
+  cursor: "cursor",
   limit: 1
-);
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example24/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example24/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.params.get_with_path(param: 'param');
+client.endpoints.params.get_with_path(param: "param")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example25/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example25/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.params.get_with_path(param: 'param');
+client.endpoints.params.get_with_path(param: "param")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example26/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example26/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.params.get_with_query(
-  query: 'query',
+  query: "query",
   number: 1
-);
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example27/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example27/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.params.get_with_query(
-  query: 'query',
+  query: "query",
   number: 1
-);
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example28/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example28/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.params.get_with_path_and_query(
-  param: 'param',
-  query: 'query'
-);
+  param: "param",
+  query: "query"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example29/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example29/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.params.get_with_path_and_query(
-  param: 'param',
-  query: 'query'
-);
+  param: "param",
+  query: "query"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example3/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example3/snippet.rb
@@ -1,10 +1,10 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.container.get_and_return_set_of_objects(request: Set.new([{
-  string: 'string'
-}]));
+  string: "string"
+}]))

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example30/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example30/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.params.modify_with_path(
-  param: 'param',
-  request: 'string'
-);
+  param: "param",
+  request: "string"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example31/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example31/snippet.rb
@@ -1,11 +1,11 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.params.modify_with_path(
-  param: 'param',
-  request: 'string'
-);
+  param: "param",
+  request: "string"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example32/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example32/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_string(request: 'string');
+client.endpoints.primitive.get_and_return_string(request: "string")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example33/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example33/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_int(request: 1);
+client.endpoints.primitive.get_and_return_int(request: 1)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example34/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example34/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_long(request: 1000000);
+client.endpoints.primitive.get_and_return_long(request: 1000000)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example35/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example35/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_double(request: 1.1);
+client.endpoints.primitive.get_and_return_double(request: 1.1)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example36/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example36/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_bool(request: true);
+client.endpoints.primitive.get_and_return_bool(request: true)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example37/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example37/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_datetime(request: '2024-01-15T09:30:00Z');
+client.endpoints.primitive.get_and_return_datetime(request: "2024-01-15T09:30:00Z")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example38/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example38/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_date(request: '2023-01-15');
+client.endpoints.primitive.get_and_return_date(request: "2023-01-15")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example39/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example39/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_uuid(request: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32');
+client.endpoints.primitive.get_and_return_uuid(request: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example4/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example4/snippet.rb
@@ -1,10 +1,10 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.container.get_and_return_map_prim_to_prim(request: {
-  string: 'string'
-});
+  string: "string"
+})

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example40/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example40/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.primitive.get_and_return_base_64(request: 'SGVsbG8gd29ybGQh');
+client.endpoints.primitive.get_and_return_base_64(request: "SGVsbG8gd29ybGQh")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example41/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example41/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.put.add(id: 'id');
+client.endpoints.put.add(id: "id")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example42/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example42/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.union.get_and_return_union();
+client.endpoints.union.get_and_return_union

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example43/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example43/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.urls.with_mixed_case();
+client.endpoints.urls.with_mixed_case

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example44/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example44/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.urls.no_ending_slash();
+client.endpoints.urls.no_ending_slash

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example45/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example45/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.urls.with_ending_slash();
+client.endpoints.urls.with_ending_slash

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example46/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example46/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.urls.with_underscores();
+client.endpoints.urls.with_underscores

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example47/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example47/snippet.rb
@@ -1,28 +1,28 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.inlined_requests.post_with_object_bodyand_response(
-  string: 'string',
+  string: "string",
   integer: 1,
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-);
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example48/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example48/snippet.rb
@@ -1,28 +1,28 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.inlined_requests.post_with_object_bodyand_response(
-  string: 'string',
+  string: "string",
   integer: 1,
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-);
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example49/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example49/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.no_auth.post_with_no_auth();
+client.no_auth.post_with_no_auth

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example5/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example5/snippet.rb
@@ -1,12 +1,12 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.container.get_and_return_map_of_prim_to_object(request: {
   string: {
-    string: 'string'
+    string: "string"
   }
-});
+})

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example50/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example50/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.no_auth.post_with_no_auth();
+client.no_auth.post_with_no_auth

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example51/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example51/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.no_req_body.get_with_no_request_body();
+client.no_req_body.get_with_no_request_body

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example52/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example52/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.no_req_body.post_with_no_request_body();
+client.no_req_body.post_with_no_request_body

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example53/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example53/snippet.rb
@@ -1,12 +1,12 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.req_with_headers.get_with_custom_header(
-  x_test_service_header: 'X-TEST-SERVICE-HEADER',
-  x_test_endpoint_header: 'X-TEST-ENDPOINT-HEADER',
-  body: 'string'
-);
+  x_test_service_header: "X-TEST-SERVICE-HEADER",
+  x_test_endpoint_header: "X-TEST-ENDPOINT-HEADER",
+  body: "string"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example6/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example6/snippet.rb
@@ -1,10 +1,10 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.container.get_and_return_optional(request: {
-  string: 'string'
-});
+  string: "string"
+})

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example7/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example7/snippet.rb
@@ -1,24 +1,24 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.content_type.post_json_patch_content_type(
-  string: 'string',
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base_64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base_64: "SGVsbG8gd29ybGQh",
+  list: ["list", "list"],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example8/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example8/snippet.rb
@@ -1,24 +1,24 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
-  string: 'string',
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base_64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base_64: "SGVsbG8gd29ybGQh",
+  list: ["list", "list"],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example9/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example9/snippet.rb
@@ -1,8 +1,8 @@
 require "seed"
 
 client = Seed::Client.new(
-  token: '<token>',
-  base_url: 'https://api.fern.com'
-);
+  token: "<token>",
+  base_url: "https://api.fern.com"
+)
 
-client.endpoints.enum.get_and_return_enum(request: 'SUNNY');
+client.endpoints.enum.get_and_return_enum(request: "SUNNY")

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/reference.md
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/reference.md
@@ -13,7 +13,7 @@
 <dd>
 
 ```ruby
-client.endpoints.container.get_and_return_list_of_primitives(request: ['string', 'string']);
+client.endpoints.container.get_and_return_list_of_primitives(request: ["string", "string"])
 ```
 </dd>
 </dl>
@@ -62,10 +62,10 @@ client.endpoints.container.get_and_return_list_of_primitives(request: ['string',
 
 ```ruby
 client.endpoints.container.get_and_return_list_of_objects(request: [{
-  string: 'string'
+  string: "string"
 }, {
-  string: 'string'
-}]);
+  string: "string"
+}])
 ```
 </dd>
 </dl>
@@ -113,7 +113,7 @@ client.endpoints.container.get_and_return_list_of_objects(request: [{
 <dd>
 
 ```ruby
-client.endpoints.container.get_and_return_set_of_primitives(request: Set.new(['string']));
+client.endpoints.container.get_and_return_set_of_primitives(request: Set.new(["string"]))
 ```
 </dd>
 </dl>
@@ -162,8 +162,8 @@ client.endpoints.container.get_and_return_set_of_primitives(request: Set.new(['s
 
 ```ruby
 client.endpoints.container.get_and_return_set_of_objects(request: Set.new([{
-  string: 'string'
-}]));
+  string: "string"
+}]))
 ```
 </dd>
 </dl>
@@ -212,8 +212,8 @@ client.endpoints.container.get_and_return_set_of_objects(request: Set.new([{
 
 ```ruby
 client.endpoints.container.get_and_return_map_prim_to_prim(request: {
-  string: 'string'
-});
+  string: "string"
+})
 ```
 </dd>
 </dl>
@@ -263,9 +263,9 @@ client.endpoints.container.get_and_return_map_prim_to_prim(request: {
 ```ruby
 client.endpoints.container.get_and_return_map_of_prim_to_object(request: {
   string: {
-    string: 'string'
+    string: "string"
   }
-});
+})
 ```
 </dd>
 </dl>
@@ -314,8 +314,8 @@ client.endpoints.container.get_and_return_map_of_prim_to_object(request: {
 
 ```ruby
 client.endpoints.container.get_and_return_optional(request: {
-  string: 'string'
-});
+  string: "string"
+})
 ```
 </dd>
 </dl>
@@ -365,22 +365,22 @@ client.endpoints.container.get_and_return_optional(request: {
 
 ```ruby
 client.endpoints.content_type.post_json_patch_content_type(
-  string: 'string',
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base_64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base_64: "SGVsbG8gd29ybGQh",
+  list: ["list", "list"],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)
 ```
 </dd>
 </dl>
@@ -429,22 +429,22 @@ client.endpoints.content_type.post_json_patch_content_type(
 
 ```ruby
 client.endpoints.content_type.post_json_patch_content_with_charset_type(
-  string: 'string',
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base_64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base_64: "SGVsbG8gd29ybGQh",
+  list: ["list", "list"],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)
 ```
 </dd>
 </dl>
@@ -493,7 +493,7 @@ client.endpoints.content_type.post_json_patch_content_with_charset_type(
 <dd>
 
 ```ruby
-client.endpoints.enum.get_and_return_enum(request: 'SUNNY');
+client.endpoints.enum.get_and_return_enum(request: "SUNNY")
 ```
 </dd>
 </dl>
@@ -542,7 +542,7 @@ client.endpoints.enum.get_and_return_enum(request: 'SUNNY');
 <dd>
 
 ```ruby
-client.endpoints.http_methods.test_get(id: 'id');
+client.endpoints.http_methods.test_get(id: "id")
 ```
 </dd>
 </dl>
@@ -590,7 +590,7 @@ client.endpoints.http_methods.test_get(id: 'id');
 <dd>
 
 ```ruby
-client.endpoints.http_methods.test_post(string: 'string');
+client.endpoints.http_methods.test_post(string: "string")
 ```
 </dd>
 </dl>
@@ -639,9 +639,9 @@ client.endpoints.http_methods.test_post(string: 'string');
 
 ```ruby
 client.endpoints.http_methods.test_put(
-  id: 'id',
-  string: 'string'
-);
+  id: "id",
+  string: "string"
+)
 ```
 </dd>
 </dl>
@@ -698,23 +698,23 @@ client.endpoints.http_methods.test_put(
 
 ```ruby
 client.endpoints.http_methods.test_patch(
-  id: 'id',
-  string: 'string',
+  id: "id",
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base_64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base_64: "SGVsbG8gd29ybGQh",
+  list: ["list", "list"],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)
 ```
 </dd>
 </dl>
@@ -770,7 +770,7 @@ client.endpoints.http_methods.test_patch(
 <dd>
 
 ```ruby
-client.endpoints.http_methods.test_delete(id: 'id');
+client.endpoints.http_methods.test_delete(id: "id")
 ```
 </dd>
 </dl>
@@ -820,22 +820,22 @@ client.endpoints.http_methods.test_delete(id: 'id');
 
 ```ruby
 client.endpoints.object.get_and_return_with_optional_field(
-  string: 'string',
+  string: "string",
   integer: 1,
   long: 1000000,
   double: 1.1,
   bool: true,
-  datetime: '2024-01-15T09:30:00Z',
-  date: '2023-01-15',
-  uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-  base_64: 'SGVsbG8gd29ybGQh',
-  list: ['list', 'list'],
-  set: Set.new(['set']),
+  datetime: "2024-01-15T09:30:00Z",
+  date: "2023-01-15",
+  uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+  base_64: "SGVsbG8gd29ybGQh",
+  list: ["list", "list"],
+  set: Set.new(["set"]),
   map: {
-    1 => 'map'
+    1 => "map"
   },
-  bigint: '1000000'
-);
+  bigint: "1000000"
+)
 ```
 </dd>
 </dl>
@@ -883,7 +883,7 @@ client.endpoints.object.get_and_return_with_optional_field(
 <dd>
 
 ```ruby
-client.endpoints.object.get_and_return_with_required_field(string: 'string');
+client.endpoints.object.get_and_return_with_required_field(string: "string")
 ```
 </dd>
 </dl>
@@ -933,9 +933,9 @@ client.endpoints.object.get_and_return_with_required_field(string: 'string');
 ```ruby
 client.endpoints.object.get_and_return_with_map_of_map(map: {
   map: {
-    map: 'map'
+    map: "map"
   }
-});
+})
 ```
 </dd>
 </dl>
@@ -984,25 +984,25 @@ client.endpoints.object.get_and_return_with_map_of_map(map: {
 
 ```ruby
 client.endpoints.object.get_and_return_nested_with_optional_field(
-  string: 'string',
+  string: "string",
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-);
+)
 ```
 </dd>
 </dl>
@@ -1051,26 +1051,26 @@ client.endpoints.object.get_and_return_nested_with_optional_field(
 
 ```ruby
 client.endpoints.object.get_and_return_nested_with_required_field(
-  string: 'string',
-  string: 'string',
+  string: "string",
+  string: "string",
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-);
+)
 ```
 </dd>
 </dl>
@@ -1127,44 +1127,44 @@ client.endpoints.object.get_and_return_nested_with_required_field(
 
 ```ruby
 client.endpoints.object.get_and_return_nested_with_required_field_as_list(request: [{
-  string: 'string',
+  string: "string",
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
 }, {
-  string: 'string',
+  string: "string",
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-}]);
+}])
 ```
 </dd>
 </dl>
@@ -1229,9 +1229,9 @@ without being converted to "2023-08-31T14:15:22.000Z".
 
 ```ruby
 client.endpoints.object.get_and_return_with_datetime_like_string(
-  datetime_like_string: '2023-08-31T14:15:22Z',
-  actual_datetime: '2023-08-31T14:15:22Z'
-);
+  datetime_like_string: "2023-08-31T14:15:22Z",
+  actual_datetime: "2023-08-31T14:15:22Z"
+)
 ```
 </dd>
 </dl>
@@ -1295,9 +1295,9 @@ List items with cursor pagination
 
 ```ruby
 client.endpoints.pagination.list_items(
-  cursor: 'cursor',
+  cursor: "cursor",
   limit: 1
-);
+)
 ```
 </dd>
 </dl>
@@ -1368,7 +1368,7 @@ GET with path param
 <dd>
 
 ```ruby
-client.endpoints.params.get_with_path(param: 'param');
+client.endpoints.params.get_with_path(param: "param")
 ```
 </dd>
 </dl>
@@ -1430,7 +1430,7 @@ GET with path param
 <dd>
 
 ```ruby
-client.endpoints.params.get_with_path(param: 'param');
+client.endpoints.params.get_with_path(param: "param")
 ```
 </dd>
 </dl>
@@ -1493,9 +1493,9 @@ GET with query param
 
 ```ruby
 client.endpoints.params.get_with_query(
-  query: 'query',
+  query: "query",
   number: 1
-);
+)
 ```
 </dd>
 </dl>
@@ -1566,9 +1566,9 @@ GET with multiple of same query param
 
 ```ruby
 client.endpoints.params.get_with_query(
-  query: 'query',
+  query: "query",
   number: 1
-);
+)
 ```
 </dd>
 </dl>
@@ -1639,9 +1639,9 @@ GET with path and query params
 
 ```ruby
 client.endpoints.params.get_with_path_and_query(
-  param: 'param',
-  query: 'query'
-);
+  param: "param",
+  query: "query"
+)
 ```
 </dd>
 </dl>
@@ -1712,9 +1712,9 @@ GET with path and query params
 
 ```ruby
 client.endpoints.params.get_with_path_and_query(
-  param: 'param',
-  query: 'query'
-);
+  param: "param",
+  query: "query"
+)
 ```
 </dd>
 </dl>
@@ -1785,9 +1785,9 @@ PUT to update with path param
 
 ```ruby
 client.endpoints.params.modify_with_path(
-  param: 'param',
-  request: 'string'
-);
+  param: "param",
+  request: "string"
+)
 ```
 </dd>
 </dl>
@@ -1858,9 +1858,9 @@ PUT to update with path param
 
 ```ruby
 client.endpoints.params.modify_with_path(
-  param: 'param',
-  request: 'string'
-);
+  param: "param",
+  request: "string"
+)
 ```
 </dd>
 </dl>
@@ -1917,7 +1917,7 @@ client.endpoints.params.modify_with_path(
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_string(request: 'string');
+client.endpoints.primitive.get_and_return_string(request: "string")
 ```
 </dd>
 </dl>
@@ -1965,7 +1965,7 @@ client.endpoints.primitive.get_and_return_string(request: 'string');
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_int(request: 1);
+client.endpoints.primitive.get_and_return_int(request: 1)
 ```
 </dd>
 </dl>
@@ -2013,7 +2013,7 @@ client.endpoints.primitive.get_and_return_int(request: 1);
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_long(request: 1000000);
+client.endpoints.primitive.get_and_return_long(request: 1000000)
 ```
 </dd>
 </dl>
@@ -2061,7 +2061,7 @@ client.endpoints.primitive.get_and_return_long(request: 1000000);
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_double(request: 1.1);
+client.endpoints.primitive.get_and_return_double(request: 1.1)
 ```
 </dd>
 </dl>
@@ -2109,7 +2109,7 @@ client.endpoints.primitive.get_and_return_double(request: 1.1);
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_bool(request: true);
+client.endpoints.primitive.get_and_return_bool(request: true)
 ```
 </dd>
 </dl>
@@ -2157,7 +2157,7 @@ client.endpoints.primitive.get_and_return_bool(request: true);
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_datetime(request: '2024-01-15T09:30:00Z');
+client.endpoints.primitive.get_and_return_datetime(request: "2024-01-15T09:30:00Z")
 ```
 </dd>
 </dl>
@@ -2205,7 +2205,7 @@ client.endpoints.primitive.get_and_return_datetime(request: '2024-01-15T09:30:00
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_date(request: '2023-01-15');
+client.endpoints.primitive.get_and_return_date(request: "2023-01-15")
 ```
 </dd>
 </dl>
@@ -2253,7 +2253,7 @@ client.endpoints.primitive.get_and_return_date(request: '2023-01-15');
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_uuid(request: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32');
+client.endpoints.primitive.get_and_return_uuid(request: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
 ```
 </dd>
 </dl>
@@ -2301,7 +2301,7 @@ client.endpoints.primitive.get_and_return_uuid(request: 'd5e9c84f-c2b2-4bf4-b4b0
 <dd>
 
 ```ruby
-client.endpoints.primitive.get_and_return_base_64(request: 'SGVsbG8gd29ybGQh');
+client.endpoints.primitive.get_and_return_base_64(request: "SGVsbG8gd29ybGQh")
 ```
 </dd>
 </dl>
@@ -2350,7 +2350,7 @@ client.endpoints.primitive.get_and_return_base_64(request: 'SGVsbG8gd29ybGQh');
 <dd>
 
 ```ruby
-client.endpoints.put.add(id: 'id');
+client.endpoints.put.add(id: "id")
 ```
 </dd>
 </dl>
@@ -2399,7 +2399,7 @@ client.endpoints.put.add(id: 'id');
 <dd>
 
 ```ruby
-client.endpoints.union.get_and_return_union();
+client.endpoints.union.get_and_return_union
 ```
 </dd>
 </dl>
@@ -2448,7 +2448,7 @@ client.endpoints.union.get_and_return_union();
 <dd>
 
 ```ruby
-client.endpoints.urls.with_mixed_case();
+client.endpoints.urls.with_mixed_case
 ```
 </dd>
 </dl>
@@ -2488,7 +2488,7 @@ client.endpoints.urls.with_mixed_case();
 <dd>
 
 ```ruby
-client.endpoints.urls.no_ending_slash();
+client.endpoints.urls.no_ending_slash
 ```
 </dd>
 </dl>
@@ -2528,7 +2528,7 @@ client.endpoints.urls.no_ending_slash();
 <dd>
 
 ```ruby
-client.endpoints.urls.with_ending_slash();
+client.endpoints.urls.with_ending_slash
 ```
 </dd>
 </dl>
@@ -2568,7 +2568,7 @@ client.endpoints.urls.with_ending_slash();
 <dd>
 
 ```ruby
-client.endpoints.urls.with_underscores();
+client.endpoints.urls.with_underscores
 ```
 </dd>
 </dl>
@@ -2624,26 +2624,26 @@ POST with custom object in request body, response is an object
 
 ```ruby
 client.inlined_requests.post_with_object_bodyand_response(
-  string: 'string',
+  string: "string",
   integer: 1,
   nested_object: {
-    string: 'string',
+    string: "string",
     integer: 1,
     long: 1000000,
     double: 1.1,
     bool: true,
-    datetime: '2024-01-15T09:30:00Z',
-    date: '2023-01-15',
-    uuid: 'd5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32',
-    base_64: 'SGVsbG8gd29ybGQh',
-    list: ['list', 'list'],
-    set: Set.new(['set']),
+    datetime: "2024-01-15T09:30:00Z",
+    date: "2023-01-15",
+    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+    base_64: "SGVsbG8gd29ybGQh",
+    list: ["list", "list"],
+    set: Set.new(["set"]),
     map: {
-      1 => 'map'
+      1 => "map"
     },
-    bigint: '1000000'
+    bigint: "1000000"
   }
-);
+)
 ```
 </dd>
 </dl>
@@ -2722,7 +2722,7 @@ POST request with no auth
 <dd>
 
 ```ruby
-client.no_auth.post_with_no_auth();
+client.no_auth.post_with_no_auth
 ```
 </dd>
 </dl>
@@ -2771,7 +2771,7 @@ client.no_auth.post_with_no_auth();
 <dd>
 
 ```ruby
-client.no_req_body.get_with_no_request_body();
+client.no_req_body.get_with_no_request_body
 ```
 </dd>
 </dl>
@@ -2811,7 +2811,7 @@ client.no_req_body.get_with_no_request_body();
 <dd>
 
 ```ruby
-client.no_req_body.post_with_no_request_body();
+client.no_req_body.post_with_no_request_body
 ```
 </dd>
 </dl>
@@ -2853,10 +2853,10 @@ client.no_req_body.post_with_no_request_body();
 
 ```ruby
 client.req_with_headers.get_with_custom_header(
-  x_test_service_header: 'X-TEST-SERVICE-HEADER',
-  x_test_endpoint_header: 'X-TEST-ENDPOINT-HEADER',
-  body: 'string'
-);
+  x_test_service_header: "X-TEST-SERVICE-HEADER",
+  x_test_endpoint_header: "X-TEST-ENDPOINT-HEADER",
+  body: "string"
+)
 ```
 </dd>
 </dl>

--- a/seed/ruby-sdk/seed.yml
+++ b/seed/ruby-sdk/seed.yml
@@ -25,7 +25,7 @@ publish:
 test:
   docker:
     image: fernapi/fern-ruby-sdk:latest
-    command: pnpm turbo run dockerTagLatest --filter @fern-api/fern-ruby-sdk
+    command: pnpm turbo run dockerTagLatest --filter @fern-api/ruby-sdk
 language: ruby
 generatorType: SDK
 defaultOutputMode: github


### PR DESCRIPTION
## Description
A couple tweaks to make RuboCop happy:

In the regular SDK, change the enforced style from `snake_case` to `normalcase`, which is strictly more permissive and allows for certain constructions like `:recaptcha_v2, :sha256` that would otherwise demand underscores between the `v` and `2`.

In the generated snippets:
- Use double-quoted strings.
- Omit trailing semicolons.
- Drop empty parentheses on no-argument method calls.
- Prevents certain kinds of RuboCop checks for dynamic snippets `(FrozenStringLiteralComment, FirstHashElementIndentation)` (less relevant for short snippets instead of full SDK examples).
- Use `%w[]` syntax for arrays of simple strings.

Changes the Docker build command in `seed.yml` to use `@fern-api/ruby-sdk` instead of `@fern-api/fern-ruby-sdk`.

## Changes Made
Ruby-v2.

## Testing
Seed regenerating now!
- [X] Unit tests added/updated
- [X] Manual testing completed
