### PR TITLE
chore(java): use IR discriminatorContext for SSE event-level discrimination

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -20,6 +20,7 @@ import com.fern.generator.exec.model.logging.MavenCoordinate;
 import com.fern.generator.exec.model.logging.PackageCoordinate;
 import com.fern.generator.exec.model.logging.SuccessfulStatusUpdate;
 import com.fern.ir.core.ObjectMappers;
+import com.fern.ir.model.commons.TypeId;
 import com.fern.ir.model.ir.IntermediateRepresentation;
 import com.fern.ir.model.publish.DirectPublish;
 import com.fern.ir.model.publish.Filesystem;
@@ -44,7 +45,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -93,8 +96,19 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         }
     }
 
+    /** Result of loading the IR, including the deserialized model and supplementary data. */
+    private static final class IrLoadResult {
+        private final IntermediateRepresentation ir;
+        private final Map<TypeId, String> discriminatorContexts;
+
+        IrLoadResult(IntermediateRepresentation ir, Map<TypeId, String> discriminatorContexts) {
+            this.ir = ir;
+            this.discriminatorContexts = discriminatorContexts;
+        }
+    }
+
     /** Loads and preprocesses the IR from file, handling integer overflow values. */
-    private static IntermediateRepresentation getIr(GeneratorConfig generatorConfig) {
+    private static IrLoadResult loadIr(GeneratorConfig generatorConfig) {
         try {
             File irFile = new File(generatorConfig.getIrFilepath());
 
@@ -107,10 +121,44 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
                 log.info("Converted {} integer overflow value(s) to long type in IR", processor.getConversions());
             }
 
-            return ObjectMappers.JSON_MAPPER.treeToValue(rootNode, IntermediateRepresentation.class);
+            Map<TypeId, String> discriminatorContexts = extractDiscriminatorContexts(rootNode);
+
+            IntermediateRepresentation ir =
+                    ObjectMappers.JSON_MAPPER.treeToValue(rootNode, IntermediateRepresentation.class);
+            return new IrLoadResult(ir, discriminatorContexts);
         } catch (IOException e) {
             throw new RuntimeException("Failed to read ir", e);
         }
+    }
+
+    /**
+     * Extracts discriminatorContext values from the raw IR JSON for union type declarations. The irV63 Java model does
+     * not expose this field (added in IR v65), but it is present in the JSON due to passthrough serialization.
+     */
+    private static Map<TypeId, String> extractDiscriminatorContexts(JsonNode rootNode) {
+        JsonNode typesNode = rootNode.get("types");
+        if (typesNode == null || !typesNode.isObject()) {
+            return Collections.emptyMap();
+        }
+        Map<TypeId, String> result = new HashMap<>();
+        Iterator<Map.Entry<String, JsonNode>> fields = typesNode.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            JsonNode typeDecl = entry.getValue();
+            JsonNode shapeNode = typeDecl.get("shape");
+            if (shapeNode == null) {
+                continue;
+            }
+            JsonNode typeField = shapeNode.get("_type");
+            if (typeField == null || !"union".equals(typeField.asText())) {
+                continue;
+            }
+            JsonNode contextNode = shapeNode.get("discriminatorContext");
+            if (contextNode != null && contextNode.isTextual()) {
+                result.put(TypeId.valueOf(entry.getKey()), contextNode.asText());
+            }
+        }
+        return Collections.unmodifiableMap(result);
     }
 
     /** Processes JSON nodes in-place to convert integer overflow values to long type. */
@@ -313,7 +361,13 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
 
     private Path outputDirectory = null;
 
+    private Map<TypeId, String> discriminatorContexts = Collections.emptyMap();
+
     protected AbstractGeneratorCli() {}
+
+    protected Map<TypeId, String> getDiscriminatorContexts() {
+        return discriminatorContexts;
+    }
 
     public final void run(String... args) {
         String pluginPath = args[0];
@@ -321,7 +375,9 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
         DefaultGeneratorExecClient generatorExecClient = new DefaultGeneratorExecClient(generatorConfig);
         try {
             log(generatorExecClient, "Starting Java SDK generation");
-            IntermediateRepresentation ir = getIr(generatorConfig);
+            IrLoadResult irLoadResult = loadIr(generatorConfig);
+            IntermediateRepresentation ir = irLoadResult.ir;
+            this.discriminatorContexts = irLoadResult.discriminatorContexts;
             this.outputDirectory = Paths.get(generatorConfig.getOutput().getPath());
             generatorConfig
                     .getOutput()

--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorContext.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorContext.java
@@ -14,6 +14,7 @@ import com.fern.ir.model.types.DeclaredTypeName;
 import com.fern.ir.model.types.ObjectTypeDeclaration;
 import com.fern.ir.model.types.Type;
 import com.fern.ir.model.types.TypeDeclaration;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ public abstract class AbstractGeneratorContext<T extends AbstractPoetClassNameFa
     private final Set<TypeId> interfaces;
     private final U customConfig;
     private final List<AuthScheme> resolvedAuthSchemes;
+    private final Map<TypeId, String> discriminatorContexts;
 
     public AbstractGeneratorContext(
             IntermediateRepresentation ir,
@@ -40,12 +42,23 @@ public abstract class AbstractGeneratorContext<T extends AbstractPoetClassNameFa
             U customConfig,
             T poetClassNameFactory,
             List<AuthScheme> resolvedAuthSchemes) {
+        this(ir, generatorConfig, customConfig, poetClassNameFactory, resolvedAuthSchemes, Collections.emptyMap());
+    }
+
+    public AbstractGeneratorContext(
+            IntermediateRepresentation ir,
+            GeneratorConfig generatorConfig,
+            U customConfig,
+            T poetClassNameFactory,
+            List<AuthScheme> resolvedAuthSchemes,
+            Map<TypeId, String> discriminatorContexts) {
         this.ir = ir;
         this.generatorConfig = generatorConfig;
         this.customConfig = customConfig;
         this.poetClassNameFactory = poetClassNameFactory;
         this.typeDefinitionsByName = ir.getTypes();
         this.resolvedAuthSchemes = resolvedAuthSchemes;
+        this.discriminatorContexts = discriminatorContexts;
         this.poetTypeNameMapper = new PoetTypeNameMapper(poetClassNameFactory, customConfig, typeDefinitionsByName);
         this.errorDefinitionsByName = ir.getErrors();
         this.globalHeaders = new GlobalHeaders(ir, poetTypeNameMapper);
@@ -96,6 +109,10 @@ public abstract class AbstractGeneratorContext<T extends AbstractPoetClassNameFa
 
     public List<AuthScheme> getResolvedAuthSchemes() {
         return resolvedAuthSchemes;
+    }
+
+    public Map<TypeId, String> getDiscriminatorContexts() {
+        return discriminatorContexts;
     }
 
     public boolean isEndpointSecurity() {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/Cli.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/Cli.java
@@ -208,7 +208,8 @@ public final class Cli extends AbstractGeneratorCli<JavaSdkCustomConfig, JavaSdk
                 generatorConfig,
                 sdkCustomConfig,
                 clientPoetClassNameFactory,
-                new FeatureResolver(ir, generatorConfig, generatorExecClient).getResolvedAuthSchemes());
+                new FeatureResolver(ir, generatorConfig, generatorExecClient).getResolvedAuthSchemes(),
+                getDiscriminatorContexts());
         generateClient(context, ir, generatorExecClient);
     }
 
@@ -239,7 +240,12 @@ public final class Cli extends AbstractGeneratorCli<JavaSdkCustomConfig, JavaSdk
         List<AuthScheme> resolvedAuthSchemes =
                 new FeatureResolver(ir, generatorConfig, generatorExecClient).getResolvedAuthSchemes();
         ClientGeneratorContext context = new ClientGeneratorContext(
-                ir, generatorConfig, customConfig, clientPoetClassNameFactory, resolvedAuthSchemes);
+                ir,
+                generatorConfig,
+                customConfig,
+                clientPoetClassNameFactory,
+                resolvedAuthSchemes,
+                getDiscriminatorContexts());
         generateClient(context, ir, generatorExecClient);
     }
 
@@ -712,7 +718,12 @@ public final class Cli extends AbstractGeneratorCli<JavaSdkCustomConfig, JavaSdk
         List<AuthScheme> resolvedAuthSchemes =
                 new FeatureResolver(ir, generatorConfig, generatorExecClient).getResolvedAuthSchemes();
         ClientGeneratorContext context = new ClientGeneratorContext(
-                ir, generatorConfig, customConfig, clientPoetClassNameFactory, resolvedAuthSchemes);
+                ir,
+                generatorConfig,
+                customConfig,
+                clientPoetClassNameFactory,
+                resolvedAuthSchemes,
+                getDiscriminatorContexts());
         GeneratedRootClient generatedClientWrapper = generateClient(context, ir, generatorExecClient);
         SampleAppGenerator sampleAppGenerator = new SampleAppGenerator(context, generatedClientWrapper);
         sampleAppGenerator.generateFiles().forEach(this::addGeneratedFile);

--- a/generators/java/sdk/src/main/java/com/fern/java/client/ClientGeneratorContext.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/ClientGeneratorContext.java
@@ -2,9 +2,11 @@ package com.fern.java.client;
 
 import com.fern.generator.exec.model.config.GeneratorConfig;
 import com.fern.ir.model.auth.AuthScheme;
+import com.fern.ir.model.commons.TypeId;
 import com.fern.ir.model.ir.IntermediateRepresentation;
 import com.fern.java.AbstractGeneratorContext;
 import java.util.List;
+import java.util.Map;
 
 public final class ClientGeneratorContext
         extends AbstractGeneratorContext<ClientPoetClassNameFactory, JavaSdkCustomConfig> {
@@ -16,6 +18,22 @@ public final class ClientGeneratorContext
             ClientPoetClassNameFactory clientPoetClassNameFactory,
             List<AuthScheme> resolvedAuthSchemes) {
         super(ir, generatorConfig, customConfig, clientPoetClassNameFactory, resolvedAuthSchemes);
+    }
+
+    public ClientGeneratorContext(
+            IntermediateRepresentation ir,
+            GeneratorConfig generatorConfig,
+            JavaSdkCustomConfig customConfig,
+            ClientPoetClassNameFactory clientPoetClassNameFactory,
+            List<AuthScheme> resolvedAuthSchemes,
+            Map<TypeId, String> discriminatorContexts) {
+        super(
+                ir,
+                generatorConfig,
+                customConfig,
+                clientPoetClassNameFactory,
+                resolvedAuthSchemes,
+                discriminatorContexts);
     }
 
     @Override

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
@@ -864,7 +864,9 @@ public abstract class AbstractHttpResponseParserGenerator {
                     // Analyze SSE payload type for discrimination
                     SseDiscriminationAnalyzer.SseDiscriminationInfo discriminationInfo =
                             SseDiscriminationAnalyzer.analyze(
-                                    sse.getPayload(), clientGeneratorContext.getTypeDeclarations());
+                                    sse.getPayload(),
+                                    clientGeneratorContext.getTypeDeclarations(),
+                                    clientGeneratorContext.getDiscriminatorContexts());
 
                     if (discriminationInfo.getType() == SseDiscriminationAnalyzer.DiscriminationType.EVENT_LEVEL) {
                         // Event-level discrimination: discriminator is at SSE envelope level

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SseDiscriminationAnalyzer.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SseDiscriminationAnalyzer.java
@@ -6,23 +6,19 @@ import com.fern.ir.model.types.Type;
 import com.fern.ir.model.types.TypeDeclaration;
 import com.fern.ir.model.types.TypeReference;
 import com.fern.ir.model.types.UnionTypeDeclaration;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Analyzes SSE payload types to determine if event-level or data-level discrimination is needed.
  *
- * <p>Following Python's approach from PR #11726: - If the union's discriminator property name matches an SSE envelope
- * field (event, id, retry, data), it's event-level discrimination. - Otherwise, it's data-level discrimination where
- * the discriminator is inside the JSON data payload.
+ * <p>Uses the IR's discriminatorContext field on UnionTypeDeclaration to determine discrimination type: - "protocol":
+ * discriminator is at the SSE envelope level (event-level discrimination) - "data" (or absent): discriminator is inside
+ * the JSON data payload (data-level discrimination)
  */
 public final class SseDiscriminationAnalyzer {
 
-    /** SSE envelope fields that indicate event-level discrimination when used as a discriminator. */
-    private static final Set<String> SSE_ENVELOPE_FIELDS = new HashSet<>(Arrays.asList("event", "id", "retry", "data"));
+    private static final String DISCRIMINATOR_CONTEXT_PROTOCOL = "protocol";
 
     /** Type of discrimination for SSE events. */
     public enum DiscriminationType {
@@ -65,52 +61,56 @@ public final class SseDiscriminationAnalyzer {
         }
     }
 
-    private SseDiscriminationAnalyzer() {
-        // Utility class
-    }
+    private SseDiscriminationAnalyzer() {}
 
     /**
-     * Analyzes the SSE payload type to determine what type of discrimination is needed.
+     * Analyzes the SSE payload type to determine what type of discrimination is needed, using the IR's
+     * discriminatorContext field.
      *
      * @param payloadType The SSE payload type reference from the IR
      * @param typeDeclarations Map of all type declarations
+     * @param discriminatorContexts Map of TypeId to discriminatorContext values extracted from the IR JSON
      * @return The discrimination info indicating how to handle SSE parsing
      */
     public static SseDiscriminationInfo analyze(
-            TypeReference payloadType, Map<TypeId, TypeDeclaration> typeDeclarations) {
+            TypeReference payloadType,
+            Map<TypeId, TypeDeclaration> typeDeclarations,
+            Map<TypeId, String> discriminatorContexts) {
 
-        // Resolve the type reference to its declaration
-        Optional<UnionTypeDeclaration> unionDeclaration = resolveUnionType(payloadType, typeDeclarations);
+        Optional<UnionResolutionResult> result = resolveUnionType(payloadType, typeDeclarations);
 
-        if (unionDeclaration.isEmpty()) {
-            // Not a discriminated union - use standard SSE parsing
+        if (result.isEmpty()) {
             return SseDiscriminationInfo.none();
         }
 
-        // Get the discriminant property name
-        String discriminatorProperty = unionDeclaration.get().getDiscriminant().getWireValue();
+        UnionResolutionResult unionResult = result.get();
+        String discriminatorProperty = unionResult.union.getDiscriminant().getWireValue();
 
-        // Check if the discriminator is an SSE envelope field
-        if (isEventLevelDiscriminator(discriminatorProperty)) {
+        String context = discriminatorContexts.getOrDefault(unionResult.typeId, "data");
+        if (DISCRIMINATOR_CONTEXT_PROTOCOL.equals(context)) {
             return SseDiscriminationInfo.eventLevel(discriminatorProperty);
         } else {
             return SseDiscriminationInfo.dataLevel(discriminatorProperty);
         }
     }
 
-    /** Checks if the discriminator property indicates event-level discrimination. */
-    public static boolean isEventLevelDiscriminator(String discriminatorProperty) {
-        return SSE_ENVELOPE_FIELDS.contains(discriminatorProperty);
+    private static final class UnionResolutionResult {
+        final TypeId typeId;
+        final UnionTypeDeclaration union;
+
+        UnionResolutionResult(TypeId typeId, UnionTypeDeclaration union) {
+            this.typeId = typeId;
+            this.union = union;
+        }
     }
 
-    /** Resolves a TypeReference to its UnionTypeDeclaration, following aliases if necessary. */
-    private static Optional<UnionTypeDeclaration> resolveUnionType(
+    /** Resolves a TypeReference to its UnionTypeDeclaration and TypeId, following aliases if necessary. */
+    private static Optional<UnionResolutionResult> resolveUnionType(
             TypeReference typeReference, Map<TypeId, TypeDeclaration> typeDeclarations) {
 
-        return typeReference.visit(new TypeReference.Visitor<Optional<UnionTypeDeclaration>>() {
+        return typeReference.visit(new TypeReference.Visitor<Optional<UnionResolutionResult>>() {
             @Override
-            public Optional<UnionTypeDeclaration> visitContainer(com.fern.ir.model.types.ContainerType container) {
-                // Handle optional/nullable containers by unwrapping
+            public Optional<UnionResolutionResult> visitContainer(com.fern.ir.model.types.ContainerType container) {
                 if (container.getOptional().isPresent()) {
                     return resolveUnionType(container.getOptional().get(), typeDeclarations);
                 }
@@ -121,62 +121,61 @@ public final class SseDiscriminationAnalyzer {
             }
 
             @Override
-            public Optional<UnionTypeDeclaration> visitNamed(NamedType named) {
+            public Optional<UnionResolutionResult> visitNamed(NamedType named) {
                 TypeDeclaration typeDeclaration = typeDeclarations.get(named.getTypeId());
                 if (typeDeclaration == null) {
                     return Optional.empty();
                 }
 
-                return typeDeclaration.getShape().visit(new Type.Visitor<Optional<UnionTypeDeclaration>>() {
+                return typeDeclaration.getShape().visit(new Type.Visitor<Optional<UnionResolutionResult>>() {
                     @Override
-                    public Optional<UnionTypeDeclaration> visitAlias(
+                    public Optional<UnionResolutionResult> visitAlias(
                             com.fern.ir.model.types.AliasTypeDeclaration alias) {
-                        // Follow alias to underlying type
                         return resolveUnionType(alias.getAliasOf(), typeDeclarations);
                     }
 
                     @Override
-                    public Optional<UnionTypeDeclaration> visitEnum(com.fern.ir.model.types.EnumTypeDeclaration enum_) {
+                    public Optional<UnionResolutionResult> visitEnum(
+                            com.fern.ir.model.types.EnumTypeDeclaration enum_) {
                         return Optional.empty();
                     }
 
                     @Override
-                    public Optional<UnionTypeDeclaration> visitObject(
+                    public Optional<UnionResolutionResult> visitObject(
                             com.fern.ir.model.types.ObjectTypeDeclaration object) {
                         return Optional.empty();
                     }
 
                     @Override
-                    public Optional<UnionTypeDeclaration> visitUnion(UnionTypeDeclaration union) {
-                        return Optional.of(union);
+                    public Optional<UnionResolutionResult> visitUnion(UnionTypeDeclaration union) {
+                        return Optional.of(new UnionResolutionResult(named.getTypeId(), union));
                     }
 
                     @Override
-                    public Optional<UnionTypeDeclaration> visitUndiscriminatedUnion(
+                    public Optional<UnionResolutionResult> visitUndiscriminatedUnion(
                             com.fern.ir.model.types.UndiscriminatedUnionTypeDeclaration undiscriminatedUnion) {
-                        // Undiscriminated unions don't have a discriminator
                         return Optional.empty();
                     }
 
                     @Override
-                    public Optional<UnionTypeDeclaration> _visitUnknown(Object unknownType) {
+                    public Optional<UnionResolutionResult> _visitUnknown(Object unknownType) {
                         return Optional.empty();
                     }
                 });
             }
 
             @Override
-            public Optional<UnionTypeDeclaration> visitPrimitive(com.fern.ir.model.types.PrimitiveType primitive) {
+            public Optional<UnionResolutionResult> visitPrimitive(com.fern.ir.model.types.PrimitiveType primitive) {
                 return Optional.empty();
             }
 
             @Override
-            public Optional<UnionTypeDeclaration> visitUnknown() {
+            public Optional<UnionResolutionResult> visitUnknown() {
                 return Optional.empty();
             }
 
             @Override
-            public Optional<UnionTypeDeclaration> _visitUnknown(Object unknownType) {
+            public Optional<UnionResolutionResult> _visitUnknown(Object unknownType) {
                 return Optional.empty();
             }
         });

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.36.2
+  changelogEntry:
+    - summary: |
+        Use the IR's discriminatorContext field to determine SSE event-level vs data-level
+        discrimination instead of manually checking SSE envelope field names.
+      type: chore
+  createdAt: "2026-02-17"
+  irVersion: 63
+
 - version: 3.36.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs [#12242](https://github.com/fern-api/fern/pull/12242)

Refactors the Java SDK generator's SSE event-level discrimination logic to use the IR's `discriminatorContext` field (added in PR #12242) instead of the manual heuristic that checked if a discriminator property name matched SSE envelope fields (`event`, `id`, `retry`, `data`).

Link to Devin run: https://app.devin.ai/sessions/76958a26d45348e6ab03ffbbc7647ad2
Requested by: @tstanmay13

## Changes Made

- **`AbstractGeneratorCli`**: Extracts `discriminatorContext` from raw IR JSON before Jackson deserialization (the irV63 Java model doesn't expose this field, but it's present in the JSON). New `IrLoadResult` wrapper, `loadIr()` replaces `getIr()`, and `extractDiscriminatorContexts()` walks the JSON tree for union types.
- **`AbstractGeneratorContext` / `ClientGeneratorContext`**: New constructor overload and getter to thread `Map<TypeId, String> discriminatorContexts` through the context hierarchy.
- **`Cli`**: All 3 `ClientGeneratorContext` construction sites pass `getDiscriminatorContexts()`.
- **`SseDiscriminationAnalyzer`**: Core change — replaces `SSE_ENVELOPE_FIELDS.contains(...)` with a lookup into the discriminator contexts map. `"protocol"` → event-level, `"data"` or absent → data-level. `resolveUnionType` now returns `UnionResolutionResult` (TypeId + union) instead of just the union declaration.
- **`AbstractHttpResponseParserGenerator`**: Updated caller to pass discriminator contexts.
- **`versions.yml`**: New 3.36.2 entry.

## Testing

- [x] Java compilation passes (`./gradlew compileJava`)
- [x] Spotless formatting passes (`./gradlew spotlessCheck`)
- [ ] No new unit tests added — relies on existing seed test coverage

## Human Review Checklist

- **Raw JSON extraction approach**: `extractDiscriminatorContexts` manually walks the IR JSON tree. This is necessary because the Java IR model (v63) doesn't expose `discriminatorContext`. Verify the JSON path (`types -> {id} -> shape -> discriminatorContext`) matches the actual IR structure.
- **Default fallback behavior change**: Previously any discriminator named `event`/`id`/`retry`/`data` was treated as event-level. Now only types explicitly marked `discriminatorContext: "protocol"` in the IR get event-level treatment. If `discriminatorContext` is absent, it defaults to `"data"`. Confirm this is the intended semantic for older IRs that predate the field.
- **Runtime `SseEventParser.java` unchanged**: The resource template still has its own `SSE_ENVELOPE_FIELDS` for runtime parsing — this is intentional (separate concern from build-time analysis).
- **No test coverage**: The new extraction logic and refactored analyzer have no unit tests. Seed tests should catch regressions, but manual verification may be needed.