### PR TITLE
chore(docs): add explicit PR title rules for Claude AI and Devin AI

### DIFF
--- a/.devin/settings.md
+++ b/.devin/settings.md
@@ -1,0 +1,22 @@
+# Devin Settings for fern-api/fern
+
+## Pull Request Title Rules
+
+PR titles are validated by CI (`.github/workflows/lint-pr-title.yml`) using [semantic-pull-request](https://github.com/amannn/action-semantic-pull-request). Both type and scope are **required**.
+
+**Format**: `<type>(<scope>): <description>`
+
+**Allowed types**: `fix`, `feat`, `revert`, `break`, `chore`
+
+**Allowed scopes**: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `postman`, `ci`, `lint`, `fastapi`, `spring`, `express`, `openapi`, `deps`, `deps-dev`, `fiber`, `pydantic`, `ai-search`, `swift`, `rust`
+
+**Examples**:
+- `chore(docs): update guidelines`
+- `feat(python): add new feature`
+- `fix(cli): resolve config loading bug`
+
+## Pull Request Guidelines
+
+- **Assignee**: Always assign the person who prompted you to create the PR as the assignee.
+- **Description**: Follow the PR template in `.github/pull_request_template.md`.
+- **Testing**: Ensure all tests pass before marking PR as ready for review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,14 @@ Here are additional TypeScript rules beyond type safety:
 
 When creating pull requests in this repository:
 
-1. **PR Title**: Must follow semantic commit message rules with format `<type>(<scope>): <description>`. The type and scope must match those defined in `.github/workflows/lint-pr-title.yml`. For example: `chore(docs): update guidelines` or `feat(python): add new feature`.
+1. **PR Title**: Must follow semantic commit message rules enforced by CI (`.github/workflows/lint-pr-title.yml`). Format: `<type>(<scope>): <description>`. Both type and scope are **required**.
+
+   **Allowed types**: `fix`, `feat`, `revert`, `break`, `chore`
+
+   **Allowed scopes**: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `postman`, `ci`, `lint`, `fastapi`, `spring`, `express`, `openapi`, `deps`, `deps-dev`, `fiber`, `pydantic`, `ai-search`, `swift`, `rust`
+
+   **Examples**: `chore(docs): update guidelines`, `feat(python): add new feature`, `fix(cli): resolve config loading bug`
+
 2. **Assignee**: Always assign the person who prompted you to create the PR as the assignee
 3. **Description**: Follow the PR template in `.github/pull_request_template.md`
 4. **Testing**: Ensure all tests pass before marking PR as ready for review


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/8ce61e515be44da5b30408a7d6376bf6)

The CI workflow `lint-pr-title.yml` enforces semantic PR title rules, but AI agents (Claude, Devin) had to read the workflow file to discover the allowed types and scopes. This PR inlines those values directly into the AI agent config files so they are immediately available without an extra file lookup.

## Changes Made

- **`CLAUDE.md`**: Expanded the PR Title guideline to explicitly list all allowed types and scopes with examples (previously just referenced the workflow file)
- **`.devin/settings.md`** (new): Created Devin AI settings file with the same PR title rules and general PR guidelines

## Review Checklist

- [ ] Verify listed types/scopes match `.github/workflows/lint-pr-title.yml` exactly — this is now a **duplicated source of truth** across three files (workflow, CLAUDE.md, .devin/settings.md). Future workflow changes will need to update these docs too.
- [ ] Confirm `.devin/settings.md` is the correct convention/path for Devin AI project-level settings

## Testing

- No code changes; docs only. No tests needed.