### PR TITLE
fix(ci): revert use prod FDR registry for dev build and tests

### DIFF
--- a/packages/cli/cli/build.dev.mjs
+++ b/packages/cli/cli/build.dev.mjs
@@ -8,7 +8,7 @@ buildCli({
         AUTH0_CLIENT_ID: "4QiMvRvRUYpnycrVDK2M59hhJ6kcHYFQ",
         DEFAULT_FIDDLE_ORIGIN: "https://fiddle-coordinator-dev2.buildwithfern.com",
         DEFAULT_VENUS_ORIGIN: "https://venus-dev2.buildwithfern.com",
-        DEFAULT_FDR_ORIGIN: "https://registry.buildwithfern.com",
+        DEFAULT_FDR_ORIGIN: "https://registry-dev2.buildwithfern.com",
         DEFAULT_FDR_LAMBDA_DOCS_ORIGIN: "https://ykq45y6fvnszd35iv5yuuatkze0rpwuz.lambda-url.us-east-1.on.aws",
         VENUS_AUDIENCE: "venus-dev",
         LOCAL_STORAGE_FOLDER: ".fern-dev",

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
@@ -19,11 +19,12 @@ export async function getLatestGeneratorVersion({
 }): Promise<string | undefined> {
     const parsedVersion = semver.parse(currentGeneratorVersion);
     // We're just using unauthed endpoints, so we don't need to pass in a token
+    const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
     const client = new GeneratorsClient({
-        environment: process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com"
+        environment: fdrOrigin
     });
     context?.logger.debug(
-        `Getting latest version for ${generatorName} with CLI version ${cliVersion}, includeMajor: ${includeMajor}, prior version: ${parsedVersion}`
+        `Getting latest version for ${generatorName} with CLI version ${cliVersion}, includeMajor: ${includeMajor}, prior version: ${parsedVersion}, FDR origin: ${fdrOrigin}`
     );
 
     const payload: FernRegistry.generators.versions.GetLatestGeneratorReleaseRequest = {
@@ -38,11 +39,20 @@ export async function getLatestGeneratorVersion({
         payload.generatorMajorVersion = parsedVersion.major;
     }
 
+    context?.logger.debug(
+        `[FDR] getLatestGeneratorRelease request: ${JSON.stringify(payload)}`
+    );
     const latestReleaseResponse = await client.generators.versions.getLatestGeneratorRelease(payload);
 
     if (latestReleaseResponse.ok) {
+        context?.logger.debug(
+            `[FDR] getLatestGeneratorRelease response for ${generatorName}: version=${latestReleaseResponse.body.version}, irVersion=${latestReleaseResponse.body.irVersion}`
+        );
         return latestReleaseResponse.body.version;
     }
+    context?.logger.debug(
+        `[FDR] getLatestGeneratorRelease failed for ${generatorName}: ${JSON.stringify(latestReleaseResponse)}`
+    );
     return undefined;
 }
 

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorVersions.ts
@@ -39,9 +39,7 @@ export async function getLatestGeneratorVersion({
         payload.generatorMajorVersion = parsedVersion.major;
     }
 
-    context?.logger.debug(
-        `[FDR] getLatestGeneratorRelease request: ${JSON.stringify(payload)}`
-    );
+    context?.logger.debug(`[FDR] getLatestGeneratorRelease request: ${JSON.stringify(payload)}`);
     const latestReleaseResponse = await client.generators.versions.getLatestGeneratorRelease(payload);
 
     if (latestReleaseResponse.ok) {

--- a/packages/cli/ete-tests/src/tests/add/__snapshots__/add.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/add/__snapshots__/add.test.ts.snap
@@ -111,11 +111,11 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 3.48.2
+        version: 2.3.2
   typescript:
     generators:
       - name: fern-typescript
-        version: 3.48.2
+        version: 0.0.247
 ",
         "name": "generators.yml",
         "type": "file",

--- a/packages/cli/ete-tests/src/tests/generators-get/__snapshots__/generators-get.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/generators-get/__snapshots__/generators-get.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`fern generator get > fern generator get --language 1`] = `"typescript"`;
 
-exports[`fern generator get > fern generator get --version 1`] = `"3.48.2"`;
+exports[`fern generator get > fern generator get --version 1`] = `"2.3.2"`;
 
 exports[`fern generator get > fern generator get to file 1`] = `
 "{
-  "version": "3.48.2",
+  "version": "2.3.2",
   "language": "typescript"
 }"
 `;

--- a/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
@@ -125,7 +125,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 3.48.2
+        version: 2.3.2
 ",
         "name": "generators.yml",
         "type": "file",
@@ -221,7 +221,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 3.48.2
+        version: 2.3.2
 ",
         "name": "generators.yml",
         "type": "file",
@@ -460,7 +460,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 3.48.2
+        version: 2.3.2
 ",
     "name": "generators.yml",
     "type": "file",

--- a/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/__test__/compatible-ir-versions.test.ts
+++ b/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/__test__/compatible-ir-versions.test.ts
@@ -5,7 +5,7 @@ import { CompatibleIrVersionsRule } from "../compatible-ir-versions.js";
 
 describe("compatible-ir-versions", () => {
     it("simple failure", async () => {
-        process.env.DEFAULT_FDR_ORIGIN = "https://registry.buildwithfern.com";
+        process.env.DEFAULT_FDR_ORIGIN = "https://registry-dev2.buildwithfern.com";
         const violations = await getViolationsForRule({
             rule: CompatibleIrVersionsRule,
             absolutePathToWorkspace: join(
@@ -30,7 +30,7 @@ describe("compatible-ir-versions", () => {
     }, 10_000);
 
     it("simple success", async () => {
-        process.env.DEFAULT_FDR_ORIGIN = "https://registry.buildwithfern.com";
+        process.env.DEFAULT_FDR_ORIGIN = "https://registry-dev2.buildwithfern.com";
         const violations = await getViolationsForRule({
             rule: CompatibleIrVersionsRule,
             absolutePathToWorkspace: join(

--- a/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
+++ b/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
@@ -41,11 +41,16 @@ export const CompatibleIrVersionsRule: Rule = {
                     const cliRelease = await fdr.generators.cli.getCliRelease(cliVersion);
                     // Again, this is to allow for offline usage, and other transient errors
                     if (!cliRelease.ok) {
-                        console.debug(`[FDR] compatible-ir-versions: getCliRelease failed for ${cliVersion}`, cliRelease);
+                        console.debug(
+                            `[FDR] compatible-ir-versions: getCliRelease failed for ${cliVersion}`,
+                            cliRelease
+                        );
                         return [];
                     }
                     const cliIrVersion = cliRelease.body.irVersion;
-                    console.debug(`[FDR] compatible-ir-versions: CLI version=${cliVersion} has irVersion=${cliIrVersion}`);
+                    console.debug(
+                        `[FDR] compatible-ir-versions: CLI version=${cliVersion} has irVersion=${cliIrVersion}`
+                    );
 
                     // Pull the generator release to get the IR version
                     let invocationIrVersion: number;
@@ -61,12 +66,16 @@ export const CompatibleIrVersionsRule: Rule = {
                             name: addDefaultDockerOrgIfNotPresent(invocation.name)
                         };
                         const maybeIrVersion = await getIrVersionForGenerator(normalizedInvocation);
-                        console.debug(`[FDR] compatible-ir-versions: irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version} = ${maybeIrVersion}`);
+                        console.debug(
+                            `[FDR] compatible-ir-versions: irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version} = ${maybeIrVersion}`
+                        );
 
                         // The above returns undefined if we can't get the IR version, so we'll just return an empty array
                         // Again, this is to allow for offline usage, and other transient errors
                         if (maybeIrVersion == null) {
-                            console.debug(`[FDR] compatible-ir-versions: could not resolve irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version}, skipping validation`);
+                            console.debug(
+                                `[FDR] compatible-ir-versions: could not resolve irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version}, skipping validation`
+                            );
                             return [];
                         }
 

--- a/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
+++ b/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
@@ -37,10 +37,12 @@ export const CompatibleIrVersionsRule: Rule = {
                     }
 
                     // Pull the CLI release to get the IR version
+                    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
                     console.debug(`[FDR] compatible-ir-versions: checking CLI release for version=${cliVersion}`);
                     const cliRelease = await fdr.generators.cli.getCliRelease(cliVersion);
                     // Again, this is to allow for offline usage, and other transient errors
                     if (!cliRelease.ok) {
+                        // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
                         console.debug(
                             `[FDR] compatible-ir-versions: getCliRelease failed for ${cliVersion}`,
                             cliRelease
@@ -48,6 +50,7 @@ export const CompatibleIrVersionsRule: Rule = {
                         return [];
                     }
                     const cliIrVersion = cliRelease.body.irVersion;
+                    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
                     console.debug(
                         `[FDR] compatible-ir-versions: CLI version=${cliVersion} has irVersion=${cliIrVersion}`
                     );
@@ -66,6 +69,7 @@ export const CompatibleIrVersionsRule: Rule = {
                             name: addDefaultDockerOrgIfNotPresent(invocation.name)
                         };
                         const maybeIrVersion = await getIrVersionForGenerator(normalizedInvocation);
+                        // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
                         console.debug(
                             `[FDR] compatible-ir-versions: irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version} = ${maybeIrVersion}`
                         );
@@ -73,6 +77,7 @@ export const CompatibleIrVersionsRule: Rule = {
                         // The above returns undefined if we can't get the IR version, so we'll just return an empty array
                         // Again, this is to allow for offline usage, and other transient errors
                         if (maybeIrVersion == null) {
+                            // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
                             console.debug(
                                 `[FDR] compatible-ir-versions: could not resolve irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version}, skipping validation`
                             );

--- a/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
+++ b/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
@@ -37,12 +37,15 @@ export const CompatibleIrVersionsRule: Rule = {
                     }
 
                     // Pull the CLI release to get the IR version
+                    console.debug(`[FDR] compatible-ir-versions: checking CLI release for version=${cliVersion}`);
                     const cliRelease = await fdr.generators.cli.getCliRelease(cliVersion);
                     // Again, this is to allow for offline usage, and other transient errors
                     if (!cliRelease.ok) {
+                        console.debug(`[FDR] compatible-ir-versions: getCliRelease failed for ${cliVersion}`, cliRelease);
                         return [];
                     }
                     const cliIrVersion = cliRelease.body.irVersion;
+                    console.debug(`[FDR] compatible-ir-versions: CLI version=${cliVersion} has irVersion=${cliIrVersion}`);
 
                     // Pull the generator release to get the IR version
                     let invocationIrVersion: number;
@@ -58,10 +61,12 @@ export const CompatibleIrVersionsRule: Rule = {
                             name: addDefaultDockerOrgIfNotPresent(invocation.name)
                         };
                         const maybeIrVersion = await getIrVersionForGenerator(normalizedInvocation);
+                        console.debug(`[FDR] compatible-ir-versions: irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version} = ${maybeIrVersion}`);
 
                         // The above returns undefined if we can't get the IR version, so we'll just return an empty array
                         // Again, this is to allow for offline usage, and other transient errors
                         if (maybeIrVersion == null) {
+                            console.debug(`[FDR] compatible-ir-versions: could not resolve irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version}, skipping validation`);
                             return [];
                         }
 

--- a/packages/core/src/services/fdrGeneratorsSdk.ts
+++ b/packages/core/src/services/fdrGeneratorsSdk.ts
@@ -7,6 +7,7 @@ export function createFdrGeneratorsSdkService({
     environment?: string;
     token: (() => string) | string | undefined;
 }): FdrClient {
+    console.debug(`[FDR] Creating generators SDK service with environment: ${environment}`);
     return new FdrClient({
         environment,
         token
@@ -20,22 +21,27 @@ export interface GeneratorInfo {
 
 export async function getIrVersionForGenerator(invocation: GeneratorInfo): Promise<number | undefined> {
     const fdr = createFdrGeneratorsSdkService({ token: undefined });
+    console.debug(`[FDR] getIrVersionForGenerator: looking up generator by image: ${invocation.name}`);
     const generatorEntity = await fdr.generators.getGeneratorByImage({
         dockerImage: invocation.name
     });
     // Again, this is to allow for offline usage, and other transient errors
     if (!generatorEntity.ok || generatorEntity.body == null) {
+        console.debug(`[FDR] getIrVersionForGenerator: getGeneratorByImage failed for ${invocation.name}`, generatorEntity);
         return undefined;
     }
+    console.debug(`[FDR] getIrVersionForGenerator: found generator id=${generatorEntity.body.id}, fetching release version=${invocation.version}`);
     const generatorRelease = await fdr.generators.versions.getGeneratorRelease(
         generatorEntity.body.id,
         invocation.version
     );
 
     if (generatorRelease.ok) {
+        console.debug(`[FDR] getIrVersionForGenerator: got release for ${invocation.name}@${invocation.version}, irVersion=${generatorRelease.body.irVersion}`);
         // We've pulled the generator release, let's get it's IR version
         return generatorRelease.body.irVersion;
     }
 
+    console.debug(`[FDR] getIrVersionForGenerator: getGeneratorRelease failed for ${generatorEntity.body.id}@${invocation.version}`, generatorRelease);
     return undefined;
 }

--- a/packages/core/src/services/fdrGeneratorsSdk.ts
+++ b/packages/core/src/services/fdrGeneratorsSdk.ts
@@ -27,21 +27,31 @@ export async function getIrVersionForGenerator(invocation: GeneratorInfo): Promi
     });
     // Again, this is to allow for offline usage, and other transient errors
     if (!generatorEntity.ok || generatorEntity.body == null) {
-        console.debug(`[FDR] getIrVersionForGenerator: getGeneratorByImage failed for ${invocation.name}`, generatorEntity);
+        console.debug(
+            `[FDR] getIrVersionForGenerator: getGeneratorByImage failed for ${invocation.name}`,
+            generatorEntity
+        );
         return undefined;
     }
-    console.debug(`[FDR] getIrVersionForGenerator: found generator id=${generatorEntity.body.id}, fetching release version=${invocation.version}`);
+    console.debug(
+        `[FDR] getIrVersionForGenerator: found generator id=${generatorEntity.body.id}, fetching release version=${invocation.version}`
+    );
     const generatorRelease = await fdr.generators.versions.getGeneratorRelease(
         generatorEntity.body.id,
         invocation.version
     );
 
     if (generatorRelease.ok) {
-        console.debug(`[FDR] getIrVersionForGenerator: got release for ${invocation.name}@${invocation.version}, irVersion=${generatorRelease.body.irVersion}`);
+        console.debug(
+            `[FDR] getIrVersionForGenerator: got release for ${invocation.name}@${invocation.version}, irVersion=${generatorRelease.body.irVersion}`
+        );
         // We've pulled the generator release, let's get it's IR version
         return generatorRelease.body.irVersion;
     }
 
-    console.debug(`[FDR] getIrVersionForGenerator: getGeneratorRelease failed for ${generatorEntity.body.id}@${invocation.version}`, generatorRelease);
+    console.debug(
+        `[FDR] getIrVersionForGenerator: getGeneratorRelease failed for ${generatorEntity.body.id}@${invocation.version}`,
+        generatorRelease
+    );
     return undefined;
 }

--- a/packages/core/src/services/fdrGeneratorsSdk.ts
+++ b/packages/core/src/services/fdrGeneratorsSdk.ts
@@ -7,6 +7,7 @@ export function createFdrGeneratorsSdkService({
     environment?: string;
     token: (() => string) | string | undefined;
 }): FdrClient {
+    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
     console.debug(`[FDR] Creating generators SDK service with environment: ${environment}`);
     return new FdrClient({
         environment,
@@ -21,18 +22,21 @@ export interface GeneratorInfo {
 
 export async function getIrVersionForGenerator(invocation: GeneratorInfo): Promise<number | undefined> {
     const fdr = createFdrGeneratorsSdkService({ token: undefined });
+    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
     console.debug(`[FDR] getIrVersionForGenerator: looking up generator by image: ${invocation.name}`);
     const generatorEntity = await fdr.generators.getGeneratorByImage({
         dockerImage: invocation.name
     });
     // Again, this is to allow for offline usage, and other transient errors
     if (!generatorEntity.ok || generatorEntity.body == null) {
+        // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
         console.debug(
             `[FDR] getIrVersionForGenerator: getGeneratorByImage failed for ${invocation.name}`,
             generatorEntity
         );
         return undefined;
     }
+    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
     console.debug(
         `[FDR] getIrVersionForGenerator: found generator id=${generatorEntity.body.id}, fetching release version=${invocation.version}`
     );
@@ -42,6 +46,7 @@ export async function getIrVersionForGenerator(invocation: GeneratorInfo): Promi
     );
 
     if (generatorRelease.ok) {
+        // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
         console.debug(
             `[FDR] getIrVersionForGenerator: got release for ${invocation.name}@${invocation.version}, irVersion=${generatorRelease.body.irVersion}`
         );
@@ -49,6 +54,7 @@ export async function getIrVersionForGenerator(invocation: GeneratorInfo): Promi
         return generatorRelease.body.irVersion;
     }
 
+    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
     console.debug(
         `[FDR] getIrVersionForGenerator: getGeneratorRelease failed for ${generatorEntity.body.id}@${invocation.version}`,
         generatorRelease


### PR DESCRIPTION
## Description

Reverts fern-api/fern#12539

Switches `DEFAULT_FDR_ORIGIN` back to `registry-dev2.buildwithfern.com` for dev builds and adds debug logging to all FDR generator SDK calls to help diagnose data discrepancies on the dev2 registry. Also fixes the `getLatestGeneratorRelease` call to always send `cliVersion` as a string (the FDR endpoint now requires it).

Link to Devin run: https://app.devin.ai/sessions/f3c9830721d34a3d9dcf8cae14101ef6
Link to Devin run (cliVersion fix): https://app.devin.ai/sessions/b08f5b601c844712abe7df3298b9c66c
Requested by: @dsinghvi (revert + logging), @davidkonigsberg (cliVersion fix)

## Changes Made

- Reverted `DEFAULT_FDR_ORIGIN` in `build.dev.mjs` from prod (`registry.buildwithfern.com`) back to dev2 (`registry-dev2.buildwithfern.com`)
- Added `[FDR]`-prefixed debug logging to generator registry API calls:
  - `fdrGeneratorsSdk.ts`: logs environment, generator lookups, release fetches, and failures
  - `compatible-ir-versions.ts`: logs CLI release lookups, IR version resolution, and skipped validations
  - `getGeneratorVersions.ts`: logs request payloads, response versions, and failures (uses `context.logger.debug`)
- Updated test snapshots and test fixtures to reflect dev2 registry data
- Fixed `getGeneratorVersions.ts` to always pass `cliVersion` as a string to `getLatestGeneratorRelease` instead of setting it to `undefined` when the value is `"0.0.0"` (the FDR endpoint now validates `cliVersion` as a required string)
- [ ] Updated README.md generator (if applicable)

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed

## ⚠️ Human Review Checklist

- **`cliVersion: "0.0.0"` is now sent to the FDR endpoint in test/dev builds** — previously this was explicitly set to `undefined` to avoid restricting on CLI version. Verify that the endpoint handles `"0.0.0"` gracefully (i.e., doesn't incorrectly filter results based on it).
- **Debug logging uses `console.debug` with `biome-ignore` suppressions** — reviewer should decide whether this diagnostic logging should remain permanently or be removed after investigation.
- **Snapshot diffs reflect dev2's stale data** — the version differences (e.g., `3.48.2` → `2.3.2`) are real data discrepancies between prod and dev2 registries, not bugs in this PR.