### PR TITLE
fix(cli): resolve Markdown snippet references in link targets for broken link checking

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.79.1
+  changelogEntry:
+    - summary: |
+        Fix `fern check --strict-broken-links` to resolve `<Markdown src="..." />` snippets used
+        inside link targets. Previously, links like `[text](<Markdown src="./snippet.mdx" />)` were
+        not resolved and could be incorrectly flagged as broken. Snippet content is now inlined
+        before link validation.
+      type: fix
+  createdAt: "2026-02-17"
+  irVersion: 65
 - version: 3.79.0
   changelogEntry:
     - summary: |

--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -41,6 +41,14 @@ describe("fern docs broken-links", () => {
         expect(stripAnsi(stdout)).toContain("All checks passed");
     }, 20_000);
 
+    it("links with Markdown snippet references should be resolved", async () => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("snippet-link")),
+            reject: false
+        });
+        expect(stripAnsi(stdout)).toContain("All checks passed");
+    }, 20_000);
+
     it("broken links in sections with path property should be detected", async () => {
         const { stdout } = await runFernCli(["docs", "broken-links"], {
             cwd: join(fixturesDir, RelativeFilePath.of("section-with-path")),

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/docs.yml
@@ -1,0 +1,8 @@
+instances:
+  - url: docs.example.com
+
+navigation:
+  - page: Test
+    path: test.mdx
+  - page: Getting Started
+    path: getting-started.mdx

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "test-org",
+  "version": "0.0.0"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/getting-started.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/getting-started.mdx
@@ -1,0 +1,3 @@
+# Getting Started
+
+Welcome to the getting started guide.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/snippets/valid-link.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/snippets/valid-link.mdx
@@ -1,0 +1,1 @@
+/getting-started

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/test.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/snippet-link/fern/test.mdx
@@ -1,0 +1,5 @@
+# Test Snippet Links
+
+This page tests that links with Markdown snippet references are resolved correctly.
+
+[Getting Started](<Markdown src="./snippets/valid-link.mdx" />)

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/collect-links.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/collect-links.ts
@@ -14,6 +14,9 @@ import { toHast } from "mdast-util-to-hast";
 import type { Position } from "unist";
 import { visit } from "unist-util-visit";
 
+const MARKDOWN_SNIPPET_REGEX = /<Markdown\s+([^>]+)\/>/g;
+const SNIPPET_SRC_REGEX = /src=(?:\{?['"]([^'"]+)['"]\}?)/;
+
 const MDX_NODE_TYPES = [
     "mdxFlowExpression",
     "mdxJsxFlowElement",
@@ -79,7 +82,9 @@ export function collectLinksAndSources({
             visitedAbsoluteFilepaths.add(absoluteFilepath);
         }
 
-        const mdast = parseMarkdownToTree(content);
+        const resolvedContent = resolveMarkdownSnippets(content, absoluteFilepath, readFile);
+
+        const mdast = parseMarkdownToTree(resolvedContent);
 
         const hast = toHast(mdast, {
             allowDangerousHtml: true,
@@ -210,6 +215,61 @@ export function collectLinksAndSources({
     } while (contentQueue.length > 0);
 
     return { links, sources };
+}
+
+function resolveMarkdownSnippets(
+    content: string,
+    absoluteFilepath: AbsoluteFilePath | undefined,
+    readFile: (path: AbsoluteFilePath) => string,
+    visited: Set<string> = new Set()
+): string {
+    if (!content.includes("<Markdown")) {
+        return content;
+    }
+
+    if (absoluteFilepath == null) {
+        return content;
+    }
+
+    let result = content;
+    let match: RegExpExecArray | null;
+    const regex = new RegExp(MARKDOWN_SNIPPET_REGEX.source, MARKDOWN_SNIPPET_REGEX.flags);
+
+    while ((match = regex.exec(content)) != null) {
+        const fullMatch = match[0];
+        const attributesString = match[1];
+        if (fullMatch == null || attributesString == null) {
+            continue;
+        }
+
+        const srcMatch = attributesString.match(SNIPPET_SRC_REGEX);
+        if (srcMatch?.[1] == null) {
+            continue;
+        }
+        const src = srcMatch[1];
+
+        if (!src.match(/\.mdx?$/)) {
+            continue;
+        }
+
+        const resolvedPath = resolve(dirname(absoluteFilepath), RelativeFilePath.of(src));
+
+        if (visited.has(resolvedPath)) {
+            continue;
+        }
+
+        try {
+            let snippetContent = readFile(resolvedPath);
+            const newVisited = new Set(visited);
+            newVisited.add(absoluteFilepath);
+            snippetContent = resolveMarkdownSnippets(snippetContent, resolvedPath, readFile, newVisited);
+            result = result.replace(fullMatch, snippetContent);
+        } catch {
+            // leave unresolvable snippets as-is
+        }
+    }
+
+    return result;
 }
 
 // acorns and other errors are being thrown when we parse the markdown

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/collect-links.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/collect-links.ts
@@ -14,9 +14,6 @@ import { toHast } from "mdast-util-to-hast";
 import type { Position } from "unist";
 import { visit } from "unist-util-visit";
 
-const MARKDOWN_SNIPPET_REGEX = /<Markdown\s+([^>]+)\/>/g;
-const SNIPPET_SRC_REGEX = /src=(?:\{?['"]([^'"]+)['"]\}?)/;
-
 const MDX_NODE_TYPES = [
     "mdxFlowExpression",
     "mdxJsxFlowElement",
@@ -82,9 +79,7 @@ export function collectLinksAndSources({
             visitedAbsoluteFilepaths.add(absoluteFilepath);
         }
 
-        const resolvedContent = resolveMarkdownSnippets(content, absoluteFilepath, readFile);
-
-        const mdast = parseMarkdownToTree(resolvedContent);
+        const mdast = parseMarkdownToTree(content);
 
         const hast = toHast(mdast, {
             allowDangerousHtml: true,
@@ -215,61 +210,6 @@ export function collectLinksAndSources({
     } while (contentQueue.length > 0);
 
     return { links, sources };
-}
-
-function resolveMarkdownSnippets(
-    content: string,
-    absoluteFilepath: AbsoluteFilePath | undefined,
-    readFile: (path: AbsoluteFilePath) => string,
-    visited: Set<string> = new Set()
-): string {
-    if (!content.includes("<Markdown")) {
-        return content;
-    }
-
-    if (absoluteFilepath == null) {
-        return content;
-    }
-
-    let result = content;
-    let match: RegExpExecArray | null;
-    const regex = new RegExp(MARKDOWN_SNIPPET_REGEX.source, MARKDOWN_SNIPPET_REGEX.flags);
-
-    while ((match = regex.exec(content)) != null) {
-        const fullMatch = match[0];
-        const attributesString = match[1];
-        if (fullMatch == null || attributesString == null) {
-            continue;
-        }
-
-        const srcMatch = attributesString.match(SNIPPET_SRC_REGEX);
-        if (srcMatch?.[1] == null) {
-            continue;
-        }
-        const src = srcMatch[1];
-
-        if (!src.match(/\.mdx?$/)) {
-            continue;
-        }
-
-        const resolvedPath = resolve(dirname(absoluteFilepath), RelativeFilePath.of(src));
-
-        if (visited.has(resolvedPath)) {
-            continue;
-        }
-
-        try {
-            let snippetContent = readFile(resolvedPath);
-            const newVisited = new Set(visited);
-            newVisited.add(absoluteFilepath);
-            snippetContent = resolveMarkdownSnippets(snippetContent, resolvedPath, readFile, newVisited);
-            result = result.replace(fullMatch, snippetContent);
-        } catch {
-            // leave unresolvable snippets as-is
-        }
-    }
-
-    return result;
 }
 
 // acorns and other errors are being thrown when we parse the markdown

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -1,5 +1,6 @@
 import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
 import { noop } from "@fern-api/core-utils";
+import { replaceReferencedMarkdown } from "@fern-api/docs-markdown-utils";
 import { convertIrToApiDefinition, DocsDefinitionResolver } from "@fern-api/docs-resolver";
 import { APIV1Read, ApiDefinition, FernNavigation } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, join, RelativeFilePath, relative } from "@fern-api/fs-utils";
@@ -94,8 +95,15 @@ export const ValidMarkdownLinks: Rule = {
                     return [];
                 }
 
+                const { markdown: resolvedContent } = await replaceReferencedMarkdown({
+                    markdown: content,
+                    absolutePathToFernFolder: workspace.absoluteFilePath,
+                    absolutePathToMarkdownFile: absoluteFilepath,
+                    context: NOOP_CONTEXT
+                });
+
                 // Find all matches in the Markdown text
-                const { pathnamesToCheck, violations } = collectPathnamesToCheck(content, {
+                const { pathnamesToCheck, violations } = collectPathnamesToCheck(resolvedContent, {
                     absoluteFilepath,
                     instanceUrls
                 });

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -95,12 +95,24 @@ export const ValidMarkdownLinks: Rule = {
                     return [];
                 }
 
+                const snippetWarnings: string[] = [];
+                const snippetContext = createMockTaskContext({
+                    logger: createLogger((_level, ...args) => {
+                        snippetWarnings.push(args.join(" "));
+                    })
+                });
+
                 const { markdown: resolvedContent } = await replaceReferencedMarkdown({
                     markdown: content,
                     absolutePathToFernFolder: workspace.absoluteFilePath,
                     absolutePathToMarkdownFile: absoluteFilepath,
-                    context: NOOP_CONTEXT
+                    context: snippetContext
                 });
+
+                const snippetViolations: RuleViolation[] = snippetWarnings.map((warning) => ({
+                    severity: "warning" as const,
+                    message: warning
+                }));
 
                 // Find all matches in the Markdown text
                 const { pathnamesToCheck, violations } = collectPathnamesToCheck(resolvedContent, {
@@ -141,7 +153,7 @@ export const ValidMarkdownLinks: Rule = {
                     })
                 );
 
-                return [...violations, ...pathToCheckViolations.flat()];
+                return [...snippetViolations, ...violations, ...pathToCheckViolations.flat()];
             },
             apiSection: async ({ workspace: apiWorkspace, config }) => {
                 const fernWorkspace = await apiWorkspace.toFernWorkspace(

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -95,24 +95,12 @@ export const ValidMarkdownLinks: Rule = {
                     return [];
                 }
 
-                const snippetWarnings: string[] = [];
-                const snippetContext = createMockTaskContext({
-                    logger: createLogger((_level, ...args) => {
-                        snippetWarnings.push(args.join(" "));
-                    })
-                });
-
                 const { markdown: resolvedContent } = await replaceReferencedMarkdown({
                     markdown: content,
                     absolutePathToFernFolder: workspace.absoluteFilePath,
                     absolutePathToMarkdownFile: absoluteFilepath,
-                    context: snippetContext
+                    context: NOOP_CONTEXT
                 });
-
-                const snippetViolations: RuleViolation[] = snippetWarnings.map((warning) => ({
-                    severity: "warning" as const,
-                    message: warning
-                }));
 
                 // Find all matches in the Markdown text
                 const { pathnamesToCheck, violations } = collectPathnamesToCheck(resolvedContent, {
@@ -153,7 +141,7 @@ export const ValidMarkdownLinks: Rule = {
                     })
                 );
 
-                return [...snippetViolations, ...violations, ...pathToCheckViolations.flat()];
+                return [...violations, ...pathToCheckViolations.flat()];
             },
             apiSection: async ({ workspace: apiWorkspace, config }) => {
                 const fernWorkspace = await apiWorkspace.toFernWorkspace(


### PR DESCRIPTION
## Description

Refs: Requested by @Ryan-Amirthan in Slack

Fixes `fern check --strict-broken-links` to correctly resolve `<Markdown src="..." />` snippet references when used inside link targets. Previously, links like `[API Explorer](<Markdown src="../../snippets/api-explorer-ga.mdx" />)` were not resolved and could be incorrectly flagged as broken links.

## Changes Made

- Calls the existing `replaceReferencedMarkdown()` utility from `@fern-api/docs-markdown-utils` in the `markdownPage` handler in `valid-markdown-link.ts`, so all `<Markdown>` snippets are resolved before link validation runs
- Added e2e test fixture `snippet-link` to validate snippet resolution in link targets
- Updated `versions.yml` with fix entry for 3.79.2

## Updates since last revision

- Refactored per Catherine's feedback: removed the custom `resolveMarkdownSnippets()` function from `collect-links.ts` and instead reuses the existing `replaceReferencedMarkdown` utility. This gives full feature parity (absolute paths, variable substitution, circular reference detection) for free.
- Removed snippet warning logging from `valid-markdown-link.ts` per Ryan's feedback — snippet resolution warnings (circular refs, missing files, etc.) are a general concern and should be surfaced wherever snippets are resolved, not specifically in the link checker. Reverted to `NOOP_CONTEXT`.

## Testing

- [x] E2e test added (`snippet-link` fixture)
- [x] Lint checks pass (`pnpm run check`)
- [x] Local CLI build + manual testing against both valid and broken snippet link fixtures

## Human Review Checklist

1. **Redundant standalone `<Markdown>` handler**: The HAST-level `<Markdown>` handler in `collect-links.ts` (lines 158-169) is now effectively a no-op for the `markdownPage` path since snippets are already resolved upstream. It still applies for the `apiSection` code path (which does not resolve snippets). Is this acceptable or should it be cleaned up?
2. **`NOOP_CONTEXT` usage**: Snippet resolution errors (circular refs, missing files, missing variables) are silently dropped via `NOOP_CONTEXT`. This is consistent with other usages in the file but means these issues won't surface during `fern check --strict-broken-links` specifically.
3. **Test coverage**: Only tests the happy path (valid snippet → valid link). Broken snippet link detection was verified manually but has no e2e test.

---

**Devin run**: https://app.devin.ai/sessions/2768f54402a348e2af36552d5f947cc7