### PR TITLE
fix(ci): use artifacts to skip compile in parity test matrix jobs

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -6,13 +6,12 @@ on:
     branches:
       - main
 
-  # Runs when triggered manually
+  # Runs when triggered manually (supports testing from any branch)
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to test (defaults to main)"
+        description: "Branch to test (defaults to the branch the workflow is dispatched from)"
         required: false
-        default: "main"
         type: string
 
   # Runs when a generator is published successfully
@@ -72,18 +71,15 @@ jobs:
             echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
           fi
 
-  # Run compile and build once to populate the turbo remote cache,
-  # so that the parallel matrix jobs get cache hits instead of
-  # racing to compile simultaneously.
   compile-and-build:
     needs: determine-generator
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || 'main' }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Install
         uses: ./.github/actions/install
@@ -96,6 +92,20 @@ jobs:
 
       - name: Build Seed CLI
         run: pnpm seed:build
+
+      - name: Upload Seed CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-cli
+          path: packages/seed/dist/
+          retention-days: 1
+
+      - name: Upload Fern CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: fern-cli
+          path: packages/cli/cli/dist/prod/
+          retention-days: 1
 
   test-remote-local-parity:
     needs: [determine-generator, compile-and-build]
@@ -109,19 +119,22 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || 'main' }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Install
         uses: ./.github/actions/install
 
-      - name: Compile
-        run: pnpm compile
+      - name: Download Seed CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: seed-cli
+          path: packages/seed/dist/
 
-      - name: Build Fern CLI
-        run: pnpm fern:build
-
-      - name: Build Seed CLI
-        run: pnpm seed:build
+      - name: Download Fern CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: fern-cli
+          path: packages/cli/cli/dist/prod/
 
       - name: Run Seed Test Remote-Local (${{ matrix.generator }})
         uses: nick-fields/retry@v3

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -136,6 +136,9 @@ jobs:
           name: fern-cli
           path: packages/cli/cli/dist/prod/
 
+      - name: Restore artifact permissions
+        run: chmod +x packages/cli/cli/dist/prod/cli.cjs packages/seed/dist/cli.cjs
+
       - name: Run Seed Test Remote-Local (${{ matrix.generator }})
         uses: nick-fields/retry@v3
         with:


### PR DESCRIPTION
## Description

Refs #12477

Optimizes the parity test workflow by compiling once on a faster runner and sharing built artifacts, instead of each matrix job redundantly compiling (~10 min each × 4 jobs).

This is a retry of #12481, which was reverted because it also removed `pnpm install` from matrix jobs. The seed CLI bundle is **not** fully self-contained — it requires `node_modules` at runtime (fails with `Cannot find module 'minimatch'`). This version keeps `pnpm install`.

## Changes Made

- Switch `compile-and-build` job to `Seed` runner (faster compile)
- Upload seed CLI (`packages/seed/dist/`) and fern CLI (`packages/cli/cli/dist/prod/`) as artifacts from `compile-and-build`
- Matrix jobs download pre-built artifacts instead of running `pnpm compile`, `pnpm fern:build`, `pnpm seed:build`
- Keep `pnpm install` in matrix jobs (required for runtime `node_modules`)
- Replace hardcoded `'main'` ref with `github.ref` so `workflow_dispatch` works from any branch (enables pre-merge testing)
- Remove `default: "main"` from the branch input
- Restore execute permissions on downloaded CLI artifacts with `chmod +x` (`actions/download-artifact` does not preserve Unix file permissions)

## Updates since last revision

**Fix: restore execute permissions after artifact download**

The first `workflow_dispatch` test on this branch failed with all 4 matrix jobs hitting `exit code: undefined` after ~18ms — both local and remote generation failed instantly with "Unknown error".

**Root cause:** `actions/download-artifact` does not preserve Unix file permissions. The fern CLI (`cli.cjs`) has a `#!/usr/bin/env node` shebang and is invoked directly by the seed CLI via `execa()`. Without the execute bit, the OS can't run the file, producing a silent failure with no exit code.

**Fix:** Added a `chmod +x` step after downloading both CLI artifacts to restore execute permissions.

## Testing

- [x] `workflow_dispatch` test on this branch passed — all 6 jobs green: https://github.com/fern-api/fern/actions/runs/22106813558
- [x] First `workflow_dispatch` test revealed missing execute permissions — fixed with `chmod +x`

## Human Review Checklist

> ⚠️ These are the riskiest areas to verify:

- [ ] Confirm `pnpm seed test-remote-local` uses the downloaded `packages/seed/dist/` artifacts and does **not** trigger a recompile via turbo. If the pnpm script runs a build step before the test, the artifact download is ineffective (still correct, just not faster).
- [ ] Confirm `github.ref` resolves correctly for all three triggers (`push`, `workflow_dispatch`, `workflow_run`). For `workflow_run`, `inputs.branch` will be empty and `github.ref` will be used — verify this points to the correct branch.
- [ ] Confirm `Seed` runner label is available for this workflow

---

Link to Devin run: https://app.devin.ai/sessions/1746b20dd6754cf4b01cbb2e729dd480
Requested by: @davidkonigsberg