### PR TITLE
fix(python): export `ConsoleLogger` and `ILogger` from core module

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,29 +1,54 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.58.1
+  changelogEntry:
+    - summary: |
+        Export `ConsoleLogger` and `ILogger` from the `core` module, allowing users to import
+        and use them directly:
+
+        ```python
+        from acme.core import ConsoleLogger, ILogger
+        ```
+      type: fix
+  createdAt: "2026-02-18"
+  irVersion: 65
+
 - version: 4.58.0
   changelogEntry:
     - summary: |
-        Add configurable logging support to generated Python SDKs. The SDK client constructor now
-        accepts a `logging` parameter that can be configured in two ways:
+        Add support for logging to the generated SDK.
+        Users can configure the logger by passing in a `logging` parameter to the client constructor.
 
-        1. **LogConfig dict**: Pass `{"level": "debug", "logger": custom_logger, "silent": False}` where:
-           - `level`: Log level threshold (`"debug"`, `"info"`, `"warn"`, or `"error"`)
-           - `logger`: Optional custom logger implementing the `ILogger` protocol (debug/info/warn/error methods)
-           - `silent`: Boolean to disable all logging (defaults to `True` for backward compatibility)
+        ```python
+        from acme import AcmeClient
+        from acme.core import ConsoleLogger
 
-        2. **Logger instance**: Pass a pre-configured `Logger` object for reuse across clients
+        client = AcmeClient(
+            token="YOUR_TOKEN",
+            logging={
+                "level": "debug",  # "info" is the default
+                "logger": ConsoleLogger(),  # ConsoleLogger is the default
+                "silent": False,  # True is the default, set to False to enable logging
+            }
+        )
+        ```
 
-        **What gets logged:**
-        - HTTP request metadata at debug level: method, URL, redacted headers, and body presence indicator
-        - HTTP response success at debug level: method, URL, and status code
-        - HTTP errors at error level: method, URL, and status code for 4xx/5xx responses
-        - Streaming request metadata at debug level
+        The `logging` parameter accepts a `LogConfig` dict with the following properties:
+        - `level`: The log level to use. Defaults to `"info"`.
+        - `logger`: The logger to use. Defaults to `ConsoleLogger`.
+        - `silent`: Whether to silence the logger. Defaults to `True`.
 
-        **Security:** Sensitive headers are automatically redacted including: `authorization`, `x-api-key`,
-        `cookie`, `x-csrf-token`, `x-session-token`, and other auth-related headers.
+        The `level` property can be one of the following values:
+        - `"debug"`
+        - `"info"`
+        - `"warn"`
+        - `"error"`
 
-        **Default behavior:** Logging is silent by default (`silent=True`) to maintain backward compatibility.
-        Set `silent=False` to enable logging output.
+        To provide a custom logger, pass an object implementing the `ILogger` protocol
+        with `debug`, `info`, `warn`, and `error` methods.
+
+        Sensitive headers (`authorization`, `x-api-key`, `cookie`, etc.) are automatically
+        redacted in logs.
       type: feat
   createdAt: "2026-02-10"
   irVersion: 65

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -130,7 +130,7 @@ class CoreUtilities:
                 directories=self.filepath,
                 file=Filepath.FilepathPart(module_name="logging"),
             ),
-            exports={"Logger", "LogConfig", "LogLevel", "create_logger"}
+            exports={"Logger", "LogConfig", "LogLevel", "ConsoleLogger", "ILogger", "create_logger"}
             if not self._exclude_types_from_init_exports
             else set(),
         )

--- a/seed/python-sdk/simple-api/src/seed/core/__init__.py
+++ b/seed/python-sdk/simple-api/src/seed/core/__init__.py
@@ -13,7 +13,7 @@ if typing.TYPE_CHECKING:
     from .http_client import AsyncHttpClient, HttpClient
     from .http_response import AsyncHttpResponse, HttpResponse
     from .jsonable_encoder import jsonable_encoder
-    from .logging import LogConfig, LogLevel, Logger, create_logger
+    from .logging import ConsoleLogger, ILogger, LogConfig, LogLevel, Logger, create_logger
     from .pydantic_utilities import (
         IS_PYDANTIC_V2,
         UniversalBaseModel,
@@ -33,10 +33,12 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncHttpClient": ".http_client",
     "AsyncHttpResponse": ".http_response",
     "BaseClientWrapper": ".client_wrapper",
+    "ConsoleLogger": ".logging",
     "FieldMetadata": ".serialization",
     "File": ".file",
     "HttpClient": ".http_client",
     "HttpResponse": ".http_response",
+    "ILogger": ".logging",
     "IS_PYDANTIC_V2": ".pydantic_utilities",
     "LogConfig": ".logging",
     "LogLevel": ".logging",
@@ -87,10 +89,12 @@ __all__ = [
     "AsyncHttpClient",
     "AsyncHttpResponse",
     "BaseClientWrapper",
+    "ConsoleLogger",
     "FieldMetadata",
     "File",
     "HttpClient",
     "HttpResponse",
+    "ILogger",
     "IS_PYDANTIC_V2",
     "LogConfig",
     "LogLevel",


### PR DESCRIPTION
## Summary
- Export `ConsoleLogger` and `ILogger` from the `core` module so users can import them directly
- Update the 4.58.0 logging changelog entry with detailed documentation matching the TypeScript SDK format

## Changes

### Generator Changes
- Added `ConsoleLogger` and `ILogger` to the logging module exports in `core_utilities.py`

### Changelog Updates
- **4.58.1**: New entry documenting the `ConsoleLogger` and `ILogger` exports
- **4.58.0**: Expanded logging documentation with:
  - Code examples showing basic usage and custom logger implementation
  - `LogConfig` property descriptions with defaults
  - Log level values
  - `ILogger` protocol requirements
  - Header redaction security note

## Usage

Users can now import logging utilities directly:

```python
from acme.core import ConsoleLogger, ILogger, LogConfig, Logger
