### PR TITLE
chore(cli): improve ete test reliability with fixed ports and timeouts

### DIFF
--- a/packages/cli/ete-tests/src/tests/docs-dev/docsDev.test.ts
+++ b/packages/cli/ete-tests/src/tests/docs-dev/docsDev.test.ts
@@ -6,6 +6,11 @@ import { captureFernCli, runFernCli } from "../../utils/runFernCli.js";
 
 const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
 
+// Use high-numbered ports unlikely to conflict with common services
+const LEGACY_PORT = "47100";
+const BETA_BACKEND_PORT = "47101";
+const DEFAULT_BACKEND_PORT = "47102";
+
 describe.sequential("fern docs dev --legacy", () => {
     it("basic docs --legacy", async () => {
         const check = await runFernCli(["check"], {
@@ -14,11 +19,11 @@ describe.sequential("fern docs dev --legacy", () => {
 
         expect(check.exitCode).toBe(0);
 
-        const process = captureFernCli(["docs", "dev", "--legacy"], {
+        const process = captureFernCli(["docs", "dev", "--legacy", "--port", LEGACY_PORT], {
             cwd: join(fixturesDir, RelativeFilePath.of("simple"))
         });
 
-        const response = await waitForServer("http://localhost:3000/v2/registry/docs/load-with-url", {
+        const response = await waitForServer(`http://localhost:${LEGACY_PORT}/v2/registry/docs/load-with-url`, {
             method: "POST"
         });
 
@@ -46,12 +51,12 @@ describe.sequential("fern docs dev --beta", () => {
 
         expect(check.exitCode).toBe(0);
 
-        const process = captureFernCli(["docs", "dev", "--beta", "--backend-port", "3001"], {
+        const process = captureFernCli(["docs", "dev", "--beta", "--backend-port", BETA_BACKEND_PORT], {
             cwd: join(fixturesDir, RelativeFilePath.of("simple")),
             reject: true
         });
 
-        const response = await waitForServer("http://localhost:3001/v2/registry/docs/load-with-url", {
+        const response = await waitForServer(`http://localhost:${BETA_BACKEND_PORT}/v2/registry/docs/load-with-url`, {
             method: "POST"
         });
 
@@ -77,13 +82,14 @@ describe.sequential("fern docs dev", () => {
 
         expect(check.exitCode).toBe(0);
 
-        const process = captureFernCli(["docs", "dev", "--backend-port", "3002"], {
+        const process = captureFernCli(["docs", "dev", "--backend-port", DEFAULT_BACKEND_PORT], {
             cwd: join(fixturesDir, RelativeFilePath.of("simple"))
         });
 
-        const response = await waitForServer("http://localhost:3002/v2/registry/docs/load-with-url", {
-            method: "POST"
-        });
+        const response = await waitForServer(
+            `http://localhost:${DEFAULT_BACKEND_PORT}/v2/registry/docs/load-with-url`,
+            { method: "POST" }
+        );
 
         expect(response.body != null).toEqual(true);
         const responseText = await response.text();
@@ -93,6 +99,9 @@ describe.sequential("fern docs dev", () => {
         expect(typeof responseBody === "object").toEqual(true);
         // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
         expect(Object.keys(responseBody as any)).toEqual(["baseUrl", "definition", "lightModeEnabled", "orgId"]);
+
+        const finishProcess = process.kill();
+        expect(finishProcess).toBeTruthy();
     }, 90_000);
 });
 

--- a/packages/cli/ete-tests/src/tests/generate/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate.test.ts
@@ -19,6 +19,9 @@ describe("fern generate", () => {
     }, 180_000);
 
     it.concurrent("ir contains fdr definitionid", async () => {
+        if (globalThis.process.env.FERN_ORG_TOKEN_DEV == null) {
+            throw new Error("FERN_ORG_TOKEN_DEV is not set");
+        }
         const { stdout, stderr } = await runFernCli(["generate", "--log-level", "debug"], {
             cwd: join(fixturesDir, RelativeFilePath.of("basic")),
             reject: false
@@ -32,21 +35,17 @@ describe("fern generate", () => {
             throw new Error(`Failed to get path to IR:\n${stdout}`);
         }
 
-        const process = exec(
-            `./ir-contains-fdr-definition-id.sh ${filepath}`,
-            { cwd: __dirname },
-            (error, stdout, stderr) => {
-                if (error) {
-                    console.error(`Error: ${error.message}`);
-                    return;
-                }
-                if (stderr) {
-                    console.error(`stderr: ${stderr}`);
-                    return;
-                }
-                console.log(`stdout: ${stdout}`);
+        exec(`./ir-contains-fdr-definition-id.sh ${filepath}`, { cwd: __dirname }, (error, stdout, stderr) => {
+            if (error) {
+                console.error(`Error: ${error.message}`);
+                return;
             }
-        );
+            if (stderr) {
+                console.error(`stderr: ${stderr}`);
+                return;
+            }
+            console.log(`stdout: ${stdout}`);
+        });
     }, 180_000);
 
     // TODO: Re-enable this test if and when it doesn't require the user to be logged in.
@@ -67,7 +66,7 @@ describe("fern generate", () => {
     }, 180_000);
 
     it.concurrent("generate docs with no auth requires login", async () => {
-        const { stdout, stderr } = await runFernCliWithoutAuthToken(["generate", "--docs"], {
+        const { stdout, stderr } = await runFernCliWithoutAuthToken(["generate", "--docs", "--no-prompt"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
             env: {
@@ -81,7 +80,7 @@ describe("fern generate", () => {
     }, 180_000);
 
     it.concurrent("generate docs with auth bypass fails", async () => {
-        const { stdout } = await runFernCliWithoutAuthToken(["generate", "--docs"], {
+        const { stdout } = await runFernCliWithoutAuthToken(["generate", "--docs", "--no-prompt"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
             env: {
@@ -93,7 +92,7 @@ describe("fern generate", () => {
     }, 180_000);
 
     it.concurrent("generate docs with auth bypass succeeds", async () => {
-        const { stdout } = await runFernCliWithoutAuthToken(["generate", "--docs"], {
+        const { stdout } = await runFernCliWithoutAuthToken(["generate", "--docs", "--no-prompt"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
             env: {

--- a/packages/cli/ete-tests/src/tests/ir/ir.test.ts
+++ b/packages/cli/ete-tests/src/tests/ir/ir.test.ts
@@ -80,7 +80,6 @@ describe("ir", () => {
                     audiences: fixture.audiences,
                     version: fixture.version
                 });
-                // biome-ignore lint/suspicious/noMisplacedAssertion: allow
                 expect(irContents).toMatchSnapshot();
             },
             90_000
@@ -95,7 +94,7 @@ describe("ir", () => {
         });
         await tmpFile.cleanup();
         expect(stdout).toContain("Wrote IR to");
-    }, 10_000);
+    }, 30_000);
 
     it.concurrent("fails with invalid version", async ({ expect }) => {
         const tmpFile = await tmp.file({ postfix: ".json" });
@@ -105,7 +104,7 @@ describe("ir", () => {
         });
         await tmpFile.cleanup();
         expect(stdout).toContain("IR v100 does not exist");
-    }, 10_000);
+    }, 30_000);
 });
 
 describe("ir from proto", () => {


### PR DESCRIPTION
- Use high-numbered fixed ports (47100-47102) for docs dev tests to avoid conflicts with common services
- Add process.kill() and assertion to docs dev test to match pattern used in other describe.sequential blocks
- Add FERN_ORG_TOKEN_DEV guard to skip IR/FDR test when token is not set
- Add --no-prompt flag to generate docs tests to avoid interactive prompts
- Increase IR test timeouts from 10s to 30s
