### PR TITLE
chore(internal): run generate-with-settings tests in parallel

### DIFF
--- a/packages/cli/ete-tests/src/tests/generate/generate-with-settings.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate-with-settings.test.ts
@@ -5,7 +5,7 @@ import tmp from "tmp-promise";
 import { runFernCli } from "../../utils/runFernCli.js";
 
 describe("fern generate with settings", () => {
-    it.concurrent("single api", async () => {
+    it.concurrent("single api", async ({ expect }) => {
         const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures/api-settings"));
 
         const tmpDir = await tmp.dir();
@@ -22,7 +22,7 @@ describe("fern generate with settings", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it.concurrent("dependencies-based api", async () => {
+    it.concurrent("dependencies-based api", async ({ expect }) => {
         const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures/api-settings-unioned"));
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);

--- a/packages/cli/ete-tests/src/tests/generate/generate-with-settings.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate-with-settings.test.ts
@@ -5,7 +5,7 @@ import tmp from "tmp-promise";
 import { runFernCli } from "../../utils/runFernCli.js";
 
 describe("fern generate with settings", () => {
-    it("single api", async () => {
+    it.concurrent("single api", async () => {
         const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures/api-settings"));
 
         const tmpDir = await tmp.dir();
@@ -22,7 +22,7 @@ describe("fern generate with settings", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it("dependencies-based api", async () => {
+    it.concurrent("dependencies-based api", async () => {
         const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures/api-settings-unioned"));
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);


### PR DESCRIPTION
## Description

Parallelizes the two test cases in `generate-with-settings.test.ts` using `it.concurrent()` to reduce overall test suite time.

[Link to Devin run](https://app.devin.ai/sessions/cc3fc81fd7ae4d9ca21228ba333c8c20) | Requested by: @Swimburger

## Changes Made

- Changed `it()` → `it.concurrent()` for both "single api" and "dependencies-based api" tests so they run in parallel
- Used `({ expect })` from the Vitest test context (required for snapshot matching in concurrent tests)

## Testing

- [x] Verified compilation passes (`pnpm --filter @fern-api/ete-tests run compile`)
- [x] Verified lint passes (`pnpm run check`)
- [x] `test-ete` CI check passes with concurrent execution

## Human Review Checklist

- [ ] Confirm that running two concurrent `fern generate --local --keepDocker` invocations doesn't cause Docker port conflicts or resource contention — each test uses its own tmp directory, but they share the Docker daemon. CI passed, but worth noting for flakiness monitoring.