### PR TITLE
fix(ruby): wire tests respect `clientModuleName`

### DIFF
--- a/generators/ruby-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -46,11 +46,9 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
     }
 
     public getRootModuleName(): string {
-        // Use moduleName config first, then clientModuleName, then organization
+        // Use moduleName config first, then organization
         // This aligns with AbstractRubyGeneratorContext.getRootModuleName()
-        return upperFirst(
-            this.customConfig?.moduleName ?? this.customConfig?.clientModuleName ?? this.config.organization
-        );
+        return upperFirst(this.customConfig?.moduleName ?? this.config.organization);
     }
 
     public isSingleEnvironmentID(

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -174,7 +174,7 @@ export class WireTestGenerator {
 
         // Build auth parameters for the client constructor
         const authParams = this.buildAuthParamsForSetup();
-        const clientClassName = `${this.context.getRootModuleName()}::Client`;
+        const clientClassName = `${this.context.getRootModuleName()}::${this.context.getRootClientClassName()}`;
 
         // Generate client instantiation with auth and base_url
         if (authParams.length > 0) {

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.1
+  changelogEntry:
+    - summary: |
+        Fix wire test generator to respect `clientModuleName` custom config instead of hardcoding `Client`.
+      type: fix
+  createdAt: "2026-02-19"
+  irVersion: 61
+
 - version: 1.0.0
   changelogEntry:
     - summary: |

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "latest",
   "generatorConfig": {
-    "enableWireTests": true
+    "enableWireTests": true,
+    "clientModuleName": "MyClient"
   },
   "sdkVersion": "0.0.1"
 }

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/README.md
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/README.md
@@ -28,7 +28,7 @@ Instantiate and use the client with the following:
 ```ruby
 require "seed"
 
-client = Seed::Client.new(token: "<token>")
+client = Seed::MyClient.new(token: "<token>")
 
 client.endpoints.container.get_and_return_list_of_primitives(request: %w[string string])
 ```
@@ -41,7 +41,7 @@ This SDK allows you to configure different custom URLs for API requests. You can
 ```ruby
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
     base_url: "https://example.com"
 )
 ```
@@ -53,7 +53,7 @@ Failed API calls will raise errors that can be rescued from granularly.
 ```ruby
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
     base_url: "https://example.com"
 )
 
@@ -90,7 +90,7 @@ Use the `max_retries` option to configure this behavior.
 ```ruby
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
     base_url: "https://example.com",
     max_retries: 3  # Configure max retries (default is 2)
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example0/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example0/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example1/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example1/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example10/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example10/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example11/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example11/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example12/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example12/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example13/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example13/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example14/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example14/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example15/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example15/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example16/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example16/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example17/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example17/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example18/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example18/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example19/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example19/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example2/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example2/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example20/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example20/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example21/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example21/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example22/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example22/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example23/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example23/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example24/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example24/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example25/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example25/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example26/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example26/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example27/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example27/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example28/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example28/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example29/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example29/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example3/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example3/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example30/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example30/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example31/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example31/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example32/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example32/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example33/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example33/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example34/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example34/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example35/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example35/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example36/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example36/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example37/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example37/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example38/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example38/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example39/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example39/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example4/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example4/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example40/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example40/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example41/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example41/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example42/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example42/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example43/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example43/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example44/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example44/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example45/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example45/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example46/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example46/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example47/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example47/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example48/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example48/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example49/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example49/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example5/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example5/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example50/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example50/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example51/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example51/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example52/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example52/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example53/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example53/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example6/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example6/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example7/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example7/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example8/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example8/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example9/snippet.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/dynamic-snippets/example9/snippet.rb
@@ -1,6 +1,6 @@
 require "seed"
 
-client = Seed::Client.new(
+client = Seed::MyClient.new(
   token: "<token>",
   base_url: "https://api.fern.com"
 )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Seed
-  class Client
+  class MyClient
     # @param base_url [String, nil]
     # @param token [String]
     #

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_container_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_container_test.rb
@@ -6,7 +6,7 @@ class EndpointsContainerWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_content_type_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_content_type_test.rb
@@ -6,7 +6,7 @@ class EndpointsContentTypeWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_enum_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_enum_test.rb
@@ -6,7 +6,7 @@ class EndpointsEnumWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_http_methods_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_http_methods_test.rb
@@ -6,7 +6,7 @@ class EndpointsHttpMethodsWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_object_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_object_test.rb
@@ -6,7 +6,7 @@ class EndpointsObjectWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_pagination_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_pagination_test.rb
@@ -6,7 +6,7 @@ class EndpointsPaginationWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_params_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_params_test.rb
@@ -6,7 +6,7 @@ class EndpointsParamsWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_primitive_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_primitive_test.rb
@@ -6,7 +6,7 @@ class EndpointsPrimitiveWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_put_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_put_test.rb
@@ -6,7 +6,7 @@ class EndpointsPutWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_union_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_union_test.rb
@@ -6,7 +6,7 @@ class EndpointsUnionWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_urls_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/endpoints_urls_test.rb
@@ -6,7 +6,7 @@ class EndpointsUrlsWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/inlined_requests_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/inlined_requests_test.rb
@@ -6,7 +6,7 @@ class InlinedRequestsWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/no_auth_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/no_auth_test.rb
@@ -6,7 +6,7 @@ class NoAuthWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/no_req_body_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/no_req_body_test.rb
@@ -6,7 +6,7 @@ class NoReqBodyWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/req_with_headers_test.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/req_with_headers_test.rb
@@ -6,7 +6,7 @@ class ReqWithHeadersWireTest < WireMockTestCase
   def setup
     super
 
-    @client = Seed::Client.new(
+    @client = Seed::MyClient.new(
       token: "<token>",
       base_url: WIREMOCK_BASE_URL
     )

--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -44,6 +44,7 @@ fixtures:
     - outputFolder: wire-tests
       customConfig:
         enableWireTests: true
+        clientModuleName: MyClient
   pagination-custom:
     - customConfig:
         customPagerName: FooPager


### PR DESCRIPTION
## Description
Exactly as in the title. Wire tests would hard-code things like `Seed::Client`; now they do `Seed::{clientModuleName}`.

## Changes Made
One-liner.

## Testing
`exhaustive:wire-tests` now also has `clientModuleName: MyClient`.
- [X] Unit tests added/updated
- [X] Manual testing completed
