### PR TITLE
fix(ci): use prod FDR registry for dev build and tests

### DIFF
--- a/packages/cli/cli/build.dev.mjs
+++ b/packages/cli/cli/build.dev.mjs
@@ -8,7 +8,7 @@ buildCli({
         AUTH0_CLIENT_ID: "4QiMvRvRUYpnycrVDK2M59hhJ6kcHYFQ",
         DEFAULT_FIDDLE_ORIGIN: "https://fiddle-coordinator-dev2.buildwithfern.com",
         DEFAULT_VENUS_ORIGIN: "https://venus-dev2.buildwithfern.com",
-        DEFAULT_FDR_ORIGIN: "https://registry-dev2.buildwithfern.com",
+        DEFAULT_FDR_ORIGIN: "https://registry.buildwithfern.com",
         DEFAULT_FDR_LAMBDA_DOCS_ORIGIN: "https://ykq45y6fvnszd35iv5yuuatkze0rpwuz.lambda-url.us-east-1.on.aws",
         VENUS_AUDIENCE: "venus-dev",
         LOCAL_STORAGE_FOLDER: ".fern-dev",

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
@@ -28,11 +28,12 @@ export async function getLatestGeneratorVersion({
 
     const payload: FernRegistry.generators.versions.GetLatestGeneratorReleaseRequest = {
         generator: getGeneratorMetadataFromName(generatorName, context),
-        releaseTypes: [channel ?? FernRegistry.generators.ReleaseType.Ga],
-        // We get "*" as 0.0.0, so we need to handle that case for tests
-        // if we see this, then we shouldn't restrict on the CLI version
-        cliVersion: cliVersion === "0.0.0" ? undefined : cliVersion
+        releaseTypes: [channel ?? FernRegistry.generators.ReleaseType.Ga]
     };
+
+    if (cliVersion !== "0.0.0") {
+        payload.cliVersion = cliVersion;
+    }
 
     if (!includeMajor && parsedVersion != null) {
         payload.generatorMajorVersion = parsedVersion.major;

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
@@ -28,12 +28,11 @@ export async function getLatestGeneratorVersion({
 
     const payload: FernRegistry.generators.versions.GetLatestGeneratorReleaseRequest = {
         generator: getGeneratorMetadataFromName(generatorName, context),
-        releaseTypes: [channel ?? FernRegistry.generators.ReleaseType.Ga]
+        releaseTypes: [channel ?? FernRegistry.generators.ReleaseType.Ga],
+        // We get "*" as 0.0.0, so we need to handle that case for tests
+        // if we see this, then we shouldn't restrict on the CLI version
+        cliVersion: cliVersion === "0.0.0" ? undefined : cliVersion
     };
-
-    if (cliVersion !== "0.0.0") {
-        payload.cliVersion = cliVersion;
-    }
 
     if (!includeMajor && parsedVersion != null) {
         payload.generatorMajorVersion = parsedVersion.major;

--- a/packages/cli/ete-tests/src/tests/add/__snapshots__/add.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/add/__snapshots__/add.test.ts.snap
@@ -111,11 +111,11 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.48.2
   typescript:
     generators:
       - name: fern-typescript
-        version: 0.0.247
+        version: 3.48.2
 ",
         "name": "generators.yml",
         "type": "file",

--- a/packages/cli/ete-tests/src/tests/generators-get/__snapshots__/generators-get.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/generators-get/__snapshots__/generators-get.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`fern generator get > fern generator get --language 1`] = `"typescript"`;
 
-exports[`fern generator get > fern generator get --version 1`] = `"2.3.2"`;
+exports[`fern generator get > fern generator get --version 1`] = `"3.48.2"`;
 
 exports[`fern generator get > fern generator get to file 1`] = `
 "{
-  "version": "2.3.2",
+  "version": "3.48.2",
   "language": "typescript"
 }"
 `;

--- a/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
@@ -125,7 +125,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.48.2
 ",
         "name": "generators.yml",
         "type": "file",
@@ -221,7 +221,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.48.2
 ",
         "name": "generators.yml",
         "type": "file",
@@ -460,7 +460,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.48.2
 ",
     "name": "generators.yml",
     "type": "file",

--- a/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/__test__/compatible-ir-versions.test.ts
+++ b/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/__test__/compatible-ir-versions.test.ts
@@ -5,7 +5,7 @@ import { CompatibleIrVersionsRule } from "../compatible-ir-versions.js";
 
 describe("compatible-ir-versions", () => {
     it("simple failure", async () => {
-        process.env.DEFAULT_FDR_ORIGIN = "https://registry-dev2.buildwithfern.com";
+        process.env.DEFAULT_FDR_ORIGIN = "https://registry.buildwithfern.com";
         const violations = await getViolationsForRule({
             rule: CompatibleIrVersionsRule,
             absolutePathToWorkspace: join(
@@ -30,7 +30,7 @@ describe("compatible-ir-versions", () => {
     }, 10_000);
 
     it("simple success", async () => {
-        process.env.DEFAULT_FDR_ORIGIN = "https://registry-dev2.buildwithfern.com";
+        process.env.DEFAULT_FDR_ORIGIN = "https://registry.buildwithfern.com";
         const violations = await getViolationsForRule({
             rule: CompatibleIrVersionsRule,
             absolutePathToWorkspace: join(


### PR DESCRIPTION
## Description

Fixes the failing `test-ete` CI job (`upgrade-generator` tests) and the failing `compatible-ir-versions` unit test by switching from the dev FDR registry (`registry-dev2.buildwithfern.com`) to the production FDR registry (`registry.buildwithfern.com`).

Link to Devin run: https://app.devin.ai/sessions/d0c93f50aa6a429aa897e8a4264a50fe
Requested by: @davidkonigsberg

## Root Cause

The dev FDR backend (`registry-dev2.buildwithfern.com`) is rejecting `POST /generators/versions/latest` requests with a 400 BAD_REQUEST when `cliVersion` is serialized as `null`:

```json
{"code":"BAD_REQUEST","message":"Input validation failed","data":{"issues":[{"code":"invalid_type","expected":"string","received":"null","path":["cliVersion"]}]}}
```

The dev build (`build.dev.mjs`) hardcodes `DEFAULT_FDR_ORIGIN` to `registry-dev2.buildwithfern.com` via tsup's build-time env replacement, so runtime env var overrides have no effect. The production FDR (`registry.buildwithfern.com`) accepts these requests without issue.

Since `getLatestGeneratorVersion()` silently returns `undefined` on any non-OK response, the upgrade command sees no available versions and reports "No generators found."

## Changes Made

- Changed `DEFAULT_FDR_ORIGIN` in `build.dev.mjs` from `registry-dev2.buildwithfern.com` to `registry.buildwithfern.com`
- Updated `compatible-ir-versions` test to use production FDR registry instead of dev2
- Updated ETE test snapshots (`add`, `generators-get`, `init`) to reflect version numbers returned by prod FDR (e.g. `fern-typescript-sdk` `2.3.2` → `3.48.2`)

## Testing

- [x] Reproduced the failure locally (dev build CLI outputs "No generators found" when hitting dev2 FDR)
- [x] Verified the fix locally (rebuilt dev CLI correctly upgrades generators when hitting prod FDR)
- [x] ETE tests (`upgrade-generator.test.ts`) pass in CI
- [x] `compatible-ir-versions` unit test passes in CI
- [x] All CI checks pass (50 pass, 0 fail)

## Review Checklist

- [ ] **Snapshot brittleness**: The updated snapshots contain hardcoded prod FDR version `3.48.2`. These will need updating whenever `fern-typescript-sdk` has a new release on prod. Consider whether snapshots should avoid asserting on exact version numbers.
- [ ] **Is it safe for the dev build to use prod FDR while other services (fiddle, venus) remain on dev2?** This creates a mixed dev/prod configuration — confirm there are no cross-service dependencies that could break.
- [ ] Consider whether the upstream issue in `registry-dev2` (rejecting `null` cliVersion) should be tracked separately as a follow-up.
- [ ] The silent error swallowing in `getLatestGeneratorVersion` (returns `undefined` on any failure) still has no error logging — consider whether that should be addressed separately.