### PR TITLE
fix(ci): replace tsc --build with tsc --composite false to prevent race condition

### DIFF
--- a/generators/base/package.json
+++ b/generators/base/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/browser-compatible-base/package.json
+++ b/generators/browser-compatible-base/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/csharp/codegen/package.json
+++ b/generators/csharp/codegen/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/csharp/dynamic-snippets/package.json
+++ b/generators/csharp/dynamic-snippets/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/csharp/formatter/package.json
+++ b/generators/csharp/formatter/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/csharp/model/package.json
+++ b/generators/csharp/model/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-csharp-model:latest ../../..",

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-csharp-sdk:latest ../../..",

--- a/generators/go-v2/ast/package.json
+++ b/generators/go-v2/ast/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/go-v2/base/package.json
+++ b/generators/go-v2/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/generators/go-v2/dynamic-snippets/package.json
+++ b/generators/go-v2/dynamic-snippets/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/go-v2/formatter/package.json
+++ b/generators/go-v2/formatter/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/go-v2/model/package.json
+++ b/generators/go-v2/model/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-go-model:latest ../../..",

--- a/generators/go-v2/sdk/package.json
+++ b/generators/go-v2/sdk/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-go-sdk:latest ../../..",

--- a/generators/java-v2/ast/package.json
+++ b/generators/java-v2/ast/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/java-v2/base/package.json
+++ b/generators/java-v2/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/generators/java-v2/dynamic-snippets/package.json
+++ b/generators/java-v2/dynamic-snippets/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-java-sdk:latest ../../..",

--- a/generators/openapi/package.json
+++ b/generators/openapi/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-openapi:latest .",

--- a/generators/php/base/package.json
+++ b/generators/php/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/generators/php/codegen/package.json
+++ b/generators/php/codegen/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/php/dynamic-snippets/package.json
+++ b/generators/php/dynamic-snippets/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/php/model/package.json
+++ b/generators/php/model/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-php-model:latest ../../..",

--- a/generators/php/sdk/package.json
+++ b/generators/php/sdk/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-php-sdk:latest ../../..",

--- a/generators/postman/package.json
+++ b/generators/postman/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-postman:latest .",

--- a/generators/python-v2/ast/package.json
+++ b/generators/python-v2/ast/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/python-v2/base/package.json
+++ b/generators/python-v2/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/python-v2/browser-compatible-base/package.json
+++ b/generators/python-v2/browser-compatible-base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/python-v2/dynamic-snippets/package.json
+++ b/generators/python-v2/dynamic-snippets/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/python-v2/fastapi/package.json
+++ b/generators/python-v2/fastapi/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-fastapi-server-v2:latest ../../..",

--- a/generators/python-v2/formatter/package.json
+++ b/generators/python-v2/formatter/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/python-v2/pydantic-model/package.json
+++ b/generators/python-v2/pydantic-model/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-pydantic-model-v2:latest ../../..",

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-python-sdk:latest ../../..",

--- a/generators/ruby-v2/ast/package.json
+++ b/generators/ruby-v2/ast/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/ruby-v2/base/package.json
+++ b/generators/ruby-v2/base/package.json
@@ -22,10 +22,10 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
     "postcompile": "rsync -a --delete ./src/asIs/ ./lib/asIs/",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/generators/ruby-v2/dynamic-snippets/package.json
+++ b/generators/ruby-v2/dynamic-snippets/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/ruby-v2/model/package.json
+++ b/generators/ruby-v2/model/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-ruby-model:latest ../../..",

--- a/generators/ruby-v2/sdk/package.json
+++ b/generators/ruby-v2/sdk/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-ruby-sdk-v2:latest ../../..",

--- a/generators/ruby/cli/package.json
+++ b/generators/ruby/cli/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/ruby/codegen/package.json
+++ b/generators/ruby/codegen/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/ruby/model/package.json
+++ b/generators/ruby/model/package.json
@@ -24,9 +24,9 @@
     "lib"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-ruby-model:latest ../../..",

--- a/generators/ruby/sdk/package.json
+++ b/generators/ruby/sdk/package.json
@@ -24,9 +24,9 @@
     "lib"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "env:prod": "env-cmd -r .env-cmdrc.cjs -e prod",

--- a/generators/rust/base/package.json
+++ b/generators/rust/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/rust/codegen/package.json
+++ b/generators/rust/codegen/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/rust/dynamic-snippets/package.json
+++ b/generators/rust/dynamic-snippets/package.json
@@ -22,8 +22,8 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "organize-imports": "organize-imports-cli tsconfig.json",

--- a/generators/rust/model/package.json
+++ b/generators/rust/model/package.json
@@ -24,9 +24,9 @@
     "lib"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-rust-model:latest ../../..",

--- a/generators/rust/sdk/package.json
+++ b/generators/rust/sdk/package.json
@@ -24,8 +24,8 @@
     "lib"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-rust-sdk:latest ../../..",

--- a/generators/swift/base/package.json
+++ b/generators/swift/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/swift/codegen/package.json
+++ b/generators/swift/codegen/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/swift/dynamic-snippets/package.json
+++ b/generators/swift/dynamic-snippets/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/swift/model/package.json
+++ b/generators/swift/model/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-swift-model:latest ../../..",

--- a/generators/swift/sdk/package.json
+++ b/generators/swift/sdk/package.json
@@ -22,9 +22,9 @@
   "types": "lib/cli.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-swift-sdk:latest ../../..",

--- a/generators/typescript-mcp/base/package.json
+++ b/generators/typescript-mcp/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript-mcp/model/package.json
+++ b/generators/typescript-mcp/model/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-typescript-mcp-model:latest ../../..",

--- a/generators/typescript-mcp/server/package.json
+++ b/generators/typescript-mcp/server/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-typescript-mcp-server:latest ../../..",

--- a/generators/typescript-v2/ast/package.json
+++ b/generators/typescript-v2/ast/package.json
@@ -21,9 +21,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript-v2/base/package.json
+++ b/generators/typescript-v2/base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript-v2/browser-compatible-base/package.json
+++ b/generators/typescript-v2/browser-compatible-base/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript-v2/dynamic-snippets/package.json
+++ b/generators/typescript-v2/dynamic-snippets/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/typescript-v2/formatter/package.json
+++ b/generators/typescript-v2/formatter/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/cli/package.json
+++ b/generators/typescript/express/cli/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-typescript-express:latest ../../../..",

--- a/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-error-generator/package.json
+++ b/generators/typescript/express/express-error-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-error-schema-generator/package.json
+++ b/generators/typescript/express/express-error-schema-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-inlined-request-body-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-register-generator/package.json
+++ b/generators/typescript/express/express-register-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-service-generator/package.json
+++ b/generators/typescript/express/express-service-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/generator/package.json
+++ b/generators/typescript/express/generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/generic-express-error-generators/package.json
+++ b/generators/typescript/express/generic-express-error-generators/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-typescript-node-sdk:latest -t fernapi/fern-typescript-sdk:latest ../../../..",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/generic-sdk-error-generators/package.json
+++ b/generators/typescript/sdk/generic-sdk-error-generators/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/abstract-error-class-generator/package.json
+++ b/generators/typescript/utils/abstract-error-class-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/abstract-schema-generator/package.json
+++ b/generators/typescript/utils/abstract-schema-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/ai/package.json
+++ b/packages/cli/ai/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "generate": "baml-cli generate --from baml_src",
     "test": "vitest --run",

--- a/packages/cli/api-importers/asyncapi-to-ir/package.json
+++ b/packages/cli/api-importers/asyncapi-to-ir/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/commons/package.json
+++ b/packages/cli/api-importers/commons/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/conjure/conjure-sdk/package.json
+++ b/packages/cli/api-importers/conjure/conjure-sdk/package.json
@@ -25,9 +25,9 @@
     "lib"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "generate": "fern generate --local",
     "test": "vitest --run --passWithNoTests",

--- a/packages/cli/api-importers/conjure/conjure-to-fern-tests/package.json
+++ b/packages/cli/api-importers/conjure/conjure-to-fern-tests/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/conjure/conjure-to-fern/package.json
+++ b/packages/cli/api-importers/conjure/conjure-to-fern/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/graphql/package.json
+++ b/packages/cli/api-importers/graphql/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi-pruner/package.json
+++ b/packages/cli/api-importers/openapi-pruner/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi-to-ir/package.json
+++ b/packages/cli/api-importers/openapi-to-ir/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi/openapi-ir/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir/package.json
@@ -25,9 +25,9 @@
     "lib"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "generate": "fern generate --local",
     "test": "vitest --passWithNoTests --run",

--- a/packages/cli/api-importers/openrpc-to-ir/package.json
+++ b/packages/cli/api-importers/openrpc-to-ir/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/v3-importer-commons/package.json
+++ b/packages/cli/api-importers/v3-importer-commons/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/v3-importer-tests/package.json
+++ b/packages/cli/api-importers/v3-importer-tests/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/packages/cli/auth/package.json
+++ b/packages/cli/auth/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/cli-logger/package.json
+++ b/packages/cli/cli-logger/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/cli-migrations/package.json
+++ b/packages/cli/cli-migrations/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/cli-source-resolver/package.json
+++ b/packages/cli/cli-source-resolver/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli:dev": "node build.dev.mjs",
     "dist:bin": "node build.compile.mjs",

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -28,9 +28,9 @@
   },
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli:dev": "node build.dev.mjs",
     "dist:cli:local": "node build.local.mjs",

--- a/packages/cli/config/package.json
+++ b/packages/cli/config/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck --ignores=readable-stream",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/configuration-loader/package.json
+++ b/packages/cli/configuration-loader/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck --ignores=readable-stream",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-importers/commons/package.json
+++ b/packages/cli/docs-importers/commons/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-importers/mintlify/package.json
+++ b/packages/cli/docs-importers/mintlify/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-importers/readme/package.json
+++ b/packages/cli/docs-importers/readme/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-markdown-utils/package.json
+++ b/packages/cli/docs-markdown-utils/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-resolver/package.json
+++ b/packages/cli/docs-resolver/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run src/utils/__test__",
     "test:debug": "vitest --run --inspect src/utils/__test__"

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/fern-definition/formatter/package.json
+++ b/packages/cli/fern-definition/formatter/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/fern-definition/ir-to-jsonschema/package.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/fern-definition/schema/package.json
+++ b/packages/cli/fern-definition/schema/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/fern-definition/validator/package.json
+++ b/packages/cli/fern-definition/validator/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/ir-generator-tests/package.json
+++ b/packages/cli/generation/ir-generator-tests/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/ir-generator/package.json
+++ b/packages/cli/generation/ir-generator/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/ir-migrations/package.json
+++ b/packages/cli/generation/ir-migrations/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/local-generation/docker-utils/package.json
+++ b/packages/cli/generation/local-generation/docker-utils/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/local-generation/local-workspace-runner/package.json
+++ b/packages/cli/generation/local-generation/local-workspace-runner/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/protoc-gen-fern/package.json
+++ b/packages/cli/generation/protoc-gen-fern/package.json
@@ -26,9 +26,9 @@
   },
   "files": ["bin", "lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/source-resolver/package.json
+++ b/packages/cli/generation/source-resolver/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/init/package.json
+++ b/packages/cli/init/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/library-docs-generator/package.json
+++ b/packages/cli/library-docs-generator/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/logger/package.json
+++ b/packages/cli/logger/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/login/package.json
+++ b/packages/cli/login/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/mock/package.json
+++ b/packages/cli/mock/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/project-loader/package.json
+++ b/packages/cli/project-loader/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/register/package.json
+++ b/packages/cli/register/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/semver-utils/package.json
+++ b/packages/cli/semver-utils/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/source/package.json
+++ b/packages/cli/source/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck --ignores=readable-stream",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/task-context/package.json
+++ b/packages/cli/task-context/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/browser-compatible-fern-workspace/package.json
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/commons/package.json
+++ b/packages/cli/workspace/commons/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/lazy-fern-workspace/package.json
+++ b/packages/cli/workspace/lazy-fern-workspace/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/loader/package.json
+++ b/packages/cli/workspace/loader/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/oss-validator/package.json
+++ b/packages/cli/workspace/oss-validator/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/yaml/generators-validator/package.json
+++ b/packages/cli/yaml/generators-validator/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/yaml/loader/package.json
+++ b/packages/cli/yaml/loader/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/casings-generator/package.json
+++ b/packages/commons/casings-generator/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/core-utils/package.json
+++ b/packages/commons/core-utils/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/fs-utils/package.json
+++ b/packages/commons/fs-utils/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/github/package.json
+++ b/packages/commons/github/package.json
@@ -23,8 +23,8 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
     "depcheck": "depcheck",
     "format": "prettier --write --ignore-unknown \"**\"",
     "format:check": "prettier --check --ignore-unknown \"**\"",

--- a/packages/commons/ir-utils/package.json
+++ b/packages/commons/ir-utils/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/loadable/package.json
+++ b/packages/commons/loadable/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/logging-execa/package.json
+++ b/packages/commons/logging-execa/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/mock-utils/package.json
+++ b/packages/commons/mock-utils/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/path-utils/package.json
+++ b/packages/commons/path-utils/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/test-utils/package.json
+++ b/packages/commons/test-utils/package.json
@@ -22,9 +22,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -15,7 +15,7 @@
   },
   "files": ["bin", "dist"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "test": "vitest --run --passWithNoTests --globals --disable-console-intercept",

--- a/packages/generator-migrations/package.json
+++ b/packages/generator-migrations/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.mts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "dist": "node build.mjs",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",

--- a/packages/ir-sdk/package.json
+++ b/packages/ir-sdk/package.json
@@ -25,9 +25,9 @@
     "lib"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "generate": "fern generate --api ir-types-latest --local",
     "test": "vitest --passWithNoTests --run",

--- a/packages/migrations-base/package.json
+++ b/packages/migrations-base/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -26,9 +26,9 @@
   },
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "generate": "fern generate --api ir-types-latest --local",
     "lint:eslint": "eslint --max-warnings 0 . --ignore-pattern=../../.eslintignore",

--- a/packages/seed/package.json
+++ b/packages/seed/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist:cli": "node build.mjs",
     "env:prod": "env-cmd -r .env-cmdrc.cjs -e prod",

--- a/packages/snippets/core/package.json
+++ b/packages/snippets/core/package.json
@@ -23,9 +23,9 @@
   "types": "lib/index.d.ts",
   "files": ["lib"],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "clean": "rm -rf ./lib && rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
+    "compile": "tsc --composite false",
+    "compile:debug": "tsc --composite false --sourceMap",
     "depcheck": "depcheck",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",


### PR DESCRIPTION
## Description

Refs: [Failed CI job](https://github.com/fern-api/fern/actions/runs/22109673176/job/63902202760?pr=12339) — intermittent `@fern-api/ir-utils:compile` failure with:
```
'"@fern-api/ir-sdk"' has no exported member named 'ExampleInlinedRequestBodyProperty'.
Did you mean 'ExampleInlinedRequestBodyExtraProperty'?
```
The type exists in `ir-sdk` source and the error disappears on re-run.

**Requested by:** @davidkonigsberg
**Link to Devin run:** https://app.devin.ai/sessions/c176a6d6126b4616b03415f9af267f95

## Root Cause Analysis

When turbo runs `compile` tasks, it respects `dependsOn: ["^compile"]` for ordering but runs sibling tasks concurrently. Each package's `tsc --build` follows **project references** in `tsconfig.json` and checks whether referenced projects need rebuilding. 25+ packages reference `ir-sdk`. If any concurrent `tsc --build` process decides `ir-sdk` is stale and starts rewriting its `lib/` output, other concurrent processes reading from `ir-sdk/lib/` can see incomplete declarations.

## Changes Made

- **`compile`**: `tsc --build` → `tsc --composite false` (174 packages)
- **`compile:debug`**: `tsc --build --sourceMap` → `tsc --composite false --sourceMap` (171 packages)
- **`clean`**: `tsc --build --clean` → `rm -f tsconfig.tsbuildinfo` (175 packages)

`tsc --composite false` overrides the `composite: true` from `tsconfig.json`, causing `tsc` to compile **only the current package** without following project references. Turbo still handles build ordering via `dependsOn: ["^compile"]`.

## ⚠️ Human Review Checklist

> **This is a large mechanical change. Please scrutinize the approach, not just the diff.**

- [ ] **Is the root cause correct?** The race condition theory is plausible but was not definitively proven — only inferred from log timing analysis and the fact that `tsc --build` follows references. The flake could have other causes (infra, turbo bug, etc.).
- [ ] **Is `tsc --composite false` the right pattern?** This is an uncommon approach. It disables `composite` at the CLI level while `tsconfig.json` still says `composite: true`. This means: (a) no `.tsbuildinfo` files → no incremental compilation, (b) `references` in tsconfig become dead config, (c) IDE behavior may diverge from build behavior.
- [ ] **Impact on local dev?** Every `pnpm run compile` in a package will now do a full recompile (no incremental builds). Turbo cache helps in CI but not for local iterative development.
- [ ] **Are there packages that rely on `.tsbuildinfo` for other tools?** The `clean` script now does `rm -f tsconfig.tsbuildinfo` but `tsc --composite false` doesn't generate it anyway.
- [ ] **Module resolution edge cases?** With `tsc --build`, TypeScript uses project references for resolution. With `tsc --composite false`, it uses normal `node_modules` resolution. Tested on `ir-sdk` and `ir-utils` but not all 175 packages.

## Testing

- [x] Local test: `ir-sdk` and `ir-utils` compile successfully with `tsc --composite false`
- [x] Local test: `turbo run compile --filter=@fern-api/ir-utils` (7 packages) passes
- [ ] Full monorepo compile (will be tested in CI)
- [ ] Seed tests (will be tested in CI)

## Alternative Approaches Considered

1. **Use `tsc` without `--composite false`**: Doesn't work — `tsc` respects `composite: true` in tsconfig and requires `--build` flag.
2. **Remove `composite: true` from all tsconfig.json files**: More invasive; affects IDE behavior and requires updating 175+ tsconfig files.
3. **Serialize compilation with turbo concurrency limits**: Would significantly slow down CI.
4. **Fix the actual race in `tsc --build`**: Not feasible — this is TypeScript compiler behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
