### PR TITLE
chore(ci): add Turbo remote cache to all workflows

### DIFF
--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+
 jobs:
   test-typescript:
     runs-on: ubuntu-latest

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -30,6 +30,10 @@ on:
         default: true
         type: boolean
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+
 jobs:
   create-dependabot-prs:
     name: Check Dependabot alerts

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -21,6 +21,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -51,6 +51,8 @@ permissions:
 
 env:
   DOCKER_BUILDKIT: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
 
 jobs:
   setup:


### PR DESCRIPTION
## Description

Refs: Turbo best practices audit

Adds `TURBO_TOKEN` and `TURBO_TEAM` environment variables to 6 CI workflows that invoke Turborepo commands but were missing remote cache configuration. Without these env vars, every `turbo run` in these workflows rebuilds from scratch instead of leveraging the shared remote cache.

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/3a41b056bb894cf0adf80aee9b8167ca)

## Changes Made

Added workflow-level `TURBO_TOKEN` / `TURBO_TEAM` env vars (matching `ci.yml` and `sdk-ete-tests.yml`) to:

- **`ci-dynamic-snippets.yml`** — 8 language jobs running `turbo run compile` + `turbo run test`
- **`seed.yml`** — `get-all-test-matrices` job running `pnpm seed:build` (invokes turbo)
- **`update-seed.yml`** — `get-all-test-matrices` job running `pnpm seed:build`
- **`test-definitions.yml`** — runs `turbo run dist:cli:dev`
- **`definitions-validation.yml`** — runs `turbo run dist:cli:prod`
- **`security-scanning-and-remediation.yml`** — grype scan job runs `turbo run dist:cli`

## Human Review Checklist

- [ ] Verify `TURBO_TOKEN` secret is configured in the repo (it should be — `ci.yml` already uses it)
- [ ] Confirm `"buildwithfern"` team name is still correct (matches existing usage in `ci.yml` L22 and `sdk-ete-tests.yml` L149)
- [ ] Note: `security-scanning-and-remediation.yml` sets the env vars at workflow level, so the `create-dependabot-prs` job (which doesn't use turbo) will have them set but unused — this is harmless

## Testing

- [ ] No unit tests applicable (CI workflow config only)
- [ ] Changes can only be validated by observing remote cache hits in subsequent workflow runs