### PR TITLE
fix(ci): fix seed workflow change detection and disable cancel-in-progress

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -17,7 +17,7 @@ on:
 # Cancel previous workflows on previous push
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   setup:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -137,16 +137,35 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          # Get sufficient history to check for changes
-          fetch-depth: 200
+          # Full history needed to compare against last successful workflow run
+          fetch-depth: 0
           sparse-checkout: |
             ${{ matrix.files }}
             .github/
+
+      - name: Get base SHA from last successful run
+        id: get-base-sha
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LAST_SUCCESS_SHA=$(gh api \
+            "/repos/${{ github.repository }}/actions/workflows/seed.yml/runs?branch=main&status=success&per_page=1" \
+            --jq '.workflow_runs[0].head_sha // empty' 2>/dev/null || echo "")
+
+          if [[ -n "$LAST_SUCCESS_SHA" ]]; then
+            echo "Last successful run SHA: $LAST_SUCCESS_SHA"
+            echo "base_sha=$LAST_SUCCESS_SHA" >> $GITHUB_OUTPUT
+          else
+            echo "No successful run found, using default change detection"
+            echo "base_sha=" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get generator changes for ${{ matrix.generator-name }}
         id: get-generator-changes
         uses: ./.github/actions/check-for-changed-files
         with:
+          base_sha: ${{ steps.get-base-sha.outputs.base_sha }}
           files: ${{ matrix.files }}
 
       - name: Set output

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -238,26 +238,29 @@ jobs:
 
       - name: Setup Base SHA
         id: setup-base-sha
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           BASE_SHA=""
 
-          # For workflow_dispatch events that aren't on main, find the last commit from the main branch and compare against that
-          # For workflows involving the main branch, compare to the last commit
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "refs/heads/main" ]]; then
             git fetch origin main
             MERGE_BASE=$(git merge-base HEAD origin/main)
             echo "Merge base commit: $MERGE_BASE"
-
             BASE_SHA=$MERGE_BASE
-          elif [[ ("${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" == "refs/heads/main") || \
-                  ("${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main") ]]; then            
-            PREVIOUS_MAIN_COMMIT=$(git rev-parse origin/main^)
-            echo "Previous commit on main: $PREVIOUS_MAIN_COMMIT"
-
-            BASE_SHA=$PREVIOUS_MAIN_COMMIT
           else
-            echo "Unexpected event and branch combination. Event: ${{ github.event_name }}, Branch: ${{ github.ref }}"
-            exit 1
+            LAST_SUCCESS_SHA=$(gh api \
+              "/repos/${{ github.repository }}/actions/workflows/update-seed.yml/runs?branch=main&status=success&per_page=1" \
+              --jq '.workflow_runs[0].head_sha // empty' 2>/dev/null || echo "")
+
+            if [[ -n "$LAST_SUCCESS_SHA" ]]; then
+              echo "Last successful run SHA: $LAST_SUCCESS_SHA"
+              BASE_SHA=$LAST_SUCCESS_SHA
+            else
+              PREVIOUS_MAIN_COMMIT=$(git rev-parse origin/main^)
+              echo "No successful run found, falling back to previous commit: $PREVIOUS_MAIN_COMMIT"
+              BASE_SHA=$PREVIOUS_MAIN_COMMIT
+            fi
           fi
 
           echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

Refs: Requested by @davidkonigsberg ([Devin run](https://app.devin.ai/sessions/4c934c418c7f4ddfbe69613f26350e47))

Both `seed.yml` and `update-seed.yml` workflows have concurrency rules that can cause intermediate runs to be cancelled or skipped. The change detection logic previously only compared against the previous single commit, so changes from cancelled/skipped runs were never tested or regenerated.

- `seed.yml` had `cancel-in-progress: true` — new pushes cancelled in-progress runs, wasting compute
- `update-seed.yml` uses `cancel-in-progress: false` — runs queue, but only the latest pending run is kept (intermediate pending runs are dropped)

In both cases, the next run that actually executes needs to cover **all** changes since the last run that completed successfully, not just the latest commit.

## Changes Made

- **`seed.yml`**: Changed `cancel-in-progress` from `true` to `false` so long-running jobs are no longer cancelled mid-execution. Added a step that queries the GitHub API for the last successful run's `head_sha` and passes it as `base_sha` to the `check-for-changed-files` action. Skipped for `pull_request` events (PR change detection against the PR base branch is already correct). Changed `fetch-depth` from `200` to `0` to ensure sufficient history.
- **`update-seed.yml`**: Replaced the `origin/main^` (single previous commit) logic with the same GitHub API lookup for push-to-main and workflow_dispatch-on-main events. Kept the existing `merge-base` logic for workflow_dispatch on non-main branches.
- Both workflows fall back to previous behavior if no successful run is found (e.g., first-ever run).

## Review Checklist

- [ ] **`cancel-in-progress: false` on seed.yml PRs** — the concurrency group includes `pull_request.number`, so with `cancel-in-progress: false`, every push to a PR will queue a run instead of cancelling the previous one. On active PRs with many rapid pushes, this could create a long queue of CI runs. Verify this is acceptable or consider keeping `cancel-in-progress: true` for PR-triggered runs only (would require splitting the concurrency config or adding a condition).
- [ ] **`fetch-depth: 0` in seed.yml** — this is a full clone instead of the previous 200-commit shallow fetch, running across 13 matrix jobs. Sparse checkout is still in effect, but verify the performance tradeoff is acceptable.
- [ ] **`status=success` filter** — the API query requires the _entire_ workflow run to have succeeded. If some generator jobs persistently fail, no run ever reaches `success` status, and the fallback (previous commit) kicks in, effectively reverting to the old behavior. Consider whether `conclusion=success` or a different filter would be more appropriate.
- [ ] **Empty `base_sha` on PR events** — when the `get-base-sha` step is skipped for PRs, its output is an empty string passed to `tj-actions/changed-files`. Verify this correctly falls through to default PR-base comparison.

## Testing
- [ ] These are CI workflow changes that can only be validated by running in GitHub Actions
- [ ] The fallback behavior preserves the existing (pre-fix) logic so there should be no regression if the API call fails