### PR TITLE
chore(ci): add turbo boundaries check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,18 @@ jobs:
       - name: Compile
         run: pnpm compile
 
+  boundaries:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - name: Check turbo boundaries
+        run: pnpm boundaries
+
   depcheck:
     runs-on: ubuntu-latest
     steps:

--- a/generators/csharp/codegen/src/index.ts
+++ b/generators/csharp/codegen/src/index.ts
@@ -13,7 +13,7 @@ export { NameRegistry } from "./context/name-registry.js";
 export { CSharp } from "./csharp.js";
 export { CsharpConfigSchema } from "./custom-config/index.js";
 export { escapeForCSharpString } from "./utils/escapeForCSharpString.js";
-export { lazy } from "./utils/lazy.js";
+export { lazy, type LazyResult } from "./utils/lazy.js";
 export * as text from "./utils/text.js";
 export { camelCase } from "./utils/text.js";
 export { type TypesOf } from "./utils/type-extractor.js";

--- a/generators/csharp/codegen/src/index.ts
+++ b/generators/csharp/codegen/src/index.ts
@@ -13,7 +13,7 @@ export { NameRegistry } from "./context/name-registry.js";
 export { CSharp } from "./csharp.js";
 export { CsharpConfigSchema } from "./custom-config/index.js";
 export { escapeForCSharpString } from "./utils/escapeForCSharpString.js";
-export { lazy, type LazyResult } from "./utils/lazy.js";
+export { type LazyResult, lazy } from "./utils/lazy.js";
 export * as text from "./utils/text.js";
 export { camelCase } from "./utils/text.js";
 export { type TypesOf } from "./utils/type-extractor.js";

--- a/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
+++ b/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
@@ -1,12 +1,10 @@
 import { assertNever } from "@fern-api/core-utils";
-import { ast, lazy, WithGeneration } from "@fern-api/csharp-codegen";
+import { ast, lazy, type LazyResult, WithGeneration } from "@fern-api/csharp-codegen";
 
 import { FernIr } from "@fern-fern/ir-sdk";
 
 type HttpHeader = FernIr.HttpHeader;
 type Literal = FernIr.Literal;
-
-import { LazyResult } from "../../../codegen/src/utils/lazy.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
 export interface OptionArgs {

--- a/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
+++ b/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
@@ -1,10 +1,11 @@
 import { assertNever } from "@fern-api/core-utils";
-import { ast, lazy, type LazyResult, WithGeneration } from "@fern-api/csharp-codegen";
+import { ast, type LazyResult, lazy, WithGeneration } from "@fern-api/csharp-codegen";
 
 import { FernIr } from "@fern-fern/ir-sdk";
 
 type HttpHeader = FernIr.HttpHeader;
 type Literal = FernIr.Literal;
+
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
 export interface OptionArgs {

--- a/generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -12,7 +12,7 @@ type EndpointId = FernIr.EndpointId;
 type FeatureId = FernIr.FeatureId;
 type Type = FernIr.Type;
 
-import { Generation } from "../../../codegen/src/context/generation-info.js";
+import { Generation } from "@fern-api/csharp-codegen";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
 interface EndpointWithFilepath {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check:biome": "biome check",
     "check": "biome check",
     "check:fix": "biome check --write",
+    "boundaries": "turbo boundaries",
     "depcheck": "turbo run depcheck --continue=always",
     "codegen:local": "pnpm fern:local generate",
     "fern": "FERN_NO_VERSION_REDIRECTION=true node --enable-source-maps ./packages/cli/cli/dist/prod/cli.cjs",

--- a/packages/cli/docs-resolver/vitest.config copy.ts
+++ b/packages/cli/docs-resolver/vitest.config copy.ts
@@ -1,1 +1,0 @@
-export { default } from "../../../shared/vitest.config.js";


### PR DESCRIPTION
## Description

Refs: Turbo boundaries adoption (Medium Impact, Correctness)

Adds `turbo boundaries` as a CI check to catch undeclared cross-package dependencies and out-of-package file imports. With 169+ packages, this protects Turbo cache correctness — if package A imports package B without declaring the dependency, Turbo won't know to rebuild A when B changes.

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/82dc53240b9d43298b846b8ed791a697)

## Changes Made

- Added `boundaries` CI job to `.github/workflows/ci.yml` (runs `turbo boundaries` on every PR/push to main)
- Added `"boundaries"` script to root `package.json`
- Fixed 3 existing boundary violations:
  - **Deleted** `packages/cli/docs-resolver/vitest.config copy.ts` — accidental duplicate file (note the space in the filename); the real config is `vitest.config.ts`
  - **Exported** `LazyResult` type from `@fern-api/csharp-codegen` package index
  - **Fixed** two relative imports in `generators/csharp/sdk/` that reached outside the package into `../../../codegen/` — now import from `@fern-api/csharp-codegen` instead

## Testing

- [x] Ran `turbo boundaries` locally — passes clean: `Checked 17015 files in 169 packages, no issues found`
- [x] `pnpm run check` (biome) passes locally
- [x] All CI checks pass (73/73), including all csharp seed tests confirming the import refactors are safe

## Human Review Checklist

- [ ] Confirm `vitest.config copy.ts` was indeed an accidental file and not referenced anywhere (the space in the filename strongly suggests a macOS Finder duplicate)
- [ ] The `boundaries` CI job is currently **not** marked as required in branch protection — consider adding it so violations actually block merge
- [ ] No `versions.yml` update was made for csharp generators since these are purely import-path refactors with no behavioral changes — confirm this aligns with repo expectations