### PR TITLE
fix: include required non-leaf properties in minimal example generation for recursive types

### DIFF
--- a/packages/commons/ir-utils/src/examples/v1/generateTypeReferenceExample.ts
+++ b/packages/commons/ir-utils/src/examples/v1/generateTypeReferenceExample.ts
@@ -9,6 +9,7 @@ import {
     TypeReference
 } from "@fern-api/ir-sdk";
 
+import { isTypeReferenceOptional } from "../../utils/isTypeReferenceOptional.js";
 import { ExampleGenerationResult } from "./ExampleGenerationResult.js";
 import { generateContainerExample, generateEmptyContainerExample } from "./generateContainerExample.js";
 import { generatePrimitiveExample } from "./generatePrimitiveExample.js";
@@ -181,8 +182,8 @@ function isLeafTypeReference(typeRef: TypeReference, typeDeclarations: Record<Ty
 /**
  * Generates a stub example for a named type when cycle detection triggers.
  * Instead of returning failure (which cascades up and kills parent examples),
- * this produces a valid example with all leaf (non-recursive) properties filled in:
- * - Objects → generates all primitive/enum/literal properties, skips recursive ones
+ * this produces a valid example with required properties filled in:
+ * - Objects → generates all leaf properties and required non-leaf properties, skips optional non-leaf ones
  * - Enums → first enum value
  * - Aliases → resolve non-recursive targets; recursive ones get empty object
  * - Unions → first noProperties variant if available; otherwise failure
@@ -202,7 +203,10 @@ function generateMinimalNamedExample({
                 ...(typeDeclaration.shape.properties ?? []),
                 ...(typeDeclaration.shape.extendedProperties ?? [])
             ]) {
-                if (!isLeafTypeReference(property.valueType, typeDeclarations)) {
+                if (
+                    !isLeafTypeReference(property.valueType, typeDeclarations) &&
+                    isTypeReferenceOptional({ typeReference: property.valueType, typeDeclarations })
+                ) {
                     continue;
                 }
                 const propertyExample = generateTypeReferenceExample({

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Unit/MockServer/GetAccountTest.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Unit/MockServer/GetAccountTest.cs
@@ -26,18 +26,74 @@ public class GetAccountTest : BaseMockServerTest
                         "resource_type": "Account",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       }
                     ],
@@ -47,9 +103,37 @@ public class GetAccountTest : BaseMockServerTest
                         "resource_type": "Account",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       }
                     }
@@ -63,18 +147,74 @@ public class GetAccountTest : BaseMockServerTest
                         "resource_type": "Account",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       },
                       {
                         "resource_type": "Account",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       }
                     ],
@@ -84,9 +224,37 @@ public class GetAccountTest : BaseMockServerTest
                         "resource_type": "Account",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       }
                     }
@@ -102,26 +270,81 @@ public class GetAccountTest : BaseMockServerTest
                       "name": "name",
                       "scripts": [],
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "practitioner": {
                       "resource_type": "Practitioner",
                       "name": "name",
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -129,9 +352,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -140,7 +362,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   },
                   {
@@ -151,26 +382,81 @@ public class GetAccountTest : BaseMockServerTest
                       "name": "name",
                       "scripts": [],
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "practitioner": {
                       "resource_type": "Practitioner",
                       "name": "name",
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -178,9 +464,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -189,7 +474,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   }
                 ],
@@ -203,26 +497,81 @@ public class GetAccountTest : BaseMockServerTest
                       "name": "name",
                       "scripts": [],
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "practitioner": {
                       "resource_type": "Practitioner",
                       "name": "name",
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -230,9 +579,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -241,7 +589,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   }
                 }
@@ -259,26 +616,81 @@ public class GetAccountTest : BaseMockServerTest
                       "name": "name",
                       "scripts": [],
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "practitioner": {
                       "resource_type": "Practitioner",
                       "name": "name",
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -286,9 +698,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -297,7 +708,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   },
                   {
@@ -308,26 +728,81 @@ public class GetAccountTest : BaseMockServerTest
                       "name": "name",
                       "scripts": [],
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "practitioner": {
                       "resource_type": "Practitioner",
                       "name": "name",
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -335,9 +810,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -346,7 +820,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   }
                 ],
@@ -360,26 +843,81 @@ public class GetAccountTest : BaseMockServerTest
                       "name": "name",
                       "scripts": [],
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "practitioner": {
                       "resource_type": "Practitioner",
                       "name": "name",
                       "id": "id",
-                      "related_resources": [],
+                      "related_resources": [
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        },
+                        {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
+                      ],
                       "memo": {
-                        "description": "description"
+                        "description": "description",
+                        "account": {
+                          "resource_type": "Account",
+                          "name": "name",
+                          "id": "id",
+                          "related_resources": [],
+                          "memo": {
+                            "description": "description"
+                          }
+                        }
                       }
                     },
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -387,9 +925,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -398,7 +935,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   }
                 }
@@ -416,27 +962,82 @@ public class GetAccountTest : BaseMockServerTest
                         "resource_type": "Script",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       },
                       {
                         "resource_type": "Script",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       }
                     ],
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -444,9 +1045,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -455,7 +1055,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   },
                   "practitioner": {
@@ -464,9 +1073,8 @@ public class GetAccountTest : BaseMockServerTest
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -474,9 +1082,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -485,34 +1092,23 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   },
                   "id": "id",
                   "related_resources": [
                     {
-                      "resource_type": "Patient",
+                      "resource_type": "Account",
                       "name": "name",
-                      "scripts": [
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        },
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        }
-                      ],
                       "id": "id",
                       "related_resources": [],
                       "memo": {
@@ -520,28 +1116,8 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     },
                     {
-                      "resource_type": "Patient",
+                      "resource_type": "Account",
                       "name": "name",
-                      "scripts": [
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        },
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        }
-                      ],
                       "id": "id",
                       "related_resources": [],
                       "memo": {
@@ -550,7 +1126,16 @@ public class GetAccountTest : BaseMockServerTest
                     }
                   ],
                   "memo": {
-                    "description": "description"
+                    "description": "description",
+                    "account": {
+                      "resource_type": "Account",
+                      "name": "name",
+                      "id": "id",
+                      "related_resources": [],
+                      "memo": {
+                        "description": "description"
+                      }
+                    }
                   }
                 },
                 {
@@ -564,27 +1149,82 @@ public class GetAccountTest : BaseMockServerTest
                         "resource_type": "Script",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       },
                       {
                         "resource_type": "Script",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       }
                     ],
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -592,9 +1232,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -603,7 +1242,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   },
                   "practitioner": {
@@ -612,9 +1260,8 @@ public class GetAccountTest : BaseMockServerTest
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -622,9 +1269,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -633,34 +1279,23 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   },
                   "id": "id",
                   "related_resources": [
                     {
-                      "resource_type": "Patient",
+                      "resource_type": "Account",
                       "name": "name",
-                      "scripts": [
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        },
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        }
-                      ],
                       "id": "id",
                       "related_resources": [],
                       "memo": {
@@ -668,28 +1303,8 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     },
                     {
-                      "resource_type": "Patient",
+                      "resource_type": "Account",
                       "name": "name",
-                      "scripts": [
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        },
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        }
-                      ],
                       "id": "id",
                       "related_resources": [],
                       "memo": {
@@ -698,7 +1313,16 @@ public class GetAccountTest : BaseMockServerTest
                     }
                   ],
                   "memo": {
-                    "description": "description"
+                    "description": "description",
+                    "account": {
+                      "resource_type": "Account",
+                      "name": "name",
+                      "id": "id",
+                      "related_resources": [],
+                      "memo": {
+                        "description": "description"
+                      }
+                    }
                   }
                 }
               ],
@@ -715,27 +1339,82 @@ public class GetAccountTest : BaseMockServerTest
                         "resource_type": "Script",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       },
                       {
                         "resource_type": "Script",
                         "name": "name",
                         "id": "id",
-                        "related_resources": [],
+                        "related_resources": [
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          },
+                          {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
+                        ],
                         "memo": {
-                          "description": "description"
+                          "description": "description",
+                          "account": {
+                            "resource_type": "Account",
+                            "name": "name",
+                            "id": "id",
+                            "related_resources": [],
+                            "memo": {
+                              "description": "description"
+                            }
+                          }
                         }
                       }
                     ],
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -743,9 +1422,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -754,7 +1432,16 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   },
                   "practitioner": {
@@ -763,9 +1450,8 @@ public class GetAccountTest : BaseMockServerTest
                     "id": "id",
                     "related_resources": [
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -773,9 +1459,8 @@ public class GetAccountTest : BaseMockServerTest
                         }
                       },
                       {
-                        "resource_type": "Patient",
+                        "resource_type": "Account",
                         "name": "name",
-                        "scripts": [],
                         "id": "id",
                         "related_resources": [],
                         "memo": {
@@ -784,34 +1469,23 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     ],
                     "memo": {
-                      "description": "description"
+                      "description": "description",
+                      "account": {
+                        "resource_type": "Account",
+                        "name": "name",
+                        "id": "id",
+                        "related_resources": [],
+                        "memo": {
+                          "description": "description"
+                        }
+                      }
                     }
                   },
                   "id": "id",
                   "related_resources": [
                     {
-                      "resource_type": "Patient",
+                      "resource_type": "Account",
                       "name": "name",
-                      "scripts": [
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        },
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        }
-                      ],
                       "id": "id",
                       "related_resources": [],
                       "memo": {
@@ -819,28 +1493,8 @@ public class GetAccountTest : BaseMockServerTest
                       }
                     },
                     {
-                      "resource_type": "Patient",
+                      "resource_type": "Account",
                       "name": "name",
-                      "scripts": [
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        },
-                        {
-                          "resource_type": "Script",
-                          "name": "name",
-                          "id": "id",
-                          "related_resources": [],
-                          "memo": {
-                            "description": "description"
-                          }
-                        }
-                      ],
                       "id": "id",
                       "related_resources": [],
                       "memo": {
@@ -849,7 +1503,16 @@ public class GetAccountTest : BaseMockServerTest
                     }
                   ],
                   "memo": {
-                    "description": "description"
+                    "description": "description",
+                    "account": {
+                      "resource_type": "Account",
+                      "name": "name",
+                      "id": "id",
+                      "related_resources": [],
+                      "memo": {
+                        "description": "description"
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Description

Fixes a flaky CI failure in the `simple-fhir` test for `csharp-sdk` (and potentially other generators). The `OneOfSerializer` was throwing `"Cannot deserialize into one of the supported types"` because auto-generated example stubs for recursive types were missing required fields.

Refs https://github.com/fern-api/fern/actions/runs/22187403735/job/64165870430?pr=12543

## Root Cause

When the V1 example generator detects a recursive cycle (e.g., `Account → related_resources → ResourceList → Account`), it calls `generateMinimalNamedExample()` to produce a stub. This stub previously **only included leaf properties** (primitives, enums, literals), skipping all complex/named types — including **required** ones like `memo: Memo`.

This produced JSON like `{"resource_type": "Account", "name": "name", "id": "id"}`, missing the required `memo` field. The C# deserializer (and likely others) then failed because `memo` is a `required` property on all four union variants (Account, Patient, Practitioner, Script), so every variant attempt threw `JsonException`.

## Changes Made

- **`packages/commons/ir-utils/src/examples/v1/generateTypeReferenceExample.ts`**: Changed `generateMinimalNamedExample` to only skip non-leaf properties that are **optional**. Required non-leaf properties (like `memo: Memo`) are now also generated in the minimal stub. Recursion is bounded by the existing `maxDepth: 3` limit and empty-container fallbacks.
- **`seed/csharp-sdk/simple-fhir/...GetAccountTest.cs`**: Updated generated snapshot — stubs now include `memo` and populated `related_resources` where previously they had empty arrays and missing fields.

## Important Review Notes

⚠️ **This change is in shared IR utils, not a specific generator.** It affects auto-generated examples for all generators that have recursive types. CI may require snapshot updates for other generators' `simple-fhir` fixtures (go-sdk, java-sdk, python-sdk, ts-sdk, etc.). Only the `csharp-sdk` snapshot was regenerated in this PR.

⚠️ **Verify the condition logic**: The key change is from `if (!isLeaf) { continue }` → `if (!isLeaf && isOptional) { continue }`. This means required non-leaf properties are now attempted instead of skipped.

## Testing

- [x] `pnpm seed test --fixture simple-fhir -g csharp-sdk` passes locally
- [x] Generated examples now include required `memo` field in recursive stubs
- [ ] CI will verify all generators (may require additional snapshot updates)

## Human Review Checklist

- [ ] Verify the condition change is correct: `!isLeafTypeReference(...) && isTypeReferenceOptional(...)` correctly skips only optional non-leaf properties
- [ ] Check if other generators' `simple-fhir` snapshots need regeneration (CI will show failures if so)
- [ ] Consider whether deeply recursive schemas with many required non-leaf properties could produce unexpectedly large examples

---

Link to Devin run: https://app.devin.ai/sessions/2d204787b1944146b26c04091212f68a  
Requested by: @davidkonigsberg