### PR TITLE
feat(cli): Add spinner for creating organization

### DIFF
--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -76,6 +76,7 @@
     "inquirer": "^9.2.15",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.2",
+    "ora": "^7.0.1",
     "tsup": "^8.5.0",
     "typescript": "5.9.3",
     "vitest": "^4.0.8",

--- a/packages/cli/cli-v2/src/init/Wizard.ts
+++ b/packages/cli/cli-v2/src/init/Wizard.ts
@@ -17,6 +17,7 @@ import { TaskContextAdapter } from "../context/adapter/TaskContextAdapter";
 import type { Context } from "../context/Context";
 import type { Language } from "../sdk/config/Language";
 import { Icons } from "../ui/format";
+import { withSpinner } from "../ui/withSpinner";
 
 const LANGUAGE_DISPLAY_NAMES: Record<Language, string> = {
     typescript: "TypeScript",
@@ -256,11 +257,13 @@ export class Wizard {
 
                 case "not-found": {
                     const taskContext = new TaskContextAdapter({ context: this.context });
-                    const created = await createOrganizationIfDoesNotExist({
-                        organization,
-                        token,
-                        context: taskContext
-                    });
+                    const created = await withSpinner("Creating organization...", () =>
+                        createOrganizationIfDoesNotExist({
+                            organization,
+                            token,
+                            context: taskContext
+                        })
+                    );
                     if (created) {
                         this.context.stderr.info(`  ${Icons.success} Created organization "${organization}"\n`);
                     }

--- a/packages/cli/cli-v2/src/ui/withSpinner.ts
+++ b/packages/cli/cli-v2/src/ui/withSpinner.ts
@@ -1,0 +1,17 @@
+import ora from "ora";
+
+export async function withSpinner<T>(message: string, operation: () => Promise<T>): Promise<T> {
+    const spinner = ora({
+        text: message,
+        indent: 2,
+        color: "cyan"
+    }).start();
+    try {
+        const result = await operation();
+        spinner.stop();
+        return result;
+    } catch (error: unknown) {
+        spinner.stop();
+        throw error;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5056,6 +5056,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
+      ora:
+        specifier: ^7.0.1
+        version: 7.0.1
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.3.3)


### PR DESCRIPTION
## Description

In the `fern init` flow, it takes a couple seconds to create an organization if it doesn't already exist. Without any visual indicator, it looks like the command hangs. This adds a lightweight spinner to improve the experience.

```sh
$ fern init
  ███████╗███████╗██████╗ ███╗   ██╗
  ██╔════╝██╔════╝██╔══██╗████╗  ██║
  █████╗  █████╗  ██████╔╝██╔██╗ ██║
  ██╔══╝  ██╔══╝  ██╔══██╗██║╚██╗██║
  ██║     ███████╗██║  ██║██║ ╚████║
  ╚═╝     ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝


  🌿 Welcome to Fern!
  Instant Docs and SDKs for your API
  https://buildwithfern.com/learn

? Organization name: amckinney-test
  ✓ Logged in as alexmckinney01@gmail.com

    # This is where the spinner is rendered before the operation is completed.
    ✓ Created organization "amckinney-test"

? What would you like to generate? (Use arrow keys)
❯ SDKs 
  Docs 
  Both 
```

## Changes Made
- Add a `withSpinner` UI helper to easily render a spinner for specific operations.

## Testing
- [] Unit tests added/updated
- [x] Manual testing completed
