### PR TITLE
fix(ci): extract compile into separate job to fix parity test flakiness

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -72,8 +72,33 @@ jobs:
             echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
           fi
 
-  test-remote-local-parity:
+  # Run compile and build once to populate the turbo remote cache,
+  # so that the parallel matrix jobs get cache hits instead of
+  # racing to compile simultaneously.
+  compile-and-build:
     needs: determine-generator
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || 'main' }}
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - name: Compile
+        run: pnpm compile
+
+      - name: Build Fern CLI
+        run: pnpm fern:build
+
+      - name: Build Seed CLI
+        run: pnpm seed:build
+
+  test-remote-local-parity:
+    needs: [determine-generator, compile-and-build]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
## Description

Fixes non-deterministic compile failures in the `test-remote-vs-local-generation-parity` workflow on main.

**Root cause:** The 4 matrix jobs (`ts-sdk`, `java-sdk`, `go-sdk`, `python-sdk`) each independently run `pnpm compile`, all sharing the same turbo remote cache. When compiling in parallel, jobs can read partially-written cache artifacts from other jobs, causing random TypeScript errors (e.g., missing `DefinitionFileSchema`, missing `WellKnownProtobufType`). Different jobs fail on different runs—confirming non-determinism. The regular CI workflow is unaffected because it has a single compile job.

## Changes Made

- Added a `compile-and-build` job that runs `pnpm compile`, `pnpm fern:build`, and `pnpm seed:build` once before the matrix fans out
- Matrix jobs now depend on `compile-and-build`, so they get turbo cache hits instead of racing to compile simultaneously
- Matrix jobs still run the compile/build steps (for correctness), but they should resolve instantly from cache

## Testing

- [ ] Cannot be directly tested on this PR branch—the workflow only triggers on push to `main`, `workflow_dispatch`, or `workflow_run`
- Verified that the last 2 completed runs on main failed at the `Compile` step with different errors in different matrix jobs, while regular CI compiled successfully on the same commits

## Review Checklist

- [ ] Confirm turbo remote cache keys will match between the `compile-and-build` job and the matrix jobs (same runner, same checkout ref, same install action, same turbo config)
- [ ] Acceptable trade-off: adds ~10 min sequential compile before the matrix, but eliminates flaky failures + retries

Link to Devin run: https://app.devin.ai/sessions/1746b20dd6754cf4b01cbb2e729dd480
Requested by: @davidkonigsberg