### PR TITLE
fix(ci): prevent promisor remote fetch failures in update-seed workflow

### DIFF
--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -59,6 +59,14 @@ runs:
         echo "Generated string: '$string_result'"
         echo "as-string=$string_result" >> $GITHUB_OUTPUT
 
+    - name: Clear partial clone state
+      shell: bash
+      run: |
+        if [ -d .git ] && git config --get remote.origin.partialclonefilter > /dev/null 2>&1; then
+          echo "Removing .git to clear partial clone state and prevent promisor remote fetch failures"
+          rm -rf .git
+        fi
+
     - name: Checkout repo
       uses: actions/checkout@v4
 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -135,7 +135,7 @@ jobs:
   changes:
     if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         generator-name: [seed, ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
@@ -230,11 +230,7 @@ jobs:
       - name: Checkout Files
         uses: actions/checkout@v4
         with:
-          # Get sufficient history to check for changes
           fetch-depth: 0
-          sparse-checkout: |
-            ${{ matrix.files }}
-            .github/
 
       - name: Setup Base SHA
         id: setup-base-sha


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-api/fern/actions/runs/22103649047/job/63880058261, https://github.com/fern-api/fern/actions/runs/22104188725/job/63882538685, https://github.com/fern-api/fern/actions/runs/22104188725/job/63882538607

Fixes intermittent `fatal: could not fetch ... from promisor remote` failures in the update-seed workflow. All three linked failures share the same root cause: `actions/checkout@v4` with `sparse-checkout` automatically adds `--filter=blob:none`, creating a blobless partial clone. When subsequent git operations need actual file blobs (e.g. disabling sparse checkout, checking out files), git tries to fetch them on-demand from the "promisor remote," which can fail with authentication errors (`fatal: could not read Username`).

## Changes Made

- **`run-seed-process/action.yaml`**: Added a step before the full checkout that detects partial clone state (`remote.origin.partialclonefilter` config) and removes `.git` if present, forcing a clean fresh checkout. This fixes the Ruby seed-update failures where the initial sparse checkout (for `.github/actions/`) left partial clone state that caused the subsequent full checkout to fail.
- **`update-seed.yml` (`changes` job)**: Removed `sparse-checkout` from the checkout step. Without sparse-checkout, `actions/checkout@v4` no longer adds `--filter=blob:none`, eliminating the promisor remote issue entirely. This fixes the Python `changes` job failure.
- Increased `changes` job timeout from 5→10 minutes to accommodate the larger clone size without sparse checkout filtering.

## Human Review Checklist

- [ ] Is the 10-minute timeout sufficient for a full `fetch-depth: 0` clone (no blob filter) of this repo across 13 matrix jobs on `ubuntu-latest`?
- [ ] The `rm -rf .git` in `run-seed-process` is conditionally gated on `partialclonefilter` being set — verify this condition is correct and won't accidentally skip cleanup when needed
- [ ] Consider whether the increased clone size for the `changes` job is an acceptable tradeoff vs. reliability (full history with all blobs vs. previously filtered)

## Testing

- [ ] These are CI workflow changes that can only be validated by running the actual update-seed workflow after merge
- [ ] No unit tests applicable

---

Link to Devin run: https://app.devin.ai/sessions/fe57612b8e6c438297969a9ed736d6a2
Requested by: @davidkonigsberg