### PR TITLE
chore(ci): add turbo boundaries check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,19 @@ jobs:
       - name: check:biome
         run: pnpm check:biome
 
+  boundaries:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - name: Check boundaries
+        run: pnpm turbo boundaries
+
   test:
     if: github.repository == 'fern-api/fern'
     runs-on: Test


### PR DESCRIPTION
## Description

Refs: Turbo best practices audit

Adds a `turbo boundaries` job to the CI workflow. This catches two types of workspace violations:
- Importing a package not listed in `package.json` dependencies
- Importing files outside the package directory

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/3a41b056bb894cf0adf80aee9b8167ca)

## Changes Made

- Added a `boundaries` job to `.github/workflows/ci.yml` that runs `pnpm turbo boundaries`
- Job uses `continue-on-error: true` since there are **3 pre-existing violations** on `main`:
  1. `generators/csharp/sdk` imports from `../codegen/` (2 files)
  2. `packages/cli/docs-resolver/vitest.config copy.ts` imports from `../../../shared/`

## Important Review Notes

- **`continue-on-error: true`**: The job will always show as yellow/warning until the 3 pre-existing violations are fixed. If you'd prefer this to be a hard gate, those violations need to be resolved first.
- **Experimental feature**: `turbo boundaries` is still marked as experimental by Vercel. Consider whether you're comfortable adopting it now vs. waiting for stable.
- **Not a required check**: Since this is a new job name, it won't be in branch protection rules. You'd need to add it manually in repo settings if you want it as a required check (after fixing existing violations).

## Testing

- [x] Ran `turbo boundaries` locally — confirmed it runs and reports the 3 known violations
- [ ] CI will validate that the job runs correctly in the workflow