### PR TITLE
fix(ci): run parity test matrix jobs sequentially to prevent branch collisions

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -6,13 +6,12 @@ on:
     branches:
       - main
 
-  # Runs when triggered manually
+  # Runs when triggered manually (supports testing from any branch)
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to test (defaults to main)"
+        description: "Branch to test (defaults to the branch the workflow is dispatched from)"
         required: false
-        default: "main"
         type: string
 
   # Runs when a generator is published successfully
@@ -72,18 +71,15 @@ jobs:
             echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
           fi
 
-  # Run compile and build once to populate the turbo remote cache,
-  # so that the parallel matrix jobs get cache hits instead of
-  # racing to compile simultaneously.
   compile-and-build:
     needs: determine-generator
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || 'main' }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Install
         uses: ./.github/actions/install
@@ -96,6 +92,20 @@ jobs:
 
       - name: Build Seed CLI
         run: pnpm seed:build
+
+      - name: Upload Seed CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-cli
+          path: packages/seed/dist/
+          retention-days: 1
+
+      - name: Upload Fern CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: fern-cli
+          path: packages/cli/cli/dist/prod/
+          retention-days: 1
 
   test-remote-local-parity:
     needs: [determine-generator, compile-and-build]
@@ -109,19 +119,22 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || 'main' }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Install
         uses: ./.github/actions/install
 
-      - name: Compile
-        run: pnpm compile
+      - name: Download Seed CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: seed-cli
+          path: packages/seed/dist/
 
-      - name: Build Fern CLI
-        run: pnpm fern:build
-
-      - name: Build Seed CLI
-        run: pnpm seed:build
+      - name: Download Fern CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: fern-cli
+          path: packages/cli/cli/dist/prod/
 
       - name: Run Seed Test Remote-Local (${{ matrix.generator }})
         uses: nick-fields/retry@v3

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -136,6 +136,9 @@ jobs:
           name: fern-cli
           path: packages/cli/cli/dist/prod/
 
+      - name: Restore artifact permissions
+        run: chmod +x packages/cli/cli/dist/prod/cli.cjs packages/seed/dist/cli.cjs
+
       - name: Run Seed Test Remote-Local (${{ matrix.generator }})
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -113,6 +113,12 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      # Run one generator at a time to prevent branch name collisions on the remote
+      # (Fiddle) target repo. Fiddle uses minute-level timestamps for branch names
+      # (e.g. fern-bot/2026-02-17T16-39Z) without a generator-specific prefix, so
+      # concurrent jobs can overwrite each other's branches and produce false parity
+      # failures. This can be removed once Fiddle includes the generator name in its
+      # branch naming (matching the local generation fix in PR #12331).
       max-parallel: 1
       matrix:
         generator: ${{ fromJson(needs.determine-generator.outputs.generators) }}

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -113,6 +113,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         generator: ${{ fromJson(needs.determine-generator.outputs.generators) }}
     steps:


### PR DESCRIPTION
## Description

Refs #12486

Fixes non-deterministic failures in the remote-vs-local parity test caused by concurrent matrix jobs overwriting each other's branches on `fern-api/empty`. This is a workaround for a Fiddle-side limitation in branch naming; the constraint can be removed once Fiddle includes generator names in its branch prefixes.

## Root Cause

Remote generation via Fiddle pushes to branches with **minute-level** timestamp precision (e.g., `fern-bot/2026-02-17T16-39Z`). When multiple matrix jobs run in parallel, their remote pushes can land within the same minute and collide on the same branch name. The last push wins, overwriting the previous generator's output. When the overwritten test then clones that branch, it gets a different generator's code, producing a false parity failure.

Evidence from [a passing run's logs](https://github.com/fern-api/fern/actions/runs/22106813558): both `ts-sdk` and `go-sdk` remote generations pushed to `fern-bot/2026-02-17T16-39Z` within 1 second of each other. The `ts-sdk` test then cloned Go SDK output, causing a 556-line diff. It only passed on attempt 3 (after other generators had finished and the branch was no longer being contested).

Local generation branches are unaffected because they include the generator name (e.g., `fern-bot/fernapi-fern-typescript-sdk/2026-02-17_16-39-30_830`), as fixed in #12331.

## Changes Made

- Added `max-parallel: 1` to the matrix strategy so generator tests run sequentially, preventing branch name collisions on `fern-api/empty`
- Added an inline comment in the workflow explaining the Fiddle branch naming limitation and linking to #12331 so future maintainers know when this constraint can be lifted

## Testing

- [ ] `workflow_dispatch` test on this branch to confirm all generators pass without retries needed

## Human Review Checklist

> ⚠️ Riskiest areas to verify:

- [ ] **Performance tradeoff**: `max-parallel: 1` means the 4 generator tests run sequentially (~3-5 min each) instead of in parallel. Confirm this added wall-clock time is acceptable given it eliminates the flakiness.
- [ ] **Concurrent workflow runs**: The existing `concurrency` group (`${{ github.workflow }}-${{ github.ref }}`) should prevent multiple workflow runs from colliding with each other. Verify this holds for all trigger types (`push`, `workflow_dispatch`, `workflow_run`).
- [ ] **Upstream fix**: The inline comment references the Fiddle branch naming limitation and PR #12331. Once Fiddle is updated to include generator names in branch prefixes, `max-parallel: 1` and the comment can be removed to restore parallel execution.

---

Link to Devin run: https://app.devin.ai/sessions/1746b20dd6754cf4b01cbb2e729dd480
Requested by: @davidkonigsberg