### PR TITLE
chore(internal): improve IR generator test performance

### DIFF
--- a/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/DynamicSnippetsConverter.test.ts
+++ b/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/DynamicSnippetsConverter.test.ts
@@ -1,29 +1,43 @@
+import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
+import { readdirSync } from "fs";
 import path from "path";
 
 import { loadApisOrThrow } from "../../loadApisOrThrow.js";
 import { generateAndSnapshotDynamicIR } from "./generateAndSnapshotDynamicIR.js";
 
-// eslint-disable-next-line @typescript-eslint/no-misused-promises
-describe("test definitions", async () => {
+describe("test definitions", () => {
     const TEST_DEFINITIONS_DIR = path.join(__dirname, "../../../../../../../test-definitions");
-    const apiWorkspaces = await loadApisOrThrow({
-        fernDirectory: join(AbsoluteFilePath.of(TEST_DEFINITIONS_DIR), RelativeFilePath.of("fern")),
-        context: createMockTaskContext(),
-        cliVersion: "0.0.0",
-        cliName: "fern",
-        commandLineApiWorkspace: undefined,
-        defaultToAllApiWorkspaces: true
-    });
+    const apiNames = readdirSync(path.join(TEST_DEFINITIONS_DIR, "fern/apis"), { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
 
-    apiWorkspaces.map(async (workspace) => {
-        it(`${workspace.workspaceName}`, async () => {
+    let workspaceMap: Map<string, AbstractAPIWorkspace<unknown>>;
+
+    beforeAll(async () => {
+        const apiWorkspaces = await loadApisOrThrow({
+            fernDirectory: join(AbsoluteFilePath.of(TEST_DEFINITIONS_DIR), RelativeFilePath.of("fern")),
+            context: createMockTaskContext(),
+            cliVersion: "0.0.0",
+            cliName: "fern",
+            commandLineApiWorkspace: undefined,
+            defaultToAllApiWorkspaces: true
+        });
+        workspaceMap = new Map(apiWorkspaces.map((w) => [w.workspaceName ?? "", w]));
+    }, 200_000);
+
+    apiNames.forEach((name) => {
+        it.concurrent(name, async () => {
+            const workspace = workspaceMap.get(name);
+            if (!workspace) {
+                throw new Error(`Workspace ${name} not found`);
+            }
             await generateAndSnapshotDynamicIR({
                 absolutePathToIr: AbsoluteFilePath.of(path.join(__dirname, "test-definitions")),
                 workspace,
                 audiences: { type: "all" },
-                workspaceName: workspace.workspaceName ?? ""
+                workspaceName: name
             });
         }, 30_000);
     });

--- a/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/DynamicSnippetsConverter.test.ts
+++ b/packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/DynamicSnippetsConverter.test.ts
@@ -1,6 +1,6 @@
-import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
+import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { readdirSync } from "fs";
 import path from "path";
 

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/generateIntermediateRepresentation.test.ts
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/generateIntermediateRepresentation.test.ts
@@ -2,9 +2,9 @@
 /* eslint-disable jest/valid-describe-callback */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 
-import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
+import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { readdirSync } from "fs";
 import path from "path";
 

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/generateIntermediateRepresentation.test.ts
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/generateIntermediateRepresentation.test.ts
@@ -2,8 +2,10 @@
 /* eslint-disable jest/valid-describe-callback */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 
+import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
+import { readdirSync } from "fs";
 import path from "path";
 
 import { loadApisOrThrow } from "../../loadApisOrThrow.js";
@@ -61,54 +63,77 @@ it.skip("fhir", async () => {
     });
 }, 200_000);
 
-describe("test definitions", async () => {
+describe("test definitions", () => {
     const TEST_DEFINITIONS_DIR = path.join(__dirname, "../../../../../../../test-definitions");
-    const apiWorkspaces = await loadApisOrThrow({
-        fernDirectory: join(AbsoluteFilePath.of(TEST_DEFINITIONS_DIR), RelativeFilePath.of("fern")),
-        context: createMockTaskContext(),
-        cliVersion: "0.0.0",
-        cliName: "fern",
-        commandLineApiWorkspace: undefined,
-        defaultToAllApiWorkspaces: true
-    });
+    const apiNames = readdirSync(path.join(TEST_DEFINITIONS_DIR, "fern/apis"), { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
 
-    apiWorkspaces.forEach((workspace) => {
-        it.concurrent(`${workspace.workspaceName}`, async () => {
+    let workspaceMap: Map<string, AbstractAPIWorkspace<unknown>>;
+
+    beforeAll(async () => {
+        const apiWorkspaces = await loadApisOrThrow({
+            fernDirectory: join(AbsoluteFilePath.of(TEST_DEFINITIONS_DIR), RelativeFilePath.of("fern")),
+            context: createMockTaskContext(),
+            cliVersion: "0.0.0",
+            cliName: "fern",
+            commandLineApiWorkspace: undefined,
+            defaultToAllApiWorkspaces: true
+        });
+        workspaceMap = new Map(apiWorkspaces.map((w) => [w.workspaceName ?? "", w]));
+    }, 200_000);
+
+    apiNames.forEach((name) => {
+        it.concurrent(name, async () => {
+            const workspace = workspaceMap.get(name);
+            if (!workspace) {
+                throw new Error(`Workspace ${name} not found`);
+            }
             await generateAndSnapshotIR({
                 absolutePathToIr: AbsoluteFilePath.of(path.join(__dirname, "test-definitions")),
                 workspace,
                 audiences: { type: "all" },
-                workspaceName: workspace.workspaceName ?? ""
+                workspaceName: name
             });
         }, 30_000);
     });
-}, 200_000);
+});
 
-describe("test definitions openapi", async () => {
+describe("test definitions openapi", () => {
     const TEST_DEFINITIONS_DIR = path.join(__dirname, "../../../../../../../test-definitions-openapi");
-    const apiWorkspaces = await loadApisOrThrow({
-        fernDirectory: join(AbsoluteFilePath.of(TEST_DEFINITIONS_DIR), RelativeFilePath.of("fern")),
-        context: createMockTaskContext(),
-        cliVersion: "0.0.0",
-        cliName: "fern",
-        commandLineApiWorkspace: undefined,
-        defaultToAllApiWorkspaces: true
-    });
+    const apiNames = readdirSync(path.join(TEST_DEFINITIONS_DIR, "fern/apis"), { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
 
-    apiWorkspaces.forEach((workspace) => {
-        it.concurrent(`${workspace.workspaceName}`, async () => {
+    let workspaceMap: Map<string, AbstractAPIWorkspace<unknown>>;
+
+    beforeAll(async () => {
+        const apiWorkspaces = await loadApisOrThrow({
+            fernDirectory: join(AbsoluteFilePath.of(TEST_DEFINITIONS_DIR), RelativeFilePath.of("fern")),
+            context: createMockTaskContext(),
+            cliVersion: "0.0.0",
+            cliName: "fern",
+            commandLineApiWorkspace: undefined,
+            defaultToAllApiWorkspaces: true
+        });
+        workspaceMap = new Map(apiWorkspaces.map((w) => [w.workspaceName ?? "", w]));
+    }, 200_000);
+
+    apiNames.forEach((name) => {
+        it.concurrent(name, async () => {
+            const workspace = workspaceMap.get(name);
+            if (!workspace) {
+                throw new Error(`Workspace ${name} not found`);
+            }
             await generateAndSnapshotIR({
                 absolutePathToIr: AbsoluteFilePath.of(path.join(__dirname, "test-definitions-openapi")),
                 workspace,
-                audiences:
-                    workspace.workspaceName === "audiences"
-                        ? { type: "select", audiences: ["public"] }
-                        : { type: "all" },
-                workspaceName: workspace.workspaceName ?? ""
+                audiences: name === "audiences" ? { type: "select", audiences: ["public"] } : { type: "all" },
+                workspaceName: name
             });
         }, 10_000);
     });
-}, 200_000);
+});
 
 it("generics", async () => {
     const GENERICS_DIR = path.join(__dirname, "fixtures/generics/fern");

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/generateIntermediateRepresentation.test.ts
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/generateIntermediateRepresentation.test.ts
@@ -73,7 +73,7 @@ describe("test definitions", async () => {
     });
 
     apiWorkspaces.forEach((workspace) => {
-        it(`${workspace.workspaceName}`, async () => {
+        it.concurrent(`${workspace.workspaceName}`, async () => {
             await generateAndSnapshotIR({
                 absolutePathToIr: AbsoluteFilePath.of(path.join(__dirname, "test-definitions")),
                 workspace,
@@ -96,7 +96,7 @@ describe("test definitions openapi", async () => {
     });
 
     apiWorkspaces.forEach((workspace) => {
-        it(`${workspace.workspaceName}`, async () => {
+        it.concurrent(`${workspace.workspaceName}`, async () => {
             await generateAndSnapshotIR({
                 absolutePathToIr: AbsoluteFilePath.of(path.join(__dirname, "test-definitions-openapi")),
                 workspace,


### PR DESCRIPTION
## Description

Improves performance of the IR generator snapshot test suite (`generateIntermediateRepresentation.test.ts` — 155 tests, ~28s) by running tests concurrently and deferring expensive workspace loading from import time to test execution time.

[Link to Devin run](https://app.devin.ai/sessions/cd418428a09444b8be3db05534ddca8b) | Requested by: @Swimburger

## Changes Made

- Changed `it(...)` → `it.concurrent(...)` in both `test definitions` and `test definitions openapi` forEach loops so vitest can overlap test execution (bounded by `maxConcurrency: 10`)
- Replaced `async describe()` callbacks with synchronous `describe()` + `beforeAll` hooks — workspace loading via `loadApisOrThrow()` is now deferred from import/collection time to test execution time
- Test registration now uses `readdirSync` to read workspace directory names synchronously (near-instant), while the expensive `loadAPIWorkspace` calls are deferred to `beforeAll`
- Applied the same pattern to `DynamicSnippetsConverter.test.ts` for consistency

Each test writes to a unique file path (`${workspaceName}.json`), so there are no file I/O conflicts with concurrent execution.

## Testing

- [x] Ran full test suite (`pnpm test`) — all 312 tests pass (311 passed, 1 skipped) across 8 test files
- [x] Ran `generateIntermediateRepresentation.test.ts` in isolation — all 154 tests pass
- [x] Verified no snapshot diffs produced

## Review Checklist

- **Workspace name assumption**: `readdirSync` reads all subdirectories in `fern/apis/` and registers a test for each. If a directory isn't a valid workspace, `beforeAll` will load it but the test will fail with `"Workspace X not found"`. This matches the previous behavior where `loadApisOrThrow` would throw on invalid workspaces.
- **Shared mutable state**: Confirm that `generateAndSnapshotIR` (and the workspace/resolver objects it uses) have no shared mutable state that could cause race conditions when tests run concurrently within the same thread.
- **Timeouts under load**: The openapi tests have a 10s timeout. Under concurrent execution with CPU contention, individual test wall times increase. Worth verifying these don't become flaky in CI.
- **Memory pressure**: With `maxConcurrency: 10`, up to 10 IR generations may be in-flight simultaneously. Large workspaces like `trace` (63MB output) and `simple-fhir` (29MB) could spike memory.