### PR TITLE
fix(cli): add --fern-definition to live-test scripts after OpenAPI default change

### DIFF
--- a/scripts/live-test.ps1
+++ b/scripts/live-test.ps1
@@ -25,7 +25,7 @@ try {
     Write-Host "Running Fern Commands!"
     $DebugPreference = "Continue"
     
-    & node $cli_path init --organization fern
+    & node $cli_path init --organization fern --fern-definition
     
     & node $cli_path add fern-java-sdk
     & node $cli_path add fern-python-sdk

--- a/scripts/live-test.sh
+++ b/scripts/live-test.sh
@@ -33,7 +33,7 @@ cd "$test_dir"
 echo "Running Fern Commands in $test_dir!"
 set -x
 
-node "$cli_path" init --organization fern
+node "$cli_path" init --organization fern --fern-definition
 
 node "$cli_path" add fern-java-sdk
 node "$cli_path" add fern-python-sdk


### PR DESCRIPTION
## Description

Refs: Fixes CI failures caused by https://github.com/fern-api/fern/commit/a09979a48083cee9bef0ac32c39656568676bf48

[Link to Devin run](https://app.devin.ai/sessions/9abe44227db242f28d591a661f2d7615) | Requested by @Swimburger

PR #12526 changed `fern init` to default to OpenAPI instead of Fern Definition, but did not update the live-test scripts. These scripts are used by CI jobs (`live-test-dev`, `live-test-dev-windows`, `publish-cli` live-test) that **only run on push to main** — they were skipped during PR CI, so the breakage wasn't caught before merge.

## Changes Made

- Added `--fern-definition` flag to `fern init` in `scripts/live-test.sh`
- Added `--fern-definition` flag to `fern init` in `scripts/live-test.ps1`

## Testing

- [ ] Manual testing completed
- Verified locally that `fern init --organization fern --fern-definition` followed by `fern add` / `fern check` works correctly

## Human Review Checklist

- **Confirm root cause**: Verify that the `live-test-dev` / `live-test-dev-windows` / `publish-cli` live-test jobs were indeed the failing CI jobs on main. These are the only places in the repo that call `fern init` without `--fern-definition` outside of ETE tests (which were already updated in #12526).
- **OpenAPI default coverage gap**: With this fix, the live-test no longer exercises the new default (OpenAPI) init path end-to-end with remote `fern generate` and `fern register`. Consider whether a separate live-test variant should be added to cover the OpenAPI default flow.