### PR TITLE
chore(ci): use shallow checkout for Docker build jobs in seed-dockers workflow

### DIFF
--- a/.github/workflows/seed-dockers.yml
+++ b/.github/workflows/seed-dockers.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -207,7 +207,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -256,7 +256,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -305,7 +305,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -354,7 +354,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Description

Refs: Performance analysis for CI improvements

Switches Docker build jobs in `seed-dockers.yml` from full git history checkout (`fetch-depth: 0`) to shallow checkout (`fetch-depth: 1`). Docker builds only need the working tree (Dockerfile + build context), not git history.

## Changes Made

- Changed `fetch-depth: 0` → `fetch-depth: 1` in all 5 Docker build jobs: `build-ts`, `build-java`, `build-python`, `build-csharp`, `build-php`
- No changes to the `changes` or `generate-sha` jobs, which have their own checkout steps and handle history/SHA detection independently

## Review Checklist

- [ ] Confirm none of the referenced Dockerfiles (`docker/seed/Dockerfile.*`) use git commands that require history
- [ ] Confirm `generate-sha` job (which needs `git rev-parse --short HEAD`) uses its own checkout and is unaffected

## Testing

- No unit tests needed — CI workflow-only change
- Can be validated on next `seed-dockers.yml` trigger

---

[Link to Devin run](https://app.devin.ai/sessions/3a41b056bb894cf0adf80aee9b8167ca) | Requested by: @Swimburger