### PR TITLE
chore(ci): add vitest github-actions reporter for inline PR annotations

### DIFF
--- a/packages/configs/vitest/base.mjs
+++ b/packages/configs/vitest/base.mjs
@@ -12,6 +12,7 @@ export const defaultConfig = {
                 fallbackCJS: true
             }
         },
+        reporters: process.env.CI ? [["default", { summary: false }], "github-actions"] : ["default"],
         maxConcurrency: 10,
         passWithNoTests: true
     }


### PR DESCRIPTION
## Description

Adds Vitest's built-in `github-actions` reporter so that failed tests surface as inline annotations directly on PR diffs.

Refs https://app.devin.ai/sessions/82dbc89441144ccbafafca370415b440
Requested by: @Swimburger

## Changes Made

- Added a `reporters` field to the shared Vitest base config (`packages/configs/vitest/base.mjs`)
- In CI (`process.env.CI`): uses `default` (with `summary: false`) + `github-actions`
- Locally: uses `default` reporter (no behavior change)
- Since all ~108 `vitest.config.ts` files across the repo inherit from this shared base config, every test suite picks up the new reporter automatically

## Review Checklist

- [ ] Confirm `summary: false` on the default reporter in CI is desired — this suppresses the terminal summary table since GitHub Actions annotations provide equivalent feedback
- [ ] Verify behavior with `mergeConfig` usage (e.g. `generators/browser-compatible-base/vitest.config.ts`) — Vitest's `mergeConfig` replaces arrays, so the reporters config from base should carry through unless explicitly overridden

## Testing

- [ ] No unit tests needed — this is a config-only change
- [ ] Can be verified by observing GitHub Actions annotations on the next PR with a failing test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
