### PR TITLE
chore(ci): parallelize fern generate ete tests

### DIFF
--- a/packages/cli/ete-tests/src/tests/generate/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate.test.ts
@@ -1,7 +1,6 @@
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { exec } from "child_process";
 import stripAnsi from "strip-ansi";
-import { vi } from "vitest";
 
 import { runFernCli, runFernCliWithoutAuthToken } from "../../utils/runFernCli.js";
 import { init } from "../init/init.js";
@@ -9,7 +8,7 @@ import { init } from "../init/init.js";
 const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
 
 describe("fern generate", () => {
-    it("default api (fern init)", async () => {
+    it.concurrent("default api (fern init)", async () => {
         const pathOfDirectory = await init();
 
         await runFernCli(["generate", "--local", "--keepDocker"], {
@@ -19,7 +18,7 @@ describe("fern generate", () => {
         expect(await doesPathExist(join(pathOfDirectory, RelativeFilePath.of("sdks/typescript")))).toBe(true);
     }, 180_000);
 
-    it("ir contains fdr definitionid", async () => {
+    it.concurrent("ir contains fdr definitionid", async () => {
         const { stdout, stderr } = await runFernCli(["generate", "--log-level", "debug"], {
             cwd: join(fixturesDir, RelativeFilePath.of("basic")),
             reject: false
@@ -67,11 +66,13 @@ describe("fern generate", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it("generate docs with no auth requires login", async () => {
-        vi.stubEnv("FERN_TOKEN", undefined);
+    it.concurrent("generate docs with no auth requires login", async () => {
         const { stdout, stderr } = await runFernCliWithoutAuthToken(["generate", "--docs"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
-            reject: false
+            reject: false,
+            env: {
+                FERN_TOKEN: ""
+            }
         });
         const output = stdout + stderr;
         expect(output).toContain(
@@ -79,21 +80,19 @@ describe("fern generate", () => {
         );
     }, 180_000);
 
-    it("generate docs with auth bypass fails", async () => {
-        vi.stubEnv("FERN_TOKEN", undefined);
+    it.concurrent("generate docs with auth bypass fails", async () => {
         const { stdout } = await runFernCliWithoutAuthToken(["generate", "--docs"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
             env: {
-                FERN_SELF_HOSTED: "true"
+                FERN_SELF_HOSTED: "true",
+                FERN_TOKEN: ""
             }
         });
         expect(stdout).toContain("No token found. Please set the FERN_TOKEN environment variable.");
     }, 180_000);
 
-    it("generate docs with auth bypass succeeds", async () => {
-        vi.stubEnv("FERN_TOKEN", "dummy");
-
+    it.concurrent("generate docs with auth bypass succeeds", async () => {
         const { stdout } = await runFernCliWithoutAuthToken(["generate", "--docs"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
@@ -105,7 +104,7 @@ describe("fern generate", () => {
         expect(stdout).toContain("ferndevtest.docs.dev.buildwithfern.com Started.");
     }, 180_000);
 
-    it("generate docs with no docs.yml file fails", async () => {
+    it.concurrent("generate docs with no docs.yml file fails", async () => {
         const { stdout } = await runFernCli(["generate", "--docs"], {
             cwd: join(fixturesDir, RelativeFilePath.of("basic")),
             reject: false


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/97282ffa4a3741568d921394c4213f8c)

Parallelizes the 7 tests in `generate/generate.test.ts` (each with a 180s timeout) by switching from sequential `it()` to `it.concurrent()`, so they run simultaneously instead of one-after-another.

## Changes Made

- Changed all active `it()` calls to `it.concurrent()` (6 tests; 1 remains `.skip`)
- Removed `vi.stubEnv("FERN_TOKEN", ...)` calls (which mutate global `process.env` and would cause race conditions under concurrency)
- Instead, pass `FERN_TOKEN: ""` explicitly in the `env` option for tests that need no auth token — this overrides any inherited `FERN_TOKEN` per-child-process without touching shared state
- Removed the now-unused `import { vi } from "vitest"`

## Important Review Notes

**`FERN_TOKEN: ""` replacing `vi.stubEnv("FERN_TOKEN", undefined)`**: The old approach globally deleted `FERN_TOKEN` from `process.env`; the new approach overrides it to `""` per child process via execa's `env` option. The CLI's `getAccessToken()` treats both `undefined` and empty string as "no token" (`tokenFromEnvVar == null || tokenFromEnvVar.trim().length === 0`), so behavior should be identical. Worth double-checking this assumption.

**Concurrency safety**: Tests operate on separate fixture dirs (read-only) or temp dirs, so no file-system contention. However, tests 1 and 2 do actual `fern generate` (Docker, network) — worth confirming these don't contend on shared resources like Docker or ports.

## Testing

- [ ] Lint passes (biome check ✓)
- [ ] ETE tests need CI to validate (cannot run locally without full Docker/CLI setup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
