### PR TITLE
fix(php): ensure --version flag takes precedence over custom composerJson config

### DIFF
--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -349,6 +349,9 @@ class ComposerJson {
             }
         };
         composerJson = mergeExtraConfigs(composerJson, this.context.customConfig.composerJson);
+        if (this.context.version != null) {
+            composerJson.version = this.context.version;
+        }
         return composerJson;
     }
 

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.3
+  changelogEntry:
+    - summary: |
+        Fix version override in composer.json. When a version is specified via the `--version` flag
+        (e.g., `fern generate --version 4.0.1`), it now takes precedence over any version set in
+        the custom `composerJson` configuration. Previously, the custom `composerJson` config could
+        silently override the CLI-specified version.
+      type: fix
+  createdAt: "2026-02-20"
+  irVersion: 62
+
 - version: 2.1.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Customer report — running `fern generate --group php-sdk --version 4.0.1` resulted in `composer.json` containing the wrong version (e.g., `0.0.73` from custom config instead of `4.0.1`).

## Changes Made

- In `ComposerJson.build()`, re-apply `this.context.version` **after** `mergeExtraConfigs()` so the CLI `--version` flag always wins over a `version` key in the user's custom `composerJson` configuration.
- Added changelog entry for PHP SDK v2.1.3.

**Root cause**: `mergeExtraConfigs(composerJson, this.context.customConfig.composerJson)` merges the user's custom `composerJson` on top of the generated config. If the custom config contains a `version` field, it silently overwrites the version that was set from the `--version` CLI flag.

**Version precedence after fix**: `--version` CLI flag > custom `composerJson.version` > default `"0.0.0"`.

## Review Checklist

- [ ] Confirm the precedence logic is correct — when `--version` is not provided (`this.context.version == null`), custom `composerJson.version` should still be respected (it is, since the guard only applies when version is non-null)
- [ ] Consider whether a unit test for this precedence behavior should be added

## Testing

- [ ] TypeScript compilation passes (`tsc --build`)
- [ ] No unit tests added — the change is a 3-line guard clause; consider requesting a test if desired

---

Link to Devin run: https://app.devin.ai/sessions/6d74bd5ab8564ef5b8b32eaed6cabd6d
Requested by: @iamnamananand996