### PR TITLE
fix(ci): use artifacts to skip redundant compile in parity test matrix jobs

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -72,9 +72,6 @@ jobs:
             echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
           fi
 
-  # Run compile and build once to populate the turbo remote cache,
-  # so that the parallel matrix jobs get cache hits instead of
-  # racing to compile simultaneously.
   compile-and-build:
     needs: determine-generator
     runs-on: ubuntu-latest
@@ -97,6 +94,20 @@ jobs:
       - name: Build Seed CLI
         run: pnpm seed:build
 
+      - name: Upload Seed CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-cli
+          path: packages/seed/dist/
+          retention-days: 1
+
+      - name: Upload Fern CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: fern-cli
+          path: packages/cli/cli/dist/prod/
+          retention-days: 1
+
   test-remote-local-parity:
     needs: [determine-generator, compile-and-build]
     runs-on: ubuntu-latest
@@ -111,17 +122,17 @@ jobs:
         with:
           ref: ${{ inputs.branch || 'main' }}
 
-      - name: Install
-        uses: ./.github/actions/install
+      - name: Download Seed CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: seed-cli
+          path: packages/seed/dist/
 
-      - name: Compile
-        run: pnpm compile
-
-      - name: Build Fern CLI
-        run: pnpm fern:build
-
-      - name: Build Seed CLI
-        run: pnpm seed:build
+      - name: Download Fern CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: fern-cli
+          path: packages/cli/cli/dist/prod/
 
       - name: Run Seed Test Remote-Local (${{ matrix.generator }})
         uses: nick-fields/retry@v3
@@ -129,7 +140,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 5
           retry_wait_seconds: 120
-          command: pnpm seed test-remote-local --generator ${{ matrix.generator }} --output-mode github
+          command: node --enable-source-maps packages/seed/dist/cli.cjs test-remote-local --generator ${{ matrix.generator }} --output-mode github
         env:
           FERN_TOKEN: ${{ secrets.FERN_FERN_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TEST_REMOTE_LOCAL_GITHUB_TOKEN }}

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -74,7 +74,7 @@ jobs:
 
   compile-and-build:
     needs: determine-generator
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 30
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
## Description

Refs #12477

Follow-up optimization to the parity test workflow fix. The previous PR extracted compile into a prerequisite job, but turbo remote cache was **not effective** — each matrix job still spent ~10 min recompiling despite the cache being populated. This PR eliminates compile/install from the matrix jobs entirely by sharing the bundled CLI artifacts directly.

## Changes Made

- Upload the bundled Seed CLI (`packages/seed/dist/`) and Fern CLI (`packages/cli/cli/dist/prod/`) as GitHub Actions artifacts from the `compile-and-build` job
- Matrix jobs download the artifacts instead of running install + compile + build (~10 min saved per job)
- Removed `pnpm install`, `pnpm compile`, `pnpm fern:build`, and `pnpm seed:build` from matrix jobs
- Changed the seed test command from `pnpm seed test-remote-local` to `node --enable-source-maps packages/seed/dist/cli.cjs test-remote-local` since pnpm is no longer installed in matrix jobs
- Switched `compile-and-build` job to `Seed` runner (larger/faster runner) to speed up the single compile step

**Expected time savings:** ~40 min total across 4 matrix jobs (each was compiling for ~10 min redundantly), plus faster compile on the `Seed` runner.

## Testing

- [ ] Cannot be directly tested on this PR branch — the workflow only triggers on `push` to `main`, `workflow_dispatch`, or `workflow_run`
- [ ] Verified the seed CLI is bundled via tsup (esbuild) into a self-contained `.cjs` file

## Human Review Checklist

> ⚠️ **Critical:** The `pnpm install` step was removed from matrix jobs. If the seed CLI has any runtime dependency on `node_modules` (i.e., something not captured by the esbuild bundle), the test will fail after merge. Please verify the seed CLI bundle is fully self-contained.

- [ ] Confirm `packages/seed/dist/cli.cjs` is a fully self-contained bundle that doesn't require `node_modules` at runtime
- [ ] Confirm the seed `test-remote-local` command doesn't need the fern CLI to be invocable via `pnpm fern` (it's downloaded to the expected path but pnpm scripts won't resolve)
- [ ] Confirm the checkout step (which provides workspace files like `seed.yml`, test definitions, etc.) is sufficient for the seed test to locate its config files
- [ ] Confirm the `Seed` runner label is available for this workflow (it's already used by CI compile job)

Link to Devin run: https://app.devin.ai/sessions/1746b20dd6754cf4b01cbb2e729dd480
Requested by: @davidkonigsberg