### PR TITLE
fix(ci): use merge-base with main for PR change detection in seed tests

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -17,7 +17,7 @@ on:
 # Cancel previous workflows on previous push
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   setup:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -143,22 +143,28 @@ jobs:
             ${{ matrix.files }}
             .github/
 
-      - name: Get base SHA from last successful run
+      - name: Get base SHA for change detection
         id: get-base-sha
-        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          LAST_SUCCESS_SHA=$(gh api \
-            "/repos/${{ github.repository }}/actions/workflows/seed.yml/runs?branch=main&status=success&per_page=1" \
-            --jq '.workflow_runs[0].head_sha // empty' 2>/dev/null || echo "")
-
-          if [[ -n "$LAST_SUCCESS_SHA" ]]; then
-            echo "Last successful run SHA: $LAST_SUCCESS_SHA"
-            echo "base_sha=$LAST_SUCCESS_SHA" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch origin main
+            MERGE_BASE=$(git merge-base HEAD origin/main)
+            echo "Using merge base with main for PR: $MERGE_BASE"
+            echo "base_sha=$MERGE_BASE" >> $GITHUB_OUTPUT
           else
-            echo "No successful run found, using default change detection"
-            echo "base_sha=" >> $GITHUB_OUTPUT
+            LAST_SUCCESS_SHA=$(gh api \
+              "/repos/${{ github.repository }}/actions/workflows/seed.yml/runs?branch=main&status=success&per_page=1" \
+              --jq '.workflow_runs[0].head_sha // empty' 2>/dev/null || echo "")
+
+            if [[ -n "$LAST_SUCCESS_SHA" ]]; then
+              echo "Last successful run SHA: $LAST_SUCCESS_SHA"
+              echo "base_sha=$LAST_SUCCESS_SHA" >> $GITHUB_OUTPUT
+            else
+              echo "No successful run found, using default change detection"
+              echo "base_sha=" >> $GITHUB_OUTPUT
+            fi
           fi
 
       - name: Get generator changes for ${{ matrix.generator-name }}


### PR DESCRIPTION
## Description

Fixes seed snapshot test change detection on pull request branches. Previously, the `get-base-sha` step was skipped entirely for PRs (via `if: github.event_name != 'pull_request'`), leaving `base_sha` empty and causing `tj-actions/changed-files` to fall back to comparing between commits rather than comparing the full branch against main.

Now, for PRs, the step explicitly computes the merge-base between HEAD and `origin/main`, ensuring all files changed in the PR (relative to main) are detected. Non-PR events (push to main, repository_dispatch, etc.) retain the existing last-successful-run-SHA behavior.

This aligns `seed.yml` with the pattern already used in `update-seed.yml` for branch-vs-main comparisons.

Refs https://app.devin.ai/sessions/76444e1bd2b249d8b82c48577916c744
Requested by: @davidkonigsberg

## Changes Made

- Removed the `if: github.event_name != 'pull_request'` guard so the step always runs
- Added PR-specific branch: fetches `origin/main` and computes `git merge-base HEAD origin/main` as `base_sha`
- Preserved existing last-successful-run logic in the `else` path for push/dispatch events
- Reverted `cancel-in-progress` back to `true` (was set to `false` in #12473) to save time on PR runs

## Testing

- [ ] Manual testing completed (requires a real PR run to validate — cannot be tested locally)

## Human Review Checklist

- [ ] Verify `git merge-base HEAD origin/main` resolves correctly in the GitHub Actions PR context (HEAD is the merge commit `refs/pull/N/merge`)
- [ ] Confirm `git fetch origin main` is necessary given the checkout already uses `fetch-depth: 0` with sparse checkout (it's a safe guard but worth understanding)
- [ ] Compare with the analogous logic in `update-seed.yml` lines 246-250 for consistency
- [ ] Accept tradeoff: `cancel-in-progress: true` means runs on main may cancel each other — combined with last-successful-run-SHA detection, a cancelled main run could cause the next run to re-detect a wider set of changes (not missed, but duplicated work)