### PR TITLE
chore(cli): refactor

### DIFF
--- a/packages/cli/cli/src/commands/upgrade/__test__/graphql-introspection.test.ts
+++ b/packages/cli/cli/src/commands/upgrade/__test__/graphql-introspection.test.ts
@@ -21,14 +21,7 @@ const mockLogger: Logger = {
     enable: vi.fn()
 };
 
-// Import functions to test - we need to export these from updateApiSpec.ts
-import {
-    extractIntrospectionData,
-    fetchGraphQLSchemaWithAutoDetection,
-    isIntrospectionResult,
-    tryDirectJSONFetch,
-    tryGraphQLIntrospection
-} from "../updateApiSpec.js";
+import { fetchGraphQLSchemaWithAutoDetection } from "../updateApiSpec.js";
 
 describe("GraphQL Auto-Detection Enhancement", () => {
     let tempDir: string;
@@ -58,191 +51,6 @@ describe("GraphQL Auto-Detection Enhancement", () => {
             email: String
         }
     `);
-
-    describe("Helper Functions", () => {
-        describe("isIntrospectionResult", () => {
-            it("should identify direct introspection result format", () => {
-                const data = { __schema: { queryType: { name: "Query" } } };
-                expect(isIntrospectionResult(data)).toBe(true);
-            });
-
-            it("should identify GraphQL response format", () => {
-                const data = { data: { __schema: { queryType: { name: "Query" } } } };
-                expect(isIntrospectionResult(data)).toBe(true);
-            });
-
-            it("should reject invalid formats", () => {
-                expect(isIntrospectionResult(null)).toBe(false);
-                expect(isIntrospectionResult(undefined)).toBe(false);
-                expect(isIntrospectionResult("string")).toBe(false);
-                expect(isIntrospectionResult({})).toBe(false);
-                expect(isIntrospectionResult({ data: {} })).toBe(false);
-            });
-        });
-
-        describe("extractIntrospectionData", () => {
-            it("should extract from direct format", () => {
-                const data = { __schema: { queryType: { name: "Query" } } };
-                expect(extractIntrospectionData(data)).toBe(data);
-            });
-
-            it("should extract from wrapped format", () => {
-                const introspectionData = { __schema: { queryType: { name: "Query" } } };
-                const data = { data: introspectionData };
-                expect(extractIntrospectionData(data)).toBe(introspectionData);
-            });
-        });
-    });
-
-    describe("tryGraphQLIntrospection", () => {
-        it("should successfully handle POST introspection", async () => {
-            const testSchema = createTestSchema();
-            const introspectionResult = introspectionFromSchema(testSchema);
-
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({ data: introspectionResult })
-            });
-
-            const result = await tryGraphQLIntrospection("http://example.com/graphql", mockLogger);
-
-            expect(result.success).toBe(true);
-            if (result.success) {
-                expect(result.result).toContain("type Query");
-                expect(result.result).toContain("type User");
-            }
-            expect(mockFetch).toHaveBeenCalledWith(
-                "http://example.com/graphql",
-                expect.objectContaining({
-                    method: "POST",
-                    headers: expect.objectContaining({
-                        "Content-Type": "application/json"
-                    }),
-                    body: expect.stringContaining("query IntrospectionQuery")
-                })
-            );
-        });
-
-        it("should handle authentication errors", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: false,
-                status: 401,
-                statusText: "Unauthorized"
-            });
-
-            const result = await tryGraphQLIntrospection("http://example.com/graphql", mockLogger);
-
-            expect(result.success).toBe(false);
-            if (!result.success) {
-                expect(result.error).toContain("requires authentication");
-            }
-        });
-
-        it("should handle GraphQL errors", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    errors: [{ message: "Invalid query" }]
-                })
-            });
-
-            const result = await tryGraphQLIntrospection("http://example.com/graphql", mockLogger);
-
-            expect(result.success).toBe(false);
-            if (!result.success) {
-                expect(result.error).toContain("GraphQL introspection errors");
-            }
-        });
-
-        it("should handle network errors", async () => {
-            mockFetch.mockRejectedValueOnce(new Error("Network error"));
-
-            const result = await tryGraphQLIntrospection("http://example.com/graphql", mockLogger);
-
-            expect(result.success).toBe(false);
-            if (!result.success) {
-                expect(result.error).toContain("Failed to perform GraphQL introspection");
-            }
-        });
-    });
-
-    describe("tryDirectJSONFetch", () => {
-        it("should successfully handle direct JSON introspection result", async () => {
-            const testSchema = createTestSchema();
-            const introspectionResult = introspectionFromSchema(testSchema);
-
-            // Mock direct introspection result (not wrapped in data)
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => introspectionResult
-            });
-
-            const result = await tryDirectJSONFetch("http://example.com/schema.json", mockLogger);
-
-            expect(result.success).toBe(true);
-            if (result.success) {
-                expect(result.result).toContain("type Query");
-                expect(result.result).toContain("type User");
-            }
-            expect(mockFetch).toHaveBeenCalledWith(
-                "http://example.com/schema.json",
-                expect.objectContaining({
-                    method: "GET",
-                    headers: expect.not.objectContaining({
-                        "Content-Type": expect.anything()
-                    })
-                })
-            );
-        });
-
-        it("should handle wrapped GraphQL response format", async () => {
-            const testSchema = createTestSchema();
-            const introspectionResult = introspectionFromSchema(testSchema);
-
-            // Mock wrapped introspection result (in data property)
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({ data: introspectionResult })
-            });
-
-            const result = await tryDirectJSONFetch("http://example.com/schema.json", mockLogger);
-
-            expect(result.success).toBe(true);
-            if (result.success) {
-                expect(result.result).toContain("type Query");
-                expect(result.result).toContain("type User");
-            }
-        });
-
-        it("should reject invalid JSON format", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({ invalidData: "not introspection" })
-            });
-
-            const result = await tryDirectJSONFetch("http://example.com/schema.json", mockLogger);
-
-            expect(result.success).toBe(false);
-            if (!result.success) {
-                expect(result.error).toContain("does not contain GraphQL introspection data");
-            }
-        });
-
-        it("should handle HTTP errors", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: false,
-                status: 404,
-                statusText: "Not Found"
-            });
-
-            const result = await tryDirectJSONFetch("http://example.com/schema.json", mockLogger);
-
-            expect(result.success).toBe(false);
-            if (!result.success) {
-                expect(result.error).toContain("Direct JSON fetch failed: 404 Not Found");
-            }
-        });
-    });
 
     describe("fetchGraphQLSchemaWithAutoDetection", () => {
         it("should succeed with POST introspection on first attempt", async () => {
@@ -371,6 +179,209 @@ describe("GraphQL Auto-Detection Enhancement", () => {
                 // Clean up - this will always run even if assertions fail
                 delete process.env.GRAPHQL_TOKEN;
             }
+        });
+
+        it("should handle POST authentication errors and retry with GET", async () => {
+            const testSchema = createTestSchema();
+            const introspectionResult = introspectionFromSchema(testSchema);
+            const testFile = join(tempDir, "schema.graphql");
+
+            // First call (POST) fails with auth error
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                statusText: "Unauthorized"
+            });
+
+            // Second call (GET) succeeds
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => introspectionResult
+            });
+
+            await fetchGraphQLSchemaWithAutoDetection("http://example.com/graphql", testFile, mockLogger);
+
+            const savedSchema = await readFile(testFile, "utf8");
+            expect(savedSchema).toContain("type Query");
+            expect(mockLogger.info).toHaveBeenCalledWith("Successfully fetched GraphQL schema using direct JSON fetch");
+        });
+
+        it("should handle POST GraphQL errors and retry with GET", async () => {
+            const testSchema = createTestSchema();
+            const introspectionResult = introspectionFromSchema(testSchema);
+            const testFile = join(tempDir, "schema.graphql");
+
+            // First call (POST) fails with GraphQL errors
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    errors: [{ message: "Introspection is disabled" }]
+                })
+            });
+
+            // Second call (GET) succeeds
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => introspectionResult
+            });
+
+            await fetchGraphQLSchemaWithAutoDetection("http://example.com/graphql", testFile, mockLogger);
+
+            const savedSchema = await readFile(testFile, "utf8");
+            expect(savedSchema).toContain("type Query");
+            expect(mockLogger.info).toHaveBeenCalledWith("Successfully fetched GraphQL schema using direct JSON fetch");
+        });
+
+        it("should handle POST returning invalid data and retry with GET", async () => {
+            const testSchema = createTestSchema();
+            const introspectionResult = introspectionFromSchema(testSchema);
+            const testFile = join(tempDir, "schema.graphql");
+
+            // First call (POST) returns invalid introspection result
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ invalidData: "not introspection" })
+            });
+
+            // Second call (GET) succeeds
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => introspectionResult
+            });
+
+            await fetchGraphQLSchemaWithAutoDetection("http://example.com/graphql", testFile, mockLogger);
+
+            const savedSchema = await readFile(testFile, "utf8");
+            expect(savedSchema).toContain("type Query");
+            expect(mockLogger.info).toHaveBeenCalledWith("Successfully fetched GraphQL schema using direct JSON fetch");
+        });
+
+        it("should handle POST network error and retry with GET", async () => {
+            const testSchema = createTestSchema();
+            const introspectionResult = introspectionFromSchema(testSchema);
+            const testFile = join(tempDir, "schema.graphql");
+
+            // First call (POST) throws network error
+            mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+            // Second call (GET) succeeds
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => introspectionResult
+            });
+
+            await fetchGraphQLSchemaWithAutoDetection("http://example.com/graphql", testFile, mockLogger);
+
+            const savedSchema = await readFile(testFile, "utf8");
+            expect(savedSchema).toContain("type Query");
+            expect(mockLogger.info).toHaveBeenCalledWith("Successfully fetched GraphQL schema using direct JSON fetch");
+        });
+
+        it("should handle GET request with wrapped introspection response", async () => {
+            const testSchema = createTestSchema();
+            const introspectionResult = introspectionFromSchema(testSchema);
+            const testFile = join(tempDir, "schema.graphql");
+
+            // First call (POST) fails
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                statusText: "Not Found"
+            });
+
+            // Second call (GET) succeeds with wrapped format
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ data: introspectionResult })
+            });
+
+            await fetchGraphQLSchemaWithAutoDetection("http://example.com/schema.json", testFile, mockLogger);
+
+            const savedSchema = await readFile(testFile, "utf8");
+            expect(savedSchema).toContain("type Query");
+            expect(savedSchema).toContain("type User");
+            expect(mockLogger.info).toHaveBeenCalledWith("Successfully fetched GraphQL schema using direct JSON fetch");
+        });
+
+        it("should fail when GET returns invalid introspection data", async () => {
+            const testFile = join(tempDir, "schema.graphql");
+
+            // First call (POST) fails
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                statusText: "Not Found"
+            });
+
+            // Second call (GET) returns invalid data
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ invalidData: "not introspection" })
+            });
+
+            await expect(
+                fetchGraphQLSchemaWithAutoDetection("http://example.com/schema.json", testFile, mockLogger)
+            ).rejects.toThrow(/Failed to fetch GraphQL schema from/);
+        });
+
+        it("should verify POST request format and content", async () => {
+            const testSchema = createTestSchema();
+            const introspectionResult = introspectionFromSchema(testSchema);
+            const testFile = join(tempDir, "schema.graphql");
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ data: introspectionResult })
+            });
+
+            await fetchGraphQLSchemaWithAutoDetection("http://example.com/graphql", testFile, mockLogger);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://example.com/graphql",
+                expect.objectContaining({
+                    method: "POST",
+                    headers: expect.objectContaining({
+                        "Content-Type": "application/json",
+                        Accept: "application/json"
+                    }),
+                    body: expect.stringContaining("query IntrospectionQuery")
+                })
+            );
+        });
+
+        it("should verify GET request format has no Content-Type header", async () => {
+            const testSchema = createTestSchema();
+            const introspectionResult = introspectionFromSchema(testSchema);
+            const testFile = join(tempDir, "schema.graphql");
+
+            // First call (POST) fails
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                statusText: "Not Found"
+            });
+
+            // Second call (GET) succeeds
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => introspectionResult
+            });
+
+            await fetchGraphQLSchemaWithAutoDetection("http://example.com/schema.json", testFile, mockLogger);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://example.com/schema.json",
+                expect.objectContaining({
+                    method: "GET",
+                    headers: expect.objectContaining({
+                        Accept: "application/json"
+                    })
+                })
+            );
+
+            // Verify Content-Type is NOT in the GET request headers
+            const getCallArgs = mockFetch.mock.calls.find((call) => call[1]?.method === "GET");
+            expect(getCallArgs?.[1]?.headers).not.toHaveProperty("Content-Type");
         });
     });
 

--- a/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
+++ b/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
@@ -54,7 +54,7 @@ function prepareAuthHeaders(url: string): Record<string, string> {
 }
 
 // Helper function to check if JSON response contains introspection data
-export function isIntrospectionResult(data: unknown): boolean {
+function isIntrospectionResult(data: unknown): boolean {
     if (!data || typeof data !== "object") {
         return false;
     }
@@ -70,7 +70,7 @@ export function isIntrospectionResult(data: unknown): boolean {
 }
 
 // Helper function to extract introspection data from response
-export function extractIntrospectionData(data: unknown): IntrospectionQuery {
+function extractIntrospectionData(data: unknown): IntrospectionQuery {
     if (!data || typeof data !== "object") {
         throw new Error("Data does not contain valid GraphQL introspection result");
     }
@@ -89,7 +89,7 @@ export function extractIntrospectionData(data: unknown): IntrospectionQuery {
 }
 
 // Try GraphQL POST introspection approach
-export async function tryGraphQLIntrospection(
+async function tryGraphQLIntrospection(
     url: string,
     logger: Logger
 ): Promise<
@@ -183,7 +183,7 @@ export async function tryGraphQLIntrospection(
 }
 
 // Try direct JSON fetch approach
-export async function tryDirectJSONFetch(
+async function tryDirectJSONFetch(
     url: string,
     logger: Logger
 ): Promise<
@@ -286,7 +286,7 @@ export async function fetchGraphQLSchemaWithAutoDetection(url: string, path: str
         `Failed to fetch GraphQL schema from ${url}.\n\n` +
         `Attempt 1 (POST introspection): ${postResult.error}\n` +
         `Attempt 2 (GET direct fetch): ${getResult.error}\n\n` +
-        `Please ensure the URL either:\n` +
+        `To update the schema from its defined origin, please ensure the origin either:\n` +
         `1. Accepts GraphQL introspection queries via POST, or\n` +
         `2. Returns introspection results directly via GET`;
 


### PR DESCRIPTION
- just use main entrypoint
- specify error to callout `origin` setting