### PR TITLE
feat(python): use fern-api/setup-fern-cli@v1 action in generated GitHub workflows

### DIFF
--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -371,8 +371,8 @@ jobs:
 """
         if write_unit_tests:
             workflow_yaml += """
-      - name: Install Fern
-        run: npm install -g fern-api
+      - name: Install Fern CLI
+        uses: fern-api/setup-fern-cli@v1
       - name: Test
         run: fern test --command "poetry run pytest -rP -n auto ."
 """
@@ -458,8 +458,8 @@ jobs:
 """
         if write_unit_tests:
             workflow_yaml += """
-      - name: Install Fern
-        run: npm install -g fern-api
+      - name: Install Fern CLI
+        uses: fern-api/setup-fern-cli@v1
       - name: Test
         run: fern test --command "poetry run pytest -rP -n auto ."
 """

--- a/seed/python-sdk/examples/legacy-wire-tests/.github/workflows/ci.yml
+++ b/seed/python-sdk/examples/legacy-wire-tests/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
-      - name: Install Fern
-        run: npm install -g fern-api
+      - name: Install Fern CLI
+        uses: fern-api/setup-fern-cli@v1
       - name: Test
         run: fern test --command "poetry run pytest -rP -n auto ."
 


### PR DESCRIPTION
## Description

Replaces `npm install -g fern-api` with the `fern-api/setup-fern-cli@v1` GitHub Action in CI workflows generated by the Python SDK generator.

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/9ff15af02aef467185fcfea7caf26208)

## Changes Made

- Updated `_get_github_workflow_legacy` and `_get_github_workflow` in the Python generator's `abstract_generator.py` to use `uses: fern-api/setup-fern-cli@v1` instead of `run: npm install -g fern-api`
- Updated the corresponding seed test snapshot (`seed/python-sdk/examples/legacy-wire-tests/.github/workflows/ci.yml`)

**Note:** Only the Python generator was affected. Other generators (Java, Go, Ruby, Postman) do not install the Fern CLI in their generated workflows.

## Testing

- [ ] Seed snapshot updated to reflect the new workflow step
- [ ] Manual review of generated YAML indentation/formatting

## Human Review Checklist

- [ ] Verify `fern-api/setup-fern-cli@v1` is the correct action reference and version tag
- [ ] Confirm the YAML indentation in the string templates is correct (`uses:` at the same level as the previous `run:`)
- [ ] This change only affects generated workflows when `write_unit_tests=True` — confirm that's the intended scope