### PR TITLE
feat(internal): use expect.assert() for type narrowing in tests

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/convertSecurityScheme.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/convertSecurityScheme.test.ts
@@ -65,7 +65,7 @@ describe("convertSecurityScheme", () => {
         expect(result.tokenEnvVar).toBeUndefined();
     });
 
-    it("should throw an error when resolving reference without context",() => {
+    it("should throw an error when resolving reference without context", () => {
         const securitySchemeRef: OpenAPIV3.ReferenceObject = {
             $ref: "#/components/securitySchemes/BearerAuth"
         };

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/convertSecurityScheme.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/convertSecurityScheme.test.ts
@@ -59,15 +59,13 @@ describe("convertSecurityScheme", () => {
         const result = convertSecurityScheme(securitySchemeRef, source, mockTaskContext, context);
 
         // Verify the result
-        expect(result).toBeDefined();
-        expect(result?.type).toBe("bearer");
-        if (result?.type === "bearer") {
-            expect(result.tokenVariableName).toBeUndefined();
-            expect(result.tokenEnvVar).toBeUndefined();
-        }
+        expect.assert(result != null);
+        expect.assert(result.type === "bearer");
+        expect(result.tokenVariableName).toBeUndefined();
+        expect(result.tokenEnvVar).toBeUndefined();
     });
 
-    it("should throw an error when resolving reference without context", () => {
+    it("should throw an error when resolving reference without context",() => {
         const securitySchemeRef: OpenAPIV3.ReferenceObject = {
             $ref: "#/components/securitySchemes/BearerAuth"
         };
@@ -86,11 +84,9 @@ describe("convertSecurityScheme", () => {
 
         const result = convertSecurityScheme(securityScheme, source, mockTaskContext);
 
-        expect(result).toBeDefined();
-        expect(result?.type).toBe("bearer");
-        if (result?.type === "bearer") {
-            expect(result.tokenVariableName).toBeUndefined();
-            expect(result.tokenEnvVar).toBeUndefined();
-        }
+        expect.assert(result != null);
+        expect.assert(result.type === "bearer");
+        expect(result.tokenVariableName).toBeUndefined();
+        expect(result.tokenEnvVar).toBeUndefined();
     });
 });

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,12 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.82.1
-  changelogEntry:
-    - summary: |
-        Use vitest `expect.assert()` for type narrowing in tests, replacing manual
-        `if`-block and `as`-cast patterns around discriminated unions.
-      type: chore
-  createdAt: "2026-02-23"
-  irVersion: 65
 - version: 3.82.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.82.1
+  changelogEntry:
+    - summary: |
+        Use vitest `expect.assert()` for type narrowing in tests, replacing manual
+        `if`-block and `as`-cast patterns around discriminated unions.
+      type: chore
+  createdAt: "2026-02-23"
+  irVersion: 65
 - version: 3.82.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/docs-yml/__test__/navigationUtils.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/navigationUtils.test.ts
@@ -1103,7 +1103,7 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
         });
     });
 
-    it("should use index.md as section overview for subdirectories",async () => {
+    it("should use index.md as section overview for subdirectories", async () => {
         let callCount = 0;
         const mockGetDir = async (path: AbsoluteFilePath) => {
             callCount++;
@@ -1157,7 +1157,7 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
         });
     });
 
-    it("should exclude index.mdx from section contents",async () => {
+    it("should exclude index.mdx from section contents", async () => {
         let callCount = 0;
         const mockGetDir = async (path: AbsoluteFilePath) => {
             callCount++;
@@ -1211,7 +1211,7 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
         expect(titles).toContain("Errors");
     });
 
-    it("should handle nested subdirectories with index.mdx",async () => {
+    it("should handle nested subdirectories with index.mdx", async () => {
         let callCount = 0;
         const mockGetDir = async (path: AbsoluteFilePath) => {
             callCount++;

--- a/packages/cli/configuration-loader/src/docs-yml/__test__/navigationUtils.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/navigationUtils.test.ts
@@ -183,14 +183,13 @@ describe("buildNavigationForDirectory", () => {
             slug: "advanced"
         });
         const firstItem = result[0];
-        if (firstItem && firstItem.type === "section") {
-            expect(firstItem.contents).toHaveLength(1);
-            expect(firstItem.contents[0]).toMatchObject({
-                type: "page",
-                title: "Authentication",
-                slug: "authentication"
-            });
-        }
+        expect.assert(firstItem?.type === "section");
+        expect(firstItem.contents).toHaveLength(1);
+        expect(firstItem.contents[0]).toMatchObject({
+            type: "page",
+            title: "Authentication",
+            slug: "authentication"
+        });
         expect(result[1]).toMatchObject({
             type: "page",
             title: "Getting Started",
@@ -278,23 +277,21 @@ describe("buildNavigationForDirectory", () => {
             slug: "guides"
         });
         const firstItem = result[0];
-        if (firstItem && firstItem.type === "section") {
-            expect(firstItem.contents).toHaveLength(1);
-            expect(firstItem.contents[0]).toMatchObject({
-                type: "section",
-                title: "Advanced",
-                slug: "advanced"
-            });
-            const secondItem = firstItem.contents[0];
-            if (secondItem && secondItem.type === "section") {
-                expect(secondItem.contents).toHaveLength(1);
-                expect(secondItem.contents[0]).toMatchObject({
-                    type: "page",
-                    title: "Authentication",
-                    slug: "authentication"
-                });
-            }
-        }
+        expect.assert(firstItem?.type === "section");
+        expect(firstItem.contents).toHaveLength(1);
+        expect(firstItem.contents[0]).toMatchObject({
+            type: "section",
+            title: "Advanced",
+            slug: "advanced"
+        });
+        const secondItem = firstItem.contents[0];
+        expect.assert(secondItem?.type === "section");
+        expect(secondItem.contents).toHaveLength(1);
+        expect(secondItem.contents[0]).toMatchObject({
+            type: "page",
+            title: "Authentication",
+            slug: "authentication"
+        });
     });
 });
 
@@ -1097,17 +1094,16 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
             slug: "guides",
             overviewAbsolutePath: "/test/guides/index.mdx"
         });
-        if (section && section.type === "section") {
-            expect(section.contents).toHaveLength(1);
-            expect(section.contents[0]).toMatchObject({
-                type: "page",
-                title: "Getting Started",
-                slug: "getting-started"
-            });
-        }
+        expect.assert(section?.type === "section");
+        expect(section.contents).toHaveLength(1);
+        expect(section.contents[0]).toMatchObject({
+            type: "page",
+            title: "Getting Started",
+            slug: "getting-started"
+        });
     });
 
-    it("should use index.md as section overview for subdirectories", async () => {
+    it("should use index.md as section overview for subdirectories",async () => {
         let callCount = 0;
         const mockGetDir = async (path: AbsoluteFilePath) => {
             callCount++;
@@ -1153,16 +1149,15 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
             slug: "guides",
             overviewAbsolutePath: "/test/guides/index.md"
         });
-        if (section && section.type === "section") {
-            expect(section.contents).toHaveLength(1);
-            expect(section.contents[0]).toMatchObject({
-                type: "page",
-                title: "Authentication"
-            });
-        }
+        expect.assert(section?.type === "section");
+        expect(section.contents).toHaveLength(1);
+        expect(section.contents[0]).toMatchObject({
+            type: "page",
+            title: "Authentication"
+        });
     });
 
-    it("should exclude index.mdx from section contents", async () => {
+    it("should exclude index.mdx from section contents",async () => {
         let callCount = 0;
         const mockGetDir = async (path: AbsoluteFilePath) => {
             callCount++;
@@ -1208,16 +1203,15 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
 
         expect(result).toHaveLength(1);
         const section = result[0];
-        if (section && section.type === "section") {
-            expect(section.contents).toHaveLength(2);
-            const titles = section.contents.map((item) => (item.type === "page" ? item.title : ""));
-            expect(titles).not.toContain("Index");
-            expect(titles).toContain("Endpoints");
-            expect(titles).toContain("Errors");
-        }
+        expect.assert(section?.type === "section");
+        expect(section.contents).toHaveLength(2);
+        const titles = section.contents.map((item) => (item.type === "page" ? item.title : ""));
+        expect(titles).not.toContain("Index");
+        expect(titles).toContain("Endpoints");
+        expect(titles).toContain("Errors");
     });
 
-    it("should handle nested subdirectories with index.mdx", async () => {
+    it("should handle nested subdirectories with index.mdx",async () => {
         let callCount = 0;
         const mockGetDir = async (path: AbsoluteFilePath) => {
             callCount++;
@@ -1277,22 +1271,20 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
             title: "Guides",
             overviewAbsolutePath: "/test/guides/index.mdx"
         });
-        if (guidesSection && guidesSection.type === "section") {
-            expect(guidesSection.contents).toHaveLength(1);
-            const advancedSection = guidesSection.contents[0];
-            expect(advancedSection).toMatchObject({
-                type: "section",
-                title: "Advanced",
-                overviewAbsolutePath: "/test/guides/advanced/index.mdx"
-            });
-            if (advancedSection && advancedSection.type === "section") {
-                expect(advancedSection.contents).toHaveLength(1);
-                expect(advancedSection.contents[0]).toMatchObject({
-                    type: "page",
-                    title: "Auth"
-                });
-            }
-        }
+        expect.assert(guidesSection?.type === "section");
+        expect(guidesSection.contents).toHaveLength(1);
+        const advancedSection = guidesSection.contents[0];
+        expect(advancedSection).toMatchObject({
+            type: "section",
+            title: "Advanced",
+            overviewAbsolutePath: "/test/guides/advanced/index.mdx"
+        });
+        expect.assert(advancedSection?.type === "section");
+        expect(advancedSection.contents).toHaveLength(1);
+        expect(advancedSection.contents[0]).toMatchObject({
+            type: "page",
+            title: "Auth"
+        });
     });
 
     it("should handle case-insensitive index file names", async () => {
@@ -1339,13 +1331,12 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
             type: "section",
             overviewAbsolutePath: "/test/guides/INDEX.MDX"
         });
-        if (section && section.type === "section") {
-            expect(section.contents).toHaveLength(1);
-            expect(section.contents[0]).toMatchObject({
-                type: "page",
-                title: "Page"
-            });
-        }
+        expect.assert(section?.type === "section");
+        expect(section.contents).toHaveLength(1);
+        expect(section.contents[0]).toMatchObject({
+            type: "page",
+            title: "Page"
+        });
     });
 
     it("should not set overviewAbsolutePath when no index file exists", async () => {
@@ -1387,9 +1378,8 @@ describe("buildNavigationForDirectory with index.mdx as section overview", () =>
             title: "Guides",
             overviewAbsolutePath: undefined
         });
-        if (section && section.type === "section") {
-            expect(section.contents).toHaveLength(1);
-        }
+        expect.assert(section?.type === "section");
+        expect(section.contents).toHaveLength(1);
     });
 });
 

--- a/packages/cli/configuration-loader/src/generators-yml/__test__/convertGeneratorsConfiguration.test.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/__test__/convertGeneratorsConfiguration.test.ts
@@ -1,9 +1,7 @@
-/* eslint-disable jest/no-conditional-expect */
-
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { createMockTaskContext } from "@fern-api/task-context";
-import { vi } from "vitest";
+import { expect, vi } from "vitest";
 
 import { convertGeneratorsConfiguration } from "../convertGeneratorsConfiguration.js";
 
@@ -178,16 +176,12 @@ describe("convertGeneratorsConfiguration", () => {
         });
 
         const output = converted.groups[0]?.generators[0]?.outputMode;
-        expect(output?.type).toEqual("githubV2");
-        if (output?.type === "githubV2") {
-            const publishInfo = output.githubV2.publishInfo;
-            expect(publishInfo?.type).toEqual("maven");
-            if (publishInfo?.type === "maven") {
-                expect(publishInfo.registryUrl).toEqual(
-                    "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-                );
-            }
-        }
+        expect.assert(output?.type === "githubV2");
+        const publishInfo = output.githubV2.publishInfo;
+        expect.assert(publishInfo?.type === "maven");
+        expect(publishInfo.registryUrl).toEqual(
+            "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        );
     });
 
     it("License Metadata", async () => {
@@ -218,10 +212,8 @@ describe("convertGeneratorsConfiguration", () => {
             context
         });
         const output = converted.groups[0]?.generators[0]?.outputMode;
-        expect(output?.type).toEqual("githubV2");
-        if (output?.type === "githubV2") {
-            expect(output.githubV2.license?.type === "basic" && output.githubV2.license.id === "MIT").toEqual(true);
-        }
+        expect.assert(output?.type === "githubV2");
+        expect(output.githubV2.license?.type === "basic" && output.githubV2.license.id === "MIT").toEqual(true);
     });
 
     it("Reviewers", async () => {
@@ -260,14 +252,13 @@ describe("convertGeneratorsConfiguration", () => {
             context
         });
         const output = converted.groups[0]?.generators[0]?.outputMode;
-        expect(output?.type).toEqual("githubV2");
-        if (output?.type === "githubV2" && output.githubV2.type === "pullRequest") {
-            expect(output.githubV2.reviewers != null).toBeTruthy();
-            expect(output.githubV2.reviewers?.length).toEqual(3);
+        expect.assert(output?.type === "githubV2");
+        expect.assert(output.githubV2.type === "pullRequest");
+        expect(output.githubV2.reviewers != null).toBeTruthy();
+        expect(output.githubV2.reviewers?.length).toEqual(3);
 
-            const reviewerNames = output.githubV2.reviewers?.map((reviewer) => reviewer.name);
-            expect(reviewerNames).toEqual(["fern-eng", "armando", "deep"]);
-        }
+        const reviewerNames = output.githubV2.reviewers?.map((reviewer) => reviewer.name);
+        expect(reviewerNames).toEqual(["fern-eng", "armando", "deep"]);
     });
 
     it("Output Metadata", async () => {
@@ -307,14 +298,12 @@ describe("convertGeneratorsConfiguration", () => {
             context
         });
         const output = converted.groups[0]?.generators[0]?.outputMode;
-        expect(output?.type).toEqual("githubV2");
-        if (output?.type === "githubV2") {
-            expect(
-                output.githubV2.publishInfo?.type === "pypi" &&
-                    output.githubV2.publishInfo.pypiMetadata?.documentationLink === "https://test.com" &&
-                    output.githubV2.publishInfo.pypiMetadata?.description === "test that's low level"
-            ).toEqual(true);
-        }
+        expect.assert(output?.type === "githubV2");
+        expect(
+            output.githubV2.publishInfo?.type === "pypi" &&
+                output.githubV2.publishInfo.pypiMetadata?.documentationLink === "https://test.com" &&
+                output.githubV2.publishInfo.pypiMetadata?.description === "test that's low level"
+        ).toEqual(true);
     });
 
     it("logs deprecation warnings for deprecated generators yml configuration", async () => {
@@ -504,14 +493,12 @@ describe("convertGeneratorsConfiguration", () => {
             });
 
             // Verify both specs inherit api-level settings
-            expect(converted.api?.type).toBe("singleNamespace");
-            if (converted.api?.type === "singleNamespace") {
-                expect(converted.api.definitions).toHaveLength(2);
-                expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
-                expect(converted.api.definitions[0]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
-                expect(converted.api.definitions[1]?.settings?.shouldUseTitleAsName).toBe(true);
-                expect(converted.api.definitions[1]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
-            }
+            expect.assert(converted.api?.type === "singleNamespace");
+            expect(converted.api.definitions).toHaveLength(2);
+            expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
+            expect(converted.api.definitions[0]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
+            expect(converted.api.definitions[1]?.settings?.shouldUseTitleAsName).toBe(true);
+            expect(converted.api.definitions[1]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
         });
 
         it("spec settings override api-level settings", async () => {
@@ -538,11 +525,9 @@ describe("convertGeneratorsConfiguration", () => {
             });
 
             // Verify spec setting overrides api-level, but other api-level settings are preserved
-            expect(converted.api?.type).toBe("singleNamespace");
-            if (converted.api?.type === "singleNamespace") {
-                expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(false);
-                expect(converted.api.definitions[0]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
-            }
+            expect.assert(converted.api?.type === "singleNamespace");
+            expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(false);
+            expect(converted.api.definitions[0]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
         });
 
         it("partial overrides preserve other api-level settings", async () => {
@@ -571,12 +556,10 @@ describe("convertGeneratorsConfiguration", () => {
             });
 
             // Verify only specified setting is overridden, others preserved from api-level
-            expect(converted.api?.type).toBe("singleNamespace");
-            if (converted.api?.type === "singleNamespace") {
-                expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(false);
-                expect(converted.api.definitions[0]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
-                expect(converted.api.definitions[0]?.settings?.coerceEnumsToLiterals).toBe(true);
-            }
+            expect.assert(converted.api?.type === "singleNamespace");
+            expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(false);
+            expect(converted.api.definitions[0]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
+            expect(converted.api.definitions[0]?.settings?.coerceEnumsToLiterals).toBe(true);
         });
 
         it("empty spec settings preserve api-level settings", async () => {
@@ -600,10 +583,8 @@ describe("convertGeneratorsConfiguration", () => {
             });
 
             // Verify empty spec settings don't erase api-level settings
-            expect(converted.api?.type).toBe("singleNamespace");
-            if (converted.api?.type === "singleNamespace") {
-                expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
-            }
+            expect.assert(converted.api?.type === "singleNamespace");
+            expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
         });
 
         it("multiple specs with different overrides", async () => {
@@ -640,22 +621,20 @@ describe("convertGeneratorsConfiguration", () => {
             });
 
             // Verify each spec has correct merged settings
-            expect(converted.api?.type).toBe("singleNamespace");
-            if (converted.api?.type === "singleNamespace") {
-                expect(converted.api.definitions).toHaveLength(3);
+            expect.assert(converted.api?.type === "singleNamespace");
+            expect(converted.api.definitions).toHaveLength(3);
 
-                // Spec 1: overrides title-as-schema-name
-                expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(false);
-                expect(converted.api.definitions[0]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
+            // Spec 1: overrides title-as-schema-name
+            expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(false);
+            expect(converted.api.definitions[0]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
 
-                // Spec 2: inherits all api-level settings
-                expect(converted.api.definitions[1]?.settings?.shouldUseTitleAsName).toBe(true);
-                expect(converted.api.definitions[1]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
+            // Spec 2: inherits all api-level settings
+            expect(converted.api.definitions[1]?.settings?.shouldUseTitleAsName).toBe(true);
+            expect(converted.api.definitions[1]?.settings?.shouldUseIdiomaticRequestNames).toBe(false);
 
-                // Spec 3: overrides idiomatic-request-names
-                expect(converted.api.definitions[2]?.settings?.shouldUseTitleAsName).toBe(true);
-                expect(converted.api.definitions[2]?.settings?.shouldUseIdiomaticRequestNames).toBe(true);
-            }
+            // Spec 3: overrides idiomatic-request-names
+            expect(converted.api.definitions[2]?.settings?.shouldUseTitleAsName).toBe(true);
+            expect(converted.api.definitions[2]?.settings?.shouldUseIdiomaticRequestNames).toBe(true);
         });
 
         it("OpenAPI-specific settings work alongside base settings", async () => {
@@ -682,12 +661,10 @@ describe("convertGeneratorsConfiguration", () => {
             });
 
             // Verify OpenAPI-specific settings merge with base settings
-            expect(converted.api?.type).toBe("singleNamespace");
-            if (converted.api?.type === "singleNamespace") {
-                expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
-                expect(converted.api.definitions[0]?.settings?.onlyIncludeReferencedSchemas).toBe(true);
-                expect(converted.api.definitions[0]?.settings?.inlinePathParameters).toBe(true);
-            }
+            expect.assert(converted.api?.type === "singleNamespace");
+            expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
+            expect(converted.api.definitions[0]?.settings?.onlyIncludeReferencedSchemas).toBe(true);
+            expect(converted.api.definitions[0]?.settings?.inlinePathParameters).toBe(true);
         });
 
         it("AsyncAPI-specific settings work alongside base settings", async () => {
@@ -713,11 +690,9 @@ describe("convertGeneratorsConfiguration", () => {
             });
 
             // Verify AsyncAPI-specific settings merge with base settings
-            expect(converted.api?.type).toBe("singleNamespace");
-            if (converted.api?.type === "singleNamespace") {
-                expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
-                expect(converted.api.definitions[0]?.settings?.asyncApiMessageNaming).toBe("v2");
-            }
+            expect.assert(converted.api?.type === "singleNamespace");
+            expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
+            expect(converted.api.definitions[0]?.settings?.asyncApiMessageNaming).toBe("v2");
         });
 
         it("no root settings maintains backward compatibility", async () => {
@@ -740,10 +715,8 @@ describe("convertGeneratorsConfiguration", () => {
             });
 
             // Verify existing configs without root settings still work
-            expect(converted.api?.type).toBe("singleNamespace");
-            if (converted.api?.type === "singleNamespace") {
-                expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
-            }
+            expect.assert(converted.api?.type === "singleNamespace");
+            expect(converted.api.definitions[0]?.settings?.shouldUseTitleAsName).toBe(true);
         });
     });
 

--- a/packages/cli/configuration-loader/src/generators-yml/__test__/convertGeneratorsConfiguration.test.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/__test__/convertGeneratorsConfiguration.test.ts
@@ -179,9 +179,7 @@ describe("convertGeneratorsConfiguration", () => {
         expect.assert(output?.type === "githubV2");
         const publishInfo = output.githubV2.publishInfo;
         expect.assert(publishInfo?.type === "maven");
-        expect(publishInfo.registryUrl).toEqual(
-            "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-        );
+        expect(publishInfo.registryUrl).toEqual("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/");
     });
 
     it("License Metadata", async () => {

--- a/packages/cli/docs-resolver/src/__test__/availability-inheritance.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/availability-inheritance.test.ts
@@ -144,54 +144,49 @@ describe("availability inheritance", () => {
         expect(getAvailability(stableSection)).toBe("stable");
 
         // Test specific endpoints within Beta Features section
-        if (betaSection?.type === "apiPackage") {
-            const userManagement = findNodeByTitle(betaSection.children, "User Management");
-            expect(getAvailability(userManagement)).toBe("beta"); // Should inherit from beta section
+        expect.assert(betaSection?.type === "apiPackage");
+        const userManagement = findNodeByTitle(betaSection.children, "User Management");
+        expect(getAvailability(userManagement)).toBe("beta"); // Should inherit from beta section
 
-            if (userManagement?.type === "apiPackage") {
-                const getUser = findEndpointByTitle(userManagement.children, "getUser");
-                const createUser = findEndpointByTitle(userManagement.children, "createUser");
-                const deleteUser = findEndpointByTitle(userManagement.children, "deleteUser");
+        expect.assert(userManagement?.type === "apiPackage");
+        const getUser = findEndpointByTitle(userManagement.children, "getUser");
+        const createUser = findEndpointByTitle(userManagement.children, "createUser");
+        const deleteUser = findEndpointByTitle(userManagement.children, "deleteUser");
 
-                // getUser should inherit beta from section
-                expect(getAvailability(getUser)).toBe("beta");
+        // getUser should inherit beta from section
+        expect(getAvailability(getUser)).toBe("beta");
 
-                // createUser has its own beta, but matches parent so should be beta
-                expect(getAvailability(createUser)).toBe("beta");
+        // createUser has its own beta, but matches parent so should be beta
+        expect(getAvailability(createUser)).toBe("beta");
 
-                // deleteUser has its own deprecated, should override parent beta
-                expect(getAvailability(deleteUser)).toBe("deprecated");
-            }
-        }
+        // deleteUser has its own deprecated, should override parent beta
+        expect(getAvailability(deleteUser)).toBe("deprecated");
 
         // Test endpoints within Admin package
-        if (adminPackage?.type === "apiPackage") {
-            const healthCheck = findEndpointByTitle(adminPackage.children, "healthCheck");
-            const reboot = findEndpointByTitle(adminPackage.children, "reboot");
+        expect.assert(adminPackage?.type === "apiPackage");
+        const healthCheck = findEndpointByTitle(adminPackage.children, "healthCheck");
+        const reboot = findEndpointByTitle(adminPackage.children, "reboot");
 
-            // healthCheck should inherit deprecated from admin package
-            expect(getAvailability(healthCheck)).toBe("deprecated");
+        // healthCheck should inherit deprecated from admin package
+        expect(getAvailability(healthCheck)).toBe("deprecated");
 
-            // reboot has its own alpha, should override parent deprecated
-            expect(getAvailability(reboot)).toBe("alpha");
-        }
+        // reboot has its own alpha, should override parent deprecated
+        expect(getAvailability(reboot)).toBe("alpha");
 
         // Test endpoints within Stable section
-        if (stableSection?.type === "apiPackage") {
-            const stableUserPackage = findNodeByTitle(stableSection.children, "users");
-            expect(getAvailability(stableUserPackage)).toBe("stable"); // Should inherit stable from section
+        expect.assert(stableSection?.type === "apiPackage");
+        const stableUserPackage = findNodeByTitle(stableSection.children, "users");
+        expect(getAvailability(stableUserPackage)).toBe("stable"); // Should inherit stable from section
 
-            if (stableUserPackage?.type === "apiPackage") {
-                const stableGetUser = findEndpointByTitle(stableUserPackage.children, "getUser");
-                const stableCreateUser = findEndpointByTitle(stableUserPackage.children, "createUser");
+        expect.assert(stableUserPackage?.type === "apiPackage");
+        const stableGetUser = findEndpointByTitle(stableUserPackage.children, "getUser");
+        const stableCreateUser = findEndpointByTitle(stableUserPackage.children, "createUser");
 
-                // getUser should inherit stable from section
-                expect(getAvailability(stableGetUser)).toBe("stable");
+        // getUser should inherit stable from section
+        expect(getAvailability(stableGetUser)).toBe("stable");
 
-                // createUser has its own beta, should override parent stable
-                expect(getAvailability(stableCreateUser)).toBe("beta");
-            }
-        }
+        // createUser has its own beta, should override parent stable
+        expect(getAvailability(stableCreateUser)).toBe("beta");
 
         // Store the full snapshot for comprehensive testing
         expect(node).toMatchSnapshot();

--- a/packages/cli/docs-resolver/src/__test__/graphql-operation-layout.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/graphql-operation-layout.test.ts
@@ -95,40 +95,35 @@ describe("GraphQL Operation Layout", () => {
         );
         expect(userOperationsSection).toBeDefined();
 
-        if (userOperationsSection && userOperationsSection.type === "apiPackage") {
-            // Should contain getUserProfile, createUser, updateUserProfile operations
-            expect(userOperationsSection.children).toHaveLength(3);
+        expect.assert(userOperationsSection?.type === "apiPackage");
+        // Should contain getUserProfile, createUser, updateUserProfile operations
+        expect(userOperationsSection.children).toHaveLength(3);
 
-            const getUserProfileOp = userOperationsSection.children.find(
-                (child) => child.type === "graphql" && child.title === "Get User Profile"
-            );
-            expect(getUserProfileOp).toBeDefined();
+        const getUserProfileOp = userOperationsSection.children.find(
+            (child) => child.type === "graphql" && child.title === "Get User Profile"
+        );
+        expect(getUserProfileOp).toBeDefined();
 
-            const createUserOp = userOperationsSection.children.find(
-                (child) => child.type === "graphql" && child.title === "Create New User"
-            );
-            expect(createUserOp).toBeDefined();
-
-            if (createUserOp && createUserOp.type === "graphql") {
-                // Should use custom slug
-                expect(createUserOp.slug).toContain("create-user");
-            }
-        }
+        const createUserOp = userOperationsSection.children.find(
+            (child) => child.type === "graphql" && child.title === "Create New User"
+        );
+        expect.assert(createUserOp?.type === "graphql");
+        // Should use custom slug
+        expect(createUserOp.slug).toContain("create-user");
 
         const adminOperationsSection = node.children.find(
             (child) => child.type === "apiPackage" && child.title === "Admin Operations"
         );
         expect(adminOperationsSection).toBeDefined();
 
-        if (adminOperationsSection && adminOperationsSection.type === "apiPackage") {
-            // Should contain getSystemInfo operation (resetSystem is hidden)
-            expect(adminOperationsSection.children.length).toBeGreaterThan(0);
+        expect.assert(adminOperationsSection?.type === "apiPackage");
+        // Should contain getSystemInfo operation (resetSystem is hidden)
+        expect(adminOperationsSection.children.length).toBeGreaterThan(0);
 
-            const getSystemInfoOp = adminOperationsSection.children.find(
-                (child) => child.type === "graphql" && child.title === "System Information"
-            );
-            expect(getSystemInfoOp).toBeDefined();
-        }
+        const getSystemInfoOp = adminOperationsSection.children.find(
+            (child) => child.type === "graphql" && child.title === "System Information"
+        );
+        expect(getSystemInfoOp).toBeDefined();
 
         // Check for the subscription operation at root level
         const userUpdatesOp = node.children.find(
@@ -136,9 +131,8 @@ describe("GraphQL Operation Layout", () => {
         );
         expect(userUpdatesOp).toBeDefined();
 
-        if (userUpdatesOp && userUpdatesOp.type === "graphql") {
-            expect(userUpdatesOp.availability).toBe("beta");
-        }
+        expect.assert(userUpdatesOp?.type === "graphql");
+        expect(userUpdatesOp.availability).toBe("beta");
     });
 
     it("should handle invalid operation format", async () => {

--- a/packages/cli/generation/ir-migrations/src/migrations/v65-to-v63/__test__/migrateFromV65ToV63.test.ts
+++ b/packages/cli/generation/ir-migrations/src/migrations/v65-to-v63/__test__/migrateFromV65ToV63.test.ts
@@ -57,10 +57,8 @@ describe("migrateFromV65ToV63", () => {
         const migratedIR = V65_TO_V63_MIGRATION.migrateBackwards(v65IR, mockContext);
 
         const migratedEndpoint = migratedIR.services["service_test"]?.endpoints[0];
-        expect(migratedEndpoint?.pagination?.type).toBe("cursor");
-        if (migratedEndpoint?.pagination?.type === "cursor") {
-            expect(migratedEndpoint.pagination.page.property.type).toBe("query");
-        }
+        expect.assert(migratedEndpoint?.pagination?.type === "cursor");
+        expect(migratedEndpoint.pagination.page.property.type).toBe("query");
     });
 
     it("removes nextUri pagination", () => {

--- a/packages/cli/library-docs-generator/src/__test__/integration.test.ts
+++ b/packages/cli/library-docs-generator/src/__test__/integration.test.ts
@@ -268,13 +268,10 @@ describe("generate() — full pipeline integration", () => {
         }
 
         // data section has nested aime section
-        // biome-ignore lint/style/noNonNullAssertion: length asserted above
-        const dataSection = result.navigation[2]!;
-        expect(dataSection.type).toBe("section");
-        if (dataSection.type === "section") {
-            expect(dataSection.children).toHaveLength(1);
-            expect(dataSection.children[0]?.title).toBe("aime");
-        }
+        const dataSection = result.navigation[2];
+        expect.assert(dataSection?.type === "section");
+        expect(dataSection.children).toHaveLength(1);
+        expect(dataSection.children[0]?.title).toBe("aime");
     });
 
     it("navigation page nodes have correct slugs and pageIds", () => {
@@ -288,10 +285,9 @@ describe("generate() — full pipeline integration", () => {
         expect(pages).toHaveLength(3);
 
         for (const page of pages) {
-            if (page.type === "page") {
-                expect(page.slug).toMatch(/^reference\/python\//);
-                expect(page.pageId).toBe(`${page.slug}.mdx`);
-            }
+            expect.assert(page.type === "page");
+            expect(page.slug).toMatch(/^reference\/python\//);
+            expect(page.pageId).toBe(`${page.slug}.mdx`);
         }
     });
 

--- a/packages/cli/library-docs-generator/src/__test__/writers.test.ts
+++ b/packages/cli/library-docs-generator/src/__test__/writers.test.ts
@@ -179,8 +179,8 @@ describe("buildNavigation", () => {
         const nav = buildNavigation(root, "ref");
         // Every submodule gets wrapped in a section by the parent
         expect(nav).toHaveLength(1);
-        expect(nav[0]?.type).toBe("section");
-        const section = nav[0] as { type: "section"; title: string; slug: string; children: NavNode[] };
+        const section = nav[0];
+        expect.assert(section?.type === "section");
         expect(section.title).toBe("utils");
         expect(section.slug).toBe("ref/pkg/utils");
         expect(section.children).toHaveLength(1);
@@ -213,12 +213,12 @@ describe("buildNavigation", () => {
         const nav = buildNavigation(root, "ref");
         expect(nav).toHaveLength(1);
         // sub is a section wrapping leaf's section
-        expect(nav[0]?.type).toBe("section");
-        const sub = nav[0] as { type: "section"; children: NavNode[] };
+        const sub = nav[0];
+        expect.assert(sub?.type === "section");
         expect(sub.children).toHaveLength(1);
         // leaf is also wrapped in a section by sub
-        expect(sub.children[0]?.type).toBe("section");
-        const leafSection = sub.children[0] as { type: "section"; children: NavNode[] };
+        const leafSection = sub.children[0];
+        expect.assert(leafSection?.type === "section");
         expect(leafSection.children).toHaveLength(1);
         expect(leafSection.children[0]?.type).toBe("page");
     });
@@ -239,8 +239,9 @@ describe("buildNavigation", () => {
         const nav = buildNavigation(root, "ref");
         // Only "filled" appears (wrapped in section); "empty" is skipped
         expect(nav).toHaveLength(1);
-        expect(nav[0]?.type).toBe("section");
-        expect((nav[0] as { title: string }).title).toBe("filled");
+        const filledSection = nav[0];
+        expect.assert(filledSection?.type === "section");
+        expect(filledSection.title).toBe("filled");
     });
 
     it("does not include root module as a node (root is section overview)", () => {
@@ -276,8 +277,8 @@ describe("buildNavigation", () => {
         });
         const nav = buildNavigation(root, "reference/python");
         // "core" gets wrapped in a section
-        expect(nav[0]?.type).toBe("section");
-        const section = nav[0] as { type: "section"; slug: string; children: NavNode[] };
+        const section = nav[0];
+        expect.assert(section?.type === "section");
         expect(section.slug).toBe("reference/python/mylib/core");
         // Inner page has same slug + pageId
         expect(section.children[0]).toEqual({
@@ -316,17 +317,14 @@ describe("buildNavigation", () => {
 
         // a -> section(b) -> section(c) -> section(d) -> page(d)
         expect(nav).toHaveLength(1);
-        // biome-ignore lint/style/noNonNullAssertion: length asserted above
-        const b = nav[0]! as { type: "section"; children: NavNode[] };
-        expect(b.type).toBe("section");
+        const b = nav[0];
+        expect.assert(b?.type === "section");
         expect(b.children).toHaveLength(1);
-        // biome-ignore lint/style/noNonNullAssertion: length asserted above
-        const c = b.children[0]! as { type: "section"; children: NavNode[] };
-        expect(c.type).toBe("section");
+        const c = b.children[0];
+        expect.assert(c?.type === "section");
         expect(c.children).toHaveLength(1);
-        // biome-ignore lint/style/noNonNullAssertion: length asserted above
-        const d = c.children[0]! as { type: "section"; title: string; children: NavNode[] };
-        expect(d.type).toBe("section");
+        const d = c.children[0];
+        expect.assert(d?.type === "section");
         expect(d.title).toBe("d");
         expect(d.children).toHaveLength(1);
         expect(d.children[0]?.type).toBe("page");
@@ -356,8 +354,8 @@ describe("buildNavigation", () => {
         const nav = buildNavigation(root, "ref");
         expect(nav).toHaveLength(1);
         // Wrapped in section, but inner page exists (docstring = content)
-        expect(nav[0]?.type).toBe("section");
-        const section = nav[0] as { type: "section"; children: NavNode[] };
+        const section = nav[0];
+        expect.assert(section?.type === "section");
         expect(section.children).toHaveLength(1);
         expect(section.children[0]?.type).toBe("page");
     });

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
@@ -2883,19 +2883,17 @@ describe("OpenAPI v3 Parser Pipeline (--from-openapi flag)", () => {
         // Validate the basic auth scheme structure
         const basicAuthScheme = intermediateRepresentation.auth.schemes[0];
         expect(basicAuthScheme).toBeDefined();
-        expect(basicAuthScheme?.type).toBe("basic");
+        expect.assert(basicAuthScheme?.type === "basic");
 
         // Verify that x-fern-basic custom names are correctly flowing through to the IR
         // The OpenAPI spec has x-fern-basic with username.name="project_id" and password.name="api_token"
-        if (basicAuthScheme?.type === "basic") {
-            // Verify custom names from x-fern-basic are used
-            expect(basicAuthScheme.username.originalName).toBe("project_id");
-            expect(basicAuthScheme.password.originalName).toBe("api_token");
+        // Verify custom names from x-fern-basic are used
+        expect(basicAuthScheme.username.originalName).toBe("project_id");
+        expect(basicAuthScheme.password.originalName).toBe("api_token");
 
-            // Verify env vars are also passed through
-            expect(basicAuthScheme.usernameEnvVar).toBe("PLANT_STORE_PROJECT_ID");
-            expect(basicAuthScheme.passwordEnvVar).toBe("PLANT_STORE_API_TOKEN");
-        }
+        // Verify env vars are also passed through
+        expect(basicAuthScheme.usernameEnvVar).toBe("PLANT_STORE_PROJECT_ID");
+        expect(basicAuthScheme.passwordEnvVar).toBe("PLANT_STORE_API_TOKEN");
 
         // Validate FDR auth schemes
         expect(fdrApiDefinition.authSchemes).toBeDefined();
@@ -2903,12 +2901,10 @@ describe("OpenAPI v3 Parser Pipeline (--from-openapi flag)", () => {
         expect(fdrAuthSchemes).toBeDefined();
         if (fdrAuthSchemes) {
             const basicAuth = Object.values(fdrAuthSchemes).find((scheme) => scheme.type === "basicAuth");
-            expect(basicAuth).toBeDefined();
-            if (basicAuth?.type === "basicAuth") {
-                // Verify custom names from x-fern-basic flow through to FDR
-                expect(basicAuth.usernameName).toBe("project_id");
-                expect(basicAuth.passwordName).toBe("api_token");
-            }
+            expect.assert(basicAuth?.type === "basicAuth");
+            // Verify custom names from x-fern-basic flow through to FDR
+            expect(basicAuth.usernameName).toBe("project_id");
+            expect(basicAuth.passwordName).toBe("api_token");
         }
 
         // Snapshot the complete output for regression testing

--- a/packages/commons/ir-utils/src/__test__/generateTypeReferenceExample.test.ts
+++ b/packages/commons/ir-utils/src/__test__/generateTypeReferenceExample.test.ts
@@ -97,15 +97,13 @@ describe("v1 cycle detection in generateTypeReferenceExample", () => {
         const elapsed = Date.now() - start;
 
         expect(elapsed).toBeLessThan(1000);
-        expect(result.type).toBe("success");
-        if (result.type === "success") {
-            const json = result.jsonExample as Record<string, unknown>;
-            expect(json).toHaveProperty("name");
-            for (const field of selfRefFields) {
-                const nested = json[field] as Record<string, unknown>;
-                expect(nested).toBeDefined();
-                expect(nested.name).toBe("name");
-            }
+        expect.assert(result.type === "success");
+        const json = result.jsonExample as Record<string, unknown>;
+        expect(json).toHaveProperty("name");
+        for (const field of selfRefFields) {
+            const nested = json[field] as Record<string, unknown>;
+            expect(nested).toBeDefined();
+            expect(nested.name).toBe("name");
         }
     });
 
@@ -126,16 +124,14 @@ describe("v1 cycle detection in generateTypeReferenceExample", () => {
         // Now succeeds: first visit generates the object, inner "self" property
         // hits cycle limit and gets a stub empty object instead of failing.
         // The stub itself is an object with a "self" property that is also a stub.
-        expect(result.type).toBe("success");
-        if (result.type === "success") {
-            const json = result.jsonExample as Record<string, unknown>;
-            expect(json).toHaveProperty("self");
-            const inner = json.self as Record<string, unknown>;
-            // The inner stub also has "self" because it recursed one more level
-            // before hitting the limit. At the deepest level, "self" is an empty stub.
-            expect(inner).toHaveProperty("self");
-            expect(inner.self).toEqual({});
-        }
+        expect.assert(result.type === "success");
+        const json = result.jsonExample as Record<string, unknown>;
+        expect(json).toHaveProperty("self");
+        const inner = json.self as Record<string, unknown>;
+        // The inner stub also has "self" because it recursed one more level
+        // before hitting the limit. At the deepest level, "self" is an empty stub.
+        expect(inner).toHaveProperty("self");
+        expect(inner.self).toEqual({});
     });
 
     it("should detect triangle cycle (A -> B -> C -> A) with optional back-edge", () => {
@@ -154,38 +150,36 @@ describe("v1 cycle detection in generateTypeReferenceExample", () => {
             skipOptionalProperties: false
         });
 
-        expect(result.type).toBe("success");
-        if (result.type === "success") {
-            const json = result.jsonExample as Record<string, unknown>;
-            expect(json).toHaveProperty("value");
-            expect(json).toHaveProperty("toB");
-            const toB = json.toB as Record<string, unknown>;
-            expect(toB).toHaveProperty("value");
-            expect(toB).toHaveProperty("toC");
-            const toC = toB.toC as Record<string, unknown>;
-            expect(toC).toHaveProperty("value");
-            expect(toC).toHaveProperty("toA");
-            const toA = toC.toA as Record<string, unknown>;
-            expect(toA).toHaveProperty("value");
-            expect(toA).toHaveProperty("toB");
-            const toB2 = toA.toB as Record<string, unknown>;
-            expect(toB2).toHaveProperty("value");
-            expect(toB2).toHaveProperty("toC");
-            const toC2 = toB2.toC as Record<string, unknown>;
-            expect(toC2).toHaveProperty("value");
-            // toA gets a stub with leaf properties and non-leaf named properties filled in recursively.
-            // The visited set prevents infinite recursion (A is visited, so toA inside C's minimal stub
-            // won't recurse back into A again).
-            expect(toC2.toA).toEqual({
+        expect.assert(result.type === "success");
+        const json = result.jsonExample as Record<string, unknown>;
+        expect(json).toHaveProperty("value");
+        expect(json).toHaveProperty("toB");
+        const toB = json.toB as Record<string, unknown>;
+        expect(toB).toHaveProperty("value");
+        expect(toB).toHaveProperty("toC");
+        const toC = toB.toC as Record<string, unknown>;
+        expect(toC).toHaveProperty("value");
+        expect(toC).toHaveProperty("toA");
+        const toA = toC.toA as Record<string, unknown>;
+        expect(toA).toHaveProperty("value");
+        expect(toA).toHaveProperty("toB");
+        const toB2 = toA.toB as Record<string, unknown>;
+        expect(toB2).toHaveProperty("value");
+        expect(toB2).toHaveProperty("toC");
+        const toC2 = toB2.toC as Record<string, unknown>;
+        expect(toC2).toHaveProperty("value");
+        // toA gets a stub with leaf properties and non-leaf named properties filled in recursively.
+        // The visited set prevents infinite recursion (A is visited, so toA inside C's minimal stub
+        // won't recurse back into A again).
+        expect(toC2.toA).toEqual({
+            value: "value",
+            toB: {
                 value: "value",
-                toB: {
-                    value: "value",
-                    toC: {
-                        value: "value"
-                    }
+                toC: {
+                    value: "value"
                 }
-            });
-        }
+            }
+        });
     });
 
     it("should allow same type in sibling branches (backtracking correctness)", () => {
@@ -203,12 +197,10 @@ describe("v1 cycle detection in generateTypeReferenceExample", () => {
             skipOptionalProperties: false
         });
 
-        expect(result.type).toBe("success");
-        if (result.type === "success") {
-            const json = result.jsonExample as Record<string, unknown>;
-            expect(json.child1).toEqual({ data: "data" });
-            expect(json.child2).toEqual({ data: "data" });
-        }
+        expect.assert(result.type === "success");
+        const json = result.jsonExample as Record<string, unknown>;
+        expect(json.child1).toEqual({ data: "data" });
+        expect(json.child2).toEqual({ data: "data" });
     });
 
     it("should generate stubs for 3-way cycle with required fields (BulkSchedule-like)", () => {
@@ -244,22 +236,20 @@ describe("v1 cycle detection in generateTypeReferenceExample", () => {
             skipOptionalProperties: false
         });
 
-        expect(result.type).toBe("success");
-        if (result.type === "success") {
-            const json = result.jsonExample as Record<string, unknown>;
-            expect(json).toHaveProperty("frequency");
-            expect(json).toHaveProperty("multi");
-            const multi = json.multi as Record<string, unknown>;
-            expect(multi).toHaveProperty("schedules");
-            const schedules = multi.schedules as Array<Record<string, unknown>>;
-            // The list should have items (not be empty) because ItemSchedule.schedule
-            // now gets a stub with leaf properties instead of failing
-            expect(schedules.length).toBeGreaterThan(0);
-            expect(schedules[0]).toHaveProperty("item");
-            expect(schedules[0]).toHaveProperty("schedule");
-            // The stub for BulkSchedule at cycle limit includes its leaf property "frequency"
-            const stubSchedule = schedules[0]?.schedule as Record<string, unknown>;
-            expect(stubSchedule).toHaveProperty("frequency");
-        }
+        expect.assert(result.type === "success");
+        const json = result.jsonExample as Record<string, unknown>;
+        expect(json).toHaveProperty("frequency");
+        expect(json).toHaveProperty("multi");
+        const multi = json.multi as Record<string, unknown>;
+        expect(multi).toHaveProperty("schedules");
+        const schedules = multi.schedules as Array<Record<string, unknown>>;
+        // The list should have items (not be empty) because ItemSchedule.schedule
+        // now gets a stub with leaf properties instead of failing
+        expect(schedules.length).toBeGreaterThan(0);
+        expect(schedules[0]).toHaveProperty("item");
+        expect(schedules[0]).toHaveProperty("schedule");
+        // The stub for BulkSchedule at cycle limit includes its leaf property "frequency"
+        const stubSchedule = schedules[0]?.schedule as Record<string, unknown>;
+        expect(stubSchedule).toHaveProperty("frequency");
     });
 });


### PR DESCRIPTION
## Description

Refs: Vitest v4 `expect.assert()` adoption

Replaces manual type narrowing patterns (`if`-blocks, `as`-casts, conditional expects) with vitest's `expect.assert()` across 10 test files. This leverages the TypeScript `asserts condition` return type so the compiler narrows discriminated unions after the assertion, removing the need for manual casts or guarded blocks.

[Link to Devin run](https://app.devin.ai/sessions/4c4e4bc3cae84f3c95b3598f0a31fa26) | Requested by @Swimburger

## Changes Made

- Replaced `if (x?.type === "value") { ...assertions... }` patterns with `expect.assert(x?.type === "value"); ...assertions...` — assertions now run unconditionally (previously silently skipped if the type didn't match)
- Replaced `as` type casts (e.g., `nav[0] as { type: "section"; ... }`) with `expect.assert()` for runtime-validated narrowing
- Replaced `expect(x).toBeDefined(); expect(x?.type).toBe("value")` pairs with `expect.assert(x != null); expect.assert(x.type === "value")`
- Removed `/* eslint-disable jest/no-conditional-expect */` and several `biome-ignore` comments that are no longer needed
- Files changed:
  - `convertGeneratorsConfiguration.test.ts`
  - `writers.test.ts` and `integration.test.ts` (library-docs-generator)
  - `convertSecurityScheme.test.ts`
  - `navigationUtils.test.ts`
  - `availability-inheritance.test.ts`
  - `graphql-operation-layout.test.ts`
  - `migrateFromV65ToV63.test.ts`
  - `openapi-from-flag.test.ts`
  - `generateTypeReferenceExample.test.ts`

## ⚠️ Items for human review

1. **Behavioral change — silent skip → hard failure**: Previously, `if (x.type === "foo") { expect(...) }` would silently skip inner assertions when the condition was false. Now `expect.assert()` will fail the test. This is intentional but means **any previously-hidden type mismatches will surface as test failures**.
2. **`integration.test.ts` line ~288**: `for (const page of pages) { expect.assert(page.type === "page") }` — the original `if` only ran assertions on pages that matched; the new code asserts *every* item is a page. Verify that `flattenNav` only returns page nodes in this context.
3. **Optional chain narrowing**: Patterns like `expect.assert(x?.type === "section")` rely on vitest correctly narrowing through optional chains. If any of these don't narrow as expected at the type level, downstream property accesses would produce TS errors (should be caught by CI).

## Testing

- [x] Local `pnpm run check` (biome) passes (only pre-existing unrelated warning in `ir.test.ts`)
- [ ] CI — affected test suites should pass with the new unconditional assertions