### PR TITLE
fix(internal): Bump `fern-python-sdk` test fixtures and assertions

### DIFF
--- a/packages/cli/ete-tests/src/tests/upgrade-generator/fixtures/fern/generators.yml
+++ b/packages/cli/ete-tests/src/tests/upgrade-generator/fixtures/fern/generators.yml
@@ -15,7 +15,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 3.0.0
+        version: 4.0.0
         smart-casing: true
         config:
           inline_request_params: false
@@ -33,6 +33,6 @@ groups:
   shouldnt-upgrade:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 2.16.0
+        version: 3.10.8
         config: {}
 default-group: local

--- a/packages/cli/ete-tests/src/tests/upgrade-generator/upgrade-generator.test.ts
+++ b/packages/cli/ete-tests/src/tests/upgrade-generator/upgrade-generator.test.ts
@@ -39,7 +39,7 @@ describe("fern generator upgrade", () => {
             }
         );
 
-        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("3.0.0");
+        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("4.0.0");
     }, 60_000);
 
     it("fern generator upgrade with filters", async () => {
@@ -82,7 +82,7 @@ describe("fern generator upgrade", () => {
             }
         );
 
-        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("3.0.0");
+        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("4.0.0");
     }, 60_000);
 
     it("fern generator help commands", async () => {
@@ -143,7 +143,7 @@ describe("fern generator upgrade", () => {
             }
         );
 
-        expect(JSON.parse((await readFile(outputFile)).toString()).version).toEqual("2.16.0");
+        expect(JSON.parse((await readFile(outputFile)).toString()).version).toEqual("3.10.8");
 
         await runFernCli(
             [
@@ -227,7 +227,7 @@ describe("fern generator upgrade", () => {
 
         expect(result.stdout).toContain("Major version upgrades available:");
         expect(result.stdout).toContain("fernapi/fern-python-sdk");
-        expect(result.stdout).toContain("2.16.0");
+        expect(result.stdout).toContain("3.10.8");
         expect(result.stdout).toContain(
             "Run: fern generator upgrade --generator fernapi/fern-python-sdk --include-major"
         );


### PR DESCRIPTION
CI fix
