### PR TITLE
fix(php): create interfaces even if aggregator-only, add interface getters

### DIFF
--- a/generators/php/sdk/src/SdkGeneratorCli.ts
+++ b/generators/php/sdk/src/SdkGeneratorCli.ts
@@ -139,8 +139,7 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
             if (!context.shouldGenerateSubpackageClient(subpackage)) {
                 continue;
             }
-            const service =
-                subpackage.service != null ? context.getHttpServiceOrThrow(subpackage.service) : undefined;
+            const service = subpackage.service != null ? context.getHttpServiceOrThrow(subpackage.service) : undefined;
             const subClientInterface = new SubPackageClientInterfaceGenerator({
                 context,
                 subpackage,

--- a/generators/php/sdk/src/SdkGeneratorCli.ts
+++ b/generators/php/sdk/src/SdkGeneratorCli.ts
@@ -130,24 +130,21 @@ export class SdkGeneratorCLI extends AbstractPhpGeneratorCli<SdkCustomConfigSche
     }
 
     private generateRootClientInterface(context: SdkGeneratorContext) {
-        const rootServiceId = context.ir.rootPackage.service;
-        if (rootServiceId == null) {
-            return;
-        }
         const rootClientInterface = new RootClientInterfaceGenerator(context);
         context.project.addSourceFiles(rootClientInterface.generate());
     }
 
     private generateSubpackageInterfaces(context: SdkGeneratorContext) {
         for (const subpackage of Object.values(context.ir.subpackages)) {
-            if (subpackage.service == null) {
+            if (!context.shouldGenerateSubpackageClient(subpackage)) {
                 continue;
             }
-            const service = context.getHttpServiceOrThrow(subpackage.service);
+            const service =
+                subpackage.service != null ? context.getHttpServiceOrThrow(subpackage.service) : undefined;
             const subClientInterface = new SubPackageClientInterfaceGenerator({
                 context,
                 subpackage,
-                serviceId: subpackage.service,
+                serviceId: subpackage.service ?? undefined,
                 service
             });
             context.project.addSourceFiles(subClientInterface.generate());

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -104,6 +104,10 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
         });
     }
 
+    public getSubpackageGetterName(subpackage: FernIr.Subpackage): string {
+        return `get${subpackage.name.pascalCase.safeName}`;
+    }
+
     public getEndpointMethodName(endpoint: FernIr.HttpEndpoint): string {
         // TODO: Propogate reserved keywords through IR via CasingsGenerator.
         const unsafeName = endpoint.name.camelCase.unsafeName;

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -57,10 +57,9 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
         const class_ = php.class_({
             name: this.context.getRootClientClassName(),
             namespace: this.context.getRootNamespace(),
-            interfaceReferences:
-                this.context.customConfig.generateClientInterfaces && this.context.ir.rootPackage.service != null
-                    ? [this.context.getRootClientInterfaceClassReference()]
-                    : undefined
+            interfaceReferences: this.context.customConfig.generateClientInterfaces
+                ? [this.context.getRootClientInterfaceClassReference()]
+                : undefined
         });
 
         if (!this.context.ir.rootPackage.hasEndpointsInTree) {
@@ -146,6 +145,12 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                     endpoint
                 });
                 class_.addMethods(methods);
+            }
+        }
+
+        if (this.context.customConfig.generateClientInterfaces) {
+            for (const subpackage of subpackages) {
+                class_.addMethod(this.getSubpackageGetterMethod(subpackage));
             }
         }
 
@@ -459,6 +464,18 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 }
             })
         };
+    }
+
+    private getSubpackageGetterMethod(subpackage: FernIr.Subpackage): php.Method {
+        return php.method({
+            name: this.context.getSubpackageGetterName(subpackage),
+            access: "public",
+            parameters: [],
+            return_: php.Type.reference(this.context.getSubpackageInterfaceClassReference(subpackage)),
+            body: php.codeblock((writer) => {
+                writer.writeTextStatement(`return $this->${subpackage.name.camelCase.safeName}`);
+            })
+        });
     }
 
     private getFromEnvOrThrowMethod(): php.Method {

--- a/generators/php/sdk/src/root-client/RootClientInterfaceGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientInterfaceGenerator.ts
@@ -1,6 +1,7 @@
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 import { FileGenerator, PhpFile } from "@fern-api/php-base";
 import { php } from "@fern-api/php-codegen";
+import { FernIr } from "@fern-fern/ir-sdk";
 
 import { SdkCustomConfigSchema } from "../SdkCustomConfig.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
@@ -29,11 +30,29 @@ export class RootClientInterfaceGenerator extends FileGenerator<PhpFile, SdkCust
             }
         }
 
+        for (const subpackage of this.getRootSubpackages()) {
+            interface_.addMethod(
+                php.method({
+                    name: this.context.getSubpackageGetterName(subpackage),
+                    access: "public",
+                    parameters: [],
+                    return_: php.Type.reference(this.context.getSubpackageInterfaceClassReference(subpackage)),
+                    noBody: true
+                })
+            );
+        }
+
         return new PhpFile({
             clazz: interface_,
             directory: RelativeFilePath.of(""),
             rootNamespace: this.context.getRootNamespace(),
             customConfig: this.context.customConfig
         });
+    }
+
+    private getRootSubpackages(): FernIr.Subpackage[] {
+        return this.context.ir.rootPackage.subpackages
+            .map((subpackageId) => this.context.getSubpackageOrThrow(subpackageId))
+            .filter((subpackage) => this.context.shouldGenerateSubpackageClient(subpackage));
     }
 }

--- a/generators/php/sdk/src/subpackage-client/SubPackageClientGenerator.ts
+++ b/generators/php/sdk/src/subpackage-client/SubPackageClientGenerator.ts
@@ -32,10 +32,9 @@ export class SubPackageClientGenerator extends FileGenerator<PhpFile, SdkCustomC
     public doGenerate(): PhpFile {
         const class_ = php.class_({
             ...this.classReference,
-            interfaceReferences:
-                this.context.customConfig.generateClientInterfaces && this.service != null
-                    ? [this.context.getSubpackageInterfaceClassReference(this.subpackage)]
-                    : undefined
+            interfaceReferences: this.context.customConfig.generateClientInterfaces
+                ? [this.context.getSubpackageInterfaceClassReference(this.subpackage)]
+                : undefined
         });
 
         const isMultiUrl = this.context.ir.environments?.environments.type === "multipleBaseUrls";
@@ -74,6 +73,24 @@ export class SubPackageClientGenerator extends FileGenerator<PhpFile, SdkCustomC
                     endpoint
                 });
                 class_.addMethods(methods);
+            }
+        }
+
+        if (this.context.customConfig.generateClientInterfaces) {
+            for (const subpackage of subpackages) {
+                class_.addMethod(
+                    php.method({
+                        name: this.context.getSubpackageGetterName(subpackage),
+                        access: "public",
+                        parameters: [],
+                        return_: php.Type.reference(
+                            this.context.getSubpackageInterfaceClassReference(subpackage)
+                        ),
+                        body: php.codeblock((writer) => {
+                            writer.writeTextStatement(`return $this->${subpackage.name.camelCase.safeName}`);
+                        })
+                    })
+                );
             }
         }
 

--- a/generators/php/sdk/src/subpackage-client/SubPackageClientGenerator.ts
+++ b/generators/php/sdk/src/subpackage-client/SubPackageClientGenerator.ts
@@ -83,9 +83,7 @@ export class SubPackageClientGenerator extends FileGenerator<PhpFile, SdkCustomC
                         name: this.context.getSubpackageGetterName(subpackage),
                         access: "public",
                         parameters: [],
-                        return_: php.Type.reference(
-                            this.context.getSubpackageInterfaceClassReference(subpackage)
-                        ),
+                        return_: php.Type.reference(this.context.getSubpackageInterfaceClassReference(subpackage)),
                         body: php.codeblock((writer) => {
                             writer.writeTextStatement(`return $this->${subpackage.name.camelCase.safeName}`);
                         })

--- a/generators/php/sdk/src/subpackage-client/SubPackageClientInterfaceGenerator.ts
+++ b/generators/php/sdk/src/subpackage-client/SubPackageClientInterfaceGenerator.ts
@@ -10,8 +10,8 @@ export declare namespace SubPackageClientInterfaceGenerator {
     interface Args {
         context: SdkGeneratorContext;
         subpackage: FernIr.Subpackage;
-        serviceId: FernIr.ServiceId;
-        service: FernIr.HttpService;
+        serviceId?: FernIr.ServiceId;
+        service?: FernIr.HttpService;
     }
 }
 
@@ -21,8 +21,8 @@ export class SubPackageClientInterfaceGenerator extends FileGenerator<
     SdkGeneratorContext
 > {
     private subpackage: FernIr.Subpackage;
-    private serviceId: FernIr.ServiceId;
-    private service: FernIr.HttpService;
+    private serviceId: FernIr.ServiceId | undefined;
+    private service: FernIr.HttpService | undefined;
 
     constructor({ context, subpackage, serviceId, service }: SubPackageClientInterfaceGenerator.Args) {
         super(context);
@@ -46,13 +46,27 @@ export class SubPackageClientInterfaceGenerator extends FileGenerator<
             namespace: this.context.getLocationForSubpackage(this.subpackage).namespace
         });
 
-        for (const endpoint of this.service.endpoints) {
-            const signatures = this.context.endpointGenerator.generateSignatures({
-                serviceId: this.serviceId,
-                service: this.service,
-                endpoint
-            });
-            interface_.addMethods(signatures);
+        if (this.service != null && this.serviceId != null) {
+            for (const endpoint of this.service.endpoints) {
+                const signatures = this.context.endpointGenerator.generateSignatures({
+                    serviceId: this.serviceId,
+                    service: this.service,
+                    endpoint
+                });
+                interface_.addMethods(signatures);
+            }
+        }
+
+        for (const childSubpackage of this.getChildSubpackages()) {
+            interface_.addMethod(
+                php.method({
+                    name: this.context.getSubpackageGetterName(childSubpackage),
+                    access: "public",
+                    parameters: [],
+                    return_: php.Type.reference(this.context.getSubpackageInterfaceClassReference(childSubpackage)),
+                    noBody: true
+                })
+            );
         }
 
         return new PhpFile({
@@ -61,5 +75,11 @@ export class SubPackageClientInterfaceGenerator extends FileGenerator<
             rootNamespace: this.context.getRootNamespace(),
             customConfig: this.context.customConfig
         });
+    }
+
+    private getChildSubpackages(): FernIr.Subpackage[] {
+        return this.subpackage.subpackages
+            .map((subpackageId) => this.context.getSubpackageOrThrow(subpackageId))
+            .filter((subpackage) => this.context.shouldGenerateSubpackageClient(subpackage));
     }
 }

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.2
+  changelogEntry:
+    - summary: |
+        Fix `generateClientInterfaces` to generate interfaces for aggregator-only clients (clients
+        that hold sub-client properties but have no direct API endpoints). Previously, these clients
+        were skipped, leaving the top-level client and intermediate grouping clients without interfaces.
+
+        Interfaces now include typed getter method signatures for each sub-client (e.g.,
+        `getUsers(): UsersClientInterface`), and the corresponding client classes implement these
+        getters.
+      type: fix
+  createdAt: "2026-02-18"
+  irVersion: 62
+
 - version: 2.1.1
   changelogEntry:
     - summary: |

--- a/seed/php-sdk/folders/with-interfaces/src/A/AClient.php
+++ b/seed/php-sdk/folders/with-interfaces/src/A/AClient.php
@@ -6,8 +6,10 @@ use Seed\A\B\BClient;
 use Seed\A\C\CClient;
 use Psr\Http\Client\ClientInterface;
 use Seed\Core\Client\RawClient;
+use Seed\A\B\BClientInterface;
+use Seed\A\C\CClientInterface;
 
-class AClient
+class AClient implements AClientInterface
 {
     /**
      * @var BClient $b
@@ -53,5 +55,21 @@ class AClient
         $this->options = $options ?? [];
         $this->b = new BClient($this->client, $this->options);
         $this->c = new CClient($this->client, $this->options);
+    }
+
+    /**
+     * @return BClientInterface
+     */
+    public function getB(): BClientInterface
+    {
+        return $this->b;
+    }
+
+    /**
+     * @return CClientInterface
+     */
+    public function getC(): CClientInterface
+    {
+        return $this->c;
     }
 }

--- a/seed/php-sdk/folders/with-interfaces/src/A/AClientInterface.php
+++ b/seed/php-sdk/folders/with-interfaces/src/A/AClientInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Seed\A;
+
+use Seed\A\B\BClientInterface;
+use Seed\A\C\CClientInterface;
+
+interface AClientInterface
+{
+    /**
+     * @return BClientInterface
+     */
+    public function getB(): BClientInterface;
+
+    /**
+     * @return CClientInterface
+     */
+    public function getC(): CClientInterface;
+}

--- a/seed/php-sdk/folders/with-interfaces/src/Folder/FolderClient.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Folder/FolderClient.php
@@ -10,6 +10,7 @@ use Seed\Exceptions\SeedApiException;
 use Seed\Core\Json\JsonApiRequest;
 use Seed\Core\Client\HttpMethod;
 use Psr\Http\Client\ClientExceptionInterface;
+use Seed\Folder\Service\ServiceClientInterface;
 
 class FolderClient implements FolderClientInterface
 {
@@ -89,5 +90,13 @@ class FolderClient implements FolderClientInterface
             statusCode: $statusCode,
             body: $response->getBody()->getContents(),
         );
+    }
+
+    /**
+     * @return ServiceClientInterface
+     */
+    public function getService(): ServiceClientInterface
+    {
+        return $this->service;
     }
 }

--- a/seed/php-sdk/folders/with-interfaces/src/Folder/FolderClientInterface.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Folder/FolderClientInterface.php
@@ -2,6 +2,8 @@
 
 namespace Seed\Folder;
 
+use Seed\Folder\Service\ServiceClientInterface;
+
 interface FolderClientInterface
 {
     /**
@@ -15,4 +17,9 @@ interface FolderClientInterface
      * } $options
      */
     public function foo(?array $options = null): void;
+
+    /**
+     * @return ServiceClientInterface
+     */
+    public function getService(): ServiceClientInterface;
 }

--- a/seed/php-sdk/folders/with-interfaces/src/SeedClient.php
+++ b/seed/php-sdk/folders/with-interfaces/src/SeedClient.php
@@ -11,6 +11,8 @@ use Seed\Exceptions\SeedApiException;
 use Seed\Core\Json\JsonApiRequest;
 use Seed\Core\Client\HttpMethod;
 use Psr\Http\Client\ClientExceptionInterface;
+use Seed\A\AClientInterface;
+use Seed\Folder\FolderClientInterface;
 
 class SeedClient implements SeedClientInterface
 {
@@ -110,5 +112,21 @@ class SeedClient implements SeedClientInterface
             statusCode: $statusCode,
             body: $response->getBody()->getContents(),
         );
+    }
+
+    /**
+     * @return AClientInterface
+     */
+    public function getA(): AClientInterface
+    {
+        return $this->a;
+    }
+
+    /**
+     * @return FolderClientInterface
+     */
+    public function getFolder(): FolderClientInterface
+    {
+        return $this->folder;
     }
 }

--- a/seed/php-sdk/folders/with-interfaces/src/SeedClientInterface.php
+++ b/seed/php-sdk/folders/with-interfaces/src/SeedClientInterface.php
@@ -2,6 +2,9 @@
 
 namespace Seed;
 
+use Seed\A\AClientInterface;
+use Seed\Folder\FolderClientInterface;
+
 interface SeedClientInterface
 {
     /**
@@ -15,4 +18,14 @@ interface SeedClientInterface
      * } $options
      */
     public function foo(?array $options = null): void;
+
+    /**
+     * @return AClientInterface
+     */
+    public function getA(): AClientInterface;
+
+    /**
+     * @return FolderClientInterface
+     */
+    public function getFolder(): FolderClientInterface;
 }

--- a/seed/php-sdk/pagination/no-custom-config/composer.json
+++ b/seed/php-sdk/pagination/no-custom-config/composer.json
@@ -42,5 +42,10 @@
     ],
     "test": "phpunit",
     "analyze": "phpstan analyze src tests --memory-limit=1G"
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
   }
 }


### PR DESCRIPTION
## Description
Generates interfaces even if they're only aggregators of sub-interfaces, and adds getters to them:
```
  Aggregator-only (e.g. AnomalyClientInterface):
  interface AnomalyClientInterface {
      public function getBlocks(): BlocksClientInterface;
  }

  Hybrid (e.g. UsersClientInterface — has endpoints AND sub-clients):
  interface UsersClientInterface {
      public function list(...): Pager;
      public function create(...): CreateUserResponseContent;
      // ... endpoint methods ...
      public function getAuthentication(): AuthenticationClientInterface;
      public function getOrganizations(): OrganizationsClientInterface;
      // ... getter methods ...
  }

  Top-level (ManagementInterface):
  interface ManagementInterface {
      public function getActions(): ActionsClientInterface;
      public function getBranding(): BrandingClientInterface;
      // ... 31 getter methods total ...
  }
```

## Changes Made
Just to `generateClientInterfaces`-flagged sections of the code, so default behavior doesn't change.

## Testing
Regenerated the `folders:with-interfaces` fixture.
- [X] Unit tests added/updated
- [X] Manual testing completed
