### PR TITLE
feat(swift): add global headers as named parameters on client constructor

### DIFF
--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -141,10 +141,12 @@ export class RootClientGenerator {
         const initializerParams = this.getConvenienceInitializerParams({
             bearerTokenParamType
         });
-        const globalHeaders = this.sdkGeneratorContext.ir.headers.filter((header) => {
-            const swiftType = this.getResolvedSwiftTypeForTypeReference(header.valueType);
-            return this.referencer.resolvesToTheSwiftType(swiftType.nonOptional(), "String");
-        });
+        const globalHeaders = this.sdkGeneratorContext.ir.headers
+            .filter((header) => !this.isLiteralTypeReference(header.valueType))
+            .filter((header) => {
+                const swiftType = this.getResolvedSwiftTypeForTypeReference(header.valueType);
+                return this.referencer.resolvesToTheSwiftType(swiftType.nonOptional(), "String");
+            });
 
         const headersArgValue =
             globalHeaders.length > 0
@@ -647,6 +649,7 @@ export class RootClientGenerator {
     private getGlobalHeaderParameters(): swift.FunctionParameter[] {
         const globalHeaders = this.sdkGeneratorContext.ir.headers;
         return globalHeaders
+            .filter((header) => !this.isLiteralTypeReference(header.valueType))
             .filter((header) => {
                 const swiftType = this.getResolvedSwiftTypeForTypeReference(header.valueType);
                 return this.referencer.resolvesToTheSwiftType(swiftType.nonOptional(), "String");
@@ -661,6 +664,24 @@ export class RootClientGenerator {
                     docsContent: header.docs
                 });
             });
+    }
+
+    private isLiteralTypeReference(typeReference: FernIr.TypeReference): boolean {
+        if (typeReference.type === "container") {
+            if (typeReference.container.type === "literal") {
+                return true;
+            }
+            if (typeReference.container.type === "optional") {
+                return this.isLiteralTypeReference(typeReference.container.optional);
+            }
+        }
+        if (typeReference.type === "named") {
+            const typeDeclaration = this.sdkGeneratorContext.ir.types[typeReference.typeId];
+            if (typeDeclaration != null && typeDeclaration.shape.type === "alias") {
+                return this.isLiteralTypeReference(typeDeclaration.shape.aliasOf);
+            }
+        }
+        return false;
     }
 
     private getResolvedSwiftTypeForTypeReference(typeReference: FernIr.TypeReference): swift.TypeReference {

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -141,7 +141,6 @@ export class RootClientGenerator {
         const initializerParams = this.getConvenienceInitializerParams({
             bearerTokenParamType
         });
-        const globalHeaderParams = this.getGlobalHeaderParameters();
         const globalHeaders = this.sdkGeneratorContext.ir.headers.filter((header) => {
             const swiftType = this.getResolvedSwiftTypeForTypeReference(header.valueType);
             return this.referencer.resolvesToTheSwiftType(swiftType.nonOptional(), "String");

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -141,6 +141,16 @@ export class RootClientGenerator {
         const initializerParams = this.getConvenienceInitializerParams({
             bearerTokenParamType
         });
+        const globalHeaderParams = this.getGlobalHeaderParameters();
+        const globalHeaders = this.sdkGeneratorContext.ir.headers.filter((header) => {
+            const swiftType = this.getResolvedSwiftTypeForTypeReference(header.valueType);
+            return this.referencer.resolvesToTheSwiftType(swiftType.nonOptional(), "String");
+        });
+
+        const headersArgValue =
+            globalHeaders.length > 0
+                ? swift.Expression.reference("mergedHeaders")
+                : swift.Expression.reference("headers");
 
         const designatedInitializerArgs: swift.FunctionArgument[] = [
             swift.functionArgument({
@@ -262,7 +272,7 @@ export class RootClientGenerator {
             }),
             swift.functionArgument({
                 label: "headers",
-                value: swift.Expression.reference("headers")
+                value: headersArgValue
             }),
             swift.functionArgument({
                 label: "timeout",
@@ -292,20 +302,62 @@ export class RootClientGenerator {
             }
         };
 
+        const bodyStatements: swift.Statement[] = [];
+
+        if (globalHeaders.length > 0) {
+            bodyStatements.push(
+                swift.Statement.variableDeclaration({
+                    unsafeName: "mergedHeaders",
+                    value: swift.Expression.rawValue("headers ?? [:]")
+                })
+            );
+            for (const header of globalHeaders) {
+                const paramName = header.name.name.camelCase.unsafeName;
+                const wireValue = header.name.wireValue;
+                const swiftType = this.getResolvedSwiftTypeForTypeReference(header.valueType);
+                if (swiftType.variant.type === "optional") {
+                    bodyStatements.push(
+                        swift.Statement.if({
+                            condition: swift.Statement.constantDeclaration({
+                                unsafeName: paramName,
+                                value: swift.Expression.reference(paramName),
+                                noTrailingNewline: true
+                            }),
+                            body: [
+                                swift.Statement.variableAssignment(
+                                    `mergedHeaders["${wireValue}"]`,
+                                    swift.Expression.reference(paramName)
+                                )
+                            ]
+                        })
+                    );
+                } else {
+                    bodyStatements.push(
+                        swift.Statement.variableAssignment(
+                            `mergedHeaders["${wireValue}"]`,
+                            swift.Expression.reference(paramName)
+                        )
+                    );
+                }
+            }
+        }
+
+        bodyStatements.push(
+            swift.Statement.expressionStatement(
+                swift.Expression.methodCall({
+                    target: swift.Expression.self(),
+                    methodName: "init",
+                    arguments_: designatedInitializerArgs,
+                    multiline: true
+                })
+            )
+        );
+
         return swift.initializer({
             accessLevel: swift.AccessLevel.Public,
             convenience: true,
             parameters: initializerParams,
-            body: swift.CodeBlock.withStatements([
-                swift.Statement.expressionStatement(
-                    swift.Expression.methodCall({
-                        target: swift.Expression.self(),
-                        methodName: "init",
-                        arguments_: designatedInitializerArgs,
-                        multiline: true
-                    })
-                )
-            ]),
+            body: swift.CodeBlock.withStatements(bodyStatements),
             multiline: true,
             docs: swift.docComment({
                 summary: getDocsSummary(),
@@ -342,6 +394,7 @@ export class RootClientGenerator {
             params.push(authSchemes.basic.usernameParam);
             params.push(authSchemes.basic.passwordParam);
         }
+        params.push(...this.getGlobalHeaderParameters());
         params.push(this.headersParam, this.timeoutParam, this.maxRetriesParam, this.urlSessionParam);
         return params;
     }
@@ -590,6 +643,36 @@ export class RootClientGenerator {
         }
 
         return paramsByScheme;
+    }
+
+    private getGlobalHeaderParameters(): swift.FunctionParameter[] {
+        const globalHeaders = this.sdkGeneratorContext.ir.headers;
+        return globalHeaders
+            .filter((header) => {
+                const swiftType = this.getResolvedSwiftTypeForTypeReference(header.valueType);
+                return this.referencer.resolvesToTheSwiftType(swiftType.nonOptional(), "String");
+            })
+            .map((header) => {
+                const swiftType = this.getResolvedSwiftTypeForTypeReference(header.valueType);
+                return swift.functionParameter({
+                    argumentLabel: header.name.name.camelCase.unsafeName,
+                    unsafeName: header.name.name.camelCase.unsafeName,
+                    type: swiftType,
+                    defaultValue: swiftType.variant.type === "optional" ? swift.Expression.rawValue("nil") : undefined,
+                    docsContent: header.docs
+                });
+            });
+    }
+
+    private getResolvedSwiftTypeForTypeReference(typeReference: FernIr.TypeReference): swift.TypeReference {
+        if (typeReference.type === "named") {
+            const { typeId } = typeReference;
+            const typeDeclaration = this.sdkGeneratorContext.ir.types[typeId];
+            if (typeDeclaration != null && typeDeclaration.shape.type === "alias") {
+                return this.getResolvedSwiftTypeForTypeReference(typeDeclaration.shape.aliasOf);
+            }
+        }
+        return this.sdkGeneratorContext.getSwiftTypeReferenceFromScope(typeReference, this.symbol);
     }
 
     private generateMethods(): swift.Method[] {

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.27.0
+  changelogEntry:
+    - type: feat
+      summary: |
+        Add global headers as named parameters on the client constructor.
+  createdAt: "2026-02-18"
+  irVersion: 61
+
 - version: 0.26.0
   changelogEntry:
     - type: feat

--- a/seed/swift-sdk/trace/Sources/TraceClient.swift
+++ b/seed/swift-sdk/trace/Sources/TraceClient.swift
@@ -25,11 +25,16 @@ public final class TraceClient: Sendable {
     public convenience init(
         baseURL: String = TraceEnvironment.prod.rawValue,
         token: String? = nil,
+        xRandomHeader: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: Networking.URLSession? = nil
     ) {
+        var mergedHeaders = headers ?? [:]
+        if let xRandomHeader = xRandomHeader {
+            mergedHeaders["X-Random-Header"] = xRandomHeader
+        }
         self.init(
             baseURL: baseURL,
             headerAuth: nil,
@@ -37,7 +42,7 @@ public final class TraceClient: Sendable {
                 .init(token: .staticToken($0))
             },
             basicAuth: nil,
-            headers: headers,
+            headers: mergedHeaders,
             timeout: timeout,
             maxRetries: maxRetries,
             urlSession: urlSession
@@ -55,11 +60,16 @@ public final class TraceClient: Sendable {
     public convenience init(
         baseURL: String = TraceEnvironment.prod.rawValue,
         token: ClientConfig.CredentialProvider? = nil,
+        xRandomHeader: String? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
         urlSession: Networking.URLSession? = nil
     ) {
+        var mergedHeaders = headers ?? [:]
+        if let xRandomHeader = xRandomHeader {
+            mergedHeaders["X-Random-Header"] = xRandomHeader
+        }
         self.init(
             baseURL: baseURL,
             headerAuth: nil,
@@ -67,7 +77,7 @@ public final class TraceClient: Sendable {
                 .init(token: .provider($0))
             },
             basicAuth: nil,
-            headers: headers,
+            headers: mergedHeaders,
             timeout: timeout,
             maxRetries: maxRetries,
             urlSession: urlSession


### PR DESCRIPTION
## Description

Refs: Requested by @tstanmay13
Link to Devin run: https://app.devin.ai/sessions/e21d2ba3895d4ca7828531f29f790426

The Swift SDK generator did not add global headers (defined via `x-fern-global-headers` / `IR.headers`) as named parameters on the client constructor. PR #12143 only addressed service-level headers on endpoint methods. This PR adds global headers to the root client constructor, matching the behavior of the TypeScript and Python generators.

## Changes Made

- Added `getGlobalHeaderParameters()` method that reads `ir.headers`, filters out literal types and non-String-resolvable types, and creates named function parameters for each global header
- Added `isLiteralTypeReference()` helper to safely detect and skip literal type headers (e.g., `literal<"1.0.0">`) before attempting type resolution — prevents crashes in the name registry
- Added `getResolvedSwiftTypeForTypeReference()` helper that follows type aliases to resolve the underlying type
- Modified `getConvenienceInitializerParams()` to include global header parameters (inserted after auth params, before the generic `headers` dict param)
- Modified `generateConvenienceInitializer()` to merge global header values into a `mergedHeaders` dictionary when global headers are present, with `if let` unwrapping for optional headers
- Updated `trace` seed fixture snapshot (new `xRandomHeader: String?` parameter on both convenience initializers)
- Bumped version to `0.27.0` in `versions.yml`

## Testing

- [x] Seed tests run locally — all 113 Swift SDK fixtures generate successfully (build failures are expected: no Swift compiler on CI runner)
- [x] `trace` fixture snapshot updated and included in diff
- [x] `bearer-token-environment-variable` fixture (literal header `X-API-Version: literal<"1.0.0">`) generates without crashing after literal-filter fix
- [x] `literal` fixture has a pre-existing generation failure (unrelated name registry issue with nested literal enums)

## Human Review Checklist

> **⚠️ Literal headers are skipped, not hardcoded:** Literal-typed global headers (e.g., `literal<"1.0.0">`, `literal<true>`) are filtered out entirely. TypeScript/Python generators handle these by automatically injecting the literal value. Confirm this is acceptable for Swift or if literal headers should be hardcoded into the headers dict.

> **⚠️ Designated initializer unchanged:** Only the convenience initializer is modified. The designated initializer receives the already-merged `headers` dict — this is intentional, but verify there's no code path where global headers bypass the convenience init.

> **⚠️ `nullable` container not checked in `isLiteralTypeReference`:** The helper checks `optional` wrappers around literals but does not check `nullable`. If a global header has type `nullable<literal<...>>`, it would not be filtered and could crash. Verify whether this case exists in practice.