### PR TITLE
fix(cli): resolve pnpm `catalog:` protocol references in CLI build output

### DIFF
--- a/packages/cli/cli-v2/build-utils.mjs
+++ b/packages/cli/cli-v2/build-utils.mjs
@@ -1,21 +1,49 @@
 import { exec } from "child_process";
+import { readFileSync } from "fs";
 import { writeFile } from "fs/promises";
 import path from "path";
 import tsup from "tsup";
 import { fileURLToPath } from "url";
 import { promisify } from "util";
+import YAML from "yaml";
 import packageJson from "./package.json" with { type: "json" };
 
 const execAsync = promisify(exec);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Read the pnpm catalog from pnpm-workspace.yaml to resolve "catalog:" references
+const workspaceYamlPath = path.join(__dirname, "../../../pnpm-workspace.yaml");
+const workspaceYaml = YAML.parse(readFileSync(workspaceYamlPath, "utf-8"));
+const pnpmCatalog = workspaceYaml.catalog ?? {};
+
+/**
+ * Resolve a version string, replacing pnpm "catalog:" protocol references
+ * with the actual version from the pnpm-workspace.yaml catalog.
+ */
+function resolveCatalogVersion(packageName, version) {
+    if (version === "catalog:") {
+        const catalogVersion = pnpmCatalog[packageName];
+        if (!catalogVersion) {
+            throw new Error(
+                `Package "${packageName}" uses "catalog:" protocol but is not defined in the pnpm-workspace.yaml catalog.`
+            );
+        }
+        return catalogVersion;
+    }
+    return version;
+}
+
 /**
  * Get a dependency version from package.json, preferring dependencies over devDependencies.
- * This ensures we don't miss runtime dependencies regardless of where they're declared.
+ * Resolves pnpm "catalog:" protocol references to actual versions.
  */
 function getDependencyVersion(packageName) {
-    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName];
+    const version = packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName];
+    if (version == null) {
+        return undefined;
+    }
+    return resolveCatalogVersion(packageName, version);
 }
 
 /**

--- a/packages/cli/cli/build-utils.mjs
+++ b/packages/cli/cli/build-utils.mjs
@@ -1,21 +1,49 @@
 import { exec } from "child_process";
+import { readFileSync } from "fs";
 import { writeFile } from "fs/promises";
 import path from "path";
 import tsup from "tsup";
 import { fileURLToPath } from "url";
 import { promisify } from "util";
+import YAML from "yaml";
 import packageJson from "./package.json" with { type: "json" };
 
 const execAsync = promisify(exec);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Read the pnpm catalog from pnpm-workspace.yaml to resolve "catalog:" references
+const workspaceYamlPath = path.join(__dirname, "../../../pnpm-workspace.yaml");
+const workspaceYaml = YAML.parse(readFileSync(workspaceYamlPath, "utf-8"));
+const pnpmCatalog = workspaceYaml.catalog ?? {};
+
+/**
+ * Resolve a version string, replacing pnpm "catalog:" protocol references
+ * with the actual version from the pnpm-workspace.yaml catalog.
+ */
+function resolveCatalogVersion(packageName, version) {
+    if (version === "catalog:") {
+        const catalogVersion = pnpmCatalog[packageName];
+        if (!catalogVersion) {
+            throw new Error(
+                `Package "${packageName}" uses "catalog:" protocol but is not defined in the pnpm-workspace.yaml catalog.`
+            );
+        }
+        return catalogVersion;
+    }
+    return version;
+}
+
 /**
  * Get a dependency version from package.json, preferring dependencies over devDependencies.
- * This ensures we don't miss runtime dependencies regardless of where they're declared.
+ * Resolves pnpm "catalog:" protocol references to actual versions.
  */
 function getDependencyVersion(packageName) {
-    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName];
+    const version = packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName];
+    if (version == null) {
+        return undefined;
+    }
+    return resolveCatalogVersion(packageName, version);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes `npm install -g @fern-api/fern-api-dev` failing with:
```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "catalog:": catalog:
```

**Root cause:** The CLI build scripts (`build-utils.mjs`) read dependency versions from the source `package.json` to write into the published `package.json`. Dependencies like `@boundaryml/baml` use pnpm's `catalog:` protocol, which gets written verbatim into the output. npm doesn't understand `catalog:` and fails.

## Changes Made

- Modified `packages/cli/cli/build-utils.mjs` and `packages/cli/cli-v2/build-utils.mjs` to:
  - Read and parse `pnpm-workspace.yaml` at build time to extract the catalog version mapping
  - Added `resolveCatalogVersion()` that replaces `"catalog:"` strings with actual semver versions from the catalog
  - Updated `getDependencyVersion()` to pipe through catalog resolution before returning

## Human Review Checklist

- [ ] **Catalog protocol variants**: This only handles the bare `"catalog:"` form. If named catalogs (e.g. `"catalog:react"`) are ever used in the future, this would need updating. Currently all usages in the repo are `"catalog:"` so this is fine.
- [ ] **Relative path `../../../pnpm-workspace.yaml`**: Assumes both build-utils files are exactly 3 levels below the repo root. Verify this holds for the repo structure.
- [ ] **Code duplication**: Both `cli/build-utils.mjs` and `cli-v2/build-utils.mjs` receive identical changes, matching the existing pattern of these being near-copies. Consider whether these should be consolidated (out of scope for this fix).

## Testing

- [x] Verified `npm view @fern-api/fern-api-dev --json` shows `@boundaryml/baml: catalog:` (confirming the bug)
- [x] Verified catalog resolution logic correctly maps `@boundaryml/baml` → `^0.211.2` from `pnpm-workspace.yaml`
- [ ] No unit tests added (build scripts have no existing test infrastructure)

---

Link to Devin run: https://app.devin.ai/sessions/04ebbcd0b5c44d879d3c0356edd03735
Requested by: @dsinghvi