### PR TITLE
fix(php): various tweaks for phpstan compliance

### DIFF
--- a/generators/php/base/src/asIs/Client/RetryDecoratingClient.Template.php
+++ b/generators/php/base/src/asIs/Client/RetryDecoratingClient.Template.php
@@ -116,7 +116,9 @@ class RetryDecoratingClient implements ClientInterface
         if (class_exists('Symfony\Component\HttpClient\Psr18Client')
             && $this->client instanceof \Symfony\Component\HttpClient\Psr18Client
         ) {
-            return $this->client->withOptions(['timeout' => $timeout])->sendRequest($request);
+            /** @var ClientInterface $clientWithTimeout */
+            $clientWithTimeout = $this->client->withOptions(['timeout' => $timeout]);
+            return $clientWithTimeout->sendRequest($request);
         }
 
         if ($warned) {

--- a/generators/php/base/src/asIs/Json/JsonDeserializer.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonDeserializer.Template.php
@@ -45,9 +45,9 @@ class JsonDeserializer
     /**
      * Deserializes an array based on type annotations (either a list or a map).
      *
-     * @param mixed[]|array<string, mixed> $data The array to be deserialized.
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
-     * @return mixed[]|array<string, mixed> The deserialized array.
+     * @param array<mixed> $data The array to be deserialized.
+     * @param array<mixed> $type The type definition from the annotation.
+     * @return array<mixed> The deserialized array.
      * @throws JsonException If deserialization fails.
      */
     public static function deserializeArray(array $data, array $type): array
@@ -134,6 +134,7 @@ class JsonDeserializer
         }
 
         if (class_exists($type) && is_array($data)) {
+            /** @var array<string, mixed> $data */
             return self::deserializeObject($data, $type);
         }
 
@@ -171,19 +172,24 @@ class JsonDeserializer
     /**
      * Deserializes a map (associative array) with defined key and value types.
      *
-     * @param array<string, mixed> $data The associative array to deserialize.
-     * @param array<string, mixed> $type The type definition for the map.
+     * @param array<mixed> $data The associative array to deserialize.
+     * @param array<mixed> $type The type definition for the map.
      * @return array<string, mixed> The deserialized map.
      * @throws JsonException If deserialization fails.
      */
     private static function deserializeMap(array $data, array $type): array
     {
         $keyType = array_key_first($type);
+        if ($keyType === null) {
+            throw new JsonException("Unexpected no key in ArrayType.");
+        }
+        $keyType = (string) $keyType;
         $valueType = $type[$keyType];
+        /** @var array<string, mixed> $result */
         $result = [];
 
         foreach ($data as $key => $item) {
-            $key = Utils::castKey($key, (string)$keyType);
+            $key = (string) Utils::castKey($key, $keyType);
             $result[$key] = self::deserializeValue($item, $valueType);
         }
 
@@ -193,14 +199,15 @@ class JsonDeserializer
     /**
      * Deserializes a list (indexed array) with a defined value type.
      *
-     * @param array<int, mixed> $data The list to deserialize.
-     * @param array<int, mixed> $type The type definition for the list.
+     * @param array<mixed> $data The list to deserialize.
+     * @param array<mixed> $type The type definition for the list.
      * @return array<int, mixed> The deserialized list.
      * @throws JsonException If deserialization fails.
      */
     private static function deserializeList(array $data, array $type): array
     {
         $valueType = $type[0];
+        /** @var array<int, mixed> */
         return array_map(fn ($item) => self::deserializeValue($item, $valueType), $data);
     }
 }

--- a/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
@@ -105,6 +105,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         if (!is_array($decodedJson)) {
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 
@@ -169,7 +170,9 @@ abstract class JsonSerializableType implements \JsonSerializable
             // Handle object
             $type = $property->getType();
             if (is_array($value) && $type instanceof ReflectionNamedType && !$type->isBuiltin()) {
-                $value = JsonDeserializer::deserializeObject($value, $type->getName());
+                /** @var array<string, mixed> $arrayValue */
+                $arrayValue = $value;
+                $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             }
 
             $args[$property->getName()] = $value;

--- a/generators/php/base/src/asIs/Json/JsonSerializer.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializer.Template.php
@@ -41,9 +41,9 @@ class JsonSerializer
     /**
      * Serializes an array based on type annotations (either a list or map).
      *
-     * @param mixed[]|array<string, mixed> $data The array to be serialized.
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
-     * @return mixed[]|array<string, mixed> The serialized array.
+     * @param array<mixed> $data The array to be serialized.
+     * @param array<mixed> $type The type definition from the annotation.
+     * @return array<mixed> The serialized array.
      * @throws JsonException If serialization fails.
      */
     public static function serializeArray(array $data, array $type): array
@@ -159,8 +159,8 @@ class JsonSerializer
     /**
      * Serializes a map (associative array) with defined key and value types.
      *
-     * @param array<string, mixed> $data The associative array to serialize.
-     * @param array<string, mixed> $type The type definition for the map.
+     * @param array<mixed> $data The associative array to serialize.
+     * @param array<mixed> $type The type definition for the map.
      * @return array<string, mixed> The serialized map.
      * @throws JsonException If serialization fails.
      */
@@ -170,11 +170,13 @@ class JsonSerializer
         if ($keyType === null) {
             throw new JsonException("Unexpected no key in ArrayType.");
         }
+        $keyType = (string) $keyType;
         $valueType = $type[$keyType];
+        /** @var array<string, mixed> $result */
         $result = [];
 
         foreach ($data as $key => $item) {
-            $key = Utils::castKey($key, $keyType);
+            $key = (string) Utils::castKey($key, $keyType);
             $result[$key] = self::serializeValue($item, $valueType);
         }
 
@@ -184,14 +186,15 @@ class JsonSerializer
     /**
      * Serializes a list (indexed array) where only the value type is defined.
      *
-     * @param array<int, mixed> $data The list to serialize.
-     * @param array<int, mixed> $type The type definition for the list.
+     * @param array<mixed> $data The list to serialize.
+     * @param array<mixed> $type The type definition for the list.
      * @return array<int, mixed> The serialized list.
      * @throws JsonException If serialization fails.
      */
     private static function serializeList(array $data, array $type): array
     {
         $valueType = $type[0];
+        /** @var array<int, mixed> */
         return array_map(fn ($item) => self::serializeValue($item, $valueType), $data);
     }
 }

--- a/generators/php/base/src/asIs/Json/Utils.Template.php
+++ b/generators/php/base/src/asIs/Json/Utils.Template.php
@@ -11,7 +11,7 @@ class Utils
     /**
      * Determines if the given type represents a map.
      *
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
+     * @param array<mixed> $type The type definition from the annotation.
      * @return bool True if the type is a map, false if it's a list.
      */
     public static function isMapType(array $type): bool
@@ -24,19 +24,20 @@ class Utils
      *
      * @param mixed $key The key to be cast.
      * @param string $keyType The type to cast the key to ('string', 'integer', 'float').
-     * @return mixed The casted key.
+     * @return int|string The casted key.
      * @throws JsonException
      */
-    public static function castKey(mixed $key, string $keyType): mixed
+    public static function castKey(mixed $key, string $keyType): int|string
     {
         if (!is_scalar($key)) {
             throw new JsonException("Key must be a scalar type.");
         }
         return match ($keyType) {
             'integer' => (int)$key,
-            'float' => (float)$key,
+            // PHP arrays don't support float keys; truncate to int
+            'float' => (int)$key,
             'string' => (string)$key,
-            default => $key,
+            default => is_int($key) ? $key : (string)$key,
         };
     }
 

--- a/generators/php/base/src/asIs/Pagination/CursorPager.Template.php
+++ b/generators/php/base/src/asIs/Pagination/CursorPager.Template.php
@@ -5,7 +5,7 @@ namespace <%= namespace%>;
 use Generator;
 
 /**
- * @template TRequest
+ * @template TRequest of object
  * @template TResponse
  * @template TItem
  * @template TCursor

--- a/generators/php/base/src/asIs/Pagination/CursorPagerTest/CursorPagerTest.Template.php
+++ b/generators/php/base/src/asIs/Pagination/CursorPagerTest/CursorPagerTest.Template.php
@@ -127,6 +127,6 @@ class CursorPagerTest extends TestCase
 
         // no more pages
         $pages->next();
-        $this->assertNull($pages->current());
+        $this->assertFalse($pages->valid());
     }
 }

--- a/generators/php/base/src/asIs/Pagination/HasNextPageOffsetPagerTest/HasNextPageOffsetPagerTest.Template.php
+++ b/generators/php/base/src/asIs/Pagination/HasNextPageOffsetPagerTest/HasNextPageOffsetPagerTest.Template.php
@@ -81,7 +81,7 @@ class HasNextPageOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn(Request $request) => $request->pagination?->page ?? 0,
+            fn(Request $request) => $request->pagination->page ?? 0,
             function (Request $request, int $offset) {
                 if($request->pagination === null) {
                     $request->pagination = new Pagination(0);

--- a/generators/php/base/src/asIs/Pagination/IntOffsetPagerTest/IntOffsetPagerTest.Template.php
+++ b/generators/php/base/src/asIs/Pagination/IntOffsetPagerTest/IntOffsetPagerTest.Template.php
@@ -79,7 +79,7 @@ class IntOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn(Request $request) => $request->pagination?->page ?? 0,
+            fn(Request $request) => $request->pagination->page ?? 0,
             function (Request $request, int $offset) {
                 if ($request->pagination === null) {
                     $request->pagination = new Pagination(0);

--- a/generators/php/base/src/asIs/Pagination/OffsetPager.Template.php
+++ b/generators/php/base/src/asIs/Pagination/OffsetPager.Template.php
@@ -5,7 +5,7 @@ namespace <%= namespace%>;
 use Generator;
 
 /**
- * @template TRequest
+ * @template TRequest of object
  * @template TResponse
  * @template TItem
  * @extends Pager<TItem>

--- a/generators/php/base/src/asIs/Pagination/StepOffsetPagerTest/StepOffsetPagerTest.Template.php
+++ b/generators/php/base/src/asIs/Pagination/StepOffsetPagerTest/StepOffsetPagerTest.Template.php
@@ -85,7 +85,7 @@ class StepOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn(Request $request) => $request->pagination?->itemOffset ?? 0,
+            fn(Request $request) => $request->pagination->itemOffset ?? 0,
             function (Request $request, int $offset) {
                 if ($request->pagination === null) {
                     $request->pagination = new Pagination(0, 2);
@@ -126,6 +126,6 @@ class StepOffsetPagerTest extends TestCase
 
         // no more pages
         $pages->next();
-        $this->assertNull($pages->current());
+        $this->assertFalse($pages->valid());
     }
 }

--- a/generators/php/sdk/src/error/BaseApiExceptionGenerator.ts
+++ b/generators/php/sdk/src/error/BaseApiExceptionGenerator.ts
@@ -71,10 +71,10 @@ export class BaseApiExceptionGenerator extends FileGenerator<PhpFile, SdkCustomC
             return_: php.Type.string(),
             body: php.codeblock((writer) => {
                 writer.controlFlow("if", php.codeblock("empty($this->body)"));
-                writer.writeTextStatement('return "$this->message; Status Code: $this->code\\n"');
+                writer.writeTextStatement("return $this->message . '; Status Code: ' . $this->getCode() . \"\\n\"");
                 writer.endControlFlow();
                 writer.writeTextStatement(
-                    'return "$this->message; Status Code: $this->code; Body: " . $this->body . "\\n"'
+                    "return $this->message . '; Status Code: ' . $this->getCode() . '; Body: ' . print_r($this->body, true) . \"\\n\""
                 );
             })
         });

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.1
+  changelogEntry:
+    - summary: |
+        Fix PHPStan static analysis errors in core runtime classes. Tightens return types
+        (e.g., `castKey` now returns `int|string` instead of `mixed`), adds missing null checks,
+        and improves PHPDoc annotations across JsonSerializer, JsonDeserializer, and Utils.
+        Also fixes `BaseApiException::__toString()` to use `getCode()` instead of direct property
+        access and `print_r()` for non-scalar body values.
+      type: fix
+    - summary: |
+        Add `of object` bound to pagination template generics (`CursorPager`, `OffsetPager`)
+        to satisfy PHPStan's requirement for `clone` on object types.
+      type: fix
+  createdAt: "2026-02-18"
+  irVersion: 62
+
 - version: 2.1.0
   changelogEntry:
     - summary: |

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Client/RetryDecoratingClient.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Client/RetryDecoratingClient.php
@@ -116,7 +116,9 @@ class RetryDecoratingClient implements ClientInterface
         if (class_exists('Symfony\Component\HttpClient\Psr18Client')
             && $this->client instanceof \Symfony\Component\HttpClient\Psr18Client
         ) {
-            return $this->client->withOptions(['timeout' => $timeout])->sendRequest($request);
+            /** @var ClientInterface $clientWithTimeout */
+            $clientWithTimeout = $this->client->withOptions(['timeout' => $timeout]);
+            return $clientWithTimeout->sendRequest($request);
         }
 
         if ($warned) {

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonDeserializer.php
@@ -45,9 +45,9 @@ class JsonDeserializer
     /**
      * Deserializes an array based on type annotations (either a list or a map).
      *
-     * @param mixed[]|array<string, mixed> $data The array to be deserialized.
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
-     * @return mixed[]|array<string, mixed> The deserialized array.
+     * @param array<mixed> $data The array to be deserialized.
+     * @param array<mixed> $type The type definition from the annotation.
+     * @return array<mixed> The deserialized array.
      * @throws JsonException If deserialization fails.
      */
     public static function deserializeArray(array $data, array $type): array
@@ -134,6 +134,7 @@ class JsonDeserializer
         }
 
         if (class_exists($type) && is_array($data)) {
+            /** @var array<string, mixed> $data */
             return self::deserializeObject($data, $type);
         }
 
@@ -171,19 +172,24 @@ class JsonDeserializer
     /**
      * Deserializes a map (associative array) with defined key and value types.
      *
-     * @param array<string, mixed> $data The associative array to deserialize.
-     * @param array<string, mixed> $type The type definition for the map.
+     * @param array<mixed> $data The associative array to deserialize.
+     * @param array<mixed> $type The type definition for the map.
      * @return array<string, mixed> The deserialized map.
      * @throws JsonException If deserialization fails.
      */
     private static function deserializeMap(array $data, array $type): array
     {
         $keyType = array_key_first($type);
+        if ($keyType === null) {
+            throw new JsonException("Unexpected no key in ArrayType.");
+        }
+        $keyType = (string) $keyType;
         $valueType = $type[$keyType];
+        /** @var array<string, mixed> $result */
         $result = [];
 
         foreach ($data as $key => $item) {
-            $key = Utils::castKey($key, (string)$keyType);
+            $key = (string) Utils::castKey($key, $keyType);
             $result[$key] = self::deserializeValue($item, $valueType);
         }
 
@@ -193,14 +199,15 @@ class JsonDeserializer
     /**
      * Deserializes a list (indexed array) with a defined value type.
      *
-     * @param array<int, mixed> $data The list to deserialize.
-     * @param array<int, mixed> $type The type definition for the list.
+     * @param array<mixed> $data The list to deserialize.
+     * @param array<mixed> $type The type definition for the list.
      * @return array<int, mixed> The deserialized list.
      * @throws JsonException If deserialization fails.
      */
     private static function deserializeList(array $data, array $type): array
     {
         $valueType = $type[0];
+        /** @var array<int, mixed> */
         return array_map(fn ($item) => self::deserializeValue($item, $valueType), $data);
     }
 }

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -105,6 +105,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         if (!is_array($decodedJson)) {
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 
@@ -169,7 +170,9 @@ abstract class JsonSerializableType implements \JsonSerializable
             // Handle object
             $type = $property->getType();
             if (is_array($value) && $type instanceof ReflectionNamedType && !$type->isBuiltin()) {
-                $value = JsonDeserializer::deserializeObject($value, $type->getName());
+                /** @var array<string, mixed> $arrayValue */
+                $arrayValue = $value;
+                $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializer.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializer.php
@@ -41,9 +41,9 @@ class JsonSerializer
     /**
      * Serializes an array based on type annotations (either a list or map).
      *
-     * @param mixed[]|array<string, mixed> $data The array to be serialized.
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
-     * @return mixed[]|array<string, mixed> The serialized array.
+     * @param array<mixed> $data The array to be serialized.
+     * @param array<mixed> $type The type definition from the annotation.
+     * @return array<mixed> The serialized array.
      * @throws JsonException If serialization fails.
      */
     public static function serializeArray(array $data, array $type): array
@@ -159,8 +159,8 @@ class JsonSerializer
     /**
      * Serializes a map (associative array) with defined key and value types.
      *
-     * @param array<string, mixed> $data The associative array to serialize.
-     * @param array<string, mixed> $type The type definition for the map.
+     * @param array<mixed> $data The associative array to serialize.
+     * @param array<mixed> $type The type definition for the map.
      * @return array<string, mixed> The serialized map.
      * @throws JsonException If serialization fails.
      */
@@ -170,11 +170,13 @@ class JsonSerializer
         if ($keyType === null) {
             throw new JsonException("Unexpected no key in ArrayType.");
         }
+        $keyType = (string) $keyType;
         $valueType = $type[$keyType];
+        /** @var array<string, mixed> $result */
         $result = [];
 
         foreach ($data as $key => $item) {
-            $key = Utils::castKey($key, $keyType);
+            $key = (string) Utils::castKey($key, $keyType);
             $result[$key] = self::serializeValue($item, $valueType);
         }
 
@@ -184,14 +186,15 @@ class JsonSerializer
     /**
      * Serializes a list (indexed array) where only the value type is defined.
      *
-     * @param array<int, mixed> $data The list to serialize.
-     * @param array<int, mixed> $type The type definition for the list.
+     * @param array<mixed> $data The list to serialize.
+     * @param array<mixed> $type The type definition for the list.
      * @return array<int, mixed> The serialized list.
      * @throws JsonException If serialization fails.
      */
     private static function serializeList(array $data, array $type): array
     {
         $valueType = $type[0];
+        /** @var array<int, mixed> */
         return array_map(fn ($item) => self::serializeValue($item, $valueType), $data);
     }
 }

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/Utils.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/Utils.php
@@ -11,7 +11,7 @@ class Utils
     /**
      * Determines if the given type represents a map.
      *
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
+     * @param array<mixed> $type The type definition from the annotation.
      * @return bool True if the type is a map, false if it's a list.
      */
     public static function isMapType(array $type): bool
@@ -24,19 +24,20 @@ class Utils
      *
      * @param mixed $key The key to be cast.
      * @param string $keyType The type to cast the key to ('string', 'integer', 'float').
-     * @return mixed The casted key.
+     * @return int|string The casted key.
      * @throws JsonException
      */
-    public static function castKey(mixed $key, string $keyType): mixed
+    public static function castKey(mixed $key, string $keyType): int|string
     {
         if (!is_scalar($key)) {
             throw new JsonException("Key must be a scalar type.");
         }
         return match ($keyType) {
             'integer' => (int)$key,
-            'float' => (float)$key,
+            // PHP arrays don't support float keys; truncate to int
+            'float' => (int)$key,
             'string' => (string)$key,
-            default => $key,
+            default => is_int($key) ? $key : (string)$key,
         };
     }
 

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Pagination/CursorPager.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Pagination/CursorPager.php
@@ -5,7 +5,7 @@ namespace Seed\Core\Pagination;
 use Generator;
 
 /**
- * @template TRequest
+ * @template TRequest of object
  * @template TResponse
  * @template TItem
  * @template TCursor

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Pagination/OffsetPager.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Pagination/OffsetPager.php
@@ -5,7 +5,7 @@ namespace Seed\Core\Pagination;
 use Generator;
 
 /**
- * @template TRequest
+ * @template TRequest of object
  * @template TResponse
  * @template TItem
  * @extends Pager<TItem>

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Exceptions/SeedApiException.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Exceptions/SeedApiException.php
@@ -46,8 +46,8 @@ class SeedApiException extends SeedException
     public function __toString(): string
     {
         if (empty($this->body)) {
-            return "$this->message; Status Code: $this->code\n";
+            return $this->message . '; Status Code: ' . $this->getCode() . "\n";
         }
-        return "$this->message; Status Code: $this->code; Body: " . $this->body . "\n";
+        return $this->message . '; Status Code: ' . $this->getCode() . '; Body: ' . print_r($this->body, true) . "\n";
     }
 }

--- a/seed/php-sdk/exhaustive/no-custom-config/tests/Core/Pagination/CursorPagerTest/CursorPagerTest.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/tests/Core/Pagination/CursorPagerTest/CursorPagerTest.php
@@ -127,6 +127,6 @@ class CursorPagerTest extends TestCase
 
         // no more pages
         $pages->next();
-        $this->assertNull($pages->current());
+        $this->assertFalse($pages->valid());
     }
 }

--- a/seed/php-sdk/exhaustive/no-custom-config/tests/Core/Pagination/HasNextPageOffsetPagerTest/HasNextPageOffsetPagerTest.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/tests/Core/Pagination/HasNextPageOffsetPagerTest/HasNextPageOffsetPagerTest.php
@@ -81,7 +81,7 @@ class HasNextPageOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn (Request $request) => $request->pagination?->page ?? 0,
+            fn (Request $request) => $request->pagination->page ?? 0,
             function (Request $request, int $offset) {
                 if ($request->pagination === null) {
                     $request->pagination = new Pagination(0);

--- a/seed/php-sdk/exhaustive/no-custom-config/tests/Core/Pagination/IntOffsetPagerTest/IntOffsetPagerTest.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/tests/Core/Pagination/IntOffsetPagerTest/IntOffsetPagerTest.php
@@ -79,7 +79,7 @@ class IntOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn (Request $request) => $request->pagination?->page ?? 0,
+            fn (Request $request) => $request->pagination->page ?? 0,
             function (Request $request, int $offset) {
                 if ($request->pagination === null) {
                     $request->pagination = new Pagination(0);

--- a/seed/php-sdk/exhaustive/no-custom-config/tests/Core/Pagination/StepOffsetPagerTest/StepOffsetPagerTest.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/tests/Core/Pagination/StepOffsetPagerTest/StepOffsetPagerTest.php
@@ -85,7 +85,7 @@ class StepOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn (Request $request) => $request->pagination?->itemOffset ?? 0,
+            fn (Request $request) => $request->pagination->itemOffset ?? 0,
             function (Request $request, int $offset) {
                 if ($request->pagination === null) {
                     $request->pagination = new Pagination(0, 2);
@@ -126,6 +126,6 @@ class StepOffsetPagerTest extends TestCase
 
         // no more pages
         $pages->next();
-        $this->assertNull($pages->current());
+        $this->assertFalse($pages->valid());
     }
 }

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Client/RetryDecoratingClient.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Client/RetryDecoratingClient.php
@@ -116,7 +116,9 @@ class RetryDecoratingClient implements ClientInterface
         if (class_exists('Symfony\Component\HttpClient\Psr18Client')
             && $this->client instanceof \Symfony\Component\HttpClient\Psr18Client
         ) {
-            return $this->client->withOptions(['timeout' => $timeout])->sendRequest($request);
+            /** @var ClientInterface $clientWithTimeout */
+            $clientWithTimeout = $this->client->withOptions(['timeout' => $timeout]);
+            return $clientWithTimeout->sendRequest($request);
         }
 
         if ($warned) {

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonDeserializer.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonDeserializer.php
@@ -45,9 +45,9 @@ class JsonDeserializer
     /**
      * Deserializes an array based on type annotations (either a list or a map).
      *
-     * @param mixed[]|array<string, mixed> $data The array to be deserialized.
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
-     * @return mixed[]|array<string, mixed> The deserialized array.
+     * @param array<mixed> $data The array to be deserialized.
+     * @param array<mixed> $type The type definition from the annotation.
+     * @return array<mixed> The deserialized array.
      * @throws JsonException If deserialization fails.
      */
     public static function deserializeArray(array $data, array $type): array
@@ -134,6 +134,7 @@ class JsonDeserializer
         }
 
         if (class_exists($type) && is_array($data)) {
+            /** @var array<string, mixed> $data */
             return self::deserializeObject($data, $type);
         }
 
@@ -171,19 +172,24 @@ class JsonDeserializer
     /**
      * Deserializes a map (associative array) with defined key and value types.
      *
-     * @param array<string, mixed> $data The associative array to deserialize.
-     * @param array<string, mixed> $type The type definition for the map.
+     * @param array<mixed> $data The associative array to deserialize.
+     * @param array<mixed> $type The type definition for the map.
      * @return array<string, mixed> The deserialized map.
      * @throws JsonException If deserialization fails.
      */
     private static function deserializeMap(array $data, array $type): array
     {
         $keyType = array_key_first($type);
+        if ($keyType === null) {
+            throw new JsonException("Unexpected no key in ArrayType.");
+        }
+        $keyType = (string) $keyType;
         $valueType = $type[$keyType];
+        /** @var array<string, mixed> $result */
         $result = [];
 
         foreach ($data as $key => $item) {
-            $key = Utils::castKey($key, (string)$keyType);
+            $key = (string) Utils::castKey($key, $keyType);
             $result[$key] = self::deserializeValue($item, $valueType);
         }
 
@@ -193,14 +199,15 @@ class JsonDeserializer
     /**
      * Deserializes a list (indexed array) with a defined value type.
      *
-     * @param array<int, mixed> $data The list to deserialize.
-     * @param array<int, mixed> $type The type definition for the list.
+     * @param array<mixed> $data The list to deserialize.
+     * @param array<mixed> $type The type definition for the list.
      * @return array<int, mixed> The deserialized list.
      * @throws JsonException If deserialization fails.
      */
     private static function deserializeList(array $data, array $type): array
     {
         $valueType = $type[0];
+        /** @var array<int, mixed> */
         return array_map(fn ($item) => self::deserializeValue($item, $valueType), $data);
     }
 }

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -105,6 +105,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         if (!is_array($decodedJson)) {
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 
@@ -169,7 +170,9 @@ abstract class JsonSerializableType implements \JsonSerializable
             // Handle object
             $type = $property->getType();
             if (is_array($value) && $type instanceof ReflectionNamedType && !$type->isBuiltin()) {
-                $value = JsonDeserializer::deserializeObject($value, $type->getName());
+                /** @var array<string, mixed> $arrayValue */
+                $arrayValue = $value;
+                $value = JsonDeserializer::deserializeObject($arrayValue, $type->getName());
             }
 
             $args[$property->getName()] = $value;

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializer.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializer.php
@@ -41,9 +41,9 @@ class JsonSerializer
     /**
      * Serializes an array based on type annotations (either a list or map).
      *
-     * @param mixed[]|array<string, mixed> $data The array to be serialized.
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
-     * @return mixed[]|array<string, mixed> The serialized array.
+     * @param array<mixed> $data The array to be serialized.
+     * @param array<mixed> $type The type definition from the annotation.
+     * @return array<mixed> The serialized array.
      * @throws JsonException If serialization fails.
      */
     public static function serializeArray(array $data, array $type): array
@@ -159,8 +159,8 @@ class JsonSerializer
     /**
      * Serializes a map (associative array) with defined key and value types.
      *
-     * @param array<string, mixed> $data The associative array to serialize.
-     * @param array<string, mixed> $type The type definition for the map.
+     * @param array<mixed> $data The associative array to serialize.
+     * @param array<mixed> $type The type definition for the map.
      * @return array<string, mixed> The serialized map.
      * @throws JsonException If serialization fails.
      */
@@ -170,11 +170,13 @@ class JsonSerializer
         if ($keyType === null) {
             throw new JsonException("Unexpected no key in ArrayType.");
         }
+        $keyType = (string) $keyType;
         $valueType = $type[$keyType];
+        /** @var array<string, mixed> $result */
         $result = [];
 
         foreach ($data as $key => $item) {
-            $key = Utils::castKey($key, $keyType);
+            $key = (string) Utils::castKey($key, $keyType);
             $result[$key] = self::serializeValue($item, $valueType);
         }
 
@@ -184,14 +186,15 @@ class JsonSerializer
     /**
      * Serializes a list (indexed array) where only the value type is defined.
      *
-     * @param array<int, mixed> $data The list to serialize.
-     * @param array<int, mixed> $type The type definition for the list.
+     * @param array<mixed> $data The list to serialize.
+     * @param array<mixed> $type The type definition for the list.
      * @return array<int, mixed> The serialized list.
      * @throws JsonException If serialization fails.
      */
     private static function serializeList(array $data, array $type): array
     {
         $valueType = $type[0];
+        /** @var array<int, mixed> */
         return array_map(fn ($item) => self::serializeValue($item, $valueType), $data);
     }
 }

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/Utils.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/Utils.php
@@ -11,7 +11,7 @@ class Utils
     /**
      * Determines if the given type represents a map.
      *
-     * @param mixed[]|array<string, mixed> $type The type definition from the annotation.
+     * @param array<mixed> $type The type definition from the annotation.
      * @return bool True if the type is a map, false if it's a list.
      */
     public static function isMapType(array $type): bool
@@ -24,19 +24,20 @@ class Utils
      *
      * @param mixed $key The key to be cast.
      * @param string $keyType The type to cast the key to ('string', 'integer', 'float').
-     * @return mixed The casted key.
+     * @return int|string The casted key.
      * @throws JsonException
      */
-    public static function castKey(mixed $key, string $keyType): mixed
+    public static function castKey(mixed $key, string $keyType): int|string
     {
         if (!is_scalar($key)) {
             throw new JsonException("Key must be a scalar type.");
         }
         return match ($keyType) {
             'integer' => (int)$key,
-            'float' => (float)$key,
+            // PHP arrays don't support float keys; truncate to int
+            'float' => (int)$key,
             'string' => (string)$key,
-            default => $key,
+            default => is_int($key) ? $key : (string)$key,
         };
     }
 

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Pagination/CursorPager.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Pagination/CursorPager.php
@@ -5,7 +5,7 @@ namespace Seed\Core\Pagination;
 use Generator;
 
 /**
- * @template TRequest
+ * @template TRequest of object
  * @template TResponse
  * @template TItem
  * @template TCursor

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Pagination/OffsetPager.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Pagination/OffsetPager.php
@@ -5,7 +5,7 @@ namespace Seed\Core\Pagination;
 use Generator;
 
 /**
- * @template TRequest
+ * @template TRequest of object
  * @template TResponse
  * @template TItem
  * @extends Pager<TItem>

--- a/seed/php-sdk/exhaustive/wire-tests/src/Exceptions/SeedApiException.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Exceptions/SeedApiException.php
@@ -46,8 +46,8 @@ class SeedApiException extends SeedException
     public function __toString(): string
     {
         if (empty($this->body)) {
-            return "$this->message; Status Code: $this->code\n";
+            return $this->message . '; Status Code: ' . $this->getCode() . "\n";
         }
-        return "$this->message; Status Code: $this->code; Body: " . $this->body . "\n";
+        return $this->message . '; Status Code: ' . $this->getCode() . '; Body: ' . print_r($this->body, true) . "\n";
     }
 }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Core/Pagination/CursorPagerTest/CursorPagerTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Core/Pagination/CursorPagerTest/CursorPagerTest.php
@@ -127,6 +127,6 @@ class CursorPagerTest extends TestCase
 
         // no more pages
         $pages->next();
-        $this->assertNull($pages->current());
+        $this->assertFalse($pages->valid());
     }
 }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Core/Pagination/HasNextPageOffsetPagerTest/HasNextPageOffsetPagerTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Core/Pagination/HasNextPageOffsetPagerTest/HasNextPageOffsetPagerTest.php
@@ -81,7 +81,7 @@ class HasNextPageOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn (Request $request) => $request->pagination?->page ?? 0,
+            fn (Request $request) => $request->pagination->page ?? 0,
             function (Request $request, int $offset) {
                 if ($request->pagination === null) {
                     $request->pagination = new Pagination(0);

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Core/Pagination/IntOffsetPagerTest/IntOffsetPagerTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Core/Pagination/IntOffsetPagerTest/IntOffsetPagerTest.php
@@ -79,7 +79,7 @@ class IntOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn (Request $request) => $request->pagination?->page ?? 0,
+            fn (Request $request) => $request->pagination->page ?? 0,
             function (Request $request, int $offset) {
                 if ($request->pagination === null) {
                     $request->pagination = new Pagination(0);

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Core/Pagination/StepOffsetPagerTest/StepOffsetPagerTest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Core/Pagination/StepOffsetPagerTest/StepOffsetPagerTest.php
@@ -85,7 +85,7 @@ class StepOffsetPagerTest extends TestCase
                 $responses->next();
                 return $response;
             },
-            fn (Request $request) => $request->pagination?->itemOffset ?? 0,
+            fn (Request $request) => $request->pagination->itemOffset ?? 0,
             function (Request $request, int $offset) {
                 if ($request->pagination === null) {
                     $request->pagination = new Pagination(0, 2);
@@ -126,6 +126,6 @@ class StepOffsetPagerTest extends TestCase
 
         // no more pages
         $pages->next();
-        $this->assertNull($pages->current());
+        $this->assertFalse($pages->valid());
     }
 }


### PR DESCRIPTION
## Description
Some tweaks for PHPStan compliance:
```
- Narrowed return types and PHPDoc annotations to match PHP's actual type semantics (e.g., `castKey`
  returns `int|string` instead of `mixed`, `array<mixed>` instead of `mixed[]|array<string, mixed>`)
- Added `@var` inline type hints throughout serialization/deserialization to satisfy PHPStan where it can't
   infer types from runtime checks
- Fixed `BaseApiException::__toString` to use `getCode()` getter and `print_r()` for non-scalar body values
- Added `of object` bound to pagination template generics (required for `clone`)
- Cleaned up redundant null-safety operators (`?->` alongside `??`) and used idiomatic generator-exhaustion
   assertions in pagination tests
```

## Changes Made
PHP generator tweaks!

## Testing
Now gives 0 errors on generated Auth0 SDK; includes seed example.
- [X] Unit tests added/updated
- [X] Manual testing completed
