### PR TITLE
chore(cli): parallelize init e2e tests

### DIFF
--- a/packages/cli/ete-tests/src/tests/init/init.test.ts
+++ b/packages/cli/ete-tests/src/tests/init/init.test.ts
@@ -14,15 +14,15 @@ import { init } from "./init.js";
 
 const FIXTURES_DIR = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
 
-describe.concurrent("fern init", () => {
-    it("no existing fern directory", async () => {
+describe("fern init", () => {
+    it.concurrent("no existing fern directory", async ({ expect }) => {
         const pathOfDirectory = await init();
         expect(
             await getDirectoryContentsForSnapshot(join(pathOfDirectory, RelativeFilePath.of(FERN_DIRECTORY)))
         ).toMatchSnapshot();
     }, 60_000);
 
-    it("no existing fern directory with fern definition", async () => {
+    it.concurrent("no existing fern directory with fern definition", async ({ expect }) => {
         const pathOfDirectory = await init({
             additionalArgs: [{ name: "--fern-definition" }]
         });
@@ -34,7 +34,7 @@ describe.concurrent("fern init", () => {
         ).toMatchSnapshot();
     }, 60_000);
 
-    it("existing fern directory", async () => {
+    it.concurrent("existing fern directory", async ({ expect }) => {
         // add existing directory
         const pathOfDirectory = await init({
             additionalArgs: [{ name: "--fern-definition" }]
@@ -57,7 +57,7 @@ describe.concurrent("fern init", () => {
         ).toBe(true);
     }, 60_000);
 
-    it("init openapi", async () => {
+    it.concurrent("init openapi", async ({ expect }) => {
         // Create a temporary directory for the OpenAPI test
         const tmpDir = await tmp.dir();
         const sourceOpenAPI = join(
@@ -78,7 +78,7 @@ describe.concurrent("fern init", () => {
         expect(await getDirectoryContentsForSnapshot(pathOfDirectory)).toMatchSnapshot();
     }, 60_000);
 
-    it("existing openapi fern directory", async () => {
+    it.concurrent("existing openapi fern directory", async ({ expect }) => {
         const pathOfDirectory = await init();
 
         await init({
@@ -128,7 +128,7 @@ describe.concurrent("fern init", () => {
         ).toBe(true);
     }, 60_000);
 
-    it("existing openapi then fern-definition", async () => {
+    it.concurrent("existing openapi then fern-definition", async ({ expect }) => {
         const pathOfDirectory = await init();
 
         await init({
@@ -159,7 +159,7 @@ describe.concurrent("fern init", () => {
         ).toBe(true);
     }, 60_000);
 
-    it("conflicting --openapi and --fern-definition flags", async () => {
+    it.concurrent("conflicting --openapi and --fern-definition flags", async ({ expect }) => {
         const tmpDir = await tmp.dir();
         const sourceOpenAPI = join(
             FIXTURES_DIR,
@@ -179,7 +179,7 @@ describe.concurrent("fern init", () => {
         expect(result.exitCode).not.toBe(0);
     }, 60_000);
 
-    it("init docs", async () => {
+    it.concurrent("init docs", async ({ expect }) => {
         const pathOfDirectory = await init({
             additionalArgs: [{ name: "--fern-definition" }]
         });
@@ -191,7 +191,7 @@ describe.concurrent("fern init", () => {
         expect(await getDirectoryContentsForSnapshot(pathOfDirectory)).toMatchSnapshot();
     }, 60_000);
 
-    it("init mintlify", async () => {
+    it.concurrent("init mintlify", async ({ expect }) => {
         const mintJsonPath = join(FIXTURES_DIR, RelativeFilePath.of("mintlify"), RelativeFilePath.of("mint.json"));
 
         const pathOfDirectory = await init({

--- a/packages/cli/ete-tests/src/tests/init/init.test.ts
+++ b/packages/cli/ete-tests/src/tests/init/init.test.ts
@@ -14,7 +14,7 @@ import { init } from "./init.js";
 
 const FIXTURES_DIR = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
 
-describe("fern init", () => {
+describe.concurrent("fern init", () => {
     it("no existing fern directory", async () => {
         const pathOfDirectory = await init();
         expect(


### PR DESCRIPTION
## Description

Parallelize the 9 `fern init` e2e tests using `it.concurrent()` with Vitest test context, allowing all test cases to run simultaneously instead of sequentially (~48s → ~9s).

Refs https://app.devin.ai/sessions/458f1aabdcd941b9a4c8961e521ba1a8
Requested by: @Swimburger

## Changes Made

- Changed each `it(` to `it.concurrent(` in `packages/cli/ete-tests/src/tests/init/init.test.ts`
- Destructured `{ expect }` from the Vitest test context in each test callback — required because `toMatchSnapshot()` cannot use the global `expect` in concurrent mode

Each test already creates its own isolated temp directory, so they are safe to run in parallel. The base vitest config already sets `maxConcurrency: 10`, which accommodates all 9 tests.

> **Note:** An initial approach using `describe.concurrent()` was attempted but Vitest does not support `toMatchSnapshot()` without the test context in concurrent tests, so `it.concurrent()` with `({ expect })` is the correct pattern.

## Testing

- [x] All 9 init tests pass concurrently (verified locally: ~8.7s wall clock vs ~48s sequential)
- [x] Snapshot assertions work correctly via test-context `expect`

## Human Review Checklist

- [ ] **Snapshot correctness**: Confirm no snapshot content changes — only the test runner parallelism changed
- [ ] **Flakiness**: Watch for any flakiness in CI from concurrent `fern init` invocations (each uses its own temp dir, so unlikely)