### PR TITLE
feat(csharp): add timing logs to C# generators

### DIFF
--- a/generators/base/src/AbstractGeneratorCli.ts
+++ b/generators/base/src/AbstractGeneratorCli.ts
@@ -38,7 +38,7 @@ export abstract class AbstractGeneratorCli<
             );
             const irStartTime = Date.now();
             const ir = await this.parseIntermediateRepresentation(config.irFilepath);
-            console.log(`[TIMING] parseIntermediateRepresentation took ${Date.now() - irStartTime}ms`);
+            const irElapsed = Date.now() - irStartTime;
             const customConfig = this.parseCustomConfigOrThrow(config.customConfig);
             const contextStartTime = Date.now();
             const context = this.constructContext({
@@ -47,10 +47,11 @@ export abstract class AbstractGeneratorCli<
                 generatorConfig: config,
                 generatorNotificationService
             });
-            console.log(`[TIMING] constructContext took ${Date.now() - contextStartTime}ms`);
+            context.logger.info(`[TIMING] parseIntermediateRepresentation took ${irElapsed}ms`);
+            context.logger.info(`[TIMING] constructContext took ${Date.now() - contextStartTime}ms`);
             const metadataStartTime = Date.now();
             await this.generateMetadata(context);
-            console.log(`[TIMING] generateMetadata took ${Date.now() - metadataStartTime}ms`);
+            context.logger.info(`[TIMING] generateMetadata took ${Date.now() - metadataStartTime}ms`);
             const outputStartTime = Date.now();
             switch (config.output.mode.type) {
                 case "publish":
@@ -65,7 +66,7 @@ export abstract class AbstractGeneratorCli<
                 default:
                     assertNever(config.output.mode);
             }
-            console.log(`[TIMING] output (${config.output.mode.type}) took ${Date.now() - outputStartTime}ms`);
+            context.logger.info(`[TIMING] output (${config.output.mode.type}) took ${Date.now() - outputStartTime}ms`);
             await generatorNotificationService.sendUpdate(
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(FernGeneratorExec.ExitStatusUpdate.successful({}))
             );

--- a/generators/base/src/AbstractGeneratorCli.ts
+++ b/generators/base/src/AbstractGeneratorCli.ts
@@ -36,15 +36,22 @@ export abstract class AbstractGeneratorCli<
                     publishingToRegistry: "MAVEN"
                 })
             );
+            const irStartTime = Date.now();
             const ir = await this.parseIntermediateRepresentation(config.irFilepath);
+            console.log(`[TIMING] parseIntermediateRepresentation took ${Date.now() - irStartTime}ms`);
             const customConfig = this.parseCustomConfigOrThrow(config.customConfig);
+            const contextStartTime = Date.now();
             const context = this.constructContext({
                 ir,
                 customConfig,
                 generatorConfig: config,
                 generatorNotificationService
             });
+            console.log(`[TIMING] constructContext took ${Date.now() - contextStartTime}ms`);
+            const metadataStartTime = Date.now();
             await this.generateMetadata(context);
+            console.log(`[TIMING] generateMetadata took ${Date.now() - metadataStartTime}ms`);
+            const outputStartTime = Date.now();
             switch (config.output.mode.type) {
                 case "publish":
                     await this.publishPackage(context);
@@ -58,6 +65,7 @@ export abstract class AbstractGeneratorCli<
                 default:
                     assertNever(config.output.mode);
             }
+            console.log(`[TIMING] output (${config.output.mode.type}) took ${Date.now() - outputStartTime}ms`);
             await generatorNotificationService.sendUpdate(
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(FernGeneratorExec.ExitStatusUpdate.successful({}))
             );

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -173,6 +173,7 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
     }
 
     public async persist(): Promise<void> {
+        const persistStartTime = Date.now();
         // Get configurable output paths
         const outputPath = this.settings.outputPath;
         const libraryPath = outputPath.library;
@@ -206,6 +207,7 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
         this.context.logger.debug(`mkdir ${absolutePathToOtherDirectory}`);
         await mkdir(absolutePathToOtherDirectory, { recursive: true });
 
+        const createProjectStartTime = Date.now();
         const absolutePathToProjectDirectory = await this.createProject({
             absolutePathToLibraryDirectory,
             absolutePathToSolutionDirectory,
@@ -213,19 +215,26 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
             libraryPath,
             solutionPath
         });
+        this.context.logger.info(`[TIMING] createProject took ${Date.now() - createProjectStartTime}ms`);
+        const createTestProjectStartTime = Date.now();
         const absolutePathToTestProjectDirectory = await this.createTestProject({
             absolutePathToTestDirectory,
             absolutePathToSolutionDirectory,
             absolutePathToProjectDirectory
         });
+        this.context.logger.info(`[TIMING] createTestProject took ${Date.now() - createTestProjectStartTime}ms`);
 
+        const writeSourceFilesStartTime = Date.now();
         for (const file of this.sourceFiles) {
             await file.write(absolutePathToProjectDirectory);
         }
+        this.context.logger.info(`[TIMING] writeSourceFiles took ${Date.now() - writeSourceFilesStartTime}ms`);
 
+        const writeTestFilesStartTime = Date.now();
         for (const file of this.testFiles) {
             await file.write(absolutePathToTestProjectDirectory);
         }
+        this.context.logger.info(`[TIMING] writeTestFiles took ${Date.now() - writeTestFilesStartTime}ms`);
 
         await this.createRawFiles();
 
@@ -301,6 +310,7 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
         await this.createCoreTestDirectory({ absolutePathToTestProjectDirectory });
         await this.createPublicCoreDirectory({ absolutePathToProjectDirectory });
 
+        const dotnetFormatStartTime = Date.now();
         if (this.settings.useDotnetFormat) {
             // apply dotnet analyzer and formatter pass 1
             await this.dotnetFormat(
@@ -325,9 +335,13 @@ dotnet_diagnostic.IDE0005.severity = error
           `
             );
         }
+        this.context.logger.info(`[TIMING] dotnetFormat took ${Date.now() - dotnetFormatStartTime}ms`);
 
         // format the code cleanly using csharpier on the full output directory
+        const csharpierStartTime = Date.now();
         await this.csharpier(this.absolutePathToOutputDirectory);
+        this.context.logger.info(`[TIMING] csharpier took ${Date.now() - csharpierStartTime}ms`);
+        this.context.logger.info(`[TIMING] persist took ${Date.now() - persistStartTime}ms`);
     }
 
     private async createProject({

--- a/generators/csharp/model/src/ModelGeneratorCli.ts
+++ b/generators/csharp/model/src/ModelGeneratorCli.ts
@@ -57,7 +57,9 @@ export class ModelGeneratorCLI extends AbstractCsharpGeneratorCli {
     }
 
     private async generate(context: ModelGeneratorContext): Promise<void> {
+        const generateStartTime = Date.now();
         const generatedTypes = generateModels({ context });
+        context.logger.info(`[TIMING] generateModels took ${Date.now() - generateStartTime}ms`);
         for (const file of generatedTypes) {
             context.project.addSourceFiles(file);
         }
@@ -71,6 +73,7 @@ export class ModelGeneratorCLI extends AbstractCsharpGeneratorCli {
             }
         }
 
+        context.logger.info(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);
         await context.project.persist();
     }
 }

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.7
+  changelogEntry:
+    - summary: |
+        Add [TIMING] log statements throughout the C# model generator to help identify performance bottlenecks during code generation, project creation, formatting, and output.
+      type: chore
+  createdAt: "2026-02-21"
+  irVersion: 62
+
 - version: 0.0.6
   changelogEntry:
     - type: internal

--- a/generators/csharp/sdk/src/SdkGeneratorCli.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorCli.ts
@@ -102,12 +102,17 @@ export class SdkGeneratorCLI extends AbstractCsharpGeneratorCli {
     }
 
     protected async generate(context: SdkGeneratorContext): Promise<void> {
+        const generateStartTime = Date.now();
         // generate names for everything up front.
+        const precalculateStartTime = Date.now();
         context.precalculate();
+        context.logger.info(`[TIMING] precalculate took ${Date.now() - precalculateStartTime}ms`);
 
         // before generating anything, generate the models first so that we
         // can identify collisions or ambiguities in the generated code.
+        const modelsStartTime = Date.now();
         const models = generateModels({ context });
+        context.logger.info(`[TIMING] generateModels took ${Date.now() - modelsStartTime}ms`);
 
         await context.snippetGenerator.populateSnippetsCache();
 
@@ -291,6 +296,7 @@ export class SdkGeneratorCLI extends AbstractCsharpGeneratorCli {
                 context.logger.warn("Failed to generate reference.md, this is OK.");
             }
         }
+        context.logger.info(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);
         await context.project.persist();
     }
 

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.22.1
+  changelogEntry:
+    - summary: |
+        Add [TIMING] log statements throughout the C# generator to help identify performance bottlenecks during code generation, project creation, formatting, and output.
+      type: chore
+  createdAt: "2026-02-21"
+  irVersion: 62
+
 - version: 2.22.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger ([Devin run](https://app.devin.ai/sessions/dff7725b1c5341198caebb138198c149))

Adds `[TIMING]` log statements to the C# generator pipeline, mirroring the pattern already used by the TypeScript generator (see `AbstractGeneratorCli.ts` and `PersistedTypescriptProject.ts` in `generators/typescript/`).

## Changes Made

- **`generators/base/src/AbstractGeneratorCli.ts`** — Added `console.log` timing for IR parsing, context construction, metadata generation, and output mode dispatch. **Note: this is the shared base class used by all generators (Java, Python, Go, C#, etc.), not just C#.**
- **`generators/csharp/base/src/project/CsharpProject.ts`** — Added `logger.info` timing inside `persist()` for: `createProject`, `createTestProject`, `writeSourceFiles`, `writeTestFiles`, `dotnetFormat`, `csharpier`, and overall `persist`.
- **`generators/csharp/sdk/src/SdkGeneratorCli.ts`** — Added timing for `precalculate`, `generateModels`, and overall `code generation`.
- **`generators/csharp/model/src/ModelGeneratorCli.ts`** — Added timing for `generateModels` and overall `code generation`.
- Version bumps: C# SDK → `2.22.1`, C# model → `0.0.7`.

## Human Review Checklist

- [ ] **Base class scope**: The `AbstractGeneratorCli.ts` change is in the shared base used by _all_ generators (not just C#). Verify this is intentional / acceptable, or if timing should be scoped to C#-only files.
- [x] **`dotnetFormat` timing**: The timer starts _before_ the `if (this.settings.useDotnetFormat)` check, so it will report `0ms` when formatting is disabled. Confirm this is acceptable vs. wrapping the timer inside the conditional.
- [ ] **Log level**: Base class uses `console.log`; C#-specific files use `context.logger.info`. Confirm this inconsistency is fine (matches existing TypeScript pattern).

## Testing

- [x] `pnpm turbo run compile` passes for `@fern-api/fern-csharp-sdk`, `@fern-api/fern-csharp-model`, and `@fern-api/base-generator` (14/14 tasks successful)
- [ ] No unit tests added (logging-only change)