### PR TITLE
fix(internal): replace tsc --build with tsc to fix parallel compilation race condition

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -27,15 +27,6 @@ runs:
     - name: Install
       uses: ./.github/actions/install
 
-    - name: Pre-build core dependencies
-      shell: bash
-      env:
-        FORCE_COLOR: "2"
-      run: |
-        # Build core-utils first to avoid race conditions in parallel compilation
-        # This ensures the dependency output files are fully written before dependent packages start
-        pnpm turbo run compile --filter @fern-api/core-utils
-
     - uses: bufbuild/buf-setup-action@v1.34.0
       with:
         github_token: ${{ github.token }}

--- a/generators/base/package.json
+++ b/generators/base/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/browser-compatible-base/package.json
+++ b/generators/browser-compatible-base/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/csharp/codegen/package.json
+++ b/generators/csharp/codegen/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/csharp/dynamic-snippets/package.json
+++ b/generators/csharp/dynamic-snippets/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/csharp/formatter/package.json
+++ b/generators/csharp/formatter/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/csharp/model/package.json
+++ b/generators/csharp/model/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-csharp-model:latest ../../..",

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-csharp-sdk:latest ../../..",

--- a/generators/go-v2/ast/package.json
+++ b/generators/go-v2/ast/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/go-v2/base/package.json
+++ b/generators/go-v2/base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/generators/go-v2/dynamic-snippets/package.json
+++ b/generators/go-v2/dynamic-snippets/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/go-v2/formatter/package.json
+++ b/generators/go-v2/formatter/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/go-v2/model/package.json
+++ b/generators/go-v2/model/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-go-model:latest ../../..",

--- a/generators/go-v2/sdk/package.json
+++ b/generators/go-v2/sdk/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-go-sdk:latest ../../..",

--- a/generators/java-v2/ast/package.json
+++ b/generators/java-v2/ast/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/java-v2/base/package.json
+++ b/generators/java-v2/base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/generators/java-v2/dynamic-snippets/package.json
+++ b/generators/java-v2/dynamic-snippets/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-java-sdk:latest ../../..",

--- a/generators/openapi/package.json
+++ b/generators/openapi/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-openapi:latest .",

--- a/generators/php/base/package.json
+++ b/generators/php/base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/generators/php/codegen/package.json
+++ b/generators/php/codegen/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/php/dynamic-snippets/package.json
+++ b/generators/php/dynamic-snippets/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/php/model/package.json
+++ b/generators/php/model/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-php-model:latest ../../..",

--- a/generators/php/sdk/package.json
+++ b/generators/php/sdk/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-php-sdk:latest ../../..",

--- a/generators/postman/package.json
+++ b/generators/postman/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-postman:latest .",

--- a/generators/python-v2/ast/package.json
+++ b/generators/python-v2/ast/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/python-v2/base/package.json
+++ b/generators/python-v2/base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/python-v2/browser-compatible-base/package.json
+++ b/generators/python-v2/browser-compatible-base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/python-v2/dynamic-snippets/package.json
+++ b/generators/python-v2/dynamic-snippets/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/python-v2/fastapi/package.json
+++ b/generators/python-v2/fastapi/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-fastapi-server-v2:latest ../../..",

--- a/generators/python-v2/formatter/package.json
+++ b/generators/python-v2/formatter/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/python-v2/pydantic-model/package.json
+++ b/generators/python-v2/pydantic-model/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-pydantic-model-v2:latest ../../..",

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-python-sdk:latest ../../..",

--- a/generators/ruby-v2/ast/package.json
+++ b/generators/ruby-v2/ast/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/ruby-v2/base/package.json
+++ b/generators/ruby-v2/base/package.json
@@ -23,9 +23,9 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
+    "compile": "tsc",
     "postcompile": "rsync -a --delete ./src/asIs/ ./lib/asIs/",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/generators/ruby-v2/dynamic-snippets/package.json
+++ b/generators/ruby-v2/dynamic-snippets/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/ruby-v2/model/package.json
+++ b/generators/ruby-v2/model/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-ruby-model:latest ../../..",

--- a/generators/ruby-v2/sdk/package.json
+++ b/generators/ruby-v2/sdk/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-ruby-sdk-v2:latest ../../..",

--- a/generators/rust/base/package.json
+++ b/generators/rust/base/package.json
@@ -25,8 +25,8 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/rust/codegen/package.json
+++ b/generators/rust/codegen/package.json
@@ -25,8 +25,8 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/rust/dynamic-snippets/package.json
+++ b/generators/rust/dynamic-snippets/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
+    "compile": "tsc",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "organize-imports": "organize-imports-cli tsconfig.json",

--- a/generators/rust/model/package.json
+++ b/generators/rust/model/package.json
@@ -25,8 +25,8 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-rust-model:latest ../../..",

--- a/generators/rust/sdk/package.json
+++ b/generators/rust/sdk/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
+    "compile": "tsc",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-rust-sdk:latest ../../..",

--- a/generators/swift/base/package.json
+++ b/generators/swift/base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/swift/codegen/package.json
+++ b/generators/swift/codegen/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/swift/dynamic-snippets/package.json
+++ b/generators/swift/dynamic-snippets/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/swift/model/package.json
+++ b/generators/swift/model/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-swift-model:latest ../../..",

--- a/generators/swift/sdk/package.json
+++ b/generators/swift/sdk/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-swift-sdk:latest ../../..",

--- a/generators/typescript-v2/ast/package.json
+++ b/generators/typescript-v2/ast/package.json
@@ -22,8 +22,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript-v2/base/package.json
+++ b/generators/typescript-v2/base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript-v2/browser-compatible-base/package.json
+++ b/generators/typescript-v2/browser-compatible-base/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript-v2/dynamic-snippets/package.json
+++ b/generators/typescript-v2/dynamic-snippets/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",

--- a/generators/typescript-v2/formatter/package.json
+++ b/generators/typescript-v2/formatter/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/cli/package.json
+++ b/generators/typescript/express/cli/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-typescript-express:latest ../../../..",

--- a/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-error-generator/package.json
+++ b/generators/typescript/express/express-error-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-error-schema-generator/package.json
+++ b/generators/typescript/express/express-error-schema-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-inlined-request-body-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-register-generator/package.json
+++ b/generators/typescript/express/express-register-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/express-service-generator/package.json
+++ b/generators/typescript/express/express-service-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/generator/package.json
+++ b/generators/typescript/express/generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/express/generic-express-error-generators/package.json
+++ b/generators/typescript/express/generic-express-error-generators/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-typescript-node-sdk:latest -t fernapi/fern-typescript-sdk:latest ../../../..",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/generic-sdk-error-generators/package.json
+++ b/generators/typescript/sdk/generic-sdk-error-generators/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/abstract-error-class-generator/package.json
+++ b/generators/typescript/utils/abstract-error-class-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/abstract-schema-generator/package.json
+++ b/generators/typescript/utils/abstract-schema-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/ai/package.json
+++ b/packages/cli/ai/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "generate": "baml-cli generate --from baml_src",
     "test": "vitest --run",

--- a/packages/cli/api-importers/asyncapi-to-ir/package.json
+++ b/packages/cli/api-importers/asyncapi-to-ir/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/commons/package.json
+++ b/packages/cli/api-importers/commons/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/conjure/conjure-sdk/package.json
+++ b/packages/cli/api-importers/conjure/conjure-sdk/package.json
@@ -26,8 +26,8 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "generate": "fern generate --local",
     "test": "vitest --run --passWithNoTests",

--- a/packages/cli/api-importers/conjure/conjure-to-fern-tests/package.json
+++ b/packages/cli/api-importers/conjure/conjure-to-fern-tests/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/conjure/conjure-to-fern/package.json
+++ b/packages/cli/api-importers/conjure/conjure-to-fern/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/graphql/package.json
+++ b/packages/cli/api-importers/graphql/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi-pruner/package.json
+++ b/packages/cli/api-importers/openapi-pruner/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi-to-ir/package.json
+++ b/packages/cli/api-importers/openapi-to-ir/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/openapi/openapi-ir/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir/package.json
@@ -26,8 +26,8 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "generate": "fern generate --local",
     "test": "vitest --passWithNoTests --run",

--- a/packages/cli/api-importers/openrpc-to-ir/package.json
+++ b/packages/cli/api-importers/openrpc-to-ir/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/v3-importer-commons/package.json
+++ b/packages/cli/api-importers/v3-importer-commons/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/api-importers/v3-importer-tests/package.json
+++ b/packages/cli/api-importers/v3-importer-tests/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",

--- a/packages/cli/auth/package.json
+++ b/packages/cli/auth/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/cli-logger/package.json
+++ b/packages/cli/cli-logger/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/cli-migrations/package.json
+++ b/packages/cli/cli-migrations/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/cli-source-resolver/package.json
+++ b/packages/cli/cli-source-resolver/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli:dev": "node build.dev.mjs",
     "dist:bin": "node build.compile.mjs",

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -29,8 +29,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist:cli:dev": "node build.dev.mjs",
     "dist:cli:local": "node build.local.mjs",

--- a/packages/cli/config/package.json
+++ b/packages/cli/config/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/configuration-loader/package.json
+++ b/packages/cli/configuration-loader/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-importers/commons/package.json
+++ b/packages/cli/docs-importers/commons/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-importers/mintlify/package.json
+++ b/packages/cli/docs-importers/mintlify/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-importers/readme/package.json
+++ b/packages/cli/docs-importers/readme/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-markdown-utils/package.json
+++ b/packages/cli/docs-markdown-utils/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/docs-resolver/package.json
+++ b/packages/cli/docs-resolver/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run src/utils/__test__",
     "test:debug": "vitest --run --inspect src/utils/__test__"

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/fern-definition/formatter/package.json
+++ b/packages/cli/fern-definition/formatter/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/fern-definition/ir-to-jsonschema/package.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/fern-definition/schema/package.json
+++ b/packages/cli/fern-definition/schema/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/fern-definition/validator/package.json
+++ b/packages/cli/fern-definition/validator/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/ir-generator-tests/package.json
+++ b/packages/cli/generation/ir-generator-tests/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/ir-generator/package.json
+++ b/packages/cli/generation/ir-generator/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/ir-migrations/package.json
+++ b/packages/cli/generation/ir-migrations/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/local-generation/docker-utils/package.json
+++ b/packages/cli/generation/local-generation/docker-utils/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/local-generation/local-workspace-runner/package.json
+++ b/packages/cli/generation/local-generation/local-workspace-runner/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/protoc-gen-fern/package.json
+++ b/packages/cli/generation/protoc-gen-fern/package.json
@@ -30,8 +30,8 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/generation/source-resolver/package.json
+++ b/packages/cli/generation/source-resolver/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/init/package.json
+++ b/packages/cli/init/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/library-docs-generator/package.json
+++ b/packages/cli/library-docs-generator/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/logger/package.json
+++ b/packages/cli/logger/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/login/package.json
+++ b/packages/cli/login/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/mock/package.json
+++ b/packages/cli/mock/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/project-loader/package.json
+++ b/packages/cli/project-loader/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/register/package.json
+++ b/packages/cli/register/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/semver-utils/package.json
+++ b/packages/cli/semver-utils/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/source/package.json
+++ b/packages/cli/source/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/task-context/package.json
+++ b/packages/cli/task-context/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/browser-compatible-fern-workspace/package.json
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/commons/package.json
+++ b/packages/cli/workspace/commons/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/lazy-fern-workspace/package.json
+++ b/packages/cli/workspace/lazy-fern-workspace/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/loader/package.json
+++ b/packages/cli/workspace/loader/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/workspace/oss-validator/package.json
+++ b/packages/cli/workspace/oss-validator/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/yaml/generators-validator/package.json
+++ b/packages/cli/yaml/generators-validator/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/cli/yaml/loader/package.json
+++ b/packages/cli/yaml/loader/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/casings-generator/package.json
+++ b/packages/commons/casings-generator/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run --passWithNoTests",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/core-utils/package.json
+++ b/packages/commons/core-utils/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/fs-utils/package.json
+++ b/packages/commons/fs-utils/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/github/package.json
+++ b/packages/commons/github/package.json
@@ -24,7 +24,7 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
+    "compile": "tsc",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "format": "prettier --write --ignore-unknown \"**\"",
     "format:check": "prettier --check --ignore-unknown \"**\"",

--- a/packages/commons/ir-utils/package.json
+++ b/packages/commons/ir-utils/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/loadable/package.json
+++ b/packages/commons/loadable/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/logging-execa/package.json
+++ b/packages/commons/logging-execa/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/mock-utils/package.json
+++ b/packages/commons/mock-utils/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/path-utils/package.json
+++ b/packages/commons/path-utils/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/commons/test-utils/package.json
+++ b/packages/commons/test-utils/package.json
@@ -23,8 +23,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "test": "vitest --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/generator-migrations/package.json
+++ b/packages/generator-migrations/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "dist": "node build.mjs",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",

--- a/packages/ir-sdk/package.json
+++ b/packages/ir-sdk/package.json
@@ -26,8 +26,8 @@
   ],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "generate": "fern generate --api ir-types-latest --local",
     "test": "vitest --passWithNoTests --run",

--- a/packages/migrations-base/package.json
+++ b/packages/migrations-base/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "test": "vitest --passWithNoTests --run",
     "test:debug": "pnpm run test --inspect --no-file-parallelism",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -27,8 +27,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "generate": "fern generate --api ir-types-latest --local",
     "lint:eslint": "eslint --max-warnings 0 . --ignore-pattern=../../.eslintignore",

--- a/packages/seed/package.json
+++ b/packages/seed/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
     "env:prod": "env-cmd -r .env-cmdrc.cjs -e prod",

--- a/packages/snippets/core/package.json
+++ b/packages/snippets/core/package.json
@@ -24,8 +24,8 @@
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist && tsc --build --clean",
-    "compile": "tsc --build",
-    "compile:debug": "tsc --build --sourceMap",
+    "compile": "tsc",
+    "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../knip.json --no-config-hints",
     "dist": "node build.mjs",
     "test": "vitest --passWithNoTests --run",


### PR DESCRIPTION
## Description

Refs intermittent CI `TS2306` compilation failures (e.g. `File '...core-utils/lib/index.d.ts' is not a module`).

When Turbo runs parallel `compile` tasks, each package's `tsc --build` independently traverses project references and can attempt to rebuild shared dependencies. With 107 packages referencing `core-utils`, multiple parallel `tsc --build` processes race to read/write `core-utils/lib/index.d.ts`, causing one process to see a partially-written file.

The fix replaces `tsc --build` with plain `tsc` so each compilation only compiles its own source files. Turbo's `dependsOn: ["^compile"]` handles dependency ordering, and pnpm workspace symlinks with `moduleResolution: "bundler"` handle type resolution through package.json `types`/`exports` fields.

Also removes the pre-build `core-utils` workaround in `cached-seed` since the root cause is addressed.

[Link to Devin run](https://app.devin.ai/sessions/9d1a2241d1504d21b78a30c7375593c8) | Requested by: @Swimburger

## Changes Made

- Changed `"compile": "tsc --build"` → `"compile": "tsc"` across 167 package.json files
- Changed `"compile:debug": "tsc --build --sourceMap"` → `"compile:debug": "tsc --sourceMap"` across 164 package.json files
- Removed the `Pre-build core dependencies` step from `.github/actions/cached-seed/action.yaml`

## Testing

- [x] Verified `@fern-api/core-utils` compiles successfully with `tsc`
- [x] Verified `@fern-api/openapi-ir-parser` and its full 9-package dependency chain compiles successfully
- [x] Local `pnpm run check` (biome) passes
- [ ] Full CI validation pending

## Human Review Checklist

- **`tsc` vs `tsc --build` type resolution**: Plain `tsc` resolves types via node_modules (pnpm symlinks) + package.json `types`/`exports` instead of project reference output directories. Verify no packages rely on project-reference-specific resolution behavior (e.g. unusual tsconfig or export setups).
- **Removing the pre-build safety net**: The `cached-seed` pre-build step is removed entirely. Consider whether keeping it as a belt-and-suspenders measure is safer while the fix is validated in CI.
- **`clean` scripts still use `tsc --build --clean`**: These were intentionally left unchanged since they're not parallelized, but the inconsistency is worth noting.
- **Local dev incremental rebuild speed**: `tsc --build` had project-reference-aware incremental logic. Plain `tsc` still uses `.tsbuildinfo` (via `composite: true`) but rebuild behavior may differ for local development workflows.