### PR TITLE
fix(csharp): fix WebSocket binary message sending and incoming message deserialization

### DIFF
--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -569,6 +569,7 @@ export class WebSocketClientGenerator extends WithGeneration {
             type: ast.Type | ast.ClassReference;
             eventType: ast.ClassReference;
             name: string | undefined;
+            discriminants: { wireValue: string; literalValue: string }[];
         }[] = [];
 
         for (const each of this.websocketChannel.messages) {
@@ -577,36 +578,33 @@ export class WebSocketClientGenerator extends WithGeneration {
                 const type = this.context.csharpTypeMapper.convert({
                     reference: each.body.bodyType
                 });
-                if (each.body.type === "reference") {
-                    const reference = each.body.bodyType;
-                    const type = this.context.csharpTypeMapper.convert({
-                        reference: each.body.bodyType
-                    });
 
-                    // if the result is a oneof, we will expand it into multiple
-                    if (is.OneOf.OneOf(type)) {
-                        for (const oneOfType of type.generics) {
-                            result.push({
-                                type: oneOfType,
-                                eventType: this.Types.WebSocketEvent(oneOfType),
-                                name: is.ClassReference(oneOfType) ? oneOfType.name : undefined
-                            });
-                        }
-                    } else {
-                        // otherwise it's just a single type here
+                // if the result is a oneof, we will expand it into multiple
+                if (is.OneOf.OneOf(type)) {
+                    for (const oneOfType of type.generics) {
                         result.push({
-                            type,
-                            eventType: this.Types.WebSocketEvent(type),
-                            name:
-                                reference._visit({
-                                    container: () => undefined,
-                                    named: (named) => named.name.pascalCase.safeName,
-                                    primitive: (value) => undefined,
-                                    unknown: () => undefined,
-                                    _other: (value) => value.type
-                                }) || each.displayName
+                            type: oneOfType,
+                            eventType: this.Types.WebSocketEvent(oneOfType),
+                            name: is.ClassReference(oneOfType) ? oneOfType.name : undefined,
+                            discriminants: []
                         });
                     }
+                } else {
+                    // otherwise it's just a single type here
+                    const discriminants = this.getDiscriminantsForType(reference);
+                    result.push({
+                        type,
+                        eventType: this.Types.WebSocketEvent(type),
+                        name:
+                            reference._visit({
+                                container: () => undefined,
+                                named: (named) => named.name.pascalCase.safeName,
+                                primitive: (value) => undefined,
+                                unknown: () => undefined,
+                                _other: (value) => value.type
+                            }) || each.displayName,
+                        discriminants
+                    });
                 }
             }
         }
@@ -691,32 +689,86 @@ export class WebSocketClientGenerator extends WithGeneration {
                 writer.writeTextStatement(`return`);
                 writer.popScope();
 
-                // there is no empirical way to determine the correct event type from the IR
-                // so the only option is to try each event model until one is successful
-                // iterate thru the event models and try to deserialize the message to the correct event
-
                 writer.writeLine();
-                writer.writeLine("// deserialize the message to find the correct event");
+                writer.writeLine("// deserialize the message to find the correct event using discriminant matching");
 
-                for (const event of this.events) {
-                    writer.pushScope();
-                    writer.write(
-                        `if(`,
-                        this.Types.JsonUtils,
-                        `.TryDeserialize(json`,
-                        `, out `,
-                        event.name,
-                        `? message))`
-                    );
-                    writer.pushScope();
+                const events = this.events;
+                const hasDiscriminants = events.some((e) => e.discriminants.length > 0);
 
-                    writer.writeTextStatement(`await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`);
-                    writer.writeTextStatement(`return`);
+                if (hasDiscriminants) {
+                    // Group events by discriminant field for efficient matching
+                    // Check each event's discriminant properties against the JSON
+                    for (const event of events) {
+                        if (event.discriminants.length > 0) {
+                            // Build a condition that checks all discriminant fields
+                            const conditions = event.discriminants.map(
+                                (d) =>
+                                    `(json.RootElement.TryGetProperty("${d.wireValue}", out var ${d.wireValue.replace(/[^a-zA-Z0-9]/g, "_")}Prop) && ${d.wireValue.replace(/[^a-zA-Z0-9]/g, "_")}Prop.ValueKind == System.Text.Json.JsonValueKind.String && ${d.wireValue.replace(/[^a-zA-Z0-9]/g, "_")}Prop.GetString() == "${d.literalValue}")`
+                            );
+                            writer.writeLine(`if(${conditions.join(" && ")})`);
+                            writer.pushScope();
+                            writer.write(
+                                `if(`,
+                                this.Types.JsonUtils,
+                                `.TryDeserialize(json`,
+                                `, out `,
+                                event.name,
+                                `? message))`
+                            );
+                            writer.pushScope();
+                            writer.writeTextStatement(
+                                `await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`
+                            );
+                            writer.writeTextStatement(`return`);
+                            writer.popScope();
+                            writer.popScope();
+                            writer.writeLine();
+                        }
+                    }
 
-                    writer.popScope();
-                    writer.popScope();
-
-                    writer.writeLine();
+                    // Fallback for events without discriminants
+                    for (const event of events) {
+                        if (event.discriminants.length === 0) {
+                            writer.pushScope();
+                            writer.write(
+                                `if(`,
+                                this.Types.JsonUtils,
+                                `.TryDeserialize(json`,
+                                `, out `,
+                                event.name,
+                                `? message))`
+                            );
+                            writer.pushScope();
+                            writer.writeTextStatement(
+                                `await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`
+                            );
+                            writer.writeTextStatement(`return`);
+                            writer.popScope();
+                            writer.popScope();
+                            writer.writeLine();
+                        }
+                    }
+                } else {
+                    // No discriminants available, fall back to trying each type
+                    for (const event of events) {
+                        writer.pushScope();
+                        writer.write(
+                            `if(`,
+                            this.Types.JsonUtils,
+                            `.TryDeserialize(json`,
+                            `, out `,
+                            event.name,
+                            `? message))`
+                        );
+                        writer.pushScope();
+                        writer.writeTextStatement(
+                            `await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`
+                        );
+                        writer.writeTextStatement(`return`);
+                        writer.popScope();
+                        writer.popScope();
+                        writer.writeLine();
+                    }
                 }
 
                 // if no event was found, raise an exception
@@ -739,6 +791,7 @@ export class WebSocketClientGenerator extends WithGeneration {
      */
     private createSendMessageMethods(cls: ast.Class): void {
         this.messages.forEach((each) => {
+            const isBinary = is.Value.byte(each.type);
             cls.addMethod({
                 access: ast.Access.Public,
                 isAsync: true,
@@ -754,9 +807,15 @@ export class WebSocketClientGenerator extends WithGeneration {
                 }),
 
                 body: this.csharp.codeblock((writer) => {
-                    writer.writeLine(`await _client.SendInstant(`);
-                    writer.writeNode(this.Types.JsonUtils);
-                    writer.writeTextStatement(`.Serialize(message)).ConfigureAwait(false)`);
+                    if (isBinary) {
+                        writer.writeTextStatement(
+                            `await _client.SendInstant(message).ConfigureAwait(false)`
+                        );
+                    } else {
+                        writer.writeLine(`await _client.SendInstant(`);
+                        writer.writeNode(this.Types.JsonUtils);
+                        writer.writeTextStatement(`.Serialize(message)).ConfigureAwait(false)`);
+                    }
                 })
             });
         });
@@ -1048,6 +1107,37 @@ export class WebSocketClientGenerator extends WithGeneration {
      * @param typeReference - The type reference to check
      * @returns True if the type is a named/object type, false for primitives and containers
      */
+    private getDiscriminantsForType(
+        typeReference: TypeReference
+    ): { wireValue: string; literalValue: string }[] {
+        const discriminants: { wireValue: string; literalValue: string }[] = [];
+        if (typeReference.type !== "named") {
+            return discriminants;
+        }
+        const typeId = typeReference.typeId;
+        const typeDeclaration = this.context.ir.types[typeId];
+        if (typeDeclaration == null || typeDeclaration.shape.type !== "object") {
+            return discriminants;
+        }
+        const allProperties = [
+            ...typeDeclaration.shape.properties,
+            ...(typeDeclaration.shape.extendedProperties ?? [])
+        ];
+        for (const property of allProperties) {
+            if (
+                property.valueType.type === "container" &&
+                property.valueType.container.type === "literal" &&
+                property.valueType.container.literal.type === "string"
+            ) {
+                discriminants.push({
+                    wireValue: property.name.wireValue,
+                    literalValue: property.valueType.container.literal.string
+                });
+            }
+        }
+        return discriminants;
+    }
+
     private isComplexType(typeReference: TypeReference): boolean {
         return typeReference._visit({
             container: (container) => {

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -716,9 +716,7 @@ export class WebSocketClientGenerator extends WithGeneration {
                                 `? message))`
                             );
                             writer.pushScope();
-                            writer.writeTextStatement(
-                                `await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`
-                            );
+                            writer.writeTextStatement(`await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`);
                             writer.writeTextStatement(`return`);
                             writer.popScope();
                             writer.popScope();
@@ -739,9 +737,7 @@ export class WebSocketClientGenerator extends WithGeneration {
                                 `? message))`
                             );
                             writer.pushScope();
-                            writer.writeTextStatement(
-                                `await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`
-                            );
+                            writer.writeTextStatement(`await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`);
                             writer.writeTextStatement(`return`);
                             writer.popScope();
                             writer.popScope();
@@ -761,9 +757,7 @@ export class WebSocketClientGenerator extends WithGeneration {
                             `? message))`
                         );
                         writer.pushScope();
-                        writer.writeTextStatement(
-                            `await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`
-                        );
+                        writer.writeTextStatement(`await ${event.name}.RaiseEvent(message!).ConfigureAwait(false)`);
                         writer.writeTextStatement(`return`);
                         writer.popScope();
                         writer.popScope();
@@ -808,9 +802,7 @@ export class WebSocketClientGenerator extends WithGeneration {
 
                 body: this.csharp.codeblock((writer) => {
                     if (isBinary) {
-                        writer.writeTextStatement(
-                            `await _client.SendInstant(message).ConfigureAwait(false)`
-                        );
+                        writer.writeTextStatement(`await _client.SendInstant(message).ConfigureAwait(false)`);
                     } else {
                         writer.writeLine(`await _client.SendInstant(`);
                         writer.writeNode(this.Types.JsonUtils);
@@ -1107,9 +1099,7 @@ export class WebSocketClientGenerator extends WithGeneration {
      * @param typeReference - The type reference to check
      * @returns True if the type is a named/object type, false for primitives and containers
      */
-    private getDiscriminantsForType(
-        typeReference: TypeReference
-    ): { wireValue: string; literalValue: string }[] {
+    private getDiscriminantsForType(typeReference: TypeReference): { wireValue: string; literalValue: string }[] {
         const discriminants: { wireValue: string; literalValue: string }[] = [];
         if (typeReference.type !== "named") {
             return discriminants;

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.20.6
+  changelogEntry:
+    - summary: |
+        Fix WebSocket binary message support: Send raw bytes directly instead of JSON-serializing binary payloads.
+        Previously, binary messages (e.g., audio data) were wrapped in JsonUtils.Serialize(), causing the server
+        to interpret them as configuration messages and respond with CONFIG_DENIED.
+      type: fix
+    - summary: |
+        Fix WebSocket incoming message deserialization: Use discriminant-based matching for server messages.
+        Previously, messages were deserialized by trying each type sequentially, which caused incorrect matches
+        (e.g., transcript messages treated as flushed) because System.Text.Json doesn't validate const field values.
+        Now checks literal/const property values in the JSON before attempting deserialization.
+      type: fix
+  createdAt: "2026-02-18"
+  irVersion: 62
+
 - version: 2.20.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs customer-reported issues with C# SDK WebSocket endpoints (Corti `/transcribe` and `/stream`).

Fixes two bugs in the C# WebSocket client code generator:
1. **Binary messages sent as JSON strings** — Audio bytes were JSON-serialized before sending, causing the server to interpret them as config messages (`CONFIG_DENIED`).
2. **Incoming messages deserialized incorrectly** — `TryDeserialize` tried each type sequentially and matched the first one that didn't throw, ignoring const/literal field values. This caused e.g. `type: "transcript"` messages to be matched as `type: "flushed"`.

Issue 3 from the report (environment optionality) was investigated but is a broader design question not addressed here.

Link to Devin run: https://app.devin.ai/sessions/2164482f074e41819f493252c20dffa8
Requested by: Chris McDonnell (@cdonel707)

## Changes Made

- **`createSendMessageMethods`**: Check if message type is binary (`is.Value.byte(each.type)`) and call `_client.SendInstant(message)` directly instead of wrapping in `JsonUtils.Serialize()`. The underlying `WebSocketClient` already has `SendInstant(byte[])` overloads that correctly use `WebSocketMessageType.Binary`.
- **`createOnTextMessageMethod`**: When event types have discriminant properties (string literals/consts), generate C# code that checks the JSON field value *before* attempting `TryDeserialize`. Falls back to the old sequential approach for events without discriminants.
- **New `getDiscriminantsForType` helper**: Looks up the IR type declaration for a named type reference and extracts properties whose `valueType` is a `container.literal.string` (i.e., const string fields like `type: "transcript"`).
- **`events` getter**: Added `discriminants` field to each event entry; also removed a redundant inner `if (each.body.type === "reference")` block that re-declared `reference` and `type` variables.
- Updated `versions.yml` with `2.20.6` changelog entry.

## Testing

- [x] TypeScript compiles cleanly (`tsc --build`)
- [x] Biome lint passes (`pnpm run check`)
- [x] Seed tests pass (all 23 required seed-test-results checks green in CI)
- [ ] Manual testing with Corti API (not possible in this environment)

## Human Review Checklist

- **Generated C# discriminant conditions**: The condition strings are long inline template literals (line ~704-707). Verify the generated C# is syntactically correct, especially the variable naming via `d.wireValue.replace(/[^a-zA-Z0-9]/g, "_")` — could produce collisions if two discriminant fields sanitize to the same name.
- **No runtime verification**: These generator changes produce different C# output, but the actual generated SDK was not compiled or tested against the Corti API. Consider generating a test SDK from the Corti spec to verify the output compiles and looks correct.
- **OneOf events get empty discriminants**: Expanded OneOf variants fall through to the non-discriminant fallback loop (same `TryDeserialize` ordering behavior as before). This is not a regression but doesn't improve the OneOf case.
- **Only string literals are checked**: `getDiscriminantsForType` ignores boolean literals. This seems fine for typical WebSocket `type` discriminators but worth noting.