### PR TITLE
chore(ci): parallelize fernignore test cases with it.concurrent

### DIFF
--- a/packages/cli/ete-tests/src/tests/generate/fernignore.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/fernignore.test.ts
@@ -28,7 +28,7 @@ Practice schema-first API design with Fern
 
 describe("fern generate --local", () => {
     // eslint-disable-next-line jest/expect-expect
-    it("Keep files listed in .fernignore from unmodified", async () => {
+    it.concurrent("Keep files listed in .fernignore from unmodified", async () => {
         const pathOfDirectory = await init();
         await runFernCli(["generate", "--local", "--keepDocker"], {
             cwd: pathOfDirectory
@@ -61,7 +61,7 @@ describe("fern generate --local", () => {
     }, 360_000);
 
     // eslint-disable-next-line jest/expect-expect
-    it("Prevent initial generation of files listed in .fernignore", async () => {
+    it.concurrent("Prevent initial generation of files listed in .fernignore", async () => {
         const pathOfDirectory = await init();
 
         // Create output directory with .fernignore BEFORE first generation


### PR DESCRIPTION
## Description

Refs: N/A

Parallelizes the two independent test cases in `fernignore.test.ts` to reduce wall-clock time. The two tests each create their own temp directory via `init()`, so they have no filesystem dependencies on each other. By running them concurrently, the total time is bounded by the slower test (~3 `fern generate --local` runs) instead of all 5 runs sequentially.

[Link to Devin run](https://app.devin.ai/sessions/b5a8ee72ad304b33996ee7e25a844b3a) | Requested by @Swimburger

## Changes Made

- Changed `it(...)` → `it.concurrent(...)` for both test cases in `fernignore.test.ts`

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed

> **Note:** This change was not locally validated. See review checklist below.

## Human Review Checklist

- [ ] **Docker contention**: Both tests use `--keepDocker`. Verify that running two concurrent `fern generate --local --keepDocker` invocations won't cause Docker container name collisions, port conflicts, or shared image/layer issues.
- [ ] **Jest concurrency config**: Confirm the project's Jest configuration (e.g., `maxConcurrency`, `maxWorkers`) doesn't implicitly serialize `it.concurrent` calls or cause unexpected behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
