### PR TITLE
feat(cli): Support 'fern sdk generate' w/ flags

### DIFF
--- a/packages/cli/cli-v2/src/api/config/converter/ApiDefinitionConverter.ts
+++ b/packages/cli/cli-v2/src/api/config/converter/ApiDefinitionConverter.ts
@@ -52,14 +52,11 @@ export class ApiDefinitionConverter {
      * @param fernYml - The loaded fern.yml schema result with source location tracking.
      * @returns Result with either the converted API definitions or validation issues
      */
-    public async convert({ fernYml }: { fernYml: FernYmlSchemaLoader.Result }): Promise<ApiDefinitionConverter.Result> {
-        if (!fernYml.success) {
-            return {
-                success: false,
-                issues: fernYml.issues
-            };
-        }
-
+    public async convert({
+        fernYml
+    }: {
+        fernYml: FernYmlSchemaLoader.Success;
+    }): Promise<ApiDefinitionConverter.Result> {
         const { api, apis } = fernYml.data;
         const sourced = fernYml.sourced;
 

--- a/packages/cli/cli-v2/src/api/resolver/ApiSpecDetector.ts
+++ b/packages/cli/cli-v2/src/api/resolver/ApiSpecDetector.ts
@@ -1,0 +1,53 @@
+import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import yaml from "js-yaml";
+import type { ApiSpecType } from "../config/ApiSpec.js";
+
+/**
+ * Supported spec types that can be auto-detected from a file.
+ */
+const DETECTABLE_SPEC_TYPES: readonly ApiSpecType[] = ["openapi", "asyncapi"];
+
+export namespace ApiSpecDetector {
+    export interface Args {
+        /* The absolute file path to the file (i.e. downloaded from a URL or local file). */
+        absoluteFilePath: AbsoluteFilePath;
+        /* The original user-provided reference (path or URL), used in error messages. */
+        reference: string;
+        /* The content of the file. */
+        content: string;
+    }
+}
+
+/**
+ * Detects the type of API specification from a file.
+ */
+export class ApiSpecDetector {
+    public async detect({ absoluteFilePath, reference, content }: ApiSpecDetector.Args): Promise<ApiSpecType> {
+        const parsed = this.parseOrThrow({ content, reference });
+        if (typeof parsed !== "object" || parsed == null) {
+            throw new Error(
+                `Could not determine API type for "${reference}". ` +
+                    `File must contain a top-level "openapi" or "asyncapi" key.`
+            );
+        }
+        for (const specType of DETECTABLE_SPEC_TYPES) {
+            if (specType in parsed) {
+                return specType;
+            }
+        }
+        throw new Error(
+            `Could not determine API type for "${reference}". ` +
+                `File must contain a top-level "openapi" or "asyncapi" key.`
+        );
+    }
+
+    private parseOrThrow({ content, reference }: { content: string; reference: string }): unknown {
+        try {
+            return yaml.load(content);
+        } catch {
+            throw new Error(
+                `Could not parse "${reference}" as YAML or JSON. Ensure the file is a valid OpenAPI or AsyncAPI specification.`
+            );
+        }
+    }
+}

--- a/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
+++ b/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
@@ -1,0 +1,125 @@
+import { AbsoluteFilePath, doesPathExist, resolve } from "@fern-api/fs-utils";
+import { mkdtemp, readFile, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import type { Context } from "../../context/Context.js";
+import type { ApiSpec, ApiSpecType } from "../config/ApiSpec.js";
+import { ApiSpecDetector } from "./ApiSpecDetector.js";
+
+export namespace ApiSpecResolver {
+    export interface Args {
+        reference: string;
+    }
+
+    export interface Result {
+        /* The absolute file path to the file (i.e. downloaded from a URL or local file). */
+        absoluteFilePath: AbsoluteFilePath;
+        /* The original user-provided reference (path or URL), used in error messages. */
+        reference: string;
+        /* The API specification. */
+        spec: ApiSpec;
+    }
+}
+
+export class ApiSpecResolver {
+    private readonly context: Context;
+    private readonly detector: ApiSpecDetector;
+
+    constructor({ context }: { context: Context }) {
+        this.context = context;
+        this.detector = new ApiSpecDetector();
+    }
+
+    /**
+     * Resolves a string reference (local path or URL) to a fully-constructed ApiSpec.
+     */
+    public async resolve(args: ApiSpecResolver.Args): Promise<ApiSpecResolver.Result> {
+        if (this.isUrl(args.reference)) {
+            return this.resolveUrl(args);
+        }
+        return this.resolveLocal(args);
+    }
+
+    private async resolveUrl({ reference }: { reference: string }): Promise<ApiSpecResolver.Result> {
+        const { content, contentType } = await this.fetchContent({ url: reference });
+        const extension = this.inferExtension({ url: reference, contentType });
+        const tempDir = await mkdtemp(path.join(tmpdir(), "fern-"));
+        const absoluteFilePath = AbsoluteFilePath.of(path.join(tempDir, `spec${extension}`));
+        await writeFile(absoluteFilePath, content, "utf-8");
+
+        const specType = await this.detector.detect({ absoluteFilePath, content, reference });
+        return {
+            absoluteFilePath,
+            reference,
+            spec: this.buildApiSpec({ absoluteFilePath, specType, origin: reference })
+        };
+    }
+
+    private async resolveLocal({ reference }: { reference: string }): Promise<ApiSpecResolver.Result> {
+        const absoluteFilePath = resolve(this.context.cwd, reference);
+        if (!(await doesPathExist(absoluteFilePath))) {
+            throw new Error(`API spec file does not exist: ${reference}`);
+        }
+
+        const content = await readFile(absoluteFilePath, "utf-8");
+        const specType = await this.detector.detect({ absoluteFilePath, content, reference });
+        return {
+            absoluteFilePath,
+            reference,
+            spec: this.buildApiSpec({ absoluteFilePath, specType })
+        };
+    }
+
+    private async fetchContent({ url }: { url: string }): Promise<{ content: string; contentType: string }> {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch "${url}": HTTP ${response.status} ${response.statusText}`);
+        }
+        const contentType = response.headers.get("content-type") ?? "";
+        if (contentType.includes("text/html")) {
+            throw new Error(
+                `The URL "${url}" returned HTML content. ` +
+                    `Ensure you're pointing to a raw spec URL, not a documentation page.`
+            );
+        }
+        const content = await response.text();
+        return { content, contentType };
+    }
+
+    private inferExtension({ url, contentType }: { url: string; contentType: string }): string {
+        const urlPath = new URL(url).pathname;
+        if (urlPath.endsWith(".json")) {
+            return ".json";
+        }
+        if (urlPath.endsWith(".yaml") || urlPath.endsWith(".yml")) {
+            return ".yaml";
+        }
+        if (contentType.includes("json")) {
+            return ".json";
+        }
+        return ".yaml";
+    }
+
+    private buildApiSpec({
+        absoluteFilePath,
+        specType,
+        origin
+    }: {
+        absoluteFilePath: AbsoluteFilePath;
+        specType: ApiSpecType;
+        origin?: string;
+    }): ApiSpec {
+        switch (specType) {
+            case "openapi":
+                return { openapi: absoluteFilePath, origin };
+            case "asyncapi":
+                return { asyncapi: absoluteFilePath, origin };
+            default:
+                throw new Error(`Unsupported spec type for flags mode: "${specType}". Supported: openapi, asyncapi`);
+        }
+    }
+
+    private isUrl(reference: string): boolean {
+        return reference.startsWith("https://") || reference.startsWith("http://");
+    }
+}

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -2,26 +2,41 @@ import { schemas } from "@fern-api/config";
 import type { Audiences } from "@fern-api/configuration";
 import type { ContainerRunner } from "@fern-api/core-utils";
 import { assertNever } from "@fern-api/core-utils";
-import { resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, doesPathExist, resolve } from "@fern-api/fs-utils";
 import { ValidationIssue } from "@fern-api/yaml-loader";
+import { readdir } from "fs/promises";
+import inquirer from "inquirer";
 import yaml from "js-yaml";
 import type { Argv } from "yargs";
 import { ApiChecker } from "../../../api/checker/ApiChecker.js";
+import type { ApiDefinition } from "../../../api/config/ApiDefinition.js";
+import { ApiSpecResolver } from "../../../api/resolver/ApiSpecResolver.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
 import { ValidationError } from "../../../errors/ValidationError.js";
+import { LANGUAGES, type Language } from "../../../sdk/config/Language.js";
 import type { Target } from "../../../sdk/config/Target.js";
 import { GeneratorPipeline } from "../../../sdk/generator/GeneratorPipeline.js";
 import { SdkStageOverrides, SdkTaskGroup } from "../../../sdk/task/SdkTaskGroup.js";
 import type { TaskStageLabels } from "../../../ui/TaskStageLabels.js";
 import type { Workspace } from "../../../workspace/Workspace.js";
+import { WorkspaceBuilder } from "../../../workspace/WorkspaceBuilder.js";
 import { command } from "../../_internal/command.js";
 
 export declare namespace GenerateCommand {
     export interface Args extends GlobalArgs {
+        /** Path or URL to an API spec file (enables no-config mode) */
+        api?: string;
+
+        /** Organization name (required in no-config mode) */
+        org?: string;
+
         /** The SDK target to generate */
         target?: string;
+
+        /** Override the generator version for the target */
+        "target-version"?: string;
 
         /** Generator group to run (from fern.yml) */
         group?: string;
@@ -41,31 +56,131 @@ export declare namespace GenerateCommand {
         /** Preview mode */
         preview: boolean;
 
-        /** Output directory for preview mode */
+        /** Output directory or git URL */
         output?: string;
+
+        /** Override the version for generated packages */
+        "output-version"?: string;
 
         /** Force generation without prompts */
         force: boolean;
-
-        /** Override the version for generated packages */
-        version?: string;
     }
 }
 
 export class GenerateCommand {
     public async handle(context: Context, args: GenerateCommand.Args): Promise<void> {
-        const workspace = await context.loadWorkspaceOrThrow();
-        if (workspace.sdks == null) {
-            throw new Error("No SDKs configured in fern.yml");
+        const result = await context.loadWorkspace();
+        if (result == null) {
+            return this.handleWithFlags(context, args);
+        }
+        if (!result.success) {
+            throw new ValidationError(result.issues);
+        }
+        return this.handleWithWorkspace(context, result.workspace, args);
+    }
+
+    private async handleWithWorkspace(
+        context: Context,
+        workspace: Workspace,
+        args: GenerateCommand.Args
+    ): Promise<void> {
+        let workspaceWithOverrides = workspace;
+
+        if (args.api != null) {
+            const resolver = new ApiSpecResolver({ context });
+            const resolvedSpec = await resolver.resolve({ reference: args.api });
+
+            const overriddenApis: Record<string, ApiDefinition> = {};
+            for (const apiName of Object.keys(workspaceWithOverrides.apis)) {
+                overriddenApis[apiName] = { specs: [resolvedSpec.spec] };
+            }
+
+            workspaceWithOverrides = { ...workspaceWithOverrides, apis: overriddenApis };
+        }
+
+        if (args.org != null) {
+            workspaceWithOverrides = {
+                ...workspaceWithOverrides,
+                org: args.org
+            };
         }
 
         const targets = this.getTargets({
-            workspace,
-            groupName: args.group ?? workspace.sdks.defaultGroup,
-            targetName: args.target
+            workspace: workspaceWithOverrides,
+            args,
+            groupName: args.group ?? workspaceWithOverrides.sdks?.defaultGroup
         });
 
-        this.validateArgs({ workspace, args, targets });
+        this.validateArgs({ workspace: workspaceWithOverrides, args, targets });
+
+        await this.runGeneration({ context, workspace: workspaceWithOverrides, targets, args, forceLocal: false });
+    }
+
+    private async handleWithFlags(context: Context, args: GenerateCommand.Args): Promise<void> {
+        const missingFlags: string[] = [];
+        if (args.api == null) {
+            missingFlags.push("--api <path|url>      Path or URL to an API spec file (e.g. ./openapi.yaml)");
+        }
+        if (args.target == null) {
+            missingFlags.push("--target <language>    The SDK language to generate (e.g. typescript)");
+        }
+        if (args.org == null) {
+            missingFlags.push("--org <name>           Your organization name (e.g. acme)");
+        }
+        if (args.output == null) {
+            missingFlags.push("--output <path|url>    Output path or git URL (e.g. ./my-sdk)");
+        }
+        if (args.group != null) {
+            missingFlags.push("remove --group         Groups are not supported without a fern.yml");
+        }
+        if (missingFlags.length > 0) {
+            throw new CliError({
+                message:
+                    `No fern.yml found, either run 'fern init' or specify all of the required flags:\n\n` +
+                    missingFlags.map((flag) => `  ${flag}`).join("\n")
+            });
+        }
+
+        // After validation, these are guaranteed to be defined.
+        const api = args.api as string;
+        const target = args.target as string;
+        const org = args.org as string;
+        const output = args.output as string;
+
+        const resolver = new ApiSpecResolver({ context });
+        const resolvedSpec = await resolver.resolve({
+            reference: api
+        });
+
+        const workspaceBuilder = new WorkspaceBuilder({ context });
+        const workspace = await workspaceBuilder.build({
+            org,
+            lang: this.resolveLanguage(target),
+            resolvedSpec,
+            output: this.parseTargetOutput({ ...args, output }),
+            targetVersion: args["target-version"]
+        });
+
+        const targets = workspace.sdks?.targets ?? [];
+        await this.runGeneration({ context, workspace, targets, args, forceLocal: true });
+    }
+
+    private async runGeneration({
+        context,
+        workspace,
+        targets,
+        args,
+        forceLocal
+    }: {
+        context: Context;
+        workspace: Workspace;
+        targets: Target[];
+        args: GenerateCommand.Args;
+        forceLocal: boolean;
+    }): Promise<void> {
+        if (workspace.sdks == null) {
+            throw new Error("No SDKs configured");
+        }
 
         const apisToCheck = [...new Set(targets.map((t) => t.api))];
         const checker = new ApiChecker({
@@ -88,8 +203,13 @@ export class GenerateCommand {
             cliVersion: workspace.cliVersion
         });
 
-        const token = this.isTokenRequired({ targets, args }) ? await context.getTokenOrPrompt() : undefined;
-        const runtime = args.local ? "local" : "remote";
+        const isLocal = forceLocal || args.local;
+
+        const token = this.isTokenRequired({ targets, args: { ...args, local: isLocal } })
+            ? await context.getTokenOrPrompt()
+            : undefined;
+
+        const runtime = isLocal ? "local" : "remote";
 
         const taskGroup = new SdkTaskGroup({ context });
         for (const target of targets) {
@@ -107,6 +227,21 @@ export class GenerateCommand {
             });
         }
 
+        // Check output directories before starting the task UI.
+        for (const target of targets) {
+            const outputPath =
+                args.output != null
+                    ? resolve(context.cwd, args.output)
+                    : context.resolveOutputFilePath(target.output.path);
+
+            if (outputPath != null) {
+                const { shouldProceed } = await this.checkOutputDirectory({ context, args, outputPath });
+                if (!shouldProceed) {
+                    throw new CliError({ message: "Generation cancelled." });
+                }
+            }
+        }
+
         const sdkInitialism = this.maybePluralSdks(targets);
 
         await taskGroup.start({
@@ -119,7 +254,7 @@ export class GenerateCommand {
                 const task = taskGroup.getTask(target.name);
                 if (task == null) {
                     // This should be unreachable.
-                    throw new Error(`Internal error; task '${target.name}' not found`);
+                    throw new CliError({ message: `Internal error; task '${target.name}' not found` });
                 }
 
                 task.start();
@@ -150,7 +285,7 @@ export class GenerateCommand {
                     preview: args.preview,
                     outputPath: args.output != null ? resolve(context.cwd, args.output) : undefined,
                     token,
-                    version: args.version
+                    version: args["output-version"]
                 });
                 if (!pipelineResult.success) {
                     task.stage.generator.fail(pipelineResult.error);
@@ -181,18 +316,14 @@ export class GenerateCommand {
         args: GenerateCommand.Args;
         targets: Target[];
     }): void {
-        if (args.output != null && !args.preview) {
-            throw new Error("The --output flag can only be used with --preview");
-        }
         if (args["container-engine"] != null && !args.local) {
-            throw new Error("The --container-engine flag can only be used with --local");
+            throw new CliError({ message: "The --container-engine flag can only be used with --local" });
         }
         if (args.group != null && args.target != null) {
-            throw new Error("The --group and --target flags cannot be used together");
+            throw new CliError({ message: "The --group and --target flags cannot be used together" });
         }
-        const defaultGroup = workspace.sdks?.defaultGroup;
-        if (defaultGroup == null && args.group == null && args.target == null) {
-            throw new Error("A --target or --group must be specified");
+        if (targets.length > 1 && args.output != null) {
+            throw new CliError({ message: "The --output flag can only be used when generating a single target" });
         }
         const issues: ValidationIssue[] = [];
         if (args.local) {
@@ -242,40 +373,102 @@ export class GenerateCommand {
     }
 
     /**
-     * Determines if a Fern token is required for the given targets and arguments.
+     * Parses the --output argument into an OutputSchema.
      *
-     * A Fern token is required if:
-     *  - The user is relying on remote generation.
-     *  - The target is using Fern's self-hosted git output mode.
+     * - Git URLs (ending in .git, or starting with https://github.com/, https://gitlab.com/, git@)
+     *   produce a self-hosted git output with token from GITHUB_TOKEN or GIT_TOKEN env vars.
+     * - Anything else is treated as a local path.
      */
-    private isTokenRequired({ targets, args }: { targets: Target[]; args: GenerateCommand.Args }): boolean {
-        return !args.local || targets.some((t) => t.output.git != null && schemas.isGitOutputSelfHosted(t.output.git));
+    private parseTargetOutput(args: GenerateCommand.Args): schemas.OutputSchema {
+        if (args.output != null && this.isGitUrl(args.output)) {
+            if (!args.local) {
+                throw new CliError({
+                    message:
+                        `Remote generation is not supported with a git URL for --output\n\n` +
+                        `  Use --local or specify a local filesystem path for --output`
+                });
+            }
+            const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
+            if (token == null) {
+                throw new CliError({
+                    message:
+                        `A git token is required when --output is a git URL.\n\n` +
+                        `  Set GITHUB_TOKEN or GIT_TOKEN:\n` +
+                        `    export GITHUB_TOKEN=ghp_xxx\n\n` +
+                        `  Or use a local path:\n` +
+                        `    --output ./my-sdk`
+                });
+            }
+            return {
+                git: {
+                    uri: args.output,
+                    token,
+                    mode: "pr"
+                }
+            };
+        }
+
+        return { path: args.output };
     }
 
     private getTargets({
         workspace,
-        groupName,
-        targetName
+        args,
+        groupName
     }: {
         workspace: Workspace;
+        args: GenerateCommand.Args;
         groupName: string | undefined;
-        targetName: string | undefined;
     }): Target[] {
-        const targets = workspace.sdks != null ? this.filterTargetsByGroup(workspace.sdks.targets, groupName) : [];
-        if (targetName != null) {
-            const filtered = targets.filter((t) => t.name === targetName);
-            if (filtered.length === 0) {
-                throw new Error(`Target '${targetName}' not found`);
+        let matched = workspace.sdks != null ? this.filterTargetsByGroup(workspace.sdks.targets, groupName) : [];
+        if (args.target != null) {
+            matched = matched.filter((t) => t.name === args.target);
+            if (matched.length === 0) {
+                throw new Error(`Target '${args.target}' not found`);
             }
-            return filtered;
         }
-        if (targets.length === 0) {
+        if (matched.length === 0) {
             if (groupName != null) {
                 throw new Error(`No targets found for group '${groupName}'`);
             }
             throw new Error("No targets configured in fern.yml");
         }
-        return targets;
+        return matched.map((target) => ({
+            ...target,
+            version: args["target-version"] ?? target.version,
+            output: args.output != null ? this.parseTargetOutput(args) : target.output
+        }));
+    }
+
+    private async checkOutputDirectory({
+        context,
+        args,
+        outputPath
+    }: {
+        context: Context;
+        args: GenerateCommand.Args;
+        outputPath: AbsoluteFilePath;
+    }): Promise<{ shouldProceed: boolean }> {
+        if (args.force || !context.isTTY) {
+            return { shouldProceed: true };
+        }
+        const exists = await doesPathExist(outputPath);
+        if (!exists) {
+            return { shouldProceed: true };
+        }
+        const files = await readdir(outputPath);
+        if (files.length === 0) {
+            return { shouldProceed: true };
+        }
+        const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+            {
+                type: "confirm",
+                name: "confirm",
+                message: `Directory ${outputPath} contains existing files that may be overwritten. Continue?`,
+                default: false
+            }
+        ]);
+        return { shouldProceed: confirm };
     }
 
     private filterTargetsByGroup(targets: Target[], groupName: string | undefined): Target[] {
@@ -283,6 +476,14 @@ export class GenerateCommand {
             return targets;
         }
         return targets.filter((target) => target.groups?.includes(groupName));
+    }
+
+    private resolveLanguage(target: string): Language {
+        const lang = target as Language;
+        if (LANGUAGES.includes(lang)) {
+            return lang;
+        }
+        throw new Error(`"${target}" is not a supported language. Supported: ${LANGUAGES.join(", ")}`);
     }
 
     private parseAudiences(audiences: string[] | undefined): Audiences | undefined {
@@ -293,10 +494,6 @@ export class GenerateCommand {
             type: "select",
             audiences
         };
-    }
-
-    private maybePluralSdks(targets: Target[]): string {
-        return targets.length === 1 ? "SDK" : "SDKs";
     }
 
     private getGitOutputStageLabels(mode: schemas.GitHubOutputModeSchema): Partial<TaskStageLabels> {
@@ -324,6 +521,30 @@ export class GenerateCommand {
         }
     }
 
+    /**
+     * Determines if a Fern token is required for the given targets and arguments.
+     *
+     * A Fern token is required if:
+     *  - The user is relying on remote generation.
+     *  - The target is using Fern's self-hosted git output mode.
+     */
+    private isTokenRequired({ targets, args }: { targets: Target[]; args: GenerateCommand.Args }): boolean {
+        return !args.local || targets.some((t) => t.output.git != null && schemas.isGitOutputSelfHosted(t.output.git));
+    }
+
+    private isGitUrl(value: string): boolean {
+        return (
+            value.endsWith(".git") ||
+            value.startsWith("https://github.com/") ||
+            value.startsWith("https://gitlab.com/") ||
+            value.startsWith("git@")
+        );
+    }
+
+    private maybePluralSdks(targets: Target[]): string {
+        return targets.length === 1 ? "SDK" : "SDKs";
+    }
+
     private indentBlock(text: string): string {
         return text
             .trimEnd()
@@ -338,13 +559,25 @@ export function addGenerateCommand(cli: Argv<GlobalArgs>): void {
     command(
         cli,
         "generate",
-        "Generate SDKs configured in fern.yml",
+        "Generate SDKs from fern.yml or directly from an API spec",
         (context, args) => cmd.handle(context, args as GenerateCommand.Args),
         (yargs) =>
             yargs
+                .option("api", {
+                    type: "string",
+                    description: "Path or URL to an API spec file (enables no-config mode)"
+                })
+                .option("org", {
+                    type: "string",
+                    description: "Organization name (required with --api)"
+                })
                 .option("target", {
                     type: "string",
                     description: "The SDK target to generate"
+                })
+                .option("target-version", {
+                    type: "string",
+                    description: "The generator version for the target"
                 })
                 .option("group", {
                     type: "string",
@@ -376,16 +609,16 @@ export function addGenerateCommand(cli: Argv<GlobalArgs>): void {
                 })
                 .option("output", {
                     type: "string",
-                    description: "Output directory for preview mode (requires --preview)"
+                    description: "Output path or git URL (required with --api; requires --preview in workspace mode)"
+                })
+                .option("output-version", {
+                    type: "string",
+                    description: "The version to use for the generated packages (e.g. 1.0.0)"
                 })
                 .option("force", {
                     type: "boolean",
                     default: false,
                     description: "Ignore prompts to confirm generation"
-                })
-                .option("version", {
-                    type: "string",
-                    description: "The version to use for the generated packages (e.g. 1.0.0)"
                 })
     );
 }

--- a/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
@@ -1,0 +1,41 @@
+import type { schemas } from "@fern-api/config";
+
+/**
+ * Parses the --output argument into an OutputSchema.
+ *
+ * - Git URLs (ending in .git, or starting with https://github.com/, https://gitlab.com/, git@)
+ *   produce a self-hosted git output with token from GITHUB_TOKEN or GIT_TOKEN env vars.
+ * - Anything else is treated as a local path.
+ */
+export function parseOutputArg(outputArg: string): schemas.OutputSchema {
+    if (isGitUrl(outputArg)) {
+        const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
+        if (token == null) {
+            throw new Error(
+                `A git token is required when --output is a git URL.\n\n` +
+                    `  Set GITHUB_TOKEN or GIT_TOKEN:\n` +
+                    `    export GITHUB_TOKEN=ghp_xxx\n\n` +
+                    `  Or use a local path:\n` +
+                    `    --output ./my-sdk`
+            );
+        }
+        return {
+            git: {
+                uri: outputArg,
+                token,
+                mode: "pr"
+            }
+        };
+    }
+
+    return { path: outputArg };
+}
+
+function isGitUrl(value: string): boolean {
+    return (
+        value.endsWith(".git") ||
+        value.startsWith("https://github.com/") ||
+        value.startsWith("https://gitlab.com/") ||
+        value.startsWith("git@")
+    );
+}

--- a/packages/cli/cli-v2/src/config/fern-yml/FernYmlBuilder.ts
+++ b/packages/cli/cli-v2/src/config/fern-yml/FernYmlBuilder.ts
@@ -10,9 +10,9 @@ export namespace FernYmlBuilder {
 
     export interface OutputConfig {
         type: "local" | "git";
+        mode?: "pr" | "release" | "push";
         path?: string;
         repository?: string;
-        mode?: "pr" | "release" | "push";
         group?: string;
     }
 

--- a/packages/cli/cli-v2/src/config/fern-yml/FernYmlSchemaLoader.ts
+++ b/packages/cli/cli-v2/src/config/fern-yml/FernYmlSchemaLoader.ts
@@ -1,6 +1,7 @@
 import { FernYmlSchema } from "@fern-api/config";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { YamlConfigLoader } from "@fern-api/yaml-loader";
+import { ValidationIssue, YamlConfigLoader } from "@fern-api/yaml-loader";
+import { ValidationError } from "../../errors/ValidationError.js";
 import { FileFinder } from "../FileFinder.js";
 
 const FILENAME = "fern.yml";
@@ -13,8 +14,19 @@ export namespace FernYmlSchemaLoader {
         cwd?: string;
     }
 
-    export type Result = YamlConfigLoader.Result<FernYmlSchema>;
-    export type Success = YamlConfigLoader.Success<FernYmlSchema>;
+    export type Result = Result.NotFound | Result.Failure | Result.Success;
+    export type Success = Result.Success;
+
+    export namespace Result {
+        export interface NotFound {
+            type: "notFound";
+        }
+        export interface Failure {
+            type: "failure";
+            issues: ValidationIssue[];
+        }
+        export type Success = { type: "success" } & YamlConfigLoader.Success<FernYmlSchema>;
+    }
 }
 
 export class FernYmlSchemaLoader {
@@ -31,18 +43,38 @@ export class FernYmlSchemaLoader {
      * Finds, loads, and validates a fern.yml configuration file.
      * This also resolves and validates any `$ref` nodes in the
      * configuration.
+     */
+    public async loadOrThrow(): Promise<FernYmlSchemaLoader.Success> {
+        const loadResult = await this.load();
+        if (loadResult.type === "notFound") {
+            throw new Error(`${FILENAME} file not found in any parent directory; did you forget to run \`fern init\`?`);
+        }
+        if (loadResult.type === "failure") {
+            throw new ValidationError(loadResult.issues);
+        }
+        return loadResult;
+    }
+
+    /**
+     * Finds, loads, and validates a fern.yml configuration file.
+     * This also resolves and validates any `$ref` nodes in the
+     * configuration.
      *
-     * @returns Result with either the parsed config or validation errors.
-     * @throws Error if fern.yml is not found.
+     * @returns `not-found` if no fern.yml exists, `failure` with validation
+     *          issues, or `success` with the parsed config.
      */
     public async load(): Promise<FernYmlSchemaLoader.Result> {
         const absoluteFilePath = await this.finder.find({ filename: FILENAME });
         if (absoluteFilePath == null) {
-            throw new Error(`${FILENAME} file not found in any parent directory; did you forget to run \`fern init\`?`);
+            return { type: "notFound" };
         }
-        return await this.loader.load({
+        const result = await this.loader.load({
             absoluteFilePath,
             schema: FernYmlSchema
         });
+        if (!result.success) {
+            return { type: "failure", issues: result.issues };
+        }
+        return { type: "success", ...result };
     }
 }

--- a/packages/cli/cli-v2/src/config/fern-yml/loadFernYml.ts
+++ b/packages/cli/cli-v2/src/config/fern-yml/loadFernYml.ts
@@ -1,7 +1,4 @@
-import type { FernYmlSchema } from "@fern-api/config";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import type { YamlConfigLoader } from "@fern-api/yaml-loader";
-import { ValidationError } from "../../errors/ValidationError.js";
 import { FernYmlSchemaLoader } from "./FernYmlSchemaLoader.js";
 
 /**
@@ -14,15 +11,7 @@ import { FernYmlSchemaLoader } from "./FernYmlSchemaLoader.js";
  * @throws ValidationError if the configuration is invalid.
  * @throws Error if fern.yml is not found.
  */
-export async function loadFernYml({
-    cwd
-}: {
-    cwd?: AbsoluteFilePath;
-}): Promise<YamlConfigLoader.Success<FernYmlSchema>> {
+export async function loadFernYml({ cwd }: { cwd?: AbsoluteFilePath }): Promise<FernYmlSchemaLoader.Success> {
     const schemaLoader = new FernYmlSchemaLoader({ cwd });
-    const result = await schemaLoader.load();
-    if (!result.success) {
-        throw new ValidationError(result.issues);
-    }
-    return result;
+    return await schemaLoader.loadOrThrow();
 }

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -8,9 +8,8 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import { CredentialStore, TokenService } from "../auth/index.js";
 import { Cache } from "../cache/index.js";
-import { loadFernYml } from "../config/fern-yml/loadFernYml.js";
+import { FernYmlSchemaLoader } from "../config/fern-yml/FernYmlSchemaLoader.js";
 import { CliError } from "../errors/CliError.js";
-import { ValidationError } from "../errors/ValidationError.js";
 import { Target } from "../sdk/config/Target.js";
 import { Icons } from "../ui/format.js";
 import type { Workspace } from "../workspace/Workspace.js";
@@ -57,16 +56,39 @@ export class Context {
         return this.ttyAwareLogger.isTTY;
     }
 
+    /**
+     * Get the TtyAwareLogger for coordinated task display.
+     * Use this to register tasks that need TTY-aware rendering.
+     */
+    public getTtyAwareLogger(): TtyAwareLogger {
+        return this.ttyAwareLogger;
+    }
+
+    /**
+     * Finish the TtyAwareLogger (call when exiting the CLI).
+     */
+    public finish(): void {
+        this.ttyAwareLogger.finish();
+    }
+
     public async loadWorkspaceOrThrow(): Promise<Workspace> {
-        const fernYml = await loadFernYml({ cwd: this.cwd });
-
+        const schemaLoader = new FernYmlSchemaLoader({ cwd: this.cwd });
+        const fernYml = await schemaLoader.loadOrThrow();
         const loader = new WorkspaceLoader({ cwd: this.cwd, logger: this.stderr });
-        const result = await loader.load({ fernYml });
-        if (!result.success) {
-            throw new ValidationError(result.issues);
-        }
+        return await loader.loadOrThrow({ fernYml });
+    }
 
-        return result.workspace;
+    public async loadWorkspace(): Promise<WorkspaceLoader.Result | undefined> {
+        const schemaLoader = new FernYmlSchemaLoader({ cwd: this.cwd });
+        const loadResult = await schemaLoader.load();
+        if (loadResult.type === "notFound") {
+            return undefined;
+        }
+        if (loadResult.type === "failure") {
+            return { success: false, issues: loadResult.issues };
+        }
+        const loader = new WorkspaceLoader({ cwd: this.cwd, logger: this.stderr });
+        return await loader.load({ fernYml: loadResult });
     }
 
     /**
@@ -160,21 +182,6 @@ export class Context {
             return AbsoluteFilePath.of(outputPath);
         }
         return join(this.cwd, RelativeFilePath.of(outputPath));
-    }
-
-    /**
-     * Get the TtyAwareLogger for coordinated task display.
-     * Use this to register tasks that need TTY-aware rendering.
-     */
-    public getTtyAwareLogger(): TtyAwareLogger {
-        return this.ttyAwareLogger;
-    }
-
-    /**
-     * Finish the TtyAwareLogger (call when exiting the CLI).
-     */
-    public finish(): void {
-        this.ttyAwareLogger.finish();
     }
 
     private async promptAndLogin(): Promise<FernUserToken> {

--- a/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
+++ b/packages/cli/cli-v2/src/sdk/config/converter/SdkConfigConverter.ts
@@ -50,13 +50,7 @@ export class SdkConfigConverter {
      * @param sourced - The sourced fern.yml schema with source location tracking.
      * @returns Result with either the converted config or validation issues.
      */
-    public convert({ fernYml }: { fernYml: FernYmlSchemaLoader.Result }): SdkConfigConverter.Result {
-        if (!fernYml.success) {
-            return {
-                success: false,
-                issues: fernYml.issues
-            };
-        }
+    public convert({ fernYml }: { fernYml: FernYmlSchemaLoader.Success }): SdkConfigConverter.Result {
         const sdks = fernYml.data.sdks;
         const sourced = fernYml.sourced.sdks;
         if (sdks == null || isNullish(sourced)) {

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyGenerationRunner.ts
@@ -11,6 +11,7 @@ import {
     GenerationRunner,
     runLocalGenerationForWorkspace
 } from "@fern-api/local-workspace-runner";
+import { LogLevel } from "@fern-api/logger";
 import { TaskResult } from "@fern-api/task-context";
 import { rm } from "fs/promises";
 import type { AiConfig } from "../../ai/config/AiConfig.js";
@@ -21,6 +22,7 @@ import type { Context } from "../../context/Context.js";
 import type { Task } from "../../ui/Task.js";
 import { LegacyGeneratorInvocationAdapter } from "../adapter/LegacyGeneratorInvocationAdapter.js";
 import type { Target } from "../config/Target.js";
+import { resolveTargetOutput } from "./utils/resolveTargetOutput.js";
 
 /**
  * Runs generation using the legacy local-generation infrastructure.
@@ -96,7 +98,11 @@ export class LegacyGenerationRunner {
     }
 
     public async run(args: LegacyGenerationRunner.RunArgs): Promise<LegacyGenerationRunner.Result> {
-        const taskContext = new TaskContextAdapter({ context: this.context, task: args.task });
+        const taskContext = new TaskContextAdapter({
+            context: this.context,
+            task: args.task,
+            logLevel: LogLevel.Info
+        });
         try {
             const generatorInvocation = await this.invocationAdapter.adapt(args.target);
             const generatorGroup: generatorsYml.GeneratorGroup = {
@@ -179,7 +185,13 @@ export class LegacyGenerationRunner {
 
         return {
             success: true,
-            output: this.context.resolveTargetOutputs(args.target)
+            output: resolveTargetOutput({
+                context: this.context,
+                task: args.task,
+                target: args.target,
+                preview: args.preview,
+                outputPath: args.outputPath
+            })
         };
     }
 

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -15,6 +15,7 @@ import type { Context } from "../../context/Context.js";
 import type { Task } from "../../ui/Task.js";
 import { LegacyGeneratorInvocationAdapter } from "../adapter/LegacyGeneratorInvocationAdapter.js";
 import type { Target } from "../config/Target.js";
+import { resolveTargetOutput } from "./utils/resolveTargetOutput.js";
 
 /**
  * Runs remote generation using the legacy remote-generation infrastructure.
@@ -75,13 +76,6 @@ export namespace LegacyRemoteGenerationRunner {
         /** Error message (on failure) */
         error?: string;
     }
-}
-
-interface GitOutput {
-    pullRequestUrl?: string;
-    commitHash?: string;
-    branchUrl?: string;
-    releaseUrl?: string;
 }
 
 export class LegacyRemoteGenerationRunner {
@@ -159,10 +153,15 @@ export class LegacyRemoteGenerationRunner {
                 };
             }
 
-            const gitOutput = this.extractGitOutputFromTaskLogs(args.task);
             return {
                 success: true,
-                output: this.resolveOutput(args, gitOutput)
+                output: resolveTargetOutput({
+                    context: this.context,
+                    task: args.task,
+                    target: args.target,
+                    preview: args.preview,
+                    outputPath: args.outputPath
+                })
             };
         } catch (error) {
             return {
@@ -225,70 +224,5 @@ export class LegacyRemoteGenerationRunner {
      */
     private isLocalGitCombo(args: LegacyRemoteGenerationRunner.RunArgs): boolean {
         return args.target.output.path != null && args.target.output.git != null && !args.preview;
-    }
-
-    /**
-     * Extract git output URLs from task logs.
-     *
-     * The remote generation service logs messages like:
-     *  - "Created pull request: https://github.com/owner/repo/pull/123"
-     *  - "Created commit abc123"
-     *  - "Pushed branch: https://github.com/owner/repo/tree/branch-name"
-     *  - "Release tagged. View here: https://github.com/owner/repo/releases/tag/v1.0.0"
-     */
-    private extractGitOutputFromTaskLogs(task: Task): GitOutput | undefined {
-        const gitOutput: GitOutput = {};
-        for (const log of task.logs ?? []) {
-            const prMatch = log.message.match(/Created pull request: (.+)/);
-            if (prMatch != null) {
-                gitOutput.pullRequestUrl = prMatch[1];
-            }
-
-            const commitMatch = log.message.match(/Created commit (\w+)/);
-            if (commitMatch != null) {
-                gitOutput.commitHash = commitMatch[1];
-            }
-
-            const branchMatch = log.message.match(/Pushed branch: (.+)/);
-            if (branchMatch != null) {
-                gitOutput.branchUrl = branchMatch[1];
-            }
-
-            const releaseMatch = log.message.match(/Release tagged\. View here: (.+)/);
-            if (releaseMatch != null) {
-                gitOutput.releaseUrl = releaseMatch[1];
-            }
-        }
-        return Object.keys(gitOutput).length > 0 ? gitOutput : undefined;
-    }
-
-    /**
-     * Resolve output URLs/paths for display.
-     */
-    private resolveOutput(
-        args: LegacyRemoteGenerationRunner.RunArgs,
-        gitOutput: GitOutput | undefined
-    ): string[] | undefined {
-        // For explicit preview mode, report the user-facing preview path.
-        if (args.preview) {
-            const previewPath =
-                args.outputPath != null
-                    ? resolve(this.context.cwd, args.outputPath)
-                    : join(this.context.cwd, RelativeFilePath.of(`.fern/preview`));
-            return [previewPath.toString()];
-        }
-        if (gitOutput != null) {
-            if (gitOutput.pullRequestUrl != null) {
-                return [gitOutput.pullRequestUrl];
-            }
-            if (gitOutput.releaseUrl != null) {
-                return [gitOutput.releaseUrl];
-            }
-            if (gitOutput.branchUrl != null) {
-                return [gitOutput.branchUrl];
-            }
-        }
-        // Fall back to target config (repo URL or local path).
-        return this.context.resolveTargetOutputs(args.target);
     }
 }

--- a/packages/cli/cli-v2/src/sdk/generator/utils/resolveTargetOutput.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/utils/resolveTargetOutput.ts
@@ -1,0 +1,84 @@
+import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
+import { join, resolve } from "path";
+import type { Context } from "../../../context/Context.js";
+import type { Task } from "../../../ui/Task.js";
+import type { Target } from "../../config/Target.js";
+
+interface GitOutput {
+    pullRequestUrl?: string;
+    commitHash?: string;
+    branchUrl?: string;
+    releaseUrl?: string;
+}
+
+export function resolveTargetOutput({
+    context,
+    task,
+    target,
+    preview,
+    outputPath
+}: {
+    context: Context;
+    task: Task;
+    target: Target;
+    preview: boolean | undefined;
+    outputPath: AbsoluteFilePath | undefined;
+}): string[] | undefined {
+    if (preview) {
+        // For explicit preview mode, report the user-facing preview path.
+        const previewPath =
+            outputPath != null
+                ? resolve(context.cwd, outputPath)
+                : join(context.cwd, RelativeFilePath.of(`.fern/preview`));
+        return [previewPath.toString()];
+    }
+    const gitOutput = extractGitOutputFromTaskLogs(task);
+    if (gitOutput != null) {
+        if (gitOutput.pullRequestUrl != null) {
+            return [gitOutput.pullRequestUrl];
+        }
+        if (gitOutput.releaseUrl != null) {
+            return [gitOutput.releaseUrl];
+        }
+        if (gitOutput.branchUrl != null) {
+            return [gitOutput.branchUrl];
+        }
+    }
+    // Fall back to target config (repo URL or local path).
+    return context.resolveTargetOutputs(target);
+}
+
+/**
+ * Extract git output URLs from task logs.
+ *
+ * The remote generation service logs messages like:
+ *  - "Created pull request: https://github.com/owner/repo/pull/123"
+ *  - "Created commit abc123"
+ *  - "Pushed branch: https://github.com/owner/repo/tree/branch-name"
+ *  - "Release tagged. View here: https://github.com/owner/repo/releases/tag/v1.0.0"
+ */
+function extractGitOutputFromTaskLogs(task: Task): GitOutput | undefined {
+    const gitOutput: GitOutput = {};
+    for (const log of task.logs ?? []) {
+        const prMatch = log.message.match(/Created pull request: (.+)/);
+        if (prMatch != null) {
+            gitOutput.pullRequestUrl = prMatch[1];
+        }
+
+        const commitMatch = log.message.match(/Created commit (\w+)/);
+        if (commitMatch != null) {
+            gitOutput.commitHash = commitMatch[1];
+        }
+
+        const branchMatch = log.message.match(/Pushed branch: (.+)/);
+        if (branchMatch != null) {
+            gitOutput.branchUrl = branchMatch[1];
+        }
+
+        const releaseMatch = log.message.match(/Release tagged\. View here: (.+)/);
+        if (releaseMatch != null) {
+            gitOutput.releaseUrl = releaseMatch[1];
+        }
+    }
+    return Object.keys(gitOutput).length > 0 ? gitOutput : undefined;
+}

--- a/packages/cli/cli-v2/src/workspace/WorkspaceBuilder.ts
+++ b/packages/cli/cli-v2/src/workspace/WorkspaceBuilder.ts
@@ -1,0 +1,67 @@
+import type { schemas } from "@fern-api/config";
+import { RelativeFilePath, relative } from "@fern-api/fs-utils";
+import { SourceLocation } from "@fern-api/source";
+import { DEFAULT_API_NAME } from "../api/config/converter/ApiDefinitionConverter.js";
+import { ApiSpecResolver } from "../api/resolver/ApiSpecResolver.js";
+import { type Context } from "../context/Context.js";
+import { getImageReferenceFromLanguage } from "../sdk/config/converter/getImageReferenceFromLanguage.js";
+import type { Language } from "../sdk/config/Language.js";
+import type { Target } from "../sdk/config/Target.js";
+import { Version } from "../version.js";
+import type { Workspace } from "./Workspace.js";
+
+export namespace WorkspaceBuilder {
+    export interface Args {
+        org: string;
+        lang: Language;
+        resolvedSpec: ApiSpecResolver.Result;
+        output: schemas.OutputSchema;
+        targetVersion?: string;
+    }
+}
+
+export class WorkspaceBuilder {
+    private readonly context: Context;
+
+    constructor({ context }: { context: Context }) {
+        this.context = context;
+    }
+
+    public async build({ org, lang, resolvedSpec, output, targetVersion }: WorkspaceBuilder.Args): Promise<Workspace> {
+        const imageRef = getImageReferenceFromLanguage({ lang, version: targetVersion });
+        const relativeApiPath = RelativeFilePath.of(relative(this.context.cwd, resolvedSpec.absoluteFilePath));
+
+        const sourceLocation = new SourceLocation({
+            absoluteFilePath: resolvedSpec.absoluteFilePath,
+            relativeFilePath: relativeApiPath,
+            line: 1,
+            column: 1
+        });
+
+        const target: Target = {
+            name: lang,
+            api: DEFAULT_API_NAME,
+            image: imageRef.image,
+            lang,
+            version: imageRef.tag,
+            sourceLocation,
+            output
+        };
+
+        const workspace: Workspace = {
+            apis: {
+                [DEFAULT_API_NAME]: {
+                    specs: [resolvedSpec.spec]
+                }
+            },
+            cliVersion: Version,
+            org,
+            sdks: {
+                org,
+                targets: [target]
+            }
+        };
+
+        return workspace;
+    }
+}

--- a/packages/cli/cli-v2/src/workspace/WorkspaceLoader.ts
+++ b/packages/cli/cli-v2/src/workspace/WorkspaceLoader.ts
@@ -6,6 +6,7 @@ import type { AiConfig } from "../ai/config/AiConfig.js";
 import type { ApiDefinition } from "../api/config/ApiDefinition.js";
 import { ApiDefinitionConverter } from "../api/config/converter/ApiDefinitionConverter.js";
 import { FernYmlSchemaLoader } from "../config/fern-yml/FernYmlSchemaLoader.js";
+import { ValidationError } from "../errors/ValidationError.js";
 import { SdkConfigConverter } from "../sdk/config/converter/SdkConfigConverter.js";
 import { SdkConfig } from "../sdk/config/SdkConfig.js";
 import { Version } from "../version.js";
@@ -46,14 +47,15 @@ export class WorkspaceLoader {
         this.logger = logger;
     }
 
-    public async load({ fernYml }: { fernYml: FernYmlSchemaLoader.Result }): Promise<WorkspaceLoader.Result> {
-        if (!fernYml.success) {
-            return {
-                success: false,
-                issues: fernYml.issues
-            };
+    public async loadOrThrow({ fernYml }: { fernYml: FernYmlSchemaLoader.Success }): Promise<Workspace> {
+        const result = await this.load({ fernYml });
+        if (!result.success) {
+            throw new ValidationError(result.issues);
         }
+        return result.workspace;
+    }
 
+    public async load({ fernYml }: { fernYml: FernYmlSchemaLoader.Success }): Promise<WorkspaceLoader.Result> {
         const ai = this.convertAi({ fernYml });
         const apis = await this.convertApis({ fernYml });
         const cliVersion = await this.convertCliVersion({ fernYml });

--- a/packages/cli/ete-tests/src/tests/v2/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/v2/generate.test.ts
@@ -212,4 +212,201 @@ paths:
             expect(result.stderrPlain.toLowerCase().includes("target")).toBe(true);
         });
     });
+
+    describe("flags-only mode (no fern.yml)", () => {
+        const SIMPLE_OPENAPI = `openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      operationId: healthCheck
+      responses:
+        "200":
+          description: OK`;
+
+        describe("flag validation", () => {
+            it("should report all missing flags when no flags are provided", async () => {
+                const fixture = await createTempFixture({
+                    "openapi.yml": SIMPLE_OPENAPI
+                });
+                try {
+                    const result = await runCliV2({
+                        args: ["sdk", "generate"],
+                        cwd: fixture.path,
+                        expectError: true
+                    });
+                    expect(result.exitCode).not.toBe(0);
+                    expect(result.stderrPlain).toContain("--api");
+                    expect(result.stderrPlain).toContain("--target");
+                    expect(result.stderrPlain).toContain("--org");
+                    expect(result.stderrPlain).toContain("--output");
+                } finally {
+                    await fixture.cleanup();
+                }
+            });
+
+            it("should report missing --target, --org, and --output when only --api is provided", async () => {
+                const fixture = await createTempFixture({
+                    "openapi.yml": SIMPLE_OPENAPI
+                });
+                try {
+                    const result = await runCliV2({
+                        args: ["sdk", "generate", "--api", "openapi.yml"],
+                        cwd: fixture.path,
+                        expectError: true
+                    });
+                    expect(result.exitCode).not.toBe(0);
+                    expect(result.stderrPlain).toContain("--target");
+                    expect(result.stderrPlain).toContain("--org");
+                    expect(result.stderrPlain).toContain("--output");
+                    expect(result.stderrPlain).not.toContain("--api");
+                } finally {
+                    await fixture.cleanup();
+                }
+            });
+
+            it("should report only the specific missing flags", async () => {
+                const fixture = await createTempFixture({
+                    "openapi.yml": SIMPLE_OPENAPI
+                });
+                try {
+                    const result = await runCliV2({
+                        args: ["sdk", "generate", "--api", "openapi.yml", "--target", "go"],
+                        cwd: fixture.path,
+                        expectError: true
+                    });
+                    expect(result.exitCode).not.toBe(0);
+                    expect(result.stderrPlain).toContain("--org");
+                    expect(result.stderrPlain).toContain("--output");
+                    expect(result.stderrPlain).not.toContain("--target");
+                    expect(result.stderrPlain).not.toContain("--api");
+                } finally {
+                    await fixture.cleanup();
+                }
+            });
+
+            it("should reject --group in flags-only mode", async () => {
+                const fixture = await createTempFixture({
+                    "openapi.yml": SIMPLE_OPENAPI
+                });
+                try {
+                    const result = await runCliV2({
+                        args: [
+                            "sdk",
+                            "generate",
+                            "--api",
+                            "openapi.yml",
+                            "--target",
+                            "go",
+                            "--org",
+                            "test-org",
+                            "--output",
+                            "./out",
+                            "--group",
+                            "prod"
+                        ],
+                        cwd: fixture.path,
+                        expectError: true
+                    });
+                    expect(result.exitCode).not.toBe(0);
+                    expect(result.stderrPlain).toContain("--group");
+                } finally {
+                    await fixture.cleanup();
+                }
+            });
+
+            it("should fail with an unsupported language", async () => {
+                const fixture = await createTempFixture({
+                    "openapi.yml": SIMPLE_OPENAPI
+                });
+                try {
+                    const result = await runCliV2({
+                        args: [
+                            "sdk",
+                            "generate",
+                            "--api",
+                            "openapi.yml",
+                            "--target",
+                            "cobol",
+                            "--org",
+                            "test-org",
+                            "--output",
+                            "./out",
+                            "--local"
+                        ],
+                        cwd: fixture.path,
+                        expectError: true
+                    });
+                    expect(result.exitCode).not.toBe(0);
+                    expect(result.stderrPlain).toContain("not a supported language");
+                } finally {
+                    await fixture.cleanup();
+                }
+            });
+        });
+
+        describe("successful generation", () => {
+            it("should generate Go SDK with all required flags", async () => {
+                const fixture = await createTempFixture({
+                    "openapi.yml": SIMPLE_OPENAPI
+                });
+                try {
+                    const result = await runCliV2({
+                        args: [
+                            "sdk",
+                            "generate",
+                            "--api",
+                            "openapi.yml",
+                            "--target",
+                            "go",
+                            "--org",
+                            "test-org",
+                            "--output",
+                            "./out",
+                            "--local"
+                        ],
+                        cwd: fixture.path,
+                        timeout: 120_000
+                    });
+                    expect(result.exitCode).toBe(0);
+
+                    const outputPath = join(AbsoluteFilePath.of(fixture.path), RelativeFilePath.of("out"));
+                    expect(await doesPathExist(outputPath)).toBe(true);
+                } finally {
+                    await fixture.cleanup();
+                }
+            }, 120_000);
+
+            it("should generate Go SDK from a URL-referenced spec", async () => {
+                const fixture = await createTempFixture({});
+                try {
+                    const result = await runCliV2({
+                        args: [
+                            "sdk",
+                            "generate",
+                            "--api",
+                            "https://petstore3.swagger.io/api/v3/openapi.json",
+                            "--target",
+                            "go",
+                            "--org",
+                            "test-org",
+                            "--output",
+                            "./out",
+                            "--local"
+                        ],
+                        cwd: fixture.path,
+                        timeout: 120_000
+                    });
+                    expect(result.exitCode).toBe(0);
+
+                    const outputPath = join(AbsoluteFilePath.of(fixture.path), RelativeFilePath.of("out"));
+                    expect(await doesPathExist(outputPath)).toBe(true);
+                } finally {
+                    await fixture.cleanup();
+                }
+            }, 120_000);
+        });
+    });
 }, 300_000);

--- a/packages/cli/ete-tests/src/tests/v2/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/v2/generate.test.ts
@@ -200,17 +200,6 @@ paths:
             expect(result.exitCode).toBe(0);
             expect(result.stdoutPlain.toLowerCase()).toMatch(/usage|options|target/i);
         });
-
-        it("should fail without required --target flag", async () => {
-            const result = await runCliV2({
-                args: ["sdk", "generate"],
-                fixture: FIXTURES.petstore,
-                expectError: true,
-                timeout: 60_000
-            });
-            expect(result.exitCode).toBe(1);
-            expect(result.stderrPlain.toLowerCase().includes("target")).toBe(true);
-        });
     });
 
     describe("flags-only mode (no fern.yml)", () => {


### PR DESCRIPTION
## Description

This adds a new experience to the `fern sdk generate` command, so that it feels more like a swiss army knife -- users can generate an SDK without a `fern.yml` as long as they specify all of the required flags. For example, consider the following:

```sh
# Fetch a remote API reference and generate an SDK locally
$ fern sdk generate \
  --api https://petstore3.swagger.io/api/v3/openapi.json \
  --org acme \
  --target go \
  --output ./sdks/go
```

```sh
# Open a pull request using your local GITHUB_TOKEN
$ fern sdk generate \
  --api ./openapi/openapi.yml \
  --org acme \
  --target go \
  --output https://github.com/acme/acme-go \
  --local
```

As you can see, this supports APIs with remote references and local files, and even includes this on the `--output` side. Plus, there are helpful messages included throughout:

```sh
$ fern sdk generate --api https://petstore3.swagger.io/api/v3/openapi.json
No fern.yml found, either run 'fern init' or specify all of the required flags:

  --target <language>    The SDK language to generate (e.g. typescript)
  --org <name>           Your organization name (e.g. acme)
  --output <path|url>    Output path or git URL (e.g. ./my-sdk)
```

## Changes Made
- Add a flag-only `fern sdk generate` experience.
- Update `fern sdk generate` (no args) to generate all targets by default.
- Add `--output-version` and `--target-version` flags.
- Restore safe prompt before destructive operations (i.e. overridden with the `--force` flag).

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
