### PR TITLE
feat(cli): add performance metrics instrumentation for docs generation

### DIFF
--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -3,7 +3,7 @@ import { filterOssWorkspaces } from "@fern-api/docs-resolver";
 import { Rules } from "@fern-api/docs-validator";
 import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
-import { runRemoteGenerationForDocsWorkspace } from "@fern-api/remote-workspace-runner";
+import { PublishDocsMetrics, runRemoteGenerationForDocsWorkspace } from "@fern-api/remote-workspace-runner";
 import chalk from "chalk";
 
 import { CliContext } from "../../cli-context/CliContext.js";
@@ -31,6 +31,7 @@ export async function generateDocsWorkspace({
     noPrompt?: boolean;
     skipUpload: boolean | undefined;
 }): Promise<void> {
+    const totalStart = performance.now();
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace == null) {
         cliContext.failAndThrow("No docs.yml file found. Please make sure your project has one.");
@@ -87,6 +88,7 @@ export async function generateDocsWorkspace({
     }
 
     await cliContext.runTaskForWorkspace(docsWorkspace, async (context) => {
+        const validationStart = performance.now();
         await validateDocsWorkspaceAndLogIssues({
             workspace: docsWorkspace,
             context,
@@ -96,17 +98,19 @@ export async function generateDocsWorkspace({
             errorOnBrokenLinks: strictBrokenLinks,
             excludeRules: getExcludeRules(brokenLinks, strictBrokenLinks, isRunningOnSelfHosted)
         });
+        const validationTimeMs = performance.now() - validationStart;
 
-        context.logger.info("Validation complete, starting remote docs generation...");
+        context.logger.info(`Validation complete in ${validationTimeMs.toFixed(0)}ms, starting remote docs generation...`);
 
         const filterStart = performance.now();
         const ossWorkspaces = await filterOssWorkspaces(project);
-        const filterTime = performance.now() - filterStart;
+        const filterTimeMs = performance.now() - filterStart;
         context.logger.debug(
-            `Filtered OSS workspaces (${ossWorkspaces.length} workspaces) in ${filterTime.toFixed(0)}ms`
+            `Filtered OSS workspaces (${ossWorkspaces.length} workspaces) in ${filterTimeMs.toFixed(0)}ms`
         );
 
         const generationStart = performance.now();
+        const publishMetrics: PublishDocsMetrics = {};
         await runRemoteGenerationForDocsWorkspace({
             organization: project.config.organization,
             apiWorkspaces: project.apiWorkspaces,
@@ -117,10 +121,36 @@ export async function generateDocsWorkspace({
             instanceUrl: instance,
             preview,
             disableTemplates,
-            skipUpload
+            skipUpload,
+            metrics: publishMetrics
         });
-        const generationTime = performance.now() - generationStart;
-        context.logger.debug(`Remote docs generation completed in ${generationTime.toFixed(0)}ms`);
+        const generationTimeMs = performance.now() - generationStart;
+        const totalTimeMs = performance.now() - totalStart;
+
+        const metricsProperties: Record<string, unknown> = {
+            totalTimeMs: Math.round(totalTimeMs),
+            validationTimeMs: Math.round(validationTimeMs),
+            ossFilterTimeMs: Math.round(filterTimeMs),
+            remoteGenerationTimeMs: Math.round(generationTimeMs),
+            ...publishMetrics,
+            apiWorkspaceCount: project.apiWorkspaces.length,
+            ossWorkspaceCount: ossWorkspaces.length,
+            preview
+        };
+
+        context.logger.info(
+            `Docs generation completed in ${(totalTimeMs / 1000).toFixed(1)}s` +
+                ` (validation: ${(validationTimeMs / 1000).toFixed(1)}s,` +
+                ` publishing: ${(generationTimeMs / 1000).toFixed(1)}s)`
+        );
+
+        if (!isRunningOnSelfHosted) {
+            await context.instrumentPostHogEvent({
+                orgId: project.config.organization,
+                command: "fern generate --docs metrics",
+                properties: metricsProperties
+            });
+        }
     });
 }
 

--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -100,7 +100,9 @@ export async function generateDocsWorkspace({
         });
         const validationTimeMs = performance.now() - validationStart;
 
-        context.logger.info(`Validation complete in ${validationTimeMs.toFixed(0)}ms, starting remote docs generation...`);
+        context.logger.info(
+            `Validation complete in ${validationTimeMs.toFixed(0)}ms, starting remote docs generation...`
+        );
 
         const filterStart = performance.now();
         const ossWorkspaces = await filterOssWorkspaces(project);

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.80.0
+  changelogEntry:
+    - summary: |
+        Add performance metrics instrumentation for `fern generate --docs`. Timing data for each
+        phase (validation, file hashing, file uploads, API registration, docs resolve, FDR publish)
+        is logged at info level and sent as a PostHog event for analysis.
+      type: feat
+  createdAt: "2026-02-17"
+  irVersion: 65
 - version: 3.79.1
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -94,6 +94,14 @@ const defaultRegisterApi: RegisterApiFn = async ({ ir }) => {
     return `${ir.apiName.snakeCase.unsafeName}-${apiCounter}`;
 };
 
+export interface ResolveMetrics {
+    parseConfigTimeMs?: number;
+    navTreeTimeMs?: number;
+    replaceRefsTimeMs?: number;
+    imageParseTimeMs?: number;
+    configConvertTimeMs?: number;
+}
+
 export interface DocsDefinitionResolverArgs {
     domain: string;
     docsWorkspace: DocsWorkspace;
@@ -117,6 +125,7 @@ export class DocsDefinitionResolver {
     private uploadFiles: UploadFilesFn;
     private registerApi: RegisterApiFn;
     private targetAudiences?: string[];
+    private _metrics: ResolveMetrics = {};
 
     constructor({
         domain,
@@ -549,7 +558,19 @@ export class DocsDefinitionResolver {
             `Total resolve time: ${totalResolveTime.toFixed(0)}ms, Memory delta: RSS=${((endMemory.rss - startMemory.rss) / 1024 / 1024).toFixed(2)}MB`
         );
 
+        this._metrics = {
+            parseConfigTimeMs: Math.round(parseTime),
+            navTreeTimeMs: Math.round(rootTime),
+            replaceRefsTimeMs: Math.round(refTime),
+            imageParseTimeMs: Math.round(imageParseTime),
+            configConvertTimeMs: Math.round(configTime)
+        };
+
         return { config, pages, jsFiles };
+    }
+
+    public getMetrics(): ResolveMetrics {
+        return this._metrics;
     }
 
     private resolveFilepath(unresolvedFilepath: string): AbsoluteFilePath;

--- a/packages/cli/docs-resolver/src/index.ts
+++ b/packages/cli/docs-resolver/src/index.ts
@@ -1,4 +1,4 @@
-export { DocsDefinitionResolver, type UploadedFile } from "./DocsDefinitionResolver.js";
+export { DocsDefinitionResolver, type ResolveMetrics, type UploadedFile } from "./DocsDefinitionResolver.js";
 export { convertIrToApiDefinition } from "./utils/convertIrToApiDefinition.js";
 export { filterOssWorkspaces } from "./utils/filterOssWorkspaces.js";
 export { generateFdrFromOpenApiWorkspaceV3 } from "./utils/generateFdrFromOpenAPIWorkspaceV3.js";

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/index.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/index.ts
@@ -1,3 +1,4 @@
 export { getDynamicGeneratorConfig } from "./getDynamicGeneratorConfig.js";
+export { type PublishDocsMetrics } from "./publishDocs.js";
 export { runRemoteGenerationForAPIWorkspace } from "./runRemoteGenerationForAPIWorkspace.js";
 export { runRemoteGenerationForDocsWorkspace } from "./runRemoteGenerationForDocsWorkspace.js";

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -204,7 +204,7 @@ export async function publishDocs({
             );
             const hashNonImageTime = performance.now() - hashNonImageStart;
             context.logger.debug(`Hashed ${filepaths.length} non-image files in ${hashNonImageTime.toFixed(0)}ms`);
-            totalFileHashTimeMs += (performance.now() - hashImageStart);
+            totalFileHashTimeMs += performance.now() - hashImageStart;
 
             if (preview) {
                 const startDocsRegisterResponse = await fdr.docs.v2.write.startDocsPreviewRegister({
@@ -246,7 +246,7 @@ export async function publishDocs({
                             context.logger.debug(`No files to upload (all ${skippedCount} up to date)`);
                         }
                     }
-                    totalFileUploadTimeMs += (performance.now() - uploadCallbackStart);
+                    totalFileUploadTimeMs += performance.now() - uploadCallbackStart;
                     return convertToFilePathPairs(
                         startDocsRegisterResponse.body.uploadUrls,
                         docsWorkspace.absoluteFilePath
@@ -303,7 +303,7 @@ export async function publishDocs({
                             context.logger.info("No files to upload (all up to date)");
                         }
                     }
-                    totalFileUploadTimeMs += (performance.now() - uploadCallbackStart);
+                    totalFileUploadTimeMs += performance.now() - uploadCallbackStart;
                     return convertToFilePathPairs(
                         startDocsRegisterResponse.body.uploadUrls,
                         docsWorkspace.absoluteFilePath
@@ -421,7 +421,7 @@ export async function publishDocs({
                     }
                 }
 
-                totalApiRegistrationTimeMs += (performance.now() - apiRegStart);
+                totalApiRegistrationTimeMs += performance.now() - apiRegStart;
                 return response.body.apiDefinitionId;
             } else {
                 switch (response.error.error) {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -32,6 +32,23 @@ const MEASURE_IMAGE_BATCH_SIZE = 10;
 const UPLOAD_FILE_BATCH_SIZE = 10;
 const HASH_CONCURRENCY = parseInt(process.env.FERN_DOCS_ASSET_HASH_CONCURRENCY ?? "32", 10);
 
+export interface PublishDocsMetrics {
+    resolveTimeMs?: number;
+    fileUploadTimeMs?: number;
+    fileUploadCount?: number;
+    fileUploadSkippedCount?: number;
+    fileHashTimeMs?: number;
+    apiRegistrationTimeMs?: number;
+    apiRegistrationCount?: number;
+    finishRegisterTimeMs?: number;
+    pageCount?: number;
+    resolveParseConfigTimeMs?: number;
+    resolveNavTreeTimeMs?: number;
+    resolveReplaceRefsTimeMs?: number;
+    resolveImageParseTimeMs?: number;
+    resolveConfigConvertTimeMs?: number;
+}
+
 interface FileWithMimeType {
     mediaType: string;
     absoluteFilePath: AbsoluteFilePath;
@@ -60,7 +77,8 @@ export async function publishDocs({
     withAiExamples = true,
     excludeApis = false,
     targetAudiences,
-    docsUrl
+    docsUrl,
+    metrics
 }: {
     token: FernToken;
     organization: string;
@@ -79,6 +97,7 @@ export async function publishDocs({
     excludeApis?: boolean;
     targetAudiences?: string[];
     docsUrl?: string;
+    metrics?: PublishDocsMetrics;
 }): Promise<void> {
     const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
     const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
@@ -94,6 +113,13 @@ export async function publishDocs({
             "Experimental flag 'exclude-apis' is enabled - API references will be excluded from S3 upload"
         );
     }
+
+    let totalFileUploadTimeMs = 0;
+    let totalFileHashTimeMs = 0;
+    let totalFileUploadCount = 0;
+    let totalFileUploadSkippedCount = 0;
+    let totalApiRegistrationTimeMs = 0;
+    let apiRegistrationCount = 0;
 
     let docsRegistrationId: string | undefined;
     let urlToOutput = customDomains[0] ?? domain;
@@ -114,6 +140,7 @@ export async function publishDocs({
         taskContext: context,
         editThisPage,
         uploadFiles: async (files) => {
+            const uploadCallbackStart = performance.now();
             const filesMap = new Map(files.map((file) => [file.absoluteFilePath, file]));
             const filesWithMimeType: FileWithMimeType[] = files
                 .map((fileMetadata) => ({
@@ -177,6 +204,7 @@ export async function publishDocs({
             );
             const hashNonImageTime = performance.now() - hashNonImageStart;
             context.logger.debug(`Hashed ${filepaths.length} non-image files in ${hashNonImageTime.toFixed(0)}ms`);
+            totalFileHashTimeMs += (performance.now() - hashImageStart);
 
             if (preview) {
                 const startDocsRegisterResponse = await fdr.docs.v2.write.startDocsPreviewRegister({
@@ -203,6 +231,8 @@ export async function publishDocs({
 
                         const uploadCount = Object.keys(urlsToUpload).length;
                         const skippedCount = skippedSet.size;
+                        totalFileUploadCount += uploadCount;
+                        totalFileUploadSkippedCount += skippedCount;
 
                         if (uploadCount > 0) {
                             context.logger.debug(`Uploading ${uploadCount} files (${skippedCount} skipped)...`);
@@ -216,6 +246,7 @@ export async function publishDocs({
                             context.logger.debug(`No files to upload (all ${skippedCount} up to date)`);
                         }
                     }
+                    totalFileUploadTimeMs += (performance.now() - uploadCallbackStart);
                     return convertToFilePathPairs(
                         startDocsRegisterResponse.body.uploadUrls,
                         docsWorkspace.absoluteFilePath
@@ -256,6 +287,9 @@ export async function publishDocs({
                         );
 
                         const uploadCount = Object.keys(urlsToUpload).length;
+                        const skippedCountProd = startDocsRegisterResponse.body.skippedFiles?.length || 0;
+                        totalFileUploadCount += uploadCount;
+                        totalFileUploadSkippedCount += skippedCountProd;
 
                         if (uploadCount > 0) {
                             context.logger.info(`↑ Uploading ${uploadCount} files...`);
@@ -269,6 +303,7 @@ export async function publishDocs({
                             context.logger.info("No files to upload (all up to date)");
                         }
                     }
+                    totalFileUploadTimeMs += (performance.now() - uploadCallbackStart);
                     return convertToFilePathPairs(
                         startDocsRegisterResponse.body.uploadUrls,
                         docsWorkspace.absoluteFilePath
@@ -288,6 +323,8 @@ export async function publishDocs({
             graphqlOperations,
             graphqlTypes
         }) => {
+            const apiRegStart = performance.now();
+            apiRegistrationCount++;
             // Use apiName from docs.yml (folder name) as the API identifier for FDR
             // This ensures users can reference APIs by their folder name in docs components
             let apiDefinition = convertIrToFdrApi({
@@ -384,6 +421,7 @@ export async function publishDocs({
                     }
                 }
 
+                totalApiRegistrationTimeMs += (performance.now() - apiRegStart);
                 return response.body.apiDefinitionId;
             } else {
                 switch (response.error.error) {
@@ -420,6 +458,7 @@ export async function publishDocs({
     const resolveStart = performance.now();
     let docsDefinition = await resolver.resolve();
     const resolveTime = performance.now() - resolveStart;
+    const resolveMetrics = resolver.getMetrics();
 
     if (docsWorkspace.config.settings?.substituteEnvVars) {
         context.logger.debug("Applying environment variable substitution to docs definition...");
@@ -448,7 +487,7 @@ export async function publishDocs({
     }
 
     context.logger.info("Publishing docs to FDR...");
-    const publishStart = performance.now();
+    const finishRegisterStart = performance.now();
     const registerDocsResponse = await fdr.docs.v2.write.finishDocsRegister(
         DocsV1Write.DocsRegistrationId(docsRegistrationId),
         {
@@ -459,8 +498,27 @@ export async function publishDocs({
     );
 
     if (registerDocsResponse.ok) {
-        const publishTime = performance.now() - publishStart;
-        context.logger.debug(`Docs published to FDR in ${publishTime.toFixed(0)}ms`);
+        const finishRegisterTime = performance.now() - finishRegisterStart;
+        context.logger.debug(`Docs published to FDR in ${finishRegisterTime.toFixed(0)}ms`);
+
+        if (metrics) {
+            metrics.resolveTimeMs = Math.round(resolveTime);
+            metrics.fileUploadTimeMs = Math.round(totalFileUploadTimeMs);
+            metrics.fileUploadCount = totalFileUploadCount;
+            metrics.fileUploadSkippedCount = totalFileUploadSkippedCount;
+            metrics.fileHashTimeMs = Math.round(totalFileHashTimeMs);
+            metrics.apiRegistrationTimeMs = Math.round(totalApiRegistrationTimeMs);
+            metrics.apiRegistrationCount = apiRegistrationCount;
+            metrics.finishRegisterTimeMs = Math.round(finishRegisterTime);
+            metrics.pageCount = pageCount;
+            if (resolveMetrics) {
+                metrics.resolveParseConfigTimeMs = resolveMetrics.parseConfigTimeMs;
+                metrics.resolveNavTreeTimeMs = resolveMetrics.navTreeTimeMs;
+                metrics.resolveReplaceRefsTimeMs = resolveMetrics.replaceRefsTimeMs;
+                metrics.resolveImageParseTimeMs = resolveMetrics.imageParseTimeMs;
+                metrics.resolveConfigConvertTimeMs = resolveMetrics.configConvertTimeMs;
+            }
+        }
 
         const url = wrapWithHttps(urlToOutput);
         await updateAiChatFromDocsDefinition({

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -3,7 +3,7 @@ import { replaceEnvVariables } from "@fern-api/core-utils";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace, DocsWorkspace } from "@fern-api/workspace-loader";
-import { publishDocs } from "./publishDocs.js";
+import { PublishDocsMetrics, publishDocs } from "./publishDocs.js";
 
 export async function runRemoteGenerationForDocsWorkspace({
     organization,
@@ -15,7 +15,8 @@ export async function runRemoteGenerationForDocsWorkspace({
     instanceUrl,
     preview,
     disableTemplates,
-    skipUpload
+    skipUpload,
+    metrics
 }: {
     organization: string;
     apiWorkspaces: AbstractAPIWorkspace<unknown>[];
@@ -27,6 +28,7 @@ export async function runRemoteGenerationForDocsWorkspace({
     preview: boolean;
     disableTemplates: boolean | undefined;
     skipUpload: boolean | undefined;
+    metrics?: PublishDocsMetrics;
 }): Promise<void> {
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated
@@ -107,7 +109,8 @@ export async function runRemoteGenerationForDocsWorkspace({
                     ? maybeInstance.audiences
                     : [maybeInstance.audiences]
                 : undefined,
-            docsUrl: maybeInstance.url
+            docsUrl: maybeInstance.url,
+            metrics
         });
         const publishTime = performance.now() - publishStart;
         context.logger.debug(`Docs publishing completed in ${publishTime.toFixed(0)}ms`);


### PR DESCRIPTION
## Description

Refs: Requested by @dsinghvi — investigating why `fern generate --docs` is slow.

Adds timing instrumentation across all major phases of docs generation and reports them as a single PostHog event (`fern generate --docs metrics`) for analysis.

[Link to Devin run](https://app.devin.ai/sessions/6b63fd02ed0f4427a4c4406f38baf742)

## Changes Made

- **`generateDocsWorkspace.ts`**: Times top-level phases (validation, OSS filtering, remote generation) and sends a consolidated PostHog event with all metrics after successful completion
- **`publishDocs.ts`**: Adds `PublishDocsMetrics` interface and accumulates timing for file hashing, file uploads (with skip counts), API registration, and FDR finish-register
- **`DocsDefinitionResolver.ts`**: Adds `ResolveMetrics` interface and `getMetrics()` method exposing sub-phase timings (config parsing, nav tree build, ref replacement, image parsing, config conversion)
- **`runRemoteGenerationForDocsWorkspace.ts`**: Passes metrics object through to `publishDocs`
- **`versions.yml`**: Version bump to 3.80.0
- [ ] Updated README.md generator (not applicable)

### Metrics captured per run:
| Metric | Description |
|--------|-------------|
| `totalTimeMs` | End-to-end time |
| `validationTimeMs` | Docs workspace validation |
| `ossFilterTimeMs` | OSS workspace filtering |
| `remoteGenerationTimeMs` | Full publish flow |
| `resolveTimeMs` | Docs definition resolution |
| `fileHashTimeMs` | SHA-256 hashing of all files |
| `fileUploadTimeMs` / `fileUploadCount` / `fileUploadSkippedCount` | S3 uploads |
| `apiRegistrationTimeMs` / `apiRegistrationCount` | FDR API registration + dynamic IR |
| `finishRegisterTimeMs` | FDR finishDocsRegister call |
| `resolveParseConfigTimeMs`, `resolveNavTreeTimeMs`, etc. | Sub-phases within resolve |

## Testing


- [ ] Unit tests added/updated — no new tests; this is additive instrumentation only
- [x] Manual review of type-checking (pre-existing errors only; no new errors introduced)
- [x] Biome formatting checks pass

## Reviewer Checklist

- **PostHog event shape**: Verify `"fern generate --docs metrics"` as the event command and the property names match what the team wants to query in PostHog dashboards
- **Mutable metrics object**: `PublishDocsMetrics` is initialized as `{}` and mutated in-place across call layers — confirm this pattern is acceptable vs. returning metrics
- **`totalFileHashTimeMs` scope**: Uses `hashImageStart` as the start marker, which captures both image + non-image hashing — verify this is the intended scope (variable name is misleading but timing appears correct)
- **Metrics only sent on success**: If the flow errors mid-way, no PostHog event is sent — confirm this is desired behavior (means no data on failed/timeout runs)
- **No behavioral changes**: This PR only adds timing measurements and logging; no functional changes to docs generation logic