### PR TITLE
fix(ci): use pnpm pack in live-test to resolve catalog: protocol references

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.82.1
+  changelogEntry:
+    - summary: |
+        Fix `live-test` CI job failing with `EUNSUPPORTEDPROTOCOL` error when installing the CLI
+        tarball. The build script writes pnpm `catalog:` protocol references into the dist
+        `package.json`, which `npm pack` passed through verbatim. Switched to `pnpm pack` so
+        that catalog references are resolved to real version numbers before the tarball is created.
+      type: fix
+  createdAt: "2026-02-23"
+  irVersion: 65
 - version: 3.82.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,14 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.82.1
-  changelogEntry:
-    - summary: |
-        Fix `live-test` CI job failing with `EUNSUPPORTEDPROTOCOL` error when installing the CLI
-        tarball. The build script writes pnpm `catalog:` protocol references into the dist
-        `package.json`, which `npm pack` passed through verbatim. Switched to `pnpm pack` so
-        that catalog references are resolved to real version numbers before the tarball is created.
-      type: fix
-  createdAt: "2026-02-23"
-  irVersion: 65
 - version: 3.82.0
   changelogEntry:
     - summary: |

--- a/scripts/live-test.sh
+++ b/scripts/live-test.sh
@@ -15,7 +15,7 @@ if [ "$test_tarball" = "true" ]; then
     
     echo "Creating tarball from $cli_dir..."
     cd "$cli_dir"
-    tarball_path="$(npm pack 2>&1 | tail -n 1)"
+    tarball_path="$(pnpm pack 2>&1 | tail -n 1)"
     echo "Created tarball: $tarball_path"
     
     install_dir="$(mktemp -d)"


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/actions/runs/22295532461/job/64491293585

Fixes the `live-test` CI job failing with `npm error Unsupported URL Type "catalog:": catalog:` when installing the CLI tarball.

Link to Devin run: https://app.devin.ai/sessions/2a255daa98e743ff81c43e2732607ad9
Requested by: @Swimburger

## Changes Made

- **`scripts/live-test.sh`**: Switched `npm pack` → `pnpm pack` so that pnpm resolves `catalog:` protocol references to real version numbers in the tarball's `package.json` before installation.

### Root Cause

The CLI build script (`build-utils.mjs` → `getDependencyVersion()`) reads dependency versions from `package.json` and writes them verbatim into the dist `package.json`. After the migration to pnpm catalogs, these versions are the string `"catalog:"` rather than actual semver ranges. `pnpm publish` (used in the real publish flow) resolves these automatically, but the live-test was using `npm pack` which does not understand the `catalog:` protocol.

## Testing

- Verified locally that `pnpm pack` in `dist/prod/` produces a tarball whose `package.json` has resolved versions (e.g. `@boundaryml/baml: "^0.211.2"`, `cli-progress: "^3.12.0"`) instead of `"catalog:"`.
- Verified `npm install` of the resulting tarball succeeds.

## Human Review Checklist

- [ ] Confirm `pnpm pack 2>&1 | tail -n 1` output parsing is compatible across CI environments (locally tested — outputs tarball filename on last line like `npm pack`)
- [ ] Note: `packages/seed/build.mjs` has a similar latent issue (line 46 reads `packageJson.dependencies["@boundaryml/baml"]` which is `"catalog:"`), but seed is internal tooling and not published — not addressed here