### PR TITLE
fix(php): ensure --version flag takes precedence over custom composerJson config

### DIFF
--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -349,6 +349,9 @@ class ComposerJson {
             }
         };
         composerJson = mergeExtraConfigs(composerJson, this.context.customConfig.composerJson);
+        if (this.context.version != null) {
+            composerJson.version = this.context.version;
+        }
         return composerJson;
     }
 

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.3
+  changelogEntry:
+    - summary: |
+        Fix `--version` flag not being applied to composer.json when custom `composerJson`
+        config is set. Previously, the `mergeExtraConfigs` utility could override the version
+        provided via `--version` with a stale version from the custom config. Now the explicitly
+        provided version always takes precedence.
+      type: fix
+  createdAt: "2026-02-19"
+  irVersion: 62
+
 - version: 2.1.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: [Slack thread](https://buildwithfern.slack.com/archives/C094V1SA1J6/p1771522989170019?thread_ts=1770999114.736579&cid=C094V1SA1J6)

When running `fern generate --group php-sdk --version 4.0.1`, the generated `composer.json` could show a stale version (e.g., `0.0.73`) instead of the user-specified version. This happens because `mergeExtraConfigs` merges the user's custom `composerJson` config _after_ the version is set, and for scalar values the custom config wins unconditionally.

## Changes Made

- After merging custom `composerJson` config, re-apply `this.context.version` if it is non-null so the explicitly provided `--version` always takes precedence
- Added changelog entry in `generators/php/sdk/versions.yml` (v2.1.3)

## Testing

- [x] Compilation passes (`pnpm --filter @fern-api/php-base compile`)
- [ ] No unit tests were added — the fix is straightforward but a reviewer should confirm it covers the reported scenario

## Reviewer Checklist

- [ ] **Root cause confidence**: The reported version was `0.0.73`, which implies the version _is_ reaching the generator (not `undefined`/`0.0.0`). The most likely source is a `composerJson.version` override in the user's custom config. Worth confirming this matches the user's actual `generators.yml`.
- [ ] **`downloadFiles` output mode**: When `output.location: local-file-system` is used, the `--version` value still does not propagate to the generator config at all (`this.context.version` will be `undefined`). This is a separate, pre-existing issue and is **not** addressed here.
- [ ] **Other fields**: Only `version` is protected from override. If other generated fields (e.g., `name`) shouldn't be overridable, the merge strategy may need broader rethinking.

---

Link to Devin run: https://app.devin.ai/sessions/228bdaba755b47188b182b806648e0da
Requested by: @aditya-arolkar-swe