### PR TITLE
fix(cli): compute doc file paths relative to fern parent dir for S3 upload

### DIFF
--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -11,6 +11,7 @@ type DynamicIrUpload = APIV1Write.DynamicIrUpload;
 type SnippetsConfig = APIV1Write.SnippetsConfig;
 type DocsDefinition = DocsV1Write.DocsDefinition;
 
+import * as posixPath from "node:path/posix";
 import { AbsoluteFilePath, convertToFernHostRelativeFilePath, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { convertIrToDynamicSnippetsIr, generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { detectAirGappedMode, OSSWorkspace } from "@fern-api/lazy-fern-workspace";
@@ -115,6 +116,14 @@ export async function publishDocs({
         editThisPage,
         uploadFiles: async (files) => {
             const filesMap = new Map(files.map((file) => [file.absoluteFilePath, file]));
+            const filePathToAbsolutePath = new Map<string, AbsoluteFilePath>(
+                files.map((file) => {
+                    const cleaned = stripLeadingDotDotSegments(
+                        convertToFernHostRelativeFilePath(file.relativeFilePath)
+                    );
+                    return [cleaned, file.absoluteFilePath];
+                })
+            );
             const filesWithMimeType: FileWithMimeType[] = files
                 .map((fileMetadata) => ({
                     ...fileMetadata,
@@ -143,7 +152,7 @@ export async function publishDocs({
 
                     const obj = {
                         filePath: CjsFdrSdk.docs.v1.write.FilePath(
-                            convertToFernHostRelativeFilePath(filePath.relativeFilePath)
+                            stripLeadingDotDotSegments(convertToFernHostRelativeFilePath(filePath.relativeFilePath))
                         ),
                         width: image.width,
                         height: image.height,
@@ -171,7 +180,9 @@ export async function publishDocs({
                 HASH_CONCURRENCY,
                 nonImageFiles,
                 async (file) => ({
-                    path: CjsFdrSdk.docs.v1.write.FilePath(convertToFernHostRelativeFilePath(file.relativeFilePath)),
+                    path: CjsFdrSdk.docs.v1.write.FilePath(
+                        stripLeadingDotDotSegments(convertToFernHostRelativeFilePath(file.relativeFilePath))
+                    ),
                     fileHash: await calculateFileHash(file.absoluteFilePath)
                 })
             );
@@ -210,7 +221,8 @@ export async function publishDocs({
                                 urlsToUpload,
                                 docsWorkspace.absoluteFilePath,
                                 context,
-                                UPLOAD_FILE_BATCH_SIZE
+                                UPLOAD_FILE_BATCH_SIZE,
+                                filePathToAbsolutePath
                             );
                         } else {
                             context.logger.debug(`No files to upload (all ${skippedCount} up to date)`);
@@ -218,7 +230,8 @@ export async function publishDocs({
                     }
                     return convertToFilePathPairs(
                         startDocsRegisterResponse.body.uploadUrls,
-                        docsWorkspace.absoluteFilePath
+                        docsWorkspace.absoluteFilePath,
+                        filePathToAbsolutePath
                     );
                 } else {
                     return await startDocsRegisterFailed(startDocsRegisterResponse.error, context, organization);
@@ -263,7 +276,8 @@ export async function publishDocs({
                                 urlsToUpload,
                                 docsWorkspace.absoluteFilePath,
                                 context,
-                                UPLOAD_FILE_BATCH_SIZE
+                                UPLOAD_FILE_BATCH_SIZE,
+                                filePathToAbsolutePath
                             );
                         } else {
                             context.logger.info("No files to upload (all up to date)");
@@ -271,7 +285,8 @@ export async function publishDocs({
                     }
                     return convertToFilePathPairs(
                         startDocsRegisterResponse.body.uploadUrls,
-                        docsWorkspace.absoluteFilePath
+                        docsWorkspace.absoluteFilePath,
+                        filePathToAbsolutePath
                     );
                 } else {
                     return startDocsRegisterFailed(startDocsRegisterResponse.error, context, organization);
@@ -495,7 +510,8 @@ async function uploadFiles(
     filesToUpload: Record<string, DocsV1Write.FileS3UploadUrl>,
     docsWorkspacePath: AbsoluteFilePath,
     context: TaskContext,
-    batchSize: number
+    batchSize: number,
+    filePathToAbsolutePath?: Map<string, AbsoluteFilePath>
 ): Promise<void> {
     const startTime = Date.now();
     const totalFiles = Object.keys(filesToUpload).length;
@@ -505,8 +521,8 @@ async function uploadFiles(
     for (const chunkedFilepaths of chunkedFilepathsToUpload) {
         await Promise.all(
             chunkedFilepaths.map(async ([key, { uploadUrl }]) => {
-                const relativeFilePath = RelativeFilePath.of(key);
-                const absoluteFilePath = resolve(docsWorkspacePath, relativeFilePath);
+                const absoluteFilePath =
+                    filePathToAbsolutePath?.get(key) ?? resolve(docsWorkspacePath, RelativeFilePath.of(key));
                 try {
                     const mimeType = mime.lookup(absoluteFilePath);
                     await axios.put(uploadUrl, await readFile(absoluteFilePath), {
@@ -532,12 +548,13 @@ async function uploadFiles(
 
 function convertToFilePathPairs(
     uploadUrls: Record<string, DocsV1Write.FileS3UploadUrl>,
-    docsWorkspacePath: AbsoluteFilePath
+    docsWorkspacePath: AbsoluteFilePath,
+    filePathToAbsolutePath?: Map<string, AbsoluteFilePath>
 ): UploadedFile[] {
     const toRet: UploadedFile[] = [];
     for (const [key, value] of Object.entries(uploadUrls)) {
         const relativeFilePath = RelativeFilePath.of(key);
-        const absoluteFilePath = resolve(docsWorkspacePath, relativeFilePath);
+        const absoluteFilePath = filePathToAbsolutePath?.get(key) ?? resolve(docsWorkspacePath, relativeFilePath);
         toRet.push({
             relativeFilePath,
             absoluteFilePath,
@@ -609,6 +626,10 @@ function getAuthenticationErrorMessage(error: unknown, organization: string): st
     }
 
     return undefined;
+}
+
+function stripLeadingDotDotSegments(filePath: string): string {
+    return posixPath.normalize(filePath).replace(/^(\.\.\/?)+/, "");
 }
 
 function parseBasePath(domain: string): string | undefined {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -11,8 +11,13 @@ type DynamicIrUpload = APIV1Write.DynamicIrUpload;
 type SnippetsConfig = APIV1Write.SnippetsConfig;
 type DocsDefinition = DocsV1Write.DocsDefinition;
 
-import * as posixPath from "node:path/posix";
-import { AbsoluteFilePath, convertToFernHostRelativeFilePath, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    convertToFernHostRelativeFilePath,
+    RelativeFilePath,
+    relative,
+    resolve
+} from "@fern-api/fs-utils";
 import { convertIrToDynamicSnippetsIr, generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { detectAirGappedMode, OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { AIExampleEnhancerConfig, convertIrToFdrApi, enhanceExamplesWithAI } from "@fern-api/register";
@@ -116,12 +121,13 @@ export async function publishDocs({
         editThisPage,
         uploadFiles: async (files) => {
             const filesMap = new Map(files.map((file) => [file.absoluteFilePath, file]));
+            const fernParentDir = resolve(docsWorkspace.absoluteFilePath, RelativeFilePath.of(".."));
             const filePathToAbsolutePath = new Map<string, AbsoluteFilePath>(
                 files.map((file) => {
-                    const cleaned = stripLeadingDotDotSegments(
-                        convertToFernHostRelativeFilePath(file.relativeFilePath)
+                    const serverPath = convertToFernHostRelativeFilePath(
+                        relative(fernParentDir, file.absoluteFilePath)
                     );
-                    return [cleaned, file.absoluteFilePath];
+                    return [serverPath, file.absoluteFilePath];
                 })
             );
             const filesWithMimeType: FileWithMimeType[] = files
@@ -152,7 +158,7 @@ export async function publishDocs({
 
                     const obj = {
                         filePath: CjsFdrSdk.docs.v1.write.FilePath(
-                            stripLeadingDotDotSegments(convertToFernHostRelativeFilePath(filePath.relativeFilePath))
+                            convertToFernHostRelativeFilePath(relative(fernParentDir, filePath.absoluteFilePath))
                         ),
                         width: image.width,
                         height: image.height,
@@ -181,7 +187,7 @@ export async function publishDocs({
                 nonImageFiles,
                 async (file) => ({
                     path: CjsFdrSdk.docs.v1.write.FilePath(
-                        stripLeadingDotDotSegments(convertToFernHostRelativeFilePath(file.relativeFilePath))
+                        convertToFernHostRelativeFilePath(relative(fernParentDir, file.absoluteFilePath))
                     ),
                     fileHash: await calculateFileHash(file.absoluteFilePath)
                 })
@@ -626,10 +632,6 @@ function getAuthenticationErrorMessage(error: unknown, organization: string): st
     }
 
     return undefined;
-}
-
-function stripLeadingDotDotSegments(filePath: string): string {
-    return posixPath.normalize(filePath).replace(/^(\.\.\/?)+/, "");
 }
 
 function parseBasePath(domain: string): string | undefined {


### PR DESCRIPTION
## Description

Refs: Reported via Slack by a customer who moved docs source files outside the `fern/` folder.

When docs source files live outside the `fern/` directory (e.g. at repo-root `docs/assets/`), `DocsDefinitionResolver.toRelativeFilepath()` computes relative paths like `../docs/assets/logo.svg`. These paths get sent to the FDR server, which constructs S3 keys like `domain/time/../docs/assets/logo.svg`. AWS signs a presigned URL for this literal key, but HTTP clients (axios) normalize the URL path before sending — so S3 receives a request for a different key (`domain/docs/assets/logo.svg`) and returns **403 Forbidden (SignatureDoesNotMatch)**.

An earlier approach attempted to fix this server-side in fern-platform via `path.posix.normalize()`, but that caused the `../` to consume the `time` segment in the S3 key (`domain/time/../x` → `domain/x`), losing time-based namespacing. A second approach stripped leading `../` segments CLI-side, but that could cause key collisions if the same relative path existed both inside and outside the fern folder. This final approach computes all paths relative to the fern folder's **parent directory**, which avoids both issues.

## Changes Made

- File paths sent to the server are now computed as `relative(fernParentDir, file.absoluteFilePath)` instead of using `file.relativeFilePath` (which was relative to the fern folder)
- A `Map<string, AbsoluteFilePath>` maps these new server paths → absolute file paths, so `uploadFiles()` and `convertToFilePathPairs()` can still resolve local files correctly during upload
- Both `uploadFiles()` and `convertToFilePathPairs()` accept an optional path map, falling back to the original `resolve(docsWorkspacePath, ...)` behavior when absent

**Example path changes:**
| File location | Old path (fern-relative) | New path (fern-parent-relative) |
|---|---|---|
| `fern/docs/assets/logo.svg` | `docs/assets/logo.svg` | `fern/docs/assets/logo.svg` |
| `repo-root/docs/assets/logo.svg` | `../docs/assets/logo.svg` ❌ | `docs/assets/logo.svg` ✅ |

## Human Review Checklist

- [ ] **S3 key change for existing deployments**: All file paths now include the fern folder name as a prefix (e.g. `docs/x.svg` → `fern/docs/x.svg`). Since S3 keys include a `time` or `hash` segment, existing objects are untouched, but the **first deployment after this change will re-upload all files** (no dedup hit). Confirm this is acceptable.
- [ ] **Downstream consumers of `UploadedFile.relativeFilePath`**: `convertToFilePathPairs` now returns the fern-parent-relative path as `relativeFilePath`. The resolver appears to only use `absoluteFilePath` and `fileId` (line 418-419), but verify no other consumer depends on the old fern-relative path.
- [ ] **Self-hosted mode**: The server's `constructS3DocsKeyWithoutTime` has a `localModeOverride` branch. This CLI change just affects what filepath string is sent — verify self-hosted deployments still work.

## Testing

- [ ] Unit tests added/updated
- [x] Biome lint passes locally
- [x] TypeScript compilation passes locally
- [ ] Manual testing completed — requires running `fern generate --docs --preview` against a repo with docs files outside `fern/` (e.g. `fern-api/ryanstep-config`)

---

[Link to Devin run](https://app.devin.ai/sessions/9553a928baa344f3a37876c50bfe29a3) | Requested by @cdonel707