### PR TITLE
chore(ci): disable seed updates until fixed

### DIFF
--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1,9 +1,9 @@
 name: Update Seed
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       language:


### PR DESCRIPTION
Seed updating CI is churning PRs. Disabling until the updates are deterministic.