### PR TITLE
chore(ci): use turbo --affected for compile and depcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,24 +28,36 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Fetch base branch for affected comparison
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Compile
-        run: pnpm compile
+        run: pnpm turbo run compile --affected
 
   depcheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Fetch base branch for affected comparison
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Check dependencies
-        run: pnpm depcheck
+        run: pnpm turbo run depcheck --affected --continue=always
 
   validate-cli-dependencies:
     runs-on: ubuntu-latest
@@ -103,6 +115,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          fetch-depth: 2
 
       - name: Install
         uses: ./.github/actions/install
@@ -122,9 +135,13 @@ jobs:
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
 
+      - name: Fetch base branch for affected comparison
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+
       - name: Run tests
         if: ${{ !github.event.inputs.update_snapshots }}
-        run: pnpm test
+        run: pnpm turbo run test --affected --filter=!@fern-api/ete-tests
 
       - name: Run tests with snapshot updates
         if: ${{ github.event.inputs.update_snapshots == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          fetch-depth: 2
 
       - name: Install
         uses: ./.github/actions/install
@@ -135,13 +134,9 @@ jobs:
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
 
-      - name: Fetch base branch for affected comparison
-        if: github.event_name == 'pull_request'
-        run: git fetch --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-
       - name: Run tests
         if: ${{ !github.event.inputs.update_snapshots }}
-        run: pnpm turbo run test --affected --filter=!@fern-api/ete-tests
+        run: pnpm test
 
       - name: Run tests with snapshot updates
         if: ${{ github.event.inputs.update_snapshots == 'true' }}


### PR DESCRIPTION
## Description

Refs: Turborepo best practices audit

Uses Turborepo's `--affected` flag for the `compile` and `depcheck` CI jobs so that only packages with changes (compared to the base branch) are processed, rather than running across all 171 workspace packages every time.

**Note:** The `test` job is intentionally **not** changed — turbo's `--affected` flag [cannot be combined with `--filter`](https://turbo.build/repo/docs/reference/run#--affected), and the test job requires `--filter=!@fern-api/ete-tests` to exclude ETE tests (which run separately with credentials in the `test-ete` job).

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/3a41b056bb894cf0adf80aee9b8167ca)

## Changes Made

- **compile**: `pnpm compile` → `pnpm turbo run compile --affected`
- **depcheck**: `pnpm depcheck` → `pnpm turbo run depcheck --affected --continue=always`
- Added `fetch-depth: 2` to checkout steps for compile and depcheck (needed for push-to-main `HEAD~1` comparison)
- Added conditional base branch fetch step for PR events (turbo reads `GITHUB_BASE_REF` to determine changed packages)

## Human Review Checklist

- [ ] **Script equivalence**: The original pnpm scripts are wrappers around `turbo run`. Confirm the new direct invocations match: `compile` → `turbo run compile` ([package.json line 16](https://github.com/fern-api/fern/blob/main/package.json#L16)), `depcheck` → `turbo run depcheck --continue=always` ([package.json line 41](https://github.com/fern-api/fern/blob/main/package.json#L41)).
- [ ] **Push-to-main behavior**: On push to main, `--affected` compares against `HEAD~1` and only runs changed packages. Previously, all packages were compiled/depchecked on every main push. Verify this is acceptable — if an undeclared cross-package dependency exists, it could be missed. (Turbo's remote cache still covers cache hits for unchanged packages either way, so the primary risk is undeclared dependencies.)
- [ ] **workflow_dispatch**: On manual runs, turbo falls back to comparing against `main` since there's no `GITHUB_BASE_REF`. This should effectively run everything if triggered from main.
- [ ] **test job excluded**: Confirm it's acceptable that `test` does not use `--affected` due to the turbo `--affected`/`--filter` mutual exclusion. The test job still benefits from turbo remote cache hits for unchanged packages.

## Testing

- [ ] CI will validate that compile and depcheck jobs run correctly with `--affected` on this PR
- [ ] Cannot test locally (CI-only workflow changes)