### PR TITLE
fix(java): disable callTimeout for streaming SSE endpoints

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import okhttp3.OkHttpClient;
@@ -173,6 +174,13 @@ public abstract class AbstractHttpResponseParserGenerator {
                         generatedClientOptions.httpClientWithTimeout(),
                         AbstractEndpointWriterVariableNameContext.REQUEST_OPTIONS_PARAMETER_NAME)
                 .endControlFlow();
+        if (isStreamingEndpoint()) {
+            httpResponseBuilder.addStatement(
+                    "$L = $L.newBuilder().callTimeout(0, $T.SECONDS).build()",
+                    variables.getDefaultedClientName(),
+                    variables.getDefaultedClientName(),
+                    TimeUnit.class);
+        }
         maybeInitializeFuture(httpResponseBuilder, getResponseType(httpEndpoint, clientGeneratorContext));
 
         addResponseHandlingCode(
@@ -192,6 +200,13 @@ public abstract class AbstractHttpResponseParserGenerator {
     public CodeBlock getResponseParserCodeBlockWithoutRequestOptions(MethodSpec.Builder endpointMethodBuilder) {
         CodeBlock.Builder httpResponseBuilder = CodeBlock.builder();
         // Note: OkHttpClient is already initialized by the caller, so we skip that here
+        if (isStreamingEndpoint()) {
+            httpResponseBuilder.addStatement(
+                    "$L = $L.newBuilder().callTimeout(0, $T.SECONDS).build()",
+                    variables.getDefaultedClientName(),
+                    variables.getDefaultedClientName(),
+                    TimeUnit.class);
+        }
         maybeInitializeFuture(httpResponseBuilder, getResponseType(httpEndpoint, clientGeneratorContext));
 
         addResponseHandlingCode(
@@ -471,6 +486,52 @@ public abstract class AbstractHttpResponseParserGenerator {
         } else {
             return TypeName.VOID;
         }
+    }
+
+    protected boolean isStreamingEndpoint() {
+        return httpEndpoint.getResponse().isPresent()
+                && httpEndpoint.getResponse().get().getBody().isPresent()
+                && httpEndpoint
+                        .getResponse()
+                        .get()
+                        .getBody()
+                        .get()
+                        .visit(new HttpResponseBody.Visitor<Boolean>() {
+                            @Override
+                            public Boolean visitJson(JsonResponse jsonResponse) {
+                                return false;
+                            }
+
+                            @Override
+                            public Boolean visitFileDownload(FileDownloadResponse fileDownloadResponse) {
+                                return false;
+                            }
+
+                            @Override
+                            public Boolean visitText(TextResponse textResponse) {
+                                return false;
+                            }
+
+                            @Override
+                            public Boolean visitBytes(BytesResponse bytesResponse) {
+                                return false;
+                            }
+
+                            @Override
+                            public Boolean visitStreaming(StreamingResponse streamingResponse) {
+                                return true;
+                            }
+
+                            @Override
+                            public Boolean visitStreamParameter(StreamParameterResponse streamParameterResponse) {
+                                return false;
+                            }
+
+                            @Override
+                            public Boolean _visitUnknown(Object o) {
+                                return false;
+                            }
+                        });
     }
 
     protected boolean shouldPreReadResponseBodyString() {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
@@ -491,47 +491,42 @@ public abstract class AbstractHttpResponseParserGenerator {
     protected boolean isStreamingEndpoint() {
         return httpEndpoint.getResponse().isPresent()
                 && httpEndpoint.getResponse().get().getBody().isPresent()
-                && httpEndpoint
-                        .getResponse()
-                        .get()
-                        .getBody()
-                        .get()
-                        .visit(new HttpResponseBody.Visitor<Boolean>() {
-                            @Override
-                            public Boolean visitJson(JsonResponse jsonResponse) {
-                                return false;
-                            }
+                && httpEndpoint.getResponse().get().getBody().get().visit(new HttpResponseBody.Visitor<Boolean>() {
+                    @Override
+                    public Boolean visitJson(JsonResponse jsonResponse) {
+                        return false;
+                    }
 
-                            @Override
-                            public Boolean visitFileDownload(FileDownloadResponse fileDownloadResponse) {
-                                return false;
-                            }
+                    @Override
+                    public Boolean visitFileDownload(FileDownloadResponse fileDownloadResponse) {
+                        return false;
+                    }
 
-                            @Override
-                            public Boolean visitText(TextResponse textResponse) {
-                                return false;
-                            }
+                    @Override
+                    public Boolean visitText(TextResponse textResponse) {
+                        return false;
+                    }
 
-                            @Override
-                            public Boolean visitBytes(BytesResponse bytesResponse) {
-                                return false;
-                            }
+                    @Override
+                    public Boolean visitBytes(BytesResponse bytesResponse) {
+                        return false;
+                    }
 
-                            @Override
-                            public Boolean visitStreaming(StreamingResponse streamingResponse) {
-                                return true;
-                            }
+                    @Override
+                    public Boolean visitStreaming(StreamingResponse streamingResponse) {
+                        return true;
+                    }
 
-                            @Override
-                            public Boolean visitStreamParameter(StreamParameterResponse streamParameterResponse) {
-                                return false;
-                            }
+                    @Override
+                    public Boolean visitStreamParameter(StreamParameterResponse streamParameterResponse) {
+                        return false;
+                    }
 
-                            @Override
-                            public Boolean _visitUnknown(Object o) {
-                                return false;
-                            }
-                        });
+                    @Override
+                    public Boolean _visitUnknown(Object o) {
+                        return false;
+                    }
+                });
     }
 
     protected boolean shouldPreReadResponseBodyString() {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.36.2
+  changelogEntry:
+    - summary: |
+        Disable OkHttp callTimeout for streaming (SSE) endpoints. The default 60-second
+        callTimeout was terminating SSE connections after ~1 minute instead of allowing
+        them to stream indefinitely. Streaming endpoints now set callTimeout to 0 (disabled)
+        so the iterator blocks on each next() call waiting for new events until the connection
+        is closed or an error occurs.
+      type: fix
+  createdAt: "2026-02-17"
+  irVersion: 63
+
 - version: 3.36.1
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/resources/dummy/AsyncRawDummyClient.java
+++ b/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/resources/dummy/AsyncRawDummyClient.java
@@ -20,6 +20,7 @@ import com.seed.javaStreamingAcceptHeader.resources.dummy.requests.GenerateStrea
 import com.seed.javaStreamingAcceptHeader.resources.dummy.types.StreamResponse;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Headers;
@@ -70,6 +71,7 @@ public class AsyncRawDummyClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         CompletableFuture<SeedJavaStreamingAcceptHeaderHttpResponse<Iterable<StreamResponse>>> future =
                 new CompletableFuture<>();
         client.newCall(okhttpRequest).enqueue(new Callback() {

--- a/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/resources/dummy/RawDummyClient.java
+++ b/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/resources/dummy/RawDummyClient.java
@@ -19,6 +19,7 @@ import com.seed.javaStreamingAcceptHeader.resources.dummy.requests.GenerateReque
 import com.seed.javaStreamingAcceptHeader.resources.dummy.requests.GenerateStreamRequest;
 import com.seed.javaStreamingAcceptHeader.resources.dummy.types.StreamResponse;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -66,6 +67,7 @@ public class RawDummyClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         try {
             Response response = client.newCall(okhttpRequest).execute();
             ResponseBody responseBody = response.body();

--- a/seed/java-sdk/server-sent-event-examples/src/main/java/com/seed/serverSentEvents/resources/completions/AsyncRawCompletionsClient.java
+++ b/seed/java-sdk/server-sent-event-examples/src/main/java/com/seed/serverSentEvents/resources/completions/AsyncRawCompletionsClient.java
@@ -19,6 +19,7 @@ import com.seed.serverSentEvents.resources.completions.types.StreamEvent;
 import com.seed.serverSentEvents.resources.completions.types.StreamedCompletion;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Headers;
@@ -69,6 +70,7 @@ public class AsyncRawCompletionsClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         CompletableFuture<SeedServerSentEventsHttpResponse<Iterable<StreamedCompletion>>> future =
                 new CompletableFuture<>();
         client.newCall(okhttpRequest).enqueue(new Callback() {
@@ -134,6 +136,7 @@ public class AsyncRawCompletionsClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         CompletableFuture<SeedServerSentEventsHttpResponse<Iterable<StreamEvent>>> future = new CompletableFuture<>();
         client.newCall(okhttpRequest).enqueue(new Callback() {
             @Override

--- a/seed/java-sdk/server-sent-event-examples/src/main/java/com/seed/serverSentEvents/resources/completions/RawCompletionsClient.java
+++ b/seed/java-sdk/server-sent-event-examples/src/main/java/com/seed/serverSentEvents/resources/completions/RawCompletionsClient.java
@@ -18,6 +18,7 @@ import com.seed.serverSentEvents.resources.completions.requests.StreamEventsRequ
 import com.seed.serverSentEvents.resources.completions.types.StreamEvent;
 import com.seed.serverSentEvents.resources.completions.types.StreamedCompletion;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -64,6 +65,7 @@ public class RawCompletionsClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         try {
             Response response = client.newCall(okhttpRequest).execute();
             ResponseBody responseBody = response.body();
@@ -112,6 +114,7 @@ public class RawCompletionsClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         try {
             Response response = client.newCall(okhttpRequest).execute();
             ResponseBody responseBody = response.body();

--- a/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/resources/completions/AsyncRawCompletionsClient.java
+++ b/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/resources/completions/AsyncRawCompletionsClient.java
@@ -18,6 +18,7 @@ import com.seed.serverSentEvents.resources.completions.requests.StreamCompletion
 import com.seed.serverSentEvents.resources.completions.types.StreamedCompletion;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Headers;
@@ -68,6 +69,7 @@ public class AsyncRawCompletionsClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         CompletableFuture<SeedServerSentEventsHttpResponse<Iterable<StreamedCompletion>>> future =
                 new CompletableFuture<>();
         client.newCall(okhttpRequest).enqueue(new Callback() {
@@ -133,6 +135,7 @@ public class AsyncRawCompletionsClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         CompletableFuture<SeedServerSentEventsHttpResponse<Iterable<StreamedCompletion>>> future =
                 new CompletableFuture<>();
         client.newCall(okhttpRequest).enqueue(new Callback() {

--- a/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/resources/completions/RawCompletionsClient.java
+++ b/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/resources/completions/RawCompletionsClient.java
@@ -17,6 +17,7 @@ import com.seed.serverSentEvents.resources.completions.requests.StreamCompletion
 import com.seed.serverSentEvents.resources.completions.requests.StreamCompletionRequestWithoutTerminator;
 import com.seed.serverSentEvents.resources.completions.types.StreamedCompletion;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -63,6 +64,7 @@ public class RawCompletionsClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         try {
             Response response = client.newCall(okhttpRequest).execute();
             ResponseBody responseBody = response.body();
@@ -112,6 +114,7 @@ public class RawCompletionsClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         try {
             Response response = client.newCall(okhttpRequest).execute();
             ResponseBody responseBody = response.body();

--- a/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/resources/dummy/AsyncRawDummyClient.java
+++ b/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/resources/dummy/AsyncRawDummyClient.java
@@ -18,6 +18,7 @@ import com.seed.streaming.resources.dummy.requests.Generateequest;
 import com.seed.streaming.resources.dummy.types.StreamResponse;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Headers;
@@ -68,6 +69,7 @@ public class AsyncRawDummyClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         CompletableFuture<SeedStreamingHttpResponse<Iterable<StreamResponse>>> future = new CompletableFuture<>();
         client.newCall(okhttpRequest).enqueue(new Callback() {
             @Override

--- a/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/resources/dummy/RawDummyClient.java
+++ b/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/resources/dummy/RawDummyClient.java
@@ -17,6 +17,7 @@ import com.seed.streaming.resources.dummy.requests.GenerateStreamRequest;
 import com.seed.streaming.resources.dummy.requests.Generateequest;
 import com.seed.streaming.resources.dummy.types.StreamResponse;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -63,6 +64,7 @@ public class RawDummyClient {
         if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
             client = clientOptions.httpClientWithTimeout(requestOptions);
         }
+        client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build();
         try {
             Response response = client.newCall(okhttpRequest).execute();
             ResponseBody responseBody = response.body();


### PR DESCRIPTION
## Description

Refs: [Slack thread](https://buildwithfern.slack.com/archives/C08CH70C8LW/p1771011275351859)

The generated Java SDK's streaming/SSE endpoints (e.g., `streamEntities()`) terminate after ~1 minute instead of blocking indefinitely for new events. This is caused by OkHttp's `callTimeout` defaulting to 60 seconds, which applies to the **entire** HTTP call lifecycle including response body streaming. When the timeout fires, OkHttp closes the connection, `Scanner.hasNextLine()` returns false, and the stream iterator ends.

The Python SDK doesn't have this issue because `httpx` timeouts apply per-read-operation, not to the overall call duration.

## Changes Made

- Added `isStreamingEndpoint()` helper in `AbstractHttpResponseParserGenerator` to detect streaming response types via the IR visitor pattern
- In `getResponseParserCodeBlock()` and `getResponseParserCodeBlockWithoutRequestOptions()`, streaming endpoints now generate code that rebuilds the OkHttp client with `callTimeout(0, TimeUnit.SECONDS)` (disabled)
- Updated `versions.yml` with v3.36.2 changelog entry
- Updated seed test snapshots for all affected streaming fixtures (`streaming`, `server-sent-events`, `server-sent-event-examples`, `java-streaming-accept-header`)

## Testing

- [x] Build passes (`./gradlew :sdk:compileJava`)
- [x] Seed tests updated/regenerated — all 4 streaming fixtures verified locally and snapshots committed
- [x] CI passing (all required checks green)
- [ ] Manual testing with an SSE endpoint

## Human Review Checklist

- **⚠️ Timeout precedence**: The `callTimeout(0)` override is applied *after* the `requestOptions` timeout check. This means streaming endpoints will **always** have callTimeout disabled, even if the user explicitly sets a timeout via `RequestOptions`. Confirm this is the desired behavior.
- **⚠️ `StreamParameter` vs `Streaming`**: `isStreamingEndpoint()` returns `true` only for `StreamingResponse`, not `StreamParameterResponse`. Verify this distinction is correct — `StreamParameter` likely represents a different concept (e.g., streamed request bodies) and should retain normal timeout behavior.
- Verify the generated code in the seed snapshots looks correct — the `client = client.newBuilder().callTimeout(0, TimeUnit.SECONDS).build()` line should appear only in streaming endpoint methods, immediately after the `requestOptions` timeout block.

---

[Link to Devin run](https://app.devin.ai/sessions/e26817c14cdb49af8dfa4f0097f1febb) | Requested by: @tstanmay13