### PR TITLE
feat(cli): Add signal handling w/ graceful shutdown

### DIFF
--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -249,6 +249,13 @@ export class GenerateCommand {
             subtitle: `org: ${workspace.sdks.org}`
         });
 
+        context.onShutdown(() => {
+            taskGroup.finish({
+                successMessage: `Successfully generated ${sdkInitialism}`,
+                errorMessage: `Generation interrupted`
+            });
+        });
+
         await Promise.all(
             targets.map(async (target) => {
                 const task = taskGroup.getTask(target.name);

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -19,6 +19,9 @@ import { LogFileWriter } from "./LogFileWriter.js";
 
 export class Context {
     private ttyAwareLogger: TtyAwareLogger;
+    private shutdownCallbacks: Array<() => void> = [];
+    private isShuttingDown = false;
+    private logFilePathPrinted = false;
 
     public readonly cwd: AbsoluteFilePath;
     public readonly logLevel: LogLevel;
@@ -138,6 +141,47 @@ export class Context {
         }
 
         return { type: "user", value: token };
+    }
+
+    /**
+     * Register a callback to run during graceful shutdown (e.g. SIGINT).
+     * Callbacks are invoked synchronously in registration order.
+     */
+    public onShutdown(callback: () => void): void {
+        this.shutdownCallbacks.push(callback);
+    }
+
+    /**
+     * Run all registered shutdown callbacks, then finish the logger.
+     */
+    public shutdown(): void {
+        if (this.isShuttingDown) {
+            return;
+        }
+        this.isShuttingDown = true;
+        for (const callback of this.shutdownCallbacks) {
+            try {
+                callback();
+            } catch {
+                // Swallow errors to ensure we always restore the terminal.
+            }
+        }
+        this.finish();
+    }
+
+    /**
+     * Print the log file path to the given stream (defaults to stderr).
+     */
+    public printLogFilePath(stream: NodeJS.WriteStream): void {
+        if (this.logFilePathPrinted) {
+            return;
+        }
+        const logFilePath = this.getLogFilePath();
+        if (logFilePath == null) {
+            return;
+        }
+        this.logFilePathPrinted = true;
+        stream.write(`\n${chalk.dim(`Logs written to: ${logFilePath}`)}\n`);
     }
 
     /**

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -7,6 +7,12 @@ import { Icons } from "../ui/format.js";
 import { Context } from "./Context.js";
 import type { GlobalArgs } from "./GlobalArgs.js";
 
+// It's standard to use 128 as the base exit code for signals.
+// https://en.wikipedia.org/wiki/Signal_(IPC)
+const SIGNAL_EXIT_CODE_BASE = 128;
+const SIGINT_EXIT_CODE = SIGNAL_EXIT_CODE_BASE + 2;
+const SIGTERM_EXIT_CODE = SIGNAL_EXIT_CODE_BASE + 15;
+
 /**
  * Wraps a command handler with context creation and error handling.
  *
@@ -18,6 +24,9 @@ export function withContext<T extends GlobalArgs>(
 ): (args: T) => Promise<void> {
     return async (args: T) => {
         const context = createContext(args);
+
+        setupSignalHandler(context);
+
         try {
             await handler(context, args);
             context.finish();
@@ -71,6 +80,16 @@ function handleError(context: Context, error: unknown): void {
     }
 
     process.stderr.write(`${chalk.red(String(error))}\n`);
+}
+
+function setupSignalHandler(context: Context): void {
+    const onSignal = (exitCode: number): void => {
+        context.shutdown();
+        context.printLogFilePath(process.stderr);
+        process.exit(exitCode);
+    };
+    process.on("SIGINT", () => onSignal(SIGINT_EXIT_CODE));
+    process.on("SIGTERM", () => onSignal(SIGTERM_EXIT_CODE));
 }
 
 function parseLogLevel(level: string): LogLevel {

--- a/packages/cli/cli-v2/src/ui/TaskGroup.ts
+++ b/packages/cli/cli-v2/src/ui/TaskGroup.ts
@@ -245,10 +245,7 @@ export class TaskGroup {
             this.stream.write(`${chalk.red("✕")} ${errorMessage} ${chalk.dim(`in ${duration}`)}\n`);
         }
 
-        const logFilePath = this.context.getLogFilePath();
-        if (logFilePath != null) {
-            this.stream.write(`\n${chalk.dim(`Logs written to: ${logFilePath}`)}\n`);
-        }
+        this.context.printLogFilePath(this.stream);
 
         this.stream.write("\n");
 


### PR DESCRIPTION
## Description

This adds signal handling (i.e. for `SIGINT` and `SIGTERM` to the CLI. With this, we can now more reliably give users a "interrupted" message and more gracefully shutdown each command.

```sh
$ fern sdk generate

◆ Generating SDK
  org: acme

┌─
│ ✗ go 492ms
│     ✓ Validated API
│     ▸ Running generator...
│     ○ Write output
└─

✕ Generation interrupted in 493ms

Logs written to: /Users/alex/.cache/fern/v1/logs/2026-02-15T19-58-52-509Z.log
```

We also utilize idiomatic exit codes like so:

```sh
$ echo "$?"
130
```

## Changes Made
- Adds graceful shutdown and signal handling to the CLI.

## Testing
- [] Unit tests added/updated
- [x] Manual testing completed
