### PR TITLE
feat(java): add `additionalProperty` methods to builders

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
@@ -148,6 +148,15 @@ public final class BuilderGenerator {
                     .addAnnotation(JsonAnySetter.class)
                     .initializer("new $T<>()", HashMap.class)
                     .build());
+            builderImplTypeSpec.addMethod(MethodSpec.methodBuilder(getAdditionalPropertyMethodName())
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(nestedBuilderClassName)
+                    .addAnnotation(ClassName.get("", "java.lang.Override"))
+                    .addParameter(String.class, "key")
+                    .addParameter(Object.class, "value")
+                    .addStatement("this.$L.put(key, value)", additionalPropertiesFieldName)
+                    .addStatement("return this")
+                    .build());
         }
 
         List<PoetTypeWithClassName> stagedBuilderTypes = new ArrayList<>();
@@ -229,6 +238,14 @@ public final class BuilderGenerator {
                     .addModifiers(Modifier.PRIVATE)
                     .addAnnotation(JsonAnySetter.class)
                     .initializer("new $T<>()", HashMap.class)
+                    .build());
+            builderImplTypeSpec.addMethod(MethodSpec.methodBuilder(getAdditionalPropertyMethodName())
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(nestedBuilderClassName)
+                    .addParameter(String.class, "key")
+                    .addParameter(Object.class, "value")
+                    .addStatement("this.$L.put(key, value)", additionalPropertiesFieldName)
+                    .addStatement("return this")
                     .build());
         }
 
@@ -373,6 +390,11 @@ public final class BuilderGenerator {
         return methodBuilder;
     }
 
+    private String getAdditionalPropertyMethodName() {
+        boolean hasConflict = allPropertyCamelCaseNames.contains("additionalProperty");
+        return hasConflict ? "_additionalProperty" : "additionalProperty";
+    }
+
     private MethodSpec.Builder getFromSetter() {
         return MethodSpec.methodBuilder(StageBuilderConstants.FROM_METHOD_NAME)
                 .addModifiers(Modifier.PUBLIC)
@@ -394,6 +416,15 @@ public final class BuilderGenerator {
                         objectClassName.nestedClass(StageBuilderConstants.FINAL_STAGE_CLASS_NAME))
                 .addModifiers(Modifier.PUBLIC)
                 .addMethod(getBaseBuildMethod().addModifiers(Modifier.ABSTRACT).build());
+
+        if (this.supportAdditionalProperties) {
+            finalStageBuilder.addMethod(MethodSpec.methodBuilder(getAdditionalPropertyMethodName())
+                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                    .returns(finalStageClassName)
+                    .addParameter(String.class, "key")
+                    .addParameter(Object.class, "value")
+                    .build());
+        }
 
         List<EnrichedObjectPropertyWithField> finalStageProperties = stagedBuilderConfig.finalStage();
         for (EnrichedObjectPropertyWithField enrichedProperty : finalStageProperties) {

--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
@@ -148,15 +148,7 @@ public final class BuilderGenerator {
                     .addAnnotation(JsonAnySetter.class)
                     .initializer("new $T<>()", HashMap.class)
                     .build());
-            builderImplTypeSpec.addMethod(MethodSpec.methodBuilder(getAdditionalPropertyMethodName())
-                    .addModifiers(Modifier.PUBLIC)
-                    .returns(nestedBuilderClassName)
-                    .addAnnotation(ClassName.get("", "java.lang.Override"))
-                    .addParameter(String.class, "key")
-                    .addParameter(Object.class, "value")
-                    .addStatement("this.$L.put(key, value)", additionalPropertiesFieldName)
-                    .addStatement("return this")
-                    .build());
+            addAdditionalPropertiesBuilderMethods(builderImplTypeSpec, nestedBuilderClassName, true);
         }
 
         List<PoetTypeWithClassName> stagedBuilderTypes = new ArrayList<>();
@@ -239,14 +231,7 @@ public final class BuilderGenerator {
                     .addAnnotation(JsonAnySetter.class)
                     .initializer("new $T<>()", HashMap.class)
                     .build());
-            builderImplTypeSpec.addMethod(MethodSpec.methodBuilder(getAdditionalPropertyMethodName())
-                    .addModifiers(Modifier.PUBLIC)
-                    .returns(nestedBuilderClassName)
-                    .addParameter(String.class, "key")
-                    .addParameter(Object.class, "value")
-                    .addStatement("this.$L.put(key, value)", additionalPropertiesFieldName)
-                    .addStatement("return this")
-                    .build());
+            addAdditionalPropertiesBuilderMethods(builderImplTypeSpec, nestedBuilderClassName, false);
         }
 
         return PoetTypeWithClassName.of(nestedBuilderClassName, builderImplTypeSpec.build());
@@ -395,6 +380,55 @@ public final class BuilderGenerator {
         return hasConflict ? "_additionalProperty" : "additionalProperty";
     }
 
+    private String getAdditionalPropertiesMethodName() {
+        boolean hasConflict = allPropertyCamelCaseNames.contains("additionalProperties");
+        return hasConflict ? "_additionalProperties" : "additionalProperties";
+    }
+
+    private void addAdditionalPropertiesBuilderMethods(
+            TypeSpec.Builder builderTypeSpec, ClassName returnClass, boolean isOverridden) {
+        // Single key-value setter
+        MethodSpec.Builder singleSetter = MethodSpec.methodBuilder(getAdditionalPropertyMethodName())
+                .addModifiers(Modifier.PUBLIC)
+                .returns(returnClass)
+                .addParameter(String.class, "key")
+                .addParameter(Object.class, "value")
+                .addStatement("this.$L.put(key, value)", additionalPropertiesFieldName)
+                .addStatement("return this");
+        if (isOverridden) {
+            singleSetter.addAnnotation(ClassName.get("", "java.lang.Override"));
+        }
+        builderTypeSpec.addMethod(singleSetter.build());
+
+        // Bulk setter
+        MethodSpec.Builder bulkSetter = MethodSpec.methodBuilder(getAdditionalPropertiesMethodName())
+                .addModifiers(Modifier.PUBLIC)
+                .returns(returnClass)
+                .addParameter(
+                        ParameterizedTypeName.get(Map.class, String.class, Object.class), additionalPropertiesFieldName)
+                .addStatement("this.$L.putAll($L)", additionalPropertiesFieldName, additionalPropertiesFieldName)
+                .addStatement("return this");
+        if (isOverridden) {
+            bulkSetter.addAnnotation(ClassName.get("", "java.lang.Override"));
+        }
+        builderTypeSpec.addMethod(bulkSetter.build());
+    }
+
+    private void addAdditionalPropertiesInterfaceMethods(TypeSpec.Builder interfaceBuilder, ClassName returnClass) {
+        interfaceBuilder.addMethod(MethodSpec.methodBuilder(getAdditionalPropertyMethodName())
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .returns(returnClass)
+                .addParameter(String.class, "key")
+                .addParameter(Object.class, "value")
+                .build());
+        interfaceBuilder.addMethod(MethodSpec.methodBuilder(getAdditionalPropertiesMethodName())
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .returns(returnClass)
+                .addParameter(
+                        ParameterizedTypeName.get(Map.class, String.class, Object.class), additionalPropertiesFieldName)
+                .build());
+    }
+
     private MethodSpec.Builder getFromSetter() {
         return MethodSpec.methodBuilder(StageBuilderConstants.FROM_METHOD_NAME)
                 .addModifiers(Modifier.PUBLIC)
@@ -418,12 +452,7 @@ public final class BuilderGenerator {
                 .addMethod(getBaseBuildMethod().addModifiers(Modifier.ABSTRACT).build());
 
         if (this.supportAdditionalProperties) {
-            finalStageBuilder.addMethod(MethodSpec.methodBuilder(getAdditionalPropertyMethodName())
-                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                    .returns(finalStageClassName)
-                    .addParameter(String.class, "key")
-                    .addParameter(Object.class, "value")
-                    .build());
+            addAdditionalPropertiesInterfaceMethods(finalStageBuilder, finalStageClassName);
         }
 
         List<EnrichedObjectPropertyWithField> finalStageProperties = stagedBuilderConfig.finalStage();

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.37.0
+  changelogEntry:
+    - summary: |
+        Add `additionalProperty(String key, Object value)` method to generated builders,
+        allowing users to set arbitrary extra fields programmatically. Previously,
+        additional properties were only populated during JSON deserialization.
+      type: feat
+  createdAt: "2026-02-18"
+  irVersion: 63
+
 - version: 3.36.3
   changelogEntry:
     - summary: Use correct Long literals (3600L) instead of int literals (3600) for `Optional<Long>` expires_in fields in OAuth token suppliers

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -2,9 +2,9 @@
 - version: 3.37.0
   changelogEntry:
     - summary: |
-        Add `additionalProperty(String key, Object value)` method to generated builders,
-        allowing users to set arbitrary extra fields programmatically. Previously,
-        additional properties were only populated during JSON deserialization.
+        Add `additionalProperty(String key, Object value)` and `additionalProperties(Map<String, Object>)`
+        methods to generated builders, allowing users to set arbitrary extra fields programmatically.
+        Previously, additional properties were only populated during JSON deserialization.
       type: feat
   createdAt: "2026-02-18"
   irVersion: 63

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePath {
 
     public interface _FinalStage {
         GetWithInlinePath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePath {
         @java.lang.Override
         public GetWithInlinePath build() {
             return new GetWithInlinePath(param, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -82,6 +82,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(param, query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -82,6 +82,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(param, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -70,6 +70,8 @@ public final class PutRequest {
 
     public interface _FinalStage {
         PutRequest build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class PutRequest {
         @java.lang.Override
         public PutRequest build() {
             return new PutRequest(id, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePath {
 
     public interface _FinalStage {
         GetWithInlinePath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePath {
         @java.lang.Override
         public GetWithInlinePath build() {
             return new GetWithInlinePath(param, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -82,6 +82,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(param, query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -82,6 +82,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(param, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -70,6 +70,8 @@ public final class PutRequest {
 
     public interface _FinalStage {
         PutRequest build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class PutRequest {
         @java.lang.Override
         public PutRequest build() {
             return new PutRequest(id, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePath {
 
     public interface _FinalStage {
         GetWithInlinePath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePath {
         @java.lang.Override
         public GetWithInlinePath build() {
             return new GetWithInlinePath(param, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -82,6 +82,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(param, query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -82,6 +82,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(param, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -70,6 +70,8 @@ public final class PutRequest {
 
     public interface _FinalStage {
         PutRequest build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class PutRequest {
         @java.lang.Override
         public PutRequest build() {
             return new PutRequest(id, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -55,5 +55,10 @@ public final class GetWithInlinePath {
         public GetWithInlinePath build() {
             return new GetWithInlinePath(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -70,6 +70,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -55,5 +55,10 @@ public final class PutRequest {
         public PutRequest build() {
             return new PutRequest(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePath {
 
     public interface _FinalStage {
         GetWithInlinePath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePath {
         @java.lang.Override
         public GetWithInlinePath build() {
             return new GetWithInlinePath(param, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -82,6 +82,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(param, query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -82,6 +82,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(param, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -70,6 +70,8 @@ public final class PutRequest {
 
     public interface _FinalStage {
         PutRequest build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class PutRequest {
         @java.lang.Override
         public PutRequest build() {
             return new PutRequest(id, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/Error.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithInlinePath.java
@@ -55,5 +55,10 @@ public final class GetWithInlinePath {
         public GetWithInlinePath build() {
             return new GetWithInlinePath(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithInlinePathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ModifyResourceAtInlinedPath.java
@@ -70,6 +70,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/PutRequest.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/PutRequest.java
@@ -55,5 +55,10 @@ public final class PutRequest {
         public PutRequest build() {
             return new PutRequest(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/Cat.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/Dog.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePath {
 
     public interface _FinalStage {
         GetWithInlinePath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePath {
         @java.lang.Override
         public GetWithInlinePath build() {
             return new GetWithInlinePath(param, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -82,6 +82,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(param, query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -82,6 +82,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(param, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -70,6 +70,8 @@ public final class PutRequest {
 
     public interface _FinalStage {
         PutRequest build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class PutRequest {
         @java.lang.Override
         public PutRequest build() {
             return new PutRequest(id, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePath {
 
     public interface _FinalStage {
         GetWithInlinePath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePath {
         @java.lang.Override
         public GetWithInlinePath build() {
             return new GetWithInlinePath(param, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -82,6 +82,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(param, query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -82,6 +82,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(param, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -70,6 +70,8 @@ public final class PutRequest {
 
     public interface _FinalStage {
         PutRequest build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class PutRequest {
         @java.lang.Override
         public PutRequest build() {
             return new PutRequest(id, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -141,5 +141,10 @@ public final class ListItemsRequest {
     public ListItemsRequest build() {
       return new ListItemsRequest(cursor, limit, additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -141,5 +141,10 @@ public final class PaginatedResponse {
     public PaginatedResponse build() {
       return new PaginatedResponse(items, next, additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -63,5 +63,10 @@ public final class GetWithInlinePath {
     public GetWithInlinePath build() {
       return new GetWithInlinePath(additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -75,6 +75,8 @@ public final class GetWithInlinePathAndQuery {
 
   public interface _FinalStage {
     GetWithInlinePathAndQuery build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -105,6 +107,12 @@ public final class GetWithInlinePathAndQuery {
     @java.lang.Override
     public GetWithInlinePathAndQuery build() {
       return new GetWithInlinePathAndQuery(query, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -161,5 +161,10 @@ public final class GetWithMultipleQuery {
     public GetWithMultipleQuery build() {
       return new GetWithMultipleQuery(query, number, additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -75,6 +75,8 @@ public final class GetWithPathAndQuery {
 
   public interface _FinalStage {
     GetWithPathAndQuery build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -105,6 +107,12 @@ public final class GetWithPathAndQuery {
     @java.lang.Override
     public GetWithPathAndQuery build() {
       return new GetWithPathAndQuery(query, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithQuery.java
@@ -87,6 +87,8 @@ public final class GetWithQuery {
 
   public interface _FinalStage {
     GetWithQuery build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -127,6 +129,12 @@ public final class GetWithQuery {
     @java.lang.Override
     public GetWithQuery build() {
       return new GetWithQuery(query, number, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -75,6 +75,8 @@ public final class ModifyResourceAtInlinedPath {
 
   public interface _FinalStage {
     ModifyResourceAtInlinedPath build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -105,6 +107,12 @@ public final class ModifyResourceAtInlinedPath {
     @java.lang.Override
     public ModifyResourceAtInlinedPath build() {
       return new ModifyResourceAtInlinedPath(body, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/requests/PutRequest.java
@@ -63,5 +63,10 @@ public final class PutRequest {
     public PutRequest build() {
       return new PutRequest(additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/types/Error.java
@@ -107,6 +107,8 @@ public final class Error {
   public interface _FinalStage {
     Error build();
 
+    _FinalStage additionalProperty(String key, Object value);
+
     _FinalStage detail(Optional<String> detail);
 
     _FinalStage detail(String detail);
@@ -192,6 +194,12 @@ public final class Error {
     @java.lang.Override
     public Error build() {
       return new Error(category, code, detail, field, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/put/types/PutResponse.java
@@ -103,5 +103,10 @@ public final class PutResponse {
     public PutResponse build() {
       return new PutResponse(errors, additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -75,6 +75,8 @@ public final class BadObjectRequestInfo {
 
   public interface _FinalStage {
     BadObjectRequestInfo build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -105,6 +107,12 @@ public final class BadObjectRequestInfo {
     @java.lang.Override
     public BadObjectRequestInfo build() {
       return new BadObjectRequestInfo(message, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -101,6 +101,8 @@ public final class PostWithObjectBody {
 
   public interface _FinalStage {
     PostWithObjectBody build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -151,6 +153,12 @@ public final class PostWithObjectBody {
     @java.lang.Override
     public PostWithObjectBody build() {
       return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
   public interface _FinalStage {
     ReqWithHeaders build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -149,6 +151,12 @@ public final class ReqWithHeaders {
     @java.lang.Override
     public ReqWithHeaders build() {
       return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/docs/types/ObjectWithDocs.java
@@ -219,6 +219,8 @@ public final class ObjectWithDocs {
 
   public interface _FinalStage {
     ObjectWithDocs build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -392,6 +394,12 @@ public final class ObjectWithDocs {
     @java.lang.Override
     public ObjectWithDocs build() {
       return new ObjectWithDocs(string, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/DoubleOptional.java
@@ -102,5 +102,10 @@ public final class DoubleOptional {
     public DoubleOptional build() {
       return new DoubleOptional(optionalAlias, additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -128,5 +128,10 @@ public final class NestedObjectWithOptionalField {
     public NestedObjectWithOptionalField build() {
       return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -88,6 +88,8 @@ public final class NestedObjectWithRequiredField {
 
   public interface _FinalStage {
     NestedObjectWithRequiredField build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -128,6 +130,12 @@ public final class NestedObjectWithRequiredField {
     @java.lang.Override
     public NestedObjectWithRequiredField build() {
       return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -101,6 +101,8 @@ public final class ObjectWithDatetimeLikeString {
 
   public interface _FinalStage {
     ObjectWithDatetimeLikeString build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -151,6 +153,12 @@ public final class ObjectWithDatetimeLikeString {
     @java.lang.Override
     public ObjectWithDatetimeLikeString build() {
       return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/ObjectWithMapOfMap.java
@@ -113,5 +113,10 @@ public final class ObjectWithMapOfMap {
     public ObjectWithMapOfMap build() {
       return new ObjectWithMapOfMap(map, additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/ObjectWithOptionalField.java
@@ -422,5 +422,10 @@ public final class ObjectWithOptionalField {
     public ObjectWithOptionalField build() {
       return new ObjectWithOptionalField(string, integer, long_, double_, bool, datetime, date, uuid, base64, list, set, map, bigint, additionalProperties);
     }
+
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
+    }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/object/types/ObjectWithRequiredField.java
@@ -75,6 +75,8 @@ public final class ObjectWithRequiredField {
 
   public interface _FinalStage {
     ObjectWithRequiredField build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -105,6 +107,12 @@ public final class ObjectWithRequiredField {
     @java.lang.Override
     public ObjectWithRequiredField build() {
       return new ObjectWithRequiredField(string, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/union/types/Cat.java
@@ -87,6 +87,8 @@ public final class Cat {
 
   public interface _FinalStage {
     Cat build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -127,6 +129,12 @@ public final class Cat {
     @java.lang.Override
     public Cat build() {
       return new Cat(name, likesToMeow, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/types/union/types/Dog.java
@@ -87,6 +87,8 @@ public final class Dog {
 
   public interface _FinalStage {
     Dog build();
+
+    _FinalStage additionalProperty(String key, Object value);
   }
 
   @JsonIgnoreProperties(
@@ -127,6 +129,12 @@ public final class Dog {
     @java.lang.Override
     public Dog build() {
       return new Dog(name, likesToWoof, additionalProperties);
+    }
+
+    @java.lang.Override
+    public Builder additionalProperty(String key, Object value) {
+      this.additionalProperties.put(key, value);
+      return this;
     }
   }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -131,5 +131,10 @@ public final class ListItemsRequest {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -132,5 +132,10 @@ public final class PaginatedResponse {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -60,5 +60,10 @@ public final class GetWithInlinePath {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -55,5 +55,10 @@ public final class GetWithInlinePath {
         public GetWithInlinePath build() {
             return new GetWithInlinePath(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -72,6 +72,8 @@ public final class GetWithInlinePathAndQuery {
         GetWithInlinePathAndQuery build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -104,6 +106,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -150,5 +150,10 @@ public final class GetWithMultipleQuery {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -72,6 +72,8 @@ public final class GetWithPathAndQuery {
         GetWithPathAndQuery build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -104,6 +106,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -84,6 +84,8 @@ public final class GetWithQuery {
         GetWithQuery build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -126,6 +128,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -72,6 +72,8 @@ public final class ModifyResourceAtInlinedPath {
         ModifyResourceAtInlinedPath build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -104,6 +106,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -70,6 +70,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -60,5 +60,10 @@ public final class PutRequest {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -55,5 +55,10 @@ public final class PutRequest {
         public PutRequest build() {
             return new PutRequest(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -111,6 +111,8 @@ public final class Error {
 
         _FinalStage additionalProperty(String key, Object value);
 
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -192,6 +194,12 @@ public final class Error {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -97,5 +97,10 @@ public final class PutResponse {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -72,6 +72,8 @@ public final class BadObjectRequestInfo {
         BadObjectRequestInfo build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -104,6 +106,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -101,6 +101,8 @@ public final class PostWithObjectBody {
         PostWithObjectBody build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -153,6 +155,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -103,6 +103,8 @@ public final class ReqWithHeaders {
         ReqWithHeaders build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -155,6 +157,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -216,6 +216,8 @@ public final class ObjectWithDocs {
         ObjectWithDocs build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -391,6 +393,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -96,5 +96,10 @@ public final class DoubleOptional {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -121,5 +121,10 @@ public final class NestedObjectWithOptionalField {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -85,6 +85,8 @@ public final class NestedObjectWithRequiredField {
         NestedObjectWithRequiredField build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -127,6 +129,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -98,6 +98,8 @@ public final class ObjectWithDatetimeLikeString {
         ObjectWithDatetimeLikeString build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -150,6 +152,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -106,5 +106,10 @@ public final class ObjectWithMapOfMap {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -424,5 +424,10 @@ public final class ObjectWithOptionalField {
             this.additionalProperties.put(key, value);
             return this;
         }
+
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -72,6 +72,8 @@ public final class ObjectWithRequiredField {
         ObjectWithRequiredField build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -104,6 +106,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -84,6 +84,8 @@ public final class Cat {
         Cat build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -126,6 +128,12 @@ public final class Cat {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -84,6 +84,8 @@ public final class Dog {
         Dog build();
 
         _FinalStage additionalProperty(String key, Object value);
+
+        _FinalStage additionalProperties(Map<String, Object> additionalProperties);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -126,6 +128,12 @@ public final class Dog {
         @java.lang.Override
         public Builder additionalProperty(String key, Object value) {
             this.additionalProperties.put(key, value);
+            return this;
+        }
+
+        @java.lang.Override
+        public Builder additionalProperties(Map<String, Object> additionalProperties) {
+            this.additionalProperties.putAll(additionalProperties);
             return this;
         }
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -55,5 +55,10 @@ public final class GetWithInlinePath {
         public GetWithInlinePath build() {
             return new GetWithInlinePath(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -70,6 +70,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -55,5 +55,10 @@ public final class PutRequest {
         public PutRequest build() {
             return new PutRequest(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -126,5 +126,10 @@ public final class ListItemsRequest {
         public ListItemsRequest build() {
             return new ListItemsRequest(cursor, limit, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/types/PaginatedResponse.java
@@ -127,5 +127,10 @@ public final class PaginatedResponse {
         public PaginatedResponse build() {
             return new PaginatedResponse(items, next, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePath.java
@@ -55,5 +55,10 @@ public final class GetWithInlinePath {
         public GetWithInlinePath build() {
             return new GetWithInlinePath(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithInlinePathAndQuery {
 
     public interface _FinalStage {
         GetWithInlinePathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithInlinePathAndQuery {
         @java.lang.Override
         public GetWithInlinePathAndQuery build() {
             return new GetWithInlinePathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -145,5 +145,10 @@ public final class GetWithMultipleQuery {
         public GetWithMultipleQuery build() {
             return new GetWithMultipleQuery(query, number, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -70,6 +70,8 @@ public final class GetWithPathAndQuery {
 
     public interface _FinalStage {
         GetWithPathAndQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class GetWithPathAndQuery {
         @java.lang.Override
         public GetWithPathAndQuery build() {
             return new GetWithPathAndQuery(query, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -82,6 +82,8 @@ public final class GetWithQuery {
 
     public interface _FinalStage {
         GetWithQuery build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class GetWithQuery {
         @java.lang.Override
         public GetWithQuery build() {
             return new GetWithQuery(query, number, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/ModifyResourceAtInlinedPath.java
@@ -70,6 +70,8 @@ public final class ModifyResourceAtInlinedPath {
 
     public interface _FinalStage {
         ModifyResourceAtInlinedPath build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ModifyResourceAtInlinedPath {
         @java.lang.Override
         public ModifyResourceAtInlinedPath build() {
             return new ModifyResourceAtInlinedPath(body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/requests/PutRequest.java
@@ -55,5 +55,10 @@ public final class PutRequest {
         public PutRequest build() {
             return new PutRequest(additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/Error.java
@@ -109,6 +109,8 @@ public final class Error {
     public interface _FinalStage {
         Error build();
 
+        _FinalStage additionalProperty(String key, Object value);
+
         _FinalStage detail(Optional<String> detail);
 
         _FinalStage detail(String detail);
@@ -185,6 +187,12 @@ public final class Error {
         @java.lang.Override
         public Error build() {
             return new Error(category, code, detail, field, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/put/types/PutResponse.java
@@ -92,5 +92,10 @@ public final class PutResponse {
         public PutResponse build() {
             return new PutResponse(errors, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/generalerrors/types/BadObjectRequestInfo.java
@@ -70,6 +70,8 @@ public final class BadObjectRequestInfo {
 
     public interface _FinalStage {
         BadObjectRequestInfo build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class BadObjectRequestInfo {
         @java.lang.Override
         public BadObjectRequestInfo build() {
             return new BadObjectRequestInfo(message, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/inlinedrequests/requests/PostWithObjectBody.java
@@ -99,6 +99,8 @@ public final class PostWithObjectBody {
 
     public interface _FinalStage {
         PostWithObjectBody build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -146,6 +148,12 @@ public final class PostWithObjectBody {
         @java.lang.Override
         public PostWithObjectBody build() {
             return new PostWithObjectBody(string, integer, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/reqwithheaders/requests/ReqWithHeaders.java
@@ -101,6 +101,8 @@ public final class ReqWithHeaders {
 
     public interface _FinalStage {
         ReqWithHeaders build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -148,6 +150,12 @@ public final class ReqWithHeaders {
         @java.lang.Override
         public ReqWithHeaders build() {
             return new ReqWithHeaders(xTestServiceHeader, xTestEndpointHeader, body, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/docs/types/ObjectWithDocs.java
@@ -214,6 +214,8 @@ public final class ObjectWithDocs {
 
     public interface _FinalStage {
         ObjectWithDocs build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -384,6 +386,12 @@ public final class ObjectWithDocs {
         @java.lang.Override
         public ObjectWithDocs build() {
             return new ObjectWithDocs(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/DoubleOptional.java
@@ -91,5 +91,10 @@ public final class DoubleOptional {
         public DoubleOptional build() {
             return new DoubleOptional(optionalAlias, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithOptionalField.java
@@ -116,5 +116,10 @@ public final class NestedObjectWithOptionalField {
         public NestedObjectWithOptionalField build() {
             return new NestedObjectWithOptionalField(string, nestedObject, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/NestedObjectWithRequiredField.java
@@ -83,6 +83,8 @@ public final class NestedObjectWithRequiredField {
 
     public interface _FinalStage {
         NestedObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -120,6 +122,12 @@ public final class NestedObjectWithRequiredField {
         @java.lang.Override
         public NestedObjectWithRequiredField build() {
             return new NestedObjectWithRequiredField(string, nestedObject, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithDatetimeLikeString.java
@@ -96,6 +96,8 @@ public final class ObjectWithDatetimeLikeString {
 
     public interface _FinalStage {
         ObjectWithDatetimeLikeString build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -143,6 +145,12 @@ public final class ObjectWithDatetimeLikeString {
         @java.lang.Override
         public ObjectWithDatetimeLikeString build() {
             return new ObjectWithDatetimeLikeString(datetimeLikeString, actualDatetime, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -101,5 +101,10 @@ public final class ObjectWithMapOfMap {
         public ObjectWithMapOfMap build() {
             return new ObjectWithMapOfMap(map, additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithOptionalField.java
@@ -419,5 +419,10 @@ public final class ObjectWithOptionalField {
                     bigint,
                     additionalProperties);
         }
+
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
+        }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithRequiredField.java
@@ -70,6 +70,8 @@ public final class ObjectWithRequiredField {
 
     public interface _FinalStage {
         ObjectWithRequiredField build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -97,6 +99,12 @@ public final class ObjectWithRequiredField {
         @java.lang.Override
         public ObjectWithRequiredField build() {
             return new ObjectWithRequiredField(string, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/union/types/Cat.java
@@ -82,6 +82,8 @@ public final class Cat {
 
     public interface _FinalStage {
         Cat build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Cat {
         @java.lang.Override
         public Cat build() {
             return new Cat(name, likesToMeow, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/union/types/Dog.java
@@ -82,6 +82,8 @@ public final class Dog {
 
     public interface _FinalStage {
         Dog build();
+
+        _FinalStage additionalProperty(String key, Object value);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -119,6 +121,12 @@ public final class Dog {
         @java.lang.Override
         public Dog build() {
             return new Dog(name, likesToWoof, additionalProperties);
+        }
+
+        @java.lang.Override
+        public Builder additionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+            return this;
         }
     }
 }


### PR DESCRIPTION
## Description
Before, builders had no way of directly editing the `AdditionalProperties` field of certain objects; now, they do:
```java
  // Single extra field
  MyObject obj = MyObject.builder()
      .knownField("value")
      .additionalProperty("customField", "customValue")
      .build();

  // Multiple extra fields — chainable
  MyObject obj = MyObject.builder()
      .knownField("value")
      .additionalProperty("foo", 42)
      .additionalProperty("bar", true)
      .additionalProperty("nested", someMap)
      .build();
 
// Or in bulk from a map
  MyObject.builder()
      .knownField("val")
      .additionalProperties(Map.of("foo", 1, "bar", 2))
      .build();
```

## Changes Made
Java generator; the `BuilderGenerator.java`.

## Testing
Lots of seed changes included!
- [X] Unit tests added/updated
- [X] Manual testing completed
