### PR TITLE
fix(docs): replace hardcoded sleep() calls with polling in docsDev.test.ts

### DIFF
--- a/packages/cli/ete-tests/src/tests/docs-dev/docsDev.test.ts
+++ b/packages/cli/ete-tests/src/tests/docs-dev/docsDev.test.ts
@@ -34,7 +34,7 @@ describe.sequential("fern docs dev --legacy", () => {
         // kill the process
         const finishProcess = process.kill();
         expect(finishProcess).toBeTruthy();
-    }, 30_000);
+    }, 90_000);
 });
 
 describe.sequential("fern docs dev --beta", () => {
@@ -66,7 +66,7 @@ describe.sequential("fern docs dev --beta", () => {
 
         const finishProcess = process.kill();
         expect(finishProcess).toBeTruthy();
-    }, 50_000);
+    }, 90_000);
 });
 
 describe.sequential("fern docs dev", () => {
@@ -93,7 +93,7 @@ describe.sequential("fern docs dev", () => {
         expect(typeof responseBody === "object").toEqual(true);
         // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
         expect(Object.keys(responseBody as any)).toEqual(["baseUrl", "definition", "lightModeEnabled", "orgId"]);
-    }, 50_000);
+    }, 90_000);
 });
 
 async function waitForServer(

--- a/packages/cli/ete-tests/src/tests/docs-dev/docsDev.test.ts
+++ b/packages/cli/ete-tests/src/tests/docs-dev/docsDev.test.ts
@@ -18,9 +18,7 @@ describe.sequential("fern docs dev --legacy", () => {
             cwd: join(fixturesDir, RelativeFilePath.of("simple"))
         });
 
-        await sleep(20_000);
-
-        const response = await fetch("http://localhost:3000/v2/registry/docs/load-with-url", {
+        const response = await waitForServer("http://localhost:3000/v2/registry/docs/load-with-url", {
             method: "POST"
         });
 
@@ -53,9 +51,7 @@ describe.sequential("fern docs dev --beta", () => {
             reject: true
         });
 
-        await sleep(40_000);
-
-        const response = await fetch("http://localhost:3001/v2/registry/docs/load-with-url", {
+        const response = await waitForServer("http://localhost:3001/v2/registry/docs/load-with-url", {
             method: "POST"
         });
 
@@ -85,9 +81,7 @@ describe.sequential("fern docs dev", () => {
             cwd: join(fixturesDir, RelativeFilePath.of("simple"))
         });
 
-        await sleep(40_000);
-
-        const response = await fetch("http://localhost:3002/v2/registry/docs/load-with-url", {
+        const response = await waitForServer("http://localhost:3002/v2/registry/docs/load-with-url", {
             method: "POST"
         });
 
@@ -102,6 +96,19 @@ describe.sequential("fern docs dev", () => {
     }, 50_000);
 });
 
-function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+async function waitForServer(
+    url: string,
+    init: Parameters<typeof fetch>[1],
+    { interval = 1_000, timeout = 60_000 }: { interval?: number; timeout?: number } = {}
+): Promise<Awaited<ReturnType<typeof fetch>>> {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        try {
+            return await fetch(url, init);
+        } catch {
+            await new Promise((resolve) => setTimeout(resolve, interval));
+        }
+    }
+    // Final attempt – let it throw if the server is still unreachable
+    return await fetch(url, init);
 }


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/16c2239deeb84488a001d1e2415b0f82)

Replaces 3 hardcoded `sleep()` calls (20s + 40s + 40s = 100s of unconditional waiting) in `docsDev.test.ts` with a `waitForServer()` polling utility that retries the fetch request every 1 second until the server responds or a 60-second timeout is reached.

## Changes Made

- Removed the `sleep()` helper function
- Added `waitForServer(url, init, { interval, timeout })` which polls the endpoint, catching connection errors and retrying at a configurable interval (default: 1s interval, 60s timeout)
- Replaced all 3 `sleep()` + `fetch()` pairs with a single `waitForServer()` call that returns the response as soon as the server is ready
- Increased all three vitest test timeouts to 90s (from 30s/50s/50s) so they comfortably exceed the 60s `waitForServer` default

## Things for reviewer to verify

- **Only connection errors trigger retries**: `waitForServer` only retries on thrown exceptions (e.g. `ECONNREFUSED`). A server that starts but returns an error HTTP status will _not_ be retried — the response is returned as-is for the test assertions to validate. Confirm this is the desired behavior.
- **90s test timeouts**: All three tests now use 90s vitest timeouts. Verify this is acceptable for CI run time.

## Testing

- [x] Biome lint passes
- [ ] ETE tests not run locally (these require a full docs dev server environment)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->