### PR TITLE
feat(cli): support multiple package managers with fallback

### DIFF
--- a/packages/cli/cli/src/__test__/rerunFernCliAtVersion.test.ts
+++ b/packages/cli/cli/src/__test__/rerunFernCliAtVersion.test.ts
@@ -1,4 +1,5 @@
 import { loggingExeca } from "@fern-api/logging-execa";
+import { Logger } from "@fern-api/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CliContext } from "../cli-context/CliContext.js";
@@ -20,22 +21,19 @@ import { detectPackageManagerRunner } from "../utils/packageManagerRunner.js";
 
 describe("rerunFernCliAtVersion", () => {
     let mockCliContext: CliContext;
-    let mockLogger: {
-        info: ReturnType<typeof vi.fn>;
-        error: ReturnType<typeof vi.fn>;
-        warn: ReturnType<typeof vi.fn>;
-        debug: ReturnType<typeof vi.fn>;
+    const mockLogger: Logger = {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
     };
 
     beforeEach(() => {
         vi.clearAllMocks();
-
-        mockLogger = {
-            info: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn(),
-            debug: vi.fn()
-        };
 
         mockCliContext = {
             logger: mockLogger,

--- a/packages/cli/cli/src/__test__/rerunFernCliAtVersion.test.ts
+++ b/packages/cli/cli/src/__test__/rerunFernCliAtVersion.test.ts
@@ -1,0 +1,357 @@
+import { loggingExeca } from "@fern-api/logging-execa";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CliContext } from "../cli-context/CliContext.js";
+import { RerunCliError, rerunFernCliAtVersion } from "../rerunFernCliAtVersion.js";
+
+vi.mock("@fern-api/logging-execa");
+vi.mock("../utils/packageManagerRunner", async () => {
+    const actual = await vi.importActual<typeof import("../utils/packageManagerRunner")>(
+        "../utils/packageManagerRunner"
+    );
+    return {
+        ...actual,
+        detectPackageManagerRunner: vi.fn()
+    };
+});
+
+import type { PackageManagerRunner } from "../utils/packageManagerRunner.js";
+import { detectPackageManagerRunner } from "../utils/packageManagerRunner.js";
+
+describe("rerunFernCliAtVersion", () => {
+    let mockCliContext: CliContext;
+    let mockLogger: {
+        info: ReturnType<typeof vi.fn>;
+        error: ReturnType<typeof vi.fn>;
+        warn: ReturnType<typeof vi.fn>;
+        debug: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockLogger = {
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+            debug: vi.fn()
+        };
+
+        mockCliContext = {
+            logger: mockLogger,
+            environment: {
+                packageVersion: "1.0.0",
+                packageName: "fern-api"
+            },
+            suppressUpgradeMessage: vi.fn(),
+            failAndThrow: vi.fn((message: string) => {
+                throw new Error(message);
+            }),
+            failWithoutThrowing: vi.fn()
+        } as unknown as CliContext;
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("package manager runner detection", () => {
+        it("should use npx when detected", async () => {
+            const npmRunner: PackageManagerRunner = {
+                type: "npm",
+                command: "npx",
+                buildArgs: (pkg: string, args: string[]) => ["--quiet", "--yes", pkg, ...args],
+                label: "npx (npm)"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(npmRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                args: ["upgrade"]
+            });
+
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("npx");
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[2]).toEqual([
+                "--quiet",
+                "--yes",
+                "fern-api@1.2.3",
+                "upgrade"
+            ]);
+        });
+
+        it("should use pnpm dlx when detected", async () => {
+            const pnpmRunner: PackageManagerRunner = {
+                type: "pnpm",
+                command: "pnpm",
+                buildArgs: (pkg: string, args: string[]) => ["dlx", pkg, ...args],
+                label: "pnpm dlx"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(pnpmRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                args: ["upgrade"]
+            });
+
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("pnpm");
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[2]).toEqual(["dlx", "fern-api@1.2.3", "upgrade"]);
+        });
+
+        it("should use yarn dlx when detected", async () => {
+            const yarnRunner: PackageManagerRunner = {
+                type: "yarn",
+                command: "yarn",
+                buildArgs: (pkg: string, args: string[]) => ["dlx", pkg, ...args],
+                label: "yarn dlx"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(yarnRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                args: ["upgrade"]
+            });
+
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("yarn");
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[2]).toEqual(["dlx", "fern-api@1.2.3", "upgrade"]);
+        });
+
+        it("should use bunx when detected", async () => {
+            const bunRunner: PackageManagerRunner = {
+                type: "bun",
+                command: "bunx",
+                buildArgs: (pkg: string, args: string[]) => [pkg, ...args],
+                label: "bunx (bun)"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(bunRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                args: ["upgrade"]
+            });
+
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("bunx");
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[2]).toEqual(["fern-api@1.2.3", "upgrade"]);
+        });
+
+        it("should use vlt when detected", async () => {
+            const vltRunner: PackageManagerRunner = {
+                type: "vlt",
+                command: "vlt",
+                buildArgs: (pkg: string, args: string[]) => ["exec", pkg, "--", ...args],
+                label: "vlt exec"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(vltRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                args: ["upgrade"]
+            });
+
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("vlt");
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[2]).toEqual(["exec", "fern-api@1.2.3", "--", "upgrade"]);
+        });
+    });
+
+    describe("when no package manager is available", () => {
+        it("should fail with descriptive error when throwOnError is true", async () => {
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(undefined);
+
+            await expect(
+                rerunFernCliAtVersion({
+                    version: "1.2.3",
+                    cliContext: mockCliContext,
+                    throwOnError: true
+                })
+            ).rejects.toThrow(RerunCliError);
+
+            await expect(
+                rerunFernCliAtVersion({
+                    version: "1.2.3",
+                    cliContext: mockCliContext,
+                    throwOnError: true
+                })
+            ).rejects.toThrow("Failed to rerun CLI at version 1.2.3");
+        });
+
+        it("should call failAndThrow when throwOnError is false", async () => {
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(undefined);
+
+            await expect(
+                rerunFernCliAtVersion({
+                    version: "1.2.3",
+                    cliContext: mockCliContext,
+                    throwOnError: false
+                })
+            ).rejects.toThrow("No supported package manager runner found");
+        });
+    });
+
+    describe("EEXIST retry", () => {
+        it("should retry on EEXIST error in stdout", async () => {
+            const npmRunner: PackageManagerRunner = {
+                type: "npm",
+                command: "npx",
+                buildArgs: (pkg: string, args: string[]) => ["--quiet", "--yes", pkg, ...args],
+                label: "npx (npm)"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(npmRunner);
+            vi.mocked(loggingExeca)
+                // First attempt: EEXIST
+                .mockResolvedValueOnce({
+                    stdout: "npm ERR! code EEXIST",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // Second attempt: success
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: false
+                } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                args: ["upgrade"]
+            });
+
+            // Should have been called twice (original + retry)
+            expect(vi.mocked(loggingExeca)).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("error handling", () => {
+        it("should throw RerunCliError when execution fails and throwOnError is true", async () => {
+            const npmRunner: PackageManagerRunner = {
+                type: "npm",
+                command: "npx",
+                buildArgs: (pkg: string, args: string[]) => ["--quiet", "--yes", pkg, ...args],
+                label: "npx (npm)"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(npmRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "some error",
+                failed: true
+            } as loggingExeca.ReturnValue);
+
+            await expect(
+                rerunFernCliAtVersion({
+                    version: "1.2.3",
+                    cliContext: mockCliContext,
+                    throwOnError: true,
+                    args: ["upgrade"]
+                })
+            ).rejects.toThrow(RerunCliError);
+        });
+
+        it("should call failWithoutThrowing when execution fails and throwOnError is false", async () => {
+            const npmRunner: PackageManagerRunner = {
+                type: "npm",
+                command: "npx",
+                buildArgs: (pkg: string, args: string[]) => ["--quiet", "--yes", pkg, ...args],
+                label: "npx (npm)"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(npmRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "some error",
+                failed: true
+            } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                throwOnError: false,
+                args: ["upgrade"]
+            });
+
+            expect(mockCliContext.failWithoutThrowing).toHaveBeenCalled();
+        });
+    });
+
+    describe("debug logging", () => {
+        it("should log the runner being used", async () => {
+            const pnpmRunner: PackageManagerRunner = {
+                type: "pnpm",
+                command: "pnpm",
+                buildArgs: (pkg: string, args: string[]) => ["dlx", pkg, ...args],
+                label: "pnpm dlx"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(pnpmRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                args: ["upgrade"]
+            });
+
+            expect(mockLogger.debug).toHaveBeenCalledWith(expect.stringContaining("pnpm dlx"));
+            expect(mockLogger.debug).toHaveBeenCalledWith(expect.stringContaining("1.2.3"));
+        });
+    });
+
+    describe("environment variables", () => {
+        it("should pass env variables through to the executed command", async () => {
+            const npmRunner: PackageManagerRunner = {
+                type: "npm",
+                command: "npx",
+                buildArgs: (pkg: string, args: string[]) => ["--quiet", "--yes", pkg, ...args],
+                label: "npx (npm)"
+            };
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(npmRunner);
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await rerunFernCliAtVersion({
+                version: "1.2.3",
+                cliContext: mockCliContext,
+                env: { MY_VAR: "my-value" },
+                args: ["upgrade"]
+            });
+
+            const execaOptions = vi.mocked(loggingExeca).mock.calls[0]?.[3] as Record<string, unknown>;
+            const envVars = execaOptions?.env as Record<string, string>;
+            expect(envVars?.MY_VAR).toBe("my-value");
+            expect(envVars?.FERN_NO_VERSION_REDIRECTION).toBe("true");
+        });
+    });
+});

--- a/packages/cli/cli/src/__test__/rerunFernCliAtVersion.test.ts
+++ b/packages/cli/cli/src/__test__/rerunFernCliAtVersion.test.ts
@@ -1,5 +1,5 @@
-import { loggingExeca } from "@fern-api/logging-execa";
 import { Logger } from "@fern-api/logger";
+import { loggingExeca } from "@fern-api/logging-execa";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CliContext } from "../cli-context/CliContext.js";

--- a/packages/cli/cli/src/__test__/rerunFernCliAtVersion.test.ts
+++ b/packages/cli/cli/src/__test__/rerunFernCliAtVersion.test.ts
@@ -155,14 +155,14 @@ describe("rerunFernCliAtVersion", () => {
             expect(vi.mocked(loggingExeca).mock.calls[0]?.[2]).toEqual(["fern-api@1.2.3", "upgrade"]);
         });
 
-        it("should use vlt when detected", async () => {
-            const vltRunner: PackageManagerRunner = {
-                type: "vlt",
-                command: "vlt",
-                buildArgs: (pkg: string, args: string[]) => ["exec", pkg, "--", ...args],
-                label: "vlt exec"
+        it("should use deno when detected", async () => {
+            const denoRunner: PackageManagerRunner = {
+                type: "deno",
+                command: "deno",
+                buildArgs: (pkg: string, args: string[]) => ["run", "-A", `npm:${pkg}`, ...args],
+                label: "deno run"
             };
-            vi.mocked(detectPackageManagerRunner).mockResolvedValue(vltRunner);
+            vi.mocked(detectPackageManagerRunner).mockResolvedValue(denoRunner);
             vi.mocked(loggingExeca).mockResolvedValueOnce({
                 stdout: "",
                 stderr: "",
@@ -175,8 +175,8 @@ describe("rerunFernCliAtVersion", () => {
                 args: ["upgrade"]
             });
 
-            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("vlt");
-            expect(vi.mocked(loggingExeca).mock.calls[0]?.[2]).toEqual(["exec", "fern-api@1.2.3", "--", "upgrade"]);
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("deno");
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[2]).toEqual(["run", "-A", "npm:fern-api@1.2.3", "upgrade"]);
         });
     });
 

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -1,9 +1,10 @@
 import type { generatorsYml } from "@fern-api/configuration";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { mkdir, readFile } from "fs/promises";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { createRequire } from "module";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 import semver from "semver";
 
 import { Migration, MigrationModule, MigratorResult } from "./types.js";
@@ -23,6 +24,95 @@ const MIGRATION_PACKAGE_NAME = "@fern-api/generator-migrations";
  */
 function getMigrationCacheDir(): string {
     return join(homedir(), ".fern", "migration-cache");
+}
+
+type InstallAttempt = {
+    label: string;
+    command: string;
+    args: string[];
+    env?: NodeJS.ProcessEnv;
+};
+
+async function ensureCacheDirHasPackageJson(cacheDir: string): Promise<void> {
+    const packageJsonPath = join(cacheDir, "package.json");
+    try {
+        await readFile(packageJsonPath, "utf-8");
+    } catch {
+        await writeFile(packageJsonPath, JSON.stringify({ name: "fern-migration-cache", private: true }, null, 2));
+    }
+}
+
+function isCommandNotFound(error: unknown): boolean {
+    if (typeof error !== "object" || error == null) {
+        return false;
+    }
+
+    if ("code" in error && (error as { code?: unknown }).code === "ENOENT") {
+        return true;
+    }
+
+    if ("message" in error && typeof (error as { message?: unknown }).message === "string") {
+        return (error as { message: string }).message.includes("ENOENT");
+    }
+
+    return false;
+}
+
+async function installPackageWithFallback(params: {
+    logger: Logger;
+    cacheDir: string;
+    packageAtVersion: string;
+}): Promise<void> {
+    const { logger, cacheDir, packageAtVersion } = params;
+
+    const attempts: InstallAttempt[] = [
+        {
+            label: "npm install",
+            command: "npm",
+            args: ["install", packageAtVersion, "--ignore-scripts", "--no-audit", "--no-fund"]
+        },
+        {
+            label: "pnpm add",
+            command: "pnpm",
+            args: ["add", packageAtVersion, "--ignore-scripts", "--no-fund"]
+        },
+        {
+            label: "yarn add",
+            command: "yarn",
+            args: ["add", packageAtVersion, "--ignore-scripts"],
+            // Force yarn berry to use node_modules instead of PnP so we can resolve imports.
+            env: { ...process.env, YARN_NODE_LINKER: "node-modules" }
+        },
+        {
+            label: "bun add",
+            command: "bun",
+            args: ["add", packageAtVersion]
+        }
+    ];
+
+    let lastError: unknown;
+    for (const attempt of attempts) {
+        try {
+            await loggingExeca(logger, attempt.command, attempt.args, {
+                cwd: cacheDir,
+                env: attempt.env
+            });
+            return;
+        } catch (error) {
+            lastError = error;
+            if (isCommandNotFound(error)) {
+                logger.debug(`${attempt.label} unavailable (command not found). Trying next package manager...`);
+                continue;
+            }
+            throw error;
+        }
+    }
+
+    throw new Error(
+        `No supported package manager found to install ${packageAtVersion}. ` +
+            `Please install one of: npm, pnpm, yarn, or bun. ` +
+            `Last error: ${lastError instanceof Error ? lastError.message : String(lastError)}`
+    );
 }
 
 /**
@@ -58,25 +148,24 @@ export async function loadMigrationModule(params: {
     await mkdir(cacheDir, { recursive: true });
 
     try {
-        // Install/update the unified migration package to the cache directory
-        // npm will check if @latest is already installed and skip reinstallation if so
-        // --ignore-scripts: Security - prevent running arbitrary code during install
-        // --no-audit: Skip audit checks for faster installation
-        // --no-fund: Skip funding messages
-        await loggingExeca(logger, "npm", [
-            "install",
-            `${MIGRATION_PACKAGE_NAME}@latest`,
-            "--prefix",
-            cacheDir,
-            "--ignore-scripts",
-            "--no-audit",
-            "--no-fund"
-        ]);
+        await ensureCacheDirHasPackageJson(cacheDir);
 
-        // Read the package.json to get the entry point from the main field
-        const packageDir = join(cacheDir, "node_modules", MIGRATION_PACKAGE_NAME);
-        const packageJsonPath = join(packageDir, "package.json");
-        const packageJsonContent = await readFile(packageJsonPath, "utf-8");
+        // Install/update the unified migration package to the cache directory.
+        // We fallback across package managers to reduce hard dependency on npm.
+        // Security: for package managers that support it, we disable lifecycle scripts.
+        await installPackageWithFallback({
+            logger,
+            cacheDir,
+            packageAtVersion: `${MIGRATION_PACKAGE_NAME}@latest`
+        });
+
+        // Resolve the installed package directory without assuming node_modules layout.
+        const require = createRequire(join(cacheDir, "package.json"));
+        const resolvedPackageJsonPath = require.resolve(`${MIGRATION_PACKAGE_NAME}/package.json`);
+        const packageDir = dirname(resolvedPackageJsonPath);
+
+        // Read the package.json to get the entry point from the main field.
+        const packageJsonContent = await readFile(resolvedPackageJsonPath, "utf-8");
         const packageJson = JSON.parse(packageJsonContent) as { main?: string };
 
         if (packageJson.main == null) {
@@ -116,9 +205,9 @@ export async function loadMigrationModule(params: {
             `Failed to load generator migrations for ${generatorName}.\n\n` +
                 `Reason: ${errorMessage}\n\n` +
                 `This error occurred while trying to install the migration package (${MIGRATION_PACKAGE_NAME}). ` +
-                `Please check your internet connection and npm configuration, then try again.\n\n` +
+                `Please check your internet connection and package manager configuration, then try again.\n\n` +
                 `If the problem persists, you can:\n` +
-                `  1. Check if npm is working: npm --version\n` +
+                `  1. Check a package manager is working (any one): npm --version / pnpm --version / yarn --version / bun --version\n` +
                 `  2. Clear the migration cache: rm -rf ~/.fern/migration-cache\n` +
                 `  3. Try the upgrade again: fern generator upgrade`
         );

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -74,7 +74,7 @@ async function installPackageWithFallback(params: {
         {
             label: "pnpm add",
             command: "pnpm",
-            args: ["add", packageAtVersion, "--ignore-scripts", "--no-fund"]
+            args: ["add", packageAtVersion, "--ignore-scripts"]
         },
         {
             label: "yarn add",

--- a/packages/cli/cli/src/rerunFernCliAtVersion.ts
+++ b/packages/cli/cli/src/rerunFernCliAtVersion.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 
 import { CliContext } from "./cli-context/CliContext.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
+import { detectPackageManagerRunner } from "./utils/packageManagerRunner.js";
 
 export class RerunCliError extends Error {
     public readonly stdout: string;
@@ -33,20 +34,29 @@ export async function rerunFernCliAtVersion({
 }): Promise<void> {
     cliContext.suppressUpgradeMessage();
 
-    const commandLineArgs = [
-        "--quiet",
-        "--yes",
-        `${cliContext.environment.packageName}@${version}`,
-        ...(args ?? process.argv.slice(2))
-    ];
+    const runner = await detectPackageManagerRunner(cliContext.logger);
+    if (runner == null) {
+        const message =
+            "No supported package manager runner found. " +
+            "Please install one of: npm (npx), pnpm, yarn, bun, or vlt.";
+        if (throwOnError) {
+            throw new RerunCliError({ version, stdout: "", stderr: message });
+        }
+        cliContext.failAndThrow(message);
+        return;
+    }
+
+    const packageAtVersion = `${cliContext.environment.packageName}@${version}`;
+    const commandLineArgs = runner.buildArgs(packageAtVersion, args ?? process.argv.slice(2));
+
     cliContext.logger.debug(
         [
-            `Re-running CLI at version ${version}.`,
-            `${chalk.dim(`+ npx ${commandLineArgs.map((arg) => `"${arg}"`).join(" ")}`)}`
+            `Re-running CLI at version ${version} using ${runner.label}.`,
+            `${chalk.dim(`+ ${runner.command} ${commandLineArgs.map((arg) => `"${arg}"`).join(" ")}`)}`
         ].join("\n")
     );
 
-    const { failed, stdout, stderr } = await loggingExeca(cliContext.logger, "npx", commandLineArgs, {
+    const { failed, stdout, stderr } = await loggingExeca(cliContext.logger, runner.command, commandLineArgs, {
         stdio: "inherit",
         reject: false,
         env: {
@@ -56,7 +66,7 @@ export async function rerunFernCliAtVersion({
         }
     });
     if (stdout.includes("code EEXIST") || stderr.includes("code EEXIST")) {
-        // try again if there is a npx conflict
+        // try again if there is an npx-style cache conflict
         return await rerunFernCliAtVersion({
             version,
             cliContext,

--- a/packages/cli/cli/src/rerunFernCliAtVersion.ts
+++ b/packages/cli/cli/src/rerunFernCliAtVersion.ts
@@ -38,7 +38,7 @@ export async function rerunFernCliAtVersion({
     if (runner == null) {
         const message =
             "No supported package manager runner found. " +
-            "Please install one of: npm (npx), pnpm, yarn, bun, or vlt.";
+            "Please install one of: npm (npx), pnpm, yarn, bun, or deno.";
         if (throwOnError) {
             throw new RerunCliError({ version, stdout: "", stderr: message });
         }

--- a/packages/cli/cli/src/utils/__test__/packageManagerRunner.test.ts
+++ b/packages/cli/cli/src/utils/__test__/packageManagerRunner.test.ts
@@ -1,5 +1,5 @@
-import { loggingExeca } from "@fern-api/logging-execa";
 import { Logger } from "@fern-api/logger";
+import { loggingExeca } from "@fern-api/logging-execa";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { detectPackageManagerRunner, getAllRunners } from "../packageManagerRunner.js";

--- a/packages/cli/cli/src/utils/__test__/packageManagerRunner.test.ts
+++ b/packages/cli/cli/src/utils/__test__/packageManagerRunner.test.ts
@@ -1,4 +1,5 @@
 import { loggingExeca } from "@fern-api/logging-execa";
+import { Logger } from "@fern-api/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { detectPackageManagerRunner, getAllRunners } from "../packageManagerRunner.js";
@@ -6,22 +7,19 @@ import { detectPackageManagerRunner, getAllRunners } from "../packageManagerRunn
 vi.mock("@fern-api/logging-execa");
 
 describe("packageManagerRunner", () => {
-    let mockLogger: {
-        info: ReturnType<typeof vi.fn>;
-        error: ReturnType<typeof vi.fn>;
-        warn: ReturnType<typeof vi.fn>;
-        debug: ReturnType<typeof vi.fn>;
+    const mockLogger: Logger = {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
     };
 
     beforeEach(() => {
         vi.clearAllMocks();
-
-        mockLogger = {
-            info: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn(),
-            debug: vi.fn()
-        };
     });
 
     afterEach(() => {

--- a/packages/cli/cli/src/utils/__test__/packageManagerRunner.test.ts
+++ b/packages/cli/cli/src/utils/__test__/packageManagerRunner.test.ts
@@ -129,7 +129,7 @@ describe("packageManagerRunner", () => {
             expect(runner?.label).toBe("bunx (bun)");
         });
 
-        it("should fall back to vlt when npx, pnpm, yarn, and bunx are not available", async () => {
+        it("should fall back to deno when npx, pnpm, yarn, and bunx are not available", async () => {
             vi.mocked(loggingExeca)
                 // npx not found
                 .mockResolvedValueOnce({
@@ -155,9 +155,9 @@ describe("packageManagerRunner", () => {
                     stderr: "",
                     failed: true
                 } as loggingExeca.ReturnValue)
-                // vlt found
+                // deno found
                 .mockResolvedValueOnce({
-                    stdout: "/usr/local/bin/vlt",
+                    stdout: "/usr/local/bin/deno",
                     stderr: "",
                     failed: false
                 } as loggingExeca.ReturnValue);
@@ -165,9 +165,9 @@ describe("packageManagerRunner", () => {
             const runner = await detectPackageManagerRunner(mockLogger);
 
             expect(runner).toBeDefined();
-            expect(runner?.type).toBe("vlt");
-            expect(runner?.command).toBe("vlt");
-            expect(runner?.label).toBe("vlt exec");
+            expect(runner?.type).toBe("deno");
+            expect(runner?.command).toBe("deno");
+            expect(runner?.label).toBe("deno run");
         });
 
         it("should return undefined when no package manager is available", async () => {
@@ -254,13 +254,13 @@ describe("packageManagerRunner", () => {
             expect(args).toEqual(["fern-api@1.2.3", "upgrade", "--from", "1.0.0"]);
         });
 
-        it("should build correct args for vlt", () => {
+        it("should build correct args for deno", () => {
             const runners = getAllRunners();
-            const vltRunner = runners.find((r) => r.type === "vlt");
-            expect(vltRunner).toBeDefined();
+            const denoRunner = runners.find((r) => r.type === "deno");
+            expect(denoRunner).toBeDefined();
 
-            const args = vltRunner?.buildArgs("fern-api@1.2.3", ["upgrade", "--from", "1.0.0"]);
-            expect(args).toEqual(["exec", "fern-api@1.2.3", "--", "upgrade", "--from", "1.0.0"]);
+            const args = denoRunner?.buildArgs("fern-api@1.2.3", ["upgrade", "--from", "1.0.0"]);
+            expect(args).toEqual(["run", "-A", "npm:fern-api@1.2.3", "upgrade", "--from", "1.0.0"]);
         });
 
         it("should handle empty args array", () => {
@@ -268,7 +268,9 @@ describe("packageManagerRunner", () => {
             for (const runner of runners) {
                 const args = runner.buildArgs("fern-api@1.0.0", []);
                 expect(args.length).toBeGreaterThan(0);
-                expect(args).toContain("fern-api@1.0.0");
+                // The package specifier should appear in at least one arg
+                // (for deno it's prefixed with "npm:")
+                expect(args.some((a) => a.includes("fern-api@1.0.0"))).toBe(true);
             }
         });
     });
@@ -286,7 +288,7 @@ describe("packageManagerRunner", () => {
             expect(types).toContain("pnpm");
             expect(types).toContain("yarn");
             expect(types).toContain("bun");
-            expect(types).toContain("vlt");
+            expect(types).toContain("deno");
         });
 
         it("should have npx as the first runner (highest priority)", () => {

--- a/packages/cli/cli/src/utils/__test__/packageManagerRunner.test.ts
+++ b/packages/cli/cli/src/utils/__test__/packageManagerRunner.test.ts
@@ -1,0 +1,300 @@
+import { loggingExeca } from "@fern-api/logging-execa";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { detectPackageManagerRunner, getAllRunners } from "../packageManagerRunner.js";
+
+vi.mock("@fern-api/logging-execa");
+
+describe("packageManagerRunner", () => {
+    let mockLogger: {
+        info: ReturnType<typeof vi.fn>;
+        error: ReturnType<typeof vi.fn>;
+        warn: ReturnType<typeof vi.fn>;
+        debug: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockLogger = {
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+            debug: vi.fn()
+        };
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("detectPackageManagerRunner", () => {
+        it("should detect npx when available", async () => {
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "/usr/local/bin/npx",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            const runner = await detectPackageManagerRunner(mockLogger);
+
+            expect(runner).toBeDefined();
+            expect(runner?.type).toBe("npm");
+            expect(runner?.command).toBe("npx");
+            expect(runner?.label).toBe("npx (npm)");
+        });
+
+        it("should fall back to pnpm when npx is not available", async () => {
+            vi.mocked(loggingExeca)
+                // npx not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // pnpm found
+                .mockResolvedValueOnce({
+                    stdout: "/usr/local/bin/pnpm",
+                    stderr: "",
+                    failed: false
+                } as loggingExeca.ReturnValue);
+
+            const runner = await detectPackageManagerRunner(mockLogger);
+
+            expect(runner).toBeDefined();
+            expect(runner?.type).toBe("pnpm");
+            expect(runner?.command).toBe("pnpm");
+            expect(runner?.label).toBe("pnpm dlx");
+        });
+
+        it("should fall back to yarn when npx and pnpm are not available", async () => {
+            vi.mocked(loggingExeca)
+                // npx not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // pnpm not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // yarn found
+                .mockResolvedValueOnce({
+                    stdout: "/usr/local/bin/yarn",
+                    stderr: "",
+                    failed: false
+                } as loggingExeca.ReturnValue);
+
+            const runner = await detectPackageManagerRunner(mockLogger);
+
+            expect(runner).toBeDefined();
+            expect(runner?.type).toBe("yarn");
+            expect(runner?.command).toBe("yarn");
+            expect(runner?.label).toBe("yarn dlx");
+        });
+
+        it("should fall back to bunx when npx, pnpm, and yarn are not available", async () => {
+            vi.mocked(loggingExeca)
+                // npx not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // pnpm not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // yarn not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // bunx found
+                .mockResolvedValueOnce({
+                    stdout: "/usr/local/bin/bunx",
+                    stderr: "",
+                    failed: false
+                } as loggingExeca.ReturnValue);
+
+            const runner = await detectPackageManagerRunner(mockLogger);
+
+            expect(runner).toBeDefined();
+            expect(runner?.type).toBe("bun");
+            expect(runner?.command).toBe("bunx");
+            expect(runner?.label).toBe("bunx (bun)");
+        });
+
+        it("should fall back to vlt when npx, pnpm, yarn, and bunx are not available", async () => {
+            vi.mocked(loggingExeca)
+                // npx not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // pnpm not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // yarn not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // bunx not found
+                .mockResolvedValueOnce({
+                    stdout: "",
+                    stderr: "",
+                    failed: true
+                } as loggingExeca.ReturnValue)
+                // vlt found
+                .mockResolvedValueOnce({
+                    stdout: "/usr/local/bin/vlt",
+                    stderr: "",
+                    failed: false
+                } as loggingExeca.ReturnValue);
+
+            const runner = await detectPackageManagerRunner(mockLogger);
+
+            expect(runner).toBeDefined();
+            expect(runner?.type).toBe("vlt");
+            expect(runner?.command).toBe("vlt");
+            expect(runner?.label).toBe("vlt exec");
+        });
+
+        it("should return undefined when no package manager is available", async () => {
+            vi.mocked(loggingExeca).mockResolvedValue({
+                stdout: "",
+                stderr: "",
+                failed: true
+            } as loggingExeca.ReturnValue);
+
+            const runner = await detectPackageManagerRunner(mockLogger);
+
+            expect(runner).toBeUndefined();
+        });
+
+        it("should use 'which' command on Unix", async () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, "platform", { value: "linux" });
+
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "/usr/local/bin/npx",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await detectPackageManagerRunner(mockLogger);
+
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("which");
+
+            Object.defineProperty(process, "platform", { value: originalPlatform });
+        });
+
+        it("should use 'where' command on Windows", async () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, "platform", { value: "win32" });
+
+            vi.mocked(loggingExeca).mockResolvedValueOnce({
+                stdout: "C:\\Program Files\\nodejs\\npx.cmd",
+                stderr: "",
+                failed: false
+            } as loggingExeca.ReturnValue);
+
+            await detectPackageManagerRunner(mockLogger);
+
+            expect(vi.mocked(loggingExeca).mock.calls[0]?.[1]).toBe("where");
+
+            Object.defineProperty(process, "platform", { value: originalPlatform });
+        });
+    });
+
+    describe("buildArgs", () => {
+        it("should build correct args for npm/npx", () => {
+            const runners = getAllRunners();
+            const npmRunner = runners.find((r) => r.type === "npm");
+            expect(npmRunner).toBeDefined();
+
+            const args = npmRunner?.buildArgs("fern-api@1.2.3", ["upgrade", "--from", "1.0.0"]);
+            expect(args).toEqual(["--quiet", "--yes", "fern-api@1.2.3", "upgrade", "--from", "1.0.0"]);
+        });
+
+        it("should build correct args for pnpm", () => {
+            const runners = getAllRunners();
+            const pnpmRunner = runners.find((r) => r.type === "pnpm");
+            expect(pnpmRunner).toBeDefined();
+
+            const args = pnpmRunner?.buildArgs("fern-api@1.2.3", ["upgrade", "--from", "1.0.0"]);
+            expect(args).toEqual(["dlx", "fern-api@1.2.3", "upgrade", "--from", "1.0.0"]);
+        });
+
+        it("should build correct args for yarn", () => {
+            const runners = getAllRunners();
+            const yarnRunner = runners.find((r) => r.type === "yarn");
+            expect(yarnRunner).toBeDefined();
+
+            const args = yarnRunner?.buildArgs("fern-api@1.2.3", ["upgrade", "--from", "1.0.0"]);
+            expect(args).toEqual(["dlx", "fern-api@1.2.3", "upgrade", "--from", "1.0.0"]);
+        });
+
+        it("should build correct args for bun/bunx", () => {
+            const runners = getAllRunners();
+            const bunRunner = runners.find((r) => r.type === "bun");
+            expect(bunRunner).toBeDefined();
+
+            const args = bunRunner?.buildArgs("fern-api@1.2.3", ["upgrade", "--from", "1.0.0"]);
+            expect(args).toEqual(["fern-api@1.2.3", "upgrade", "--from", "1.0.0"]);
+        });
+
+        it("should build correct args for vlt", () => {
+            const runners = getAllRunners();
+            const vltRunner = runners.find((r) => r.type === "vlt");
+            expect(vltRunner).toBeDefined();
+
+            const args = vltRunner?.buildArgs("fern-api@1.2.3", ["upgrade", "--from", "1.0.0"]);
+            expect(args).toEqual(["exec", "fern-api@1.2.3", "--", "upgrade", "--from", "1.0.0"]);
+        });
+
+        it("should handle empty args array", () => {
+            const runners = getAllRunners();
+            for (const runner of runners) {
+                const args = runner.buildArgs("fern-api@1.0.0", []);
+                expect(args.length).toBeGreaterThan(0);
+                expect(args).toContain("fern-api@1.0.0");
+            }
+        });
+    });
+
+    describe("getAllRunners", () => {
+        it("should return all 5 runners", () => {
+            const runners = getAllRunners();
+            expect(runners).toHaveLength(5);
+        });
+
+        it("should include all expected package manager types", () => {
+            const runners = getAllRunners();
+            const types = runners.map((r) => r.type);
+            expect(types).toContain("npm");
+            expect(types).toContain("pnpm");
+            expect(types).toContain("yarn");
+            expect(types).toContain("bun");
+            expect(types).toContain("vlt");
+        });
+
+        it("should have npx as the first runner (highest priority)", () => {
+            const runners = getAllRunners();
+            expect(runners[0]?.type).toBe("npm");
+            expect(runners[0]?.command).toBe("npx");
+        });
+    });
+});

--- a/packages/cli/cli/src/utils/packageManagerRunner.ts
+++ b/packages/cli/cli/src/utils/packageManagerRunner.ts
@@ -7,7 +7,7 @@ import { loggingExeca } from "@fern-api/logging-execa";
  */
 export interface PackageManagerRunner {
     /** The type of package manager */
-    type: "npm" | "pnpm" | "yarn" | "bun" | "vlt";
+    type: "npm" | "pnpm" | "yarn" | "bun" | "deno";
     /** The command to execute (e.g., "npx", "pnpm", "bunx") */
     command: string;
     /**
@@ -55,12 +55,12 @@ const RUNNERS: PackageManagerRunner[] = [
         label: "bunx (bun)"
     },
     {
-        type: "vlt",
-        command: "vlt",
+        type: "deno",
+        command: "deno",
         buildArgs(packageAtVersion: string, args: string[]): string[] {
-            return ["exec", packageAtVersion, "--", ...args];
+            return ["run", "-A", `npm:${packageAtVersion}`, ...args];
         },
-        label: "vlt exec"
+        label: "deno run"
     }
 ];
 
@@ -82,7 +82,7 @@ async function commandExists(logger: Logger, command: string): Promise<boolean> 
 /**
  * Detect the first available package manager runner on the system.
  *
- * Checks in order: npx, pnpm, yarn, bunx, vlt.
+ * Checks in order: npx, pnpm, yarn, bunx, deno.
  * Returns the first runner whose command is found on PATH.
  *
  * @param logger - Logger instance for debug output

--- a/packages/cli/cli/src/utils/packageManagerRunner.ts
+++ b/packages/cli/cli/src/utils/packageManagerRunner.ts
@@ -1,0 +1,109 @@
+import { Logger } from "@fern-api/logger";
+import { loggingExeca } from "@fern-api/logging-execa";
+
+/**
+ * Represents a package manager runner that can execute one-off packages
+ * (equivalent to npx for npm).
+ */
+export interface PackageManagerRunner {
+    /** The type of package manager */
+    type: "npm" | "pnpm" | "yarn" | "bun" | "vlt";
+    /** The command to execute (e.g., "npx", "pnpm", "bunx") */
+    command: string;
+    /**
+     * Build the full argument list for running a package at a specific version.
+     * @param packageAtVersion - The package specifier, e.g. "fern-api@1.2.3"
+     * @param args - Additional arguments to pass to the package
+     * @returns The full argument list to pass to the command
+     */
+    buildArgs(packageAtVersion: string, args: string[]): string[];
+    /** Human-readable label for log messages */
+    label: string;
+}
+
+const RUNNERS: PackageManagerRunner[] = [
+    {
+        type: "npm",
+        command: "npx",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return ["--quiet", "--yes", packageAtVersion, ...args];
+        },
+        label: "npx (npm)"
+    },
+    {
+        type: "pnpm",
+        command: "pnpm",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return ["dlx", packageAtVersion, ...args];
+        },
+        label: "pnpm dlx"
+    },
+    {
+        type: "yarn",
+        command: "yarn",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return ["dlx", packageAtVersion, ...args];
+        },
+        label: "yarn dlx"
+    },
+    {
+        type: "bun",
+        command: "bunx",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return [packageAtVersion, ...args];
+        },
+        label: "bunx (bun)"
+    },
+    {
+        type: "vlt",
+        command: "vlt",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return ["exec", packageAtVersion, "--", ...args];
+        },
+        label: "vlt exec"
+    }
+];
+
+/**
+ * Check if a command exists on the system.
+ */
+async function commandExists(logger: Logger, command: string): Promise<boolean> {
+    const isWindows = process.platform === "win32";
+    const whichCommand = isWindows ? "where" : "which";
+
+    const { failed } = await loggingExeca(logger, whichCommand, [command], {
+        doNotPipeOutput: true,
+        reject: false
+    });
+
+    return !failed;
+}
+
+/**
+ * Detect the first available package manager runner on the system.
+ *
+ * Checks in order: npx, pnpm, yarn, bunx, vlt.
+ * Returns the first runner whose command is found on PATH.
+ *
+ * @param logger - Logger instance for debug output
+ * @returns The detected runner, or undefined if none are available
+ */
+export async function detectPackageManagerRunner(logger: Logger): Promise<PackageManagerRunner | undefined> {
+    for (const runner of RUNNERS) {
+        logger.debug(`Checking for ${runner.label} (${runner.command})...`);
+        const exists = await commandExists(logger, runner.command);
+        if (exists) {
+            logger.debug(`Found ${runner.label}`);
+            return runner;
+        }
+        logger.debug(`${runner.label} not found`);
+    }
+    return undefined;
+}
+
+/**
+ * Returns all defined runners (useful for testing and error messages).
+ */
+export function getAllRunners(): readonly PackageManagerRunner[] {
+    return RUNNERS;
+}

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -8,6 +8,11 @@
         bunx (bun), deno run, and uses the first one found. If no supported runner is available,
         a clear error message is shown.
       type: feat
+    - summary: |
+        Generator migration package installation now falls back across package managers
+        (npm, pnpm, yarn, bun) instead of requiring npm. Security flags like `--ignore-scripts`
+        are applied where supported.
+      type: feat
   createdAt: "2026-02-22"
   irVersion: 65
 - version: 3.82.0

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.83.0
+  changelogEntry:
+    - summary: |
+        Support multiple package manager runners with automatic fallback in the CLI version
+        redirection flow. Previously, `rerunFernCliAtVersion` was hardcoded to use `npx`.
+        Now the CLI detects available package managers in order: npx (npm), pnpm dlx, yarn dlx,
+        bunx (bun), vlt exec, and uses the first one found. If no supported runner is available,
+        a clear error message is shown.
+      type: feat
+  createdAt: "2026-02-22"
+  irVersion: 65
 - version: 3.82.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -5,7 +5,7 @@
         Support multiple package manager runners with automatic fallback in the CLI version
         redirection flow. Previously, `rerunFernCliAtVersion` was hardcoded to use `npx`.
         Now the CLI detects available package managers in order: npx (npm), pnpm dlx, yarn dlx,
-        bunx (bun), vlt exec, and uses the first one found. If no supported runner is available,
+        bunx (bun), deno run, and uses the first one found. If no supported runner is available,
         a clear error message is shown.
       type: feat
   createdAt: "2026-02-22"

--- a/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
+++ b/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
@@ -1,5 +1,8 @@
 import { CONSOLE_LOGGER } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -11,6 +14,7 @@ import { describe, expect, it } from "vitest";
  */
 
 const TIMEOUT = 120_000;
+const MODULE_INSTALL_TIMEOUT = 300_000;
 
 const WHICH_COMMAND = process.platform === "win32" ? "where" : "which";
 
@@ -97,6 +101,12 @@ async function isCommandAvailable(command: string): Promise<boolean> {
     } catch {
         return false;
     }
+}
+
+async function createTempProjectDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "fern-pm-install-"));
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "fern-pm-install", private: true }, null, 2));
+    return dir;
 }
 
 describe("package-manager-runner e2e", () => {
@@ -349,5 +359,78 @@ describe("package-manager-runner e2e", () => {
             },
             TIMEOUT
         );
+    });
+
+    describe("module install + import", () => {
+        const PACKAGE_AT_VERSION = "is-number@7.0.0";
+
+        const installers = [
+            {
+                label: "npm install",
+                command: "npm",
+                args: ["install", PACKAGE_AT_VERSION, "--ignore-scripts", "--no-audit", "--no-fund"],
+                env: undefined
+            },
+            {
+                label: "pnpm add",
+                command: "pnpm",
+                args: ["add", PACKAGE_AT_VERSION, "--ignore-scripts", "--no-fund"],
+                env: undefined
+            },
+            {
+                label: "yarn add",
+                command: "yarn",
+                args: ["add", PACKAGE_AT_VERSION, "--ignore-scripts"],
+                env: { ...process.env, YARN_NODE_LINKER: "node-modules" }
+            },
+            {
+                label: "bun add",
+                command: "bun",
+                args: ["add", PACKAGE_AT_VERSION],
+                env: undefined
+            }
+        ];
+
+        for (const installer of installers) {
+            it(
+                `${installer.label} can install and import a module-only package`,
+                async () => {
+                    const available = await isCommandAvailable(installer.command);
+                    if (!available) {
+                        console.log(`Skipping: ${installer.command} not available`);
+                        return;
+                    }
+
+                    const dir = await createTempProjectDir();
+                    try {
+                        const installResult = await loggingExeca(CONSOLE_LOGGER, installer.command, installer.args, {
+                            cwd: dir,
+                            doNotPipeOutput: true,
+                            reject: false,
+                            env: installer.env
+                        });
+
+                        expect(installResult.failed).toBe(false);
+
+                        const importResult = await loggingExeca(
+                            CONSOLE_LOGGER,
+                            "node",
+                            ["-e", "console.log(typeof require('is-number'))"],
+                            {
+                                cwd: dir,
+                                doNotPipeOutput: true,
+                                reject: false
+                            }
+                        );
+
+                        expect(importResult.failed).toBe(false);
+                        expect(importResult.stdout.trim()).toBe("function");
+                    } finally {
+                        await rm(dir, { recursive: true, force: true });
+                    }
+                },
+                MODULE_INSTALL_TIMEOUT
+            );
+        }
     });
 });

--- a/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
+++ b/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
@@ -374,7 +374,7 @@ describe("package-manager-runner e2e", () => {
             {
                 label: "pnpm add",
                 command: "pnpm",
-                args: ["add", PACKAGE_AT_VERSION, "--ignore-scripts", "--no-fund"],
+                args: ["add", PACKAGE_AT_VERSION, "--ignore-scripts"],
                 env: undefined
             },
             {

--- a/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
+++ b/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
@@ -2,8 +2,6 @@ import { CONSOLE_LOGGER } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { describe, expect, it } from "vitest";
 
-import { detectPackageManagerRunner, getAllRunners } from "../../../../cli/src/utils/packageManagerRunner.js";
-
 /**
  * E2E tests for package manager runner fallback support.
  *
@@ -15,6 +13,79 @@ import { detectPackageManagerRunner, getAllRunners } from "../../../../cli/src/u
 const TIMEOUT = 120_000;
 
 const WHICH_COMMAND = process.platform === "win32" ? "where" : "which";
+
+/**
+ * Mirror of the PackageManagerRunner interface from the CLI source.
+ * Defined here so that E2E tests don't import across package boundaries.
+ */
+interface PackageManagerRunner {
+    type: "npm" | "pnpm" | "yarn" | "bun" | "deno";
+    command: string;
+    buildArgs(packageAtVersion: string, args: string[]): string[];
+    label: string;
+}
+
+/**
+ * Runner definitions identical to those in packageManagerRunner.ts.
+ * Duplicated here intentionally so the E2E tests exercise the same
+ * command/arg patterns without a cross-package import.
+ */
+const ALL_RUNNERS: PackageManagerRunner[] = [
+    {
+        type: "npm",
+        command: "npx",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return ["--quiet", "--yes", packageAtVersion, ...args];
+        },
+        label: "npx (npm)"
+    },
+    {
+        type: "pnpm",
+        command: "pnpm",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return ["dlx", packageAtVersion, ...args];
+        },
+        label: "pnpm dlx"
+    },
+    {
+        type: "yarn",
+        command: "yarn",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return ["dlx", packageAtVersion, ...args];
+        },
+        label: "yarn dlx"
+    },
+    {
+        type: "bun",
+        command: "bunx",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return [packageAtVersion, ...args];
+        },
+        label: "bunx (bun)"
+    },
+    {
+        type: "deno",
+        command: "deno",
+        buildArgs(packageAtVersion: string, args: string[]): string[] {
+            return ["run", "-A", `npm:${packageAtVersion}`, ...args];
+        },
+        label: "deno run"
+    }
+];
+
+/**
+ * Detect the first available package manager runner, mirroring the
+ * production detectPackageManagerRunner() logic.
+ */
+async function detectPackageManagerRunner(): Promise<PackageManagerRunner | undefined> {
+    for (const runner of ALL_RUNNERS) {
+        const exists = await isCommandAvailable(runner.command);
+        if (exists) {
+            return runner;
+        }
+    }
+    return undefined;
+}
 
 async function isCommandAvailable(command: string): Promise<boolean> {
     try {
@@ -151,7 +222,7 @@ describe("package-manager-runner e2e", () => {
         it(
             "should detect an available runner via real which/where",
             async () => {
-                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                const runner = await detectPackageManagerRunner();
                 // At least one PM should be installed in any reasonable environment
                 expect(runner).toBeDefined();
                 expect(runner?.type).toBeDefined();
@@ -165,7 +236,7 @@ describe("package-manager-runner e2e", () => {
         it(
             "should return a runner whose command actually exists on PATH",
             async () => {
-                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                const runner = await detectPackageManagerRunner();
                 if (runner == null) {
                     console.log("Skipping: no package manager detected");
                     return;
@@ -187,7 +258,7 @@ describe("package-manager-runner e2e", () => {
                     return;
                 }
 
-                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                const runner = await detectPackageManagerRunner();
                 // If npx is available, it should always be selected first
                 expect(runner?.type).toBe("npm");
                 expect(runner?.command).toBe("npx");
@@ -200,7 +271,7 @@ describe("package-manager-runner e2e", () => {
         it(
             "detected runner buildArgs produces a working command",
             async () => {
-                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                const runner = await detectPackageManagerRunner();
                 if (runner == null) {
                     console.log("Skipping: no package manager detected");
                     return;
@@ -223,7 +294,7 @@ describe("package-manager-runner e2e", () => {
         it(
             "each available runner's buildArgs produces a working command",
             async () => {
-                const runners = getAllRunners();
+                const runners = ALL_RUNNERS;
                 for (const runner of runners) {
                     const available = await isCommandAvailable(runner.command);
                     if (!available) {
@@ -260,7 +331,7 @@ describe("package-manager-runner e2e", () => {
         it(
             "buildArgs works with a pinned version",
             async () => {
-                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                const runner = await detectPackageManagerRunner();
                 if (runner == null) {
                     console.log("Skipping: no package manager detected");
                     return;

--- a/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
+++ b/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
@@ -1,0 +1,138 @@
+import { CONSOLE_LOGGER } from "@fern-api/logger";
+import { loggingExeca } from "@fern-api/logging-execa";
+import { describe, expect, it } from "vitest";
+
+/**
+ * E2E tests for package manager runner fallback support.
+ *
+ * These tests invoke real package managers to execute a lightweight npm package
+ * (cowsay) and verify they produce output. Each test is skipped if the
+ * corresponding package manager is not installed.
+ */
+
+const TIMEOUT = 120_000;
+
+async function isCommandAvailable(command: string): Promise<boolean> {
+    try {
+        const { failed } = await loggingExeca(CONSOLE_LOGGER, "which", [command], {
+            doNotPipeOutput: true,
+            reject: false
+        });
+        return !failed;
+    } catch {
+        return false;
+    }
+}
+
+describe("package-manager-runner e2e", () => {
+    it(
+        "npx can execute an npm package",
+        async () => {
+            const available = await isCommandAvailable("npx");
+            if (!available) {
+                console.log("Skipping: npx not available");
+                return;
+            }
+
+            const result = await loggingExeca(CONSOLE_LOGGER, "npx", ["--quiet", "--yes", "cowsay@latest", "hello"], {
+                doNotPipeOutput: true,
+                reject: false
+            });
+
+            expect(result.failed).toBe(false);
+            expect(result.stdout).toContain("hello");
+        },
+        TIMEOUT
+    );
+
+    it(
+        "pnpm dlx can execute an npm package",
+        async () => {
+            const available = await isCommandAvailable("pnpm");
+            if (!available) {
+                console.log("Skipping: pnpm not available");
+                return;
+            }
+
+            const result = await loggingExeca(CONSOLE_LOGGER, "pnpm", ["dlx", "cowsay@latest", "hello"], {
+                doNotPipeOutput: true,
+                reject: false
+            });
+
+            expect(result.failed).toBe(false);
+            expect(result.stdout).toContain("hello");
+        },
+        TIMEOUT
+    );
+
+    it(
+        "yarn dlx can execute an npm package",
+        async () => {
+            const available = await isCommandAvailable("yarn");
+            if (!available) {
+                console.log("Skipping: yarn not available");
+                return;
+            }
+
+            // Check yarn version - dlx only works on yarn >= 2
+            const { stdout: yarnVersion } = await loggingExeca(CONSOLE_LOGGER, "yarn", ["--version"], {
+                doNotPipeOutput: true,
+                reject: false
+            });
+            const majorVersion = parseInt(yarnVersion.trim().split(".")[0] ?? "0", 10);
+            if (majorVersion < 2) {
+                console.log(`Skipping: yarn ${yarnVersion.trim()} does not support dlx (requires >= 2)`);
+                return;
+            }
+
+            const result = await loggingExeca(CONSOLE_LOGGER, "yarn", ["dlx", "cowsay@latest", "hello"], {
+                doNotPipeOutput: true,
+                reject: false
+            });
+
+            expect(result.failed).toBe(false);
+            expect(result.stdout).toContain("hello");
+        },
+        TIMEOUT
+    );
+
+    it(
+        "bunx can execute an npm package",
+        async () => {
+            const available = await isCommandAvailable("bunx");
+            if (!available) {
+                console.log("Skipping: bunx not available");
+                return;
+            }
+
+            const result = await loggingExeca(CONSOLE_LOGGER, "bunx", ["cowsay@latest", "hello"], {
+                doNotPipeOutput: true,
+                reject: false
+            });
+
+            expect(result.failed).toBe(false);
+            expect(result.stdout).toContain("hello");
+        },
+        TIMEOUT
+    );
+
+    it(
+        "deno run can execute an npm package",
+        async () => {
+            const available = await isCommandAvailable("deno");
+            if (!available) {
+                console.log("Skipping: deno not available");
+                return;
+            }
+
+            const result = await loggingExeca(CONSOLE_LOGGER, "deno", ["run", "-A", "npm:cowsay@latest", "hello"], {
+                doNotPipeOutput: true,
+                reject: false
+            });
+
+            expect(result.failed).toBe(false);
+            expect(result.stdout).toContain("hello");
+        },
+        TIMEOUT
+    );
+});

--- a/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
+++ b/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
@@ -2,6 +2,8 @@ import { CONSOLE_LOGGER } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { describe, expect, it } from "vitest";
 
+import { detectPackageManagerRunner, getAllRunners } from "../../../../cli/src/utils/packageManagerRunner.js";
+
 /**
  * E2E tests for package manager runner fallback support.
  *
@@ -27,114 +29,254 @@ async function isCommandAvailable(command: string): Promise<boolean> {
 }
 
 describe("package-manager-runner e2e", () => {
-    it(
-        "npx can execute an npm package",
-        async () => {
-            const available = await isCommandAvailable("npx");
-            if (!available) {
-                console.log("Skipping: npx not available");
-                return;
-            }
+    describe("direct invocation", () => {
+        it(
+            "npx can execute an npm package",
+            async () => {
+                const available = await isCommandAvailable("npx");
+                if (!available) {
+                    console.log("Skipping: npx not available");
+                    return;
+                }
 
-            const result = await loggingExeca(CONSOLE_LOGGER, "npx", ["--quiet", "--yes", "cowsay@latest", "hello"], {
-                doNotPipeOutput: true,
-                reject: false
-            });
+                const result = await loggingExeca(
+                    CONSOLE_LOGGER,
+                    "npx",
+                    ["--quiet", "--yes", "cowsay@latest", "hello"],
+                    {
+                        doNotPipeOutput: true,
+                        reject: false
+                    }
+                );
 
-            expect(result.failed).toBe(false);
-            expect(result.stdout).toContain("hello");
-        },
-        TIMEOUT
-    );
+                expect(result.failed).toBe(false);
+                expect(result.stdout).toContain("hello");
+            },
+            TIMEOUT
+        );
 
-    it(
-        "pnpm dlx can execute an npm package",
-        async () => {
-            const available = await isCommandAvailable("pnpm");
-            if (!available) {
-                console.log("Skipping: pnpm not available");
-                return;
-            }
+        it(
+            "pnpm dlx can execute an npm package",
+            async () => {
+                const available = await isCommandAvailable("pnpm");
+                if (!available) {
+                    console.log("Skipping: pnpm not available");
+                    return;
+                }
 
-            const result = await loggingExeca(CONSOLE_LOGGER, "pnpm", ["dlx", "cowsay@latest", "hello"], {
-                doNotPipeOutput: true,
-                reject: false
-            });
+                const result = await loggingExeca(CONSOLE_LOGGER, "pnpm", ["dlx", "cowsay@latest", "hello"], {
+                    doNotPipeOutput: true,
+                    reject: false
+                });
 
-            expect(result.failed).toBe(false);
-            expect(result.stdout).toContain("hello");
-        },
-        TIMEOUT
-    );
+                expect(result.failed).toBe(false);
+                expect(result.stdout).toContain("hello");
+            },
+            TIMEOUT
+        );
 
-    it(
-        "yarn dlx can execute an npm package",
-        async () => {
-            const available = await isCommandAvailable("yarn");
-            if (!available) {
-                console.log("Skipping: yarn not available");
-                return;
-            }
+        it(
+            "yarn dlx can execute an npm package",
+            async () => {
+                const available = await isCommandAvailable("yarn");
+                if (!available) {
+                    console.log("Skipping: yarn not available");
+                    return;
+                }
 
-            // Check yarn version - dlx only works on yarn >= 2
-            const { stdout: yarnVersion } = await loggingExeca(CONSOLE_LOGGER, "yarn", ["--version"], {
-                doNotPipeOutput: true,
-                reject: false
-            });
-            const majorVersion = parseInt(yarnVersion.trim().split(".")[0] ?? "0", 10);
-            if (majorVersion < 2) {
-                console.log(`Skipping: yarn ${yarnVersion.trim()} does not support dlx (requires >= 2)`);
-                return;
-            }
+                // Check yarn version - dlx only works on yarn >= 2
+                const { stdout: yarnVersion } = await loggingExeca(CONSOLE_LOGGER, "yarn", ["--version"], {
+                    doNotPipeOutput: true,
+                    reject: false
+                });
+                const majorVersion = parseInt(yarnVersion.trim().split(".")[0] ?? "0", 10);
+                if (majorVersion < 2) {
+                    console.log(`Skipping: yarn ${yarnVersion.trim()} does not support dlx (requires >= 2)`);
+                    return;
+                }
 
-            const result = await loggingExeca(CONSOLE_LOGGER, "yarn", ["dlx", "cowsay@latest", "hello"], {
-                doNotPipeOutput: true,
-                reject: false
-            });
+                const result = await loggingExeca(CONSOLE_LOGGER, "yarn", ["dlx", "cowsay@latest", "hello"], {
+                    doNotPipeOutput: true,
+                    reject: false
+                });
 
-            expect(result.failed).toBe(false);
-            expect(result.stdout).toContain("hello");
-        },
-        TIMEOUT
-    );
+                expect(result.failed).toBe(false);
+                expect(result.stdout).toContain("hello");
+            },
+            TIMEOUT
+        );
 
-    it(
-        "bunx can execute an npm package",
-        async () => {
-            const available = await isCommandAvailable("bunx");
-            if (!available) {
-                console.log("Skipping: bunx not available");
-                return;
-            }
+        it(
+            "bunx can execute an npm package",
+            async () => {
+                const available = await isCommandAvailable("bunx");
+                if (!available) {
+                    console.log("Skipping: bunx not available");
+                    return;
+                }
 
-            const result = await loggingExeca(CONSOLE_LOGGER, "bunx", ["cowsay@latest", "hello"], {
-                doNotPipeOutput: true,
-                reject: false
-            });
+                const result = await loggingExeca(CONSOLE_LOGGER, "bunx", ["cowsay@latest", "hello"], {
+                    doNotPipeOutput: true,
+                    reject: false
+                });
 
-            expect(result.failed).toBe(false);
-            expect(result.stdout).toContain("hello");
-        },
-        TIMEOUT
-    );
+                expect(result.failed).toBe(false);
+                expect(result.stdout).toContain("hello");
+            },
+            TIMEOUT
+        );
 
-    it(
-        "deno run can execute an npm package",
-        async () => {
-            const available = await isCommandAvailable("deno");
-            if (!available) {
-                console.log("Skipping: deno not available");
-                return;
-            }
+        it(
+            "deno run can execute an npm package",
+            async () => {
+                const available = await isCommandAvailable("deno");
+                if (!available) {
+                    console.log("Skipping: deno not available");
+                    return;
+                }
 
-            const result = await loggingExeca(CONSOLE_LOGGER, "deno", ["run", "-A", "npm:cowsay@latest", "hello"], {
-                doNotPipeOutput: true,
-                reject: false
-            });
+                const result = await loggingExeca(CONSOLE_LOGGER, "deno", ["run", "-A", "npm:cowsay@latest", "hello"], {
+                    doNotPipeOutput: true,
+                    reject: false
+                });
 
-            expect(result.failed).toBe(false);
-            expect(result.stdout).toContain("hello");
-        },
-        TIMEOUT
-    );
+                expect(result.failed).toBe(false);
+                expect(result.stdout).toContain("hello");
+            },
+            TIMEOUT
+        );
+    });
+
+    describe("detectPackageManagerRunner", () => {
+        it(
+            "should detect an available runner via real which/where",
+            async () => {
+                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                // At least one PM should be installed in any reasonable environment
+                expect(runner).toBeDefined();
+                expect(runner?.type).toBeDefined();
+                expect(runner?.command).toBeDefined();
+                expect(runner?.label).toBeDefined();
+                expect(typeof runner?.buildArgs).toBe("function");
+            },
+            TIMEOUT
+        );
+
+        it(
+            "should return a runner whose command actually exists on PATH",
+            async () => {
+                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                if (runner == null) {
+                    console.log("Skipping: no package manager detected");
+                    return;
+                }
+
+                // Verify the detected command actually exists
+                const available = await isCommandAvailable(runner.command);
+                expect(available).toBe(true);
+            },
+            TIMEOUT
+        );
+
+        it(
+            "should respect priority order (npx first if available)",
+            async () => {
+                const npxAvailable = await isCommandAvailable("npx");
+                if (!npxAvailable) {
+                    console.log("Skipping: npx not available to test priority");
+                    return;
+                }
+
+                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                // If npx is available, it should always be selected first
+                expect(runner?.type).toBe("npm");
+                expect(runner?.command).toBe("npx");
+            },
+            TIMEOUT
+        );
+    });
+
+    describe("buildArgs integration", () => {
+        it(
+            "detected runner buildArgs produces a working command",
+            async () => {
+                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                if (runner == null) {
+                    console.log("Skipping: no package manager detected");
+                    return;
+                }
+
+                // Use the runner's own buildArgs to construct the command,
+                // then execute it for real
+                const args = runner.buildArgs("cowsay@latest", ["hello from buildArgs"]);
+                const result = await loggingExeca(CONSOLE_LOGGER, runner.command, args, {
+                    doNotPipeOutput: true,
+                    reject: false
+                });
+
+                expect(result.failed).toBe(false);
+                expect(result.stdout).toContain("hello from buildArgs");
+            },
+            TIMEOUT
+        );
+
+        it(
+            "each available runner's buildArgs produces a working command",
+            async () => {
+                const runners = getAllRunners();
+                for (const runner of runners) {
+                    const available = await isCommandAvailable(runner.command);
+                    if (!available) {
+                        console.log(`Skipping ${runner.label}: ${runner.command} not available`);
+                        continue;
+                    }
+
+                    // For yarn, check version since dlx requires >= 2
+                    if (runner.type === "yarn") {
+                        const { stdout: yarnVersion } = await loggingExeca(CONSOLE_LOGGER, "yarn", ["--version"], {
+                            doNotPipeOutput: true,
+                            reject: false
+                        });
+                        const majorVersion = parseInt(yarnVersion.trim().split(".")[0] ?? "0", 10);
+                        if (majorVersion < 2) {
+                            console.log(`Skipping ${runner.label}: yarn ${yarnVersion.trim()} does not support dlx`);
+                            continue;
+                        }
+                    }
+
+                    const args = runner.buildArgs("cowsay@latest", ["hello"]);
+                    const result = await loggingExeca(CONSOLE_LOGGER, runner.command, args, {
+                        doNotPipeOutput: true,
+                        reject: false
+                    });
+
+                    expect(result.failed).toBe(false);
+                    expect(result.stdout).toContain("hello");
+                }
+            },
+            TIMEOUT
+        );
+
+        it(
+            "buildArgs works with a pinned version",
+            async () => {
+                const runner = await detectPackageManagerRunner(CONSOLE_LOGGER);
+                if (runner == null) {
+                    console.log("Skipping: no package manager detected");
+                    return;
+                }
+
+                // Pin to a specific version to verify version specifiers work
+                const args = runner.buildArgs("cowsay@1.6.0", ["pinned version"]);
+                const result = await loggingExeca(CONSOLE_LOGGER, runner.command, args, {
+                    doNotPipeOutput: true,
+                    reject: false
+                });
+
+                expect(result.failed).toBe(false);
+                expect(result.stdout).toContain("pinned version");
+            },
+            TIMEOUT
+        );
+    });
 });

--- a/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
+++ b/packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts
@@ -12,9 +12,11 @@ import { describe, expect, it } from "vitest";
 
 const TIMEOUT = 120_000;
 
+const WHICH_COMMAND = process.platform === "win32" ? "where" : "which";
+
 async function isCommandAvailable(command: string): Promise<boolean> {
     try {
-        const { failed } = await loggingExeca(CONSOLE_LOGGER, "which", [command], {
+        const { failed } = await loggingExeca(CONSOLE_LOGGER, WHICH_COMMAND, [command], {
             doNotPipeOutput: true,
             reject: false
         });


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger
Link to Devin run: https://app.devin.ai/sessions/554d78556a7047469f70976e42c90a49

Replace hardcoded `npx` usage in `rerunFernCliAtVersion` and hardcoded `npm install` in the generator migrations loader with automatic detection of the first available package manager. The CLI now supports: **npx** (npm), **pnpm dlx**, **yarn dlx**, **bunx** (bun), and **deno run** for CLI re-execution, and **npm** → **pnpm** → **yarn** → **bun** for module installation (generator migrations).

> **Note:** vlt was originally considered but removed because it requires `node:sqlite`, which is not available in Node 22. Deno was added as a replacement for CLI execution. Deno is not included in the module-install fallback since `deno install` does not produce a `node_modules` layout compatible with `createRequire`.

## Changes Made

- **New utility**: `packages/cli/cli/src/utils/packageManagerRunner.ts`
  - `PackageManagerRunner` interface with `type`, `command`, `buildArgs()`, and `label`
  - `detectPackageManagerRunner()` — shells out to `which`/`where` (platform-aware) for each runner in priority order
  - `getAllRunners()` — exposes the full runner list for tests
- **Modified**: `packages/cli/cli/src/rerunFernCliAtVersion.ts`
  - Calls `detectPackageManagerRunner()` instead of hardcoding `npx`
  - Fails with a descriptive message when no runner is found
  - Debug log now includes which runner is being used
- **Modified**: `packages/cli/cli/src/commands/upgrade/migrations/loader.ts`
  - New `installPackageWithFallback()` function tries npm → pnpm → yarn → bun for installing `@fern-api/generator-migrations`
  - Security flags (`--ignore-scripts`) applied where supported (npm, pnpm, yarn)
  - Uses `createRequire` for package resolution instead of hardcoded `node_modules` path
  - Error messages updated to reference "package manager" instead of "npm"
- **New E2E tests**: `packages/cli/ete-tests/src/tests/package-manager-runner/packageManagerRunner.test.ts`
  - **Direct invocation** (5 tests): Invokes real `npx`, `pnpm dlx`, `yarn dlx`, `bunx`, and `deno run` with `cowsay@latest`
  - **Detection** (3 tests): Calls real `detectPackageManagerRunner()` with actual `which`/`where`, verifies detected command exists on PATH, verifies npx-first priority
  - **buildArgs integration** (3 tests): Uses each runner's `buildArgs()` output to execute a real command; tests pinned version specifiers (`cowsay@1.6.0`)
  - **Module install + import** (4 tests): Installs `is-number@7.0.0` into a temp directory using each PM, then verifies it can be imported via `require()`
  - Each test gracefully skips if the corresponding PM is not installed
- **Version bump**: `versions.yml` → 3.83.0 (feat) with two changelog entries

## Testing

- [x] Unit tests for runner detection, fallback order, arg building, and platform detection (`packageManagerRunner.test.ts` — 17 tests)
- [x] Integration tests for `rerunFernCliAtVersion` covering all 5 runners, error handling, EEXIST retry, env passthrough (`rerunFernCliAtVersion.test.ts` — 12 tests)
- [x] **E2E tests** invoking real package managers — direct invocation, `detectPackageManagerRunner()` detection, `buildArgs` integration, and module install+import (`ete-tests/.../packageManagerRunner.test.ts` — 15 tests; skips unavailable PMs)
- [x] Biome lint passes
- [x] All CI checks pass (compile, lint, biome, test, test-ete, depcheck)

## Updates since last revision

- **Extended fallback to generator migrations**: The `@fern-api/generator-migrations` package is now installed using the same fallback logic (npm → pnpm → yarn → bun) instead of requiring npm
- **Added module install E2E tests**: New tests verify each package manager can install a module-only package into a temp directory and successfully import it
- **Fixed pnpm flag**: Removed unsupported `--no-fund` flag from pnpm commands (pnpm doesn't support this flag)

## ⚠️ Items for reviewer attention

1. **E2E tests use early-return for unavailable PMs** — When a PM is not installed, the test returns early and reports as "passed" rather than using `it.skip()`. CI won't distinguish "tested and passed" vs "skipped because unavailable".
2. **No runtime fallthrough** — If a detected PM fails at runtime (e.g. `yarn dlx` on Yarn Classic v1, which doesn't support `dlx`), the CLI does **not** try the next runner. The E2E test correctly checks yarn version before testing `dlx`, but the production code does not.
3. **Detection runs on every call** — `detectPackageManagerRunner` spawns subprocesses (`which`/`where`) each invocation. There is no caching. Adds small latency proportional to missing PMs before the first hit.
4. **Deno E2E test not verified locally** — Deno was not installed in the dev environment, so the deno E2E test was only verified via unit/mock tests. It will only run in CI if deno is available there.
5. **Windows compatibility relies on unit tests** — The `which` vs `where` logic is tested via mocked `process.platform` in unit tests, but there's no actual Windows CI run to verify real-world behavior.
6. **Bun security gap** — Bun's `add` command does not support `--ignore-scripts`. The code comment mentions `trustedDependencies` but nothing is configured. This means lifecycle scripts will run when installing via bun, which is a security risk for untrusted packages.
7. **Yarn Berry PnP compatibility** — The migration loader forces `YARN_NODE_LINKER=node-modules` to ensure `createRequire` can resolve the installed package. If this env var is ignored or overridden, yarn PnP mode could cause resolution failures.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->