### PR TITLE
chore(internal): parallelize IR generation tests

### DIFF
--- a/packages/cli/ete-tests/src/tests/ir/generateIrAsString.ts
+++ b/packages/cli/ete-tests/src/tests/ir/generateIrAsString.ts
@@ -1,6 +1,7 @@
 import { generatorsYml } from "@fern-api/configuration";
-import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { readFile, rm } from "fs/promises";
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { readFile } from "fs/promises";
+import tmp from "tmp-promise";
 
 import { runFernCli } from "../../utils/runFernCli.js";
 
@@ -17,8 +18,8 @@ export async function generateIrAsString({
     apiName?: string;
     version?: string;
 }): Promise<string> {
-    const irOutputPath = join(fixturePath, RelativeFilePath.of("ir.json"));
-    await rm(irOutputPath, { force: true, recursive: true });
+    const tmpFile = await tmp.file({ postfix: ".json" });
+    const irOutputPath = AbsoluteFilePath.of(tmpFile.path);
 
     const command = ["ir", irOutputPath];
     if (language != null) {
@@ -42,5 +43,6 @@ export async function generateIrAsString({
     });
 
     const irContents = await readFile(irOutputPath);
+    await tmpFile.cleanup();
     return irContents.toString();
 }

--- a/packages/cli/ete-tests/src/tests/ir/ir.test.ts
+++ b/packages/cli/ete-tests/src/tests/ir/ir.test.ts
@@ -2,6 +2,7 @@ import { generatorsYml } from "@fern-api/configuration";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { readFile } from "fs/promises";
 import path from "path";
+import tmp from "tmp-promise";
 import { runFernCli } from "../../utils/runFernCli.js";
 import { generateIrAsString } from "./generateIrAsString.js";
 
@@ -69,7 +70,7 @@ interface Fixture {
 describe("ir", () => {
     for (const fixture of FIXTURES) {
         const { only = false } = fixture;
-        (only ? it.only : it)(
+        (only ? it.only : it.concurrent)(
             `${JSON.stringify(fixture)}`,
             async () => {
                 const fixturePath = join(FIXTURES_DIR, RelativeFilePath.of(fixture.name));
@@ -86,19 +87,23 @@ describe("ir", () => {
         );
     }
 
-    it("works with latest version", async () => {
-        const { stdout } = await runFernCli(["ir", "ir.json", "--version", "v27"], {
+    it.concurrent("works with latest version", async () => {
+        const tmpFile = await tmp.file({ postfix: ".json" });
+        const { stdout } = await runFernCli(["ir", tmpFile.path, "--version", "v27"], {
             cwd: join(FIXTURES_DIR, RelativeFilePath.of("migration")),
             reject: false
         });
+        await tmpFile.cleanup();
         expect(stdout).toContain("Wrote IR to");
     }, 10_000);
 
-    it("fails with invalid version", async () => {
-        const { stdout } = await runFernCli(["ir", "ir.json", "--version", "v100"], {
+    it.concurrent("fails with invalid version", async () => {
+        const tmpFile = await tmp.file({ postfix: ".json" });
+        const { stdout } = await runFernCli(["ir", tmpFile.path, "--version", "v100"], {
             cwd: join(FIXTURES_DIR, RelativeFilePath.of("migration")),
             reject: false
         });
+        await tmpFile.cleanup();
         expect(stdout).toContain("IR v100 does not exist");
     }, 10_000);
 });

--- a/packages/cli/ete-tests/src/tests/ir/ir.test.ts
+++ b/packages/cli/ete-tests/src/tests/ir/ir.test.ts
@@ -72,7 +72,7 @@ describe("ir", () => {
         const { only = false } = fixture;
         (only ? it.only : it.concurrent)(
             `${JSON.stringify(fixture)}`,
-            async () => {
+            async ({ expect }) => {
                 const fixturePath = join(FIXTURES_DIR, RelativeFilePath.of(fixture.name));
                 const irContents = await generateIrAsString({
                     fixturePath,
@@ -87,7 +87,7 @@ describe("ir", () => {
         );
     }
 
-    it.concurrent("works with latest version", async () => {
+    it.concurrent("works with latest version", async ({ expect }) => {
         const tmpFile = await tmp.file({ postfix: ".json" });
         const { stdout } = await runFernCli(["ir", tmpFile.path, "--version", "v27"], {
             cwd: join(FIXTURES_DIR, RelativeFilePath.of("migration")),
@@ -97,7 +97,7 @@ describe("ir", () => {
         expect(stdout).toContain("Wrote IR to");
     }, 10_000);
 
-    it.concurrent("fails with invalid version", async () => {
+    it.concurrent("fails with invalid version", async ({ expect }) => {
         const tmpFile = await tmp.file({ postfix: ".json" });
         const { stdout } = await runFernCli(["ir", tmpFile.path, "--version", "v100"], {
             cwd: join(FIXTURES_DIR, RelativeFilePath.of("migration")),


### PR DESCRIPTION
## Description

Parallelizes the IR generation end-to-end tests to reduce wall-clock time. Previously, all 17 tests ran sequentially (~1 min); now they run concurrently via `it.concurrent`.

Refs: [Devin run](https://app.devin.ai/sessions/38ca3cff54594cb5980bed9e614de737) | Requested by @Swimburger

## Changes Made

- **`generateIrAsString.ts`**: Replaced fixed `fixtures/<name>/ir.json` output path with a unique temp file via `tmp-promise`. This eliminates file conflicts when multiple tests share the same fixture directory (e.g., the 3 `"simple"` variants, or `"migration"` used by both fixture and version tests). Temp files are cleaned up after reading.
- **`ir.test.ts`**: Switched all `it(...)` calls to `it.concurrent(...)` (15 fixture tests + 2 version tests). The version tests also now write to temp files since they call `runFernCli` directly.
- Removed unused imports (`join`, `RelativeFilePath`, `rm`) from `generateIrAsString.ts`.

## Review Checklist

- [x] Verify snapshot tests still pass in CI — IR output should be path-independent but worth confirming
- [x] `tmp-promise` is already listed as a dependency in `ete-tests/package.json` (no new dependency added)
- [x] `generateIrAsString` is also imported by `dependencies.test.ts` — function signature is unchanged, so no breakage expected
- [x] `it.only` fallback for debugging is preserved (only the non-`.only` path changed to `.concurrent`)

## Testing

- [x] TypeScript compilation passes (`pnpm --filter @fern-api/ete-tests run compile`)
- [ ] CI to confirm snapshot tests still match
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
