### PR TITLE
chore(internal): remove development/source exports from package.json files

### DIFF
--- a/generators/base/package.json
+++ b/generators/base/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/base/package.json
+++ b/generators/base/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/browser-compatible-base/package.json
+++ b/generators/browser-compatible-base/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/browser-compatible-base/package.json
+++ b/generators/browser-compatible-base/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/csharp/codegen/package.json
+++ b/generators/csharp/codegen/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/csharp/codegen/package.json
+++ b/generators/csharp/codegen/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/csharp/dynamic-snippets/package.json
+++ b/generators/csharp/dynamic-snippets/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/csharp/dynamic-snippets/package.json
+++ b/generators/csharp/dynamic-snippets/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/csharp/formatter/package.json
+++ b/generators/csharp/formatter/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/csharp/formatter/package.json
+++ b/generators/csharp/formatter/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/csharp/model/package.json
+++ b/generators/csharp/model/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/csharp/model/package.json
+++ b/generators/csharp/model/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/go-v2/ast/package.json
+++ b/generators/go-v2/ast/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/go-v2/ast/package.json
+++ b/generators/go-v2/ast/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/go-v2/base/package.json
+++ b/generators/go-v2/base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/go-v2/base/package.json
+++ b/generators/go-v2/base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/go-v2/dynamic-snippets/package.json
+++ b/generators/go-v2/dynamic-snippets/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/go-v2/dynamic-snippets/package.json
+++ b/generators/go-v2/dynamic-snippets/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/go-v2/formatter/package.json
+++ b/generators/go-v2/formatter/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/go-v2/formatter/package.json
+++ b/generators/go-v2/formatter/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/go-v2/model/package.json
+++ b/generators/go-v2/model/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/go-v2/model/package.json
+++ b/generators/go-v2/model/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/go-v2/sdk/package.json
+++ b/generators/go-v2/sdk/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/go-v2/sdk/package.json
+++ b/generators/go-v2/sdk/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/java-v2/ast/package.json
+++ b/generators/java-v2/ast/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/java-v2/ast/package.json
+++ b/generators/java-v2/ast/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/java-v2/base/package.json
+++ b/generators/java-v2/base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/java-v2/base/package.json
+++ b/generators/java-v2/base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/java-v2/dynamic-snippets/package.json
+++ b/generators/java-v2/dynamic-snippets/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/java-v2/dynamic-snippets/package.json
+++ b/generators/java-v2/dynamic-snippets/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/openapi/package.json
+++ b/generators/openapi/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/openapi/package.json
+++ b/generators/openapi/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/php/base/package.json
+++ b/generators/php/base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/php/base/package.json
+++ b/generators/php/base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/php/codegen/package.json
+++ b/generators/php/codegen/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/php/codegen/package.json
+++ b/generators/php/codegen/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/php/dynamic-snippets/package.json
+++ b/generators/php/dynamic-snippets/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/php/dynamic-snippets/package.json
+++ b/generators/php/dynamic-snippets/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/php/model/package.json
+++ b/generators/php/model/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/php/model/package.json
+++ b/generators/php/model/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/php/sdk/package.json
+++ b/generators/php/sdk/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/php/sdk/package.json
+++ b/generators/php/sdk/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/postman/package.json
+++ b/generators/postman/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/postman/package.json
+++ b/generators/postman/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/python-v2/ast/package.json
+++ b/generators/python-v2/ast/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/python-v2/ast/package.json
+++ b/generators/python-v2/ast/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/python-v2/base/package.json
+++ b/generators/python-v2/base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/python-v2/base/package.json
+++ b/generators/python-v2/base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/python-v2/browser-compatible-base/package.json
+++ b/generators/python-v2/browser-compatible-base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/python-v2/browser-compatible-base/package.json
+++ b/generators/python-v2/browser-compatible-base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/python-v2/dynamic-snippets/package.json
+++ b/generators/python-v2/dynamic-snippets/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/python-v2/dynamic-snippets/package.json
+++ b/generators/python-v2/dynamic-snippets/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/python-v2/fastapi/package.json
+++ b/generators/python-v2/fastapi/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/python-v2/fastapi/package.json
+++ b/generators/python-v2/fastapi/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/python-v2/formatter/package.json
+++ b/generators/python-v2/formatter/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/python-v2/formatter/package.json
+++ b/generators/python-v2/formatter/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/python-v2/pydantic-model/package.json
+++ b/generators/python-v2/pydantic-model/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/python-v2/pydantic-model/package.json
+++ b/generators/python-v2/pydantic-model/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/python-v2/sdk/package.json
+++ b/generators/python-v2/sdk/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/ruby-v2/ast/package.json
+++ b/generators/ruby-v2/ast/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/ruby-v2/ast/package.json
+++ b/generators/ruby-v2/ast/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/ruby-v2/base/package.json
+++ b/generators/ruby-v2/base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/ruby-v2/base/package.json
+++ b/generators/ruby-v2/base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/ruby-v2/dynamic-snippets/package.json
+++ b/generators/ruby-v2/dynamic-snippets/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/ruby-v2/dynamic-snippets/package.json
+++ b/generators/ruby-v2/dynamic-snippets/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/ruby-v2/model/package.json
+++ b/generators/ruby-v2/model/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/ruby-v2/model/package.json
+++ b/generators/ruby-v2/model/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/ruby-v2/sdk/package.json
+++ b/generators/ruby-v2/sdk/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/ruby-v2/sdk/package.json
+++ b/generators/ruby-v2/sdk/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/rust/base/package.json
+++ b/generators/rust/base/package.json
@@ -10,15 +10,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/generators/rust/codegen/package.json
+++ b/generators/rust/codegen/package.json
@@ -10,15 +10,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/generators/rust/dynamic-snippets/package.json
+++ b/generators/rust/dynamic-snippets/package.json
@@ -9,8 +9,6 @@
   },
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
@@ -18,7 +16,6 @@
   },
   "main": "lib/index.js",
   "module": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/generators/rust/model/package.json
+++ b/generators/rust/model/package.json
@@ -10,15 +10,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/generators/rust/sdk/package.json
+++ b/generators/rust/sdk/package.json
@@ -10,15 +10,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/generators/swift/base/package.json
+++ b/generators/swift/base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/swift/base/package.json
+++ b/generators/swift/base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/swift/codegen/package.json
+++ b/generators/swift/codegen/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/swift/codegen/package.json
+++ b/generators/swift/codegen/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/swift/dynamic-snippets/package.json
+++ b/generators/swift/dynamic-snippets/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/swift/dynamic-snippets/package.json
+++ b/generators/swift/dynamic-snippets/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/swift/model/package.json
+++ b/generators/swift/model/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/swift/model/package.json
+++ b/generators/swift/model/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/swift/sdk/package.json
+++ b/generators/swift/sdk/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/cli.js",
-  "source": "src/cli.ts",
   "types": "lib/cli.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/swift/sdk/package.json
+++ b/generators/swift/sdk/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/cli.js",
   "types": "lib/cli.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript-v2/ast/package.json
+++ b/generators/typescript-v2/ast/package.json
@@ -9,17 +9,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript-v2/ast/package.json
+++ b/generators/typescript-v2/ast/package.json
@@ -16,9 +16,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript-v2/base/package.json
+++ b/generators/typescript-v2/base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript-v2/base/package.json
+++ b/generators/typescript-v2/base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript-v2/browser-compatible-base/package.json
+++ b/generators/typescript-v2/browser-compatible-base/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript-v2/browser-compatible-base/package.json
+++ b/generators/typescript-v2/browser-compatible-base/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript-v2/dynamic-snippets/package.json
+++ b/generators/typescript-v2/dynamic-snippets/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript-v2/dynamic-snippets/package.json
+++ b/generators/typescript-v2/dynamic-snippets/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript-v2/formatter/package.json
+++ b/generators/typescript-v2/formatter/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript-v2/formatter/package.json
+++ b/generators/typescript-v2/formatter/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/cli/package.json
+++ b/generators/typescript/express/cli/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript/express/cli/package.json
+++ b/generators/typescript/express/cli/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-error-generator/package.json
+++ b/generators/typescript/express/express-error-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-error-generator/package.json
+++ b/generators/typescript/express/express-error-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-error-schema-generator/package.json
+++ b/generators/typescript/express/express-error-schema-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-error-schema-generator/package.json
+++ b/generators/typescript/express/express-error-schema-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-inlined-request-body-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-inlined-request-body-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-register-generator/package.json
+++ b/generators/typescript/express/express-register-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-register-generator/package.json
+++ b/generators/typescript/express/express-register-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-service-generator/package.json
+++ b/generators/typescript/express/express-service-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-service-generator/package.json
+++ b/generators/typescript/express/express-service-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/generator/package.json
+++ b/generators/typescript/express/generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/generator/package.json
+++ b/generators/typescript/express/generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/generic-express-error-generators/package.json
+++ b/generators/typescript/express/generic-express-error-generators/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/generic-express-error-generators/package.json
+++ b/generators/typescript/express/generic-express-error-generators/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/generic-sdk-error-generators/package.json
+++ b/generators/typescript/sdk/generic-sdk-error-generators/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/generic-sdk-error-generators/package.json
+++ b/generators/typescript/sdk/generic-sdk-error-generators/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/abstract-error-class-generator/package.json
+++ b/generators/typescript/utils/abstract-error-class-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/abstract-error-class-generator/package.json
+++ b/generators/typescript/utils/abstract-error-class-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/abstract-schema-generator/package.json
+++ b/generators/typescript/utils/abstract-schema-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/abstract-schema-generator/package.json
+++ b/generators/typescript/utils/abstract-schema-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/ai/package.json
+++ b/packages/cli/ai/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/ai/package.json
+++ b/packages/cli/ai/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/asyncapi-to-ir/package.json
+++ b/packages/cli/api-importers/asyncapi-to-ir/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/asyncapi-to-ir/package.json
+++ b/packages/cli/api-importers/asyncapi-to-ir/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/commons/package.json
+++ b/packages/cli/api-importers/commons/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/commons/package.json
+++ b/packages/cli/api-importers/commons/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/conjure/conjure-sdk/package.json
+++ b/packages/cli/api-importers/conjure/conjure-sdk/package.json
@@ -11,15 +11,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/cli/api-importers/conjure/conjure-to-fern-tests/package.json
+++ b/packages/cli/api-importers/conjure/conjure-to-fern-tests/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/conjure/conjure-to-fern-tests/package.json
+++ b/packages/cli/api-importers/conjure/conjure-to-fern-tests/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/conjure/conjure-to-fern/package.json
+++ b/packages/cli/api-importers/conjure/conjure-to-fern/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/conjure/conjure-to-fern/package.json
+++ b/packages/cli/api-importers/conjure/conjure-to-fern/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/graphql/package.json
+++ b/packages/cli/api-importers/graphql/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/graphql/package.json
+++ b/packages/cli/api-importers/graphql/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi-pruner/package.json
+++ b/packages/cli/api-importers/openapi-pruner/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi-pruner/package.json
+++ b/packages/cli/api-importers/openapi-pruner/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi-to-ir/package.json
+++ b/packages/cli/api-importers/openapi-to-ir/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi-to-ir/package.json
+++ b/packages/cli/api-importers/openapi-to-ir/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openapi/openapi-ir/package.json
+++ b/packages/cli/api-importers/openapi/openapi-ir/package.json
@@ -11,15 +11,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/cli/api-importers/openrpc-to-ir/package.json
+++ b/packages/cli/api-importers/openrpc-to-ir/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/openrpc-to-ir/package.json
+++ b/packages/cli/api-importers/openrpc-to-ir/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/v3-importer-commons/package.json
+++ b/packages/cli/api-importers/v3-importer-commons/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/v3-importer-commons/package.json
+++ b/packages/cli/api-importers/v3-importer-commons/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/v3-importer-tests/package.json
+++ b/packages/cli/api-importers/v3-importer-tests/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/api-importers/v3-importer-tests/package.json
+++ b/packages/cli/api-importers/v3-importer-tests/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/auth/package.json
+++ b/packages/cli/auth/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/auth/package.json
+++ b/packages/cli/auth/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/cli-logger/package.json
+++ b/packages/cli/cli-logger/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/cli-logger/package.json
+++ b/packages/cli/cli-logger/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/cli-migrations/package.json
+++ b/packages/cli/cli-migrations/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/cli-migrations/package.json
+++ b/packages/cli/cli-migrations/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/cli-source-resolver/package.json
+++ b/packages/cli/cli-source-resolver/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/cli-source-resolver/package.json
+++ b/packages/cli/cli-source-resolver/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -23,9 +23,7 @@
     "fern:local": "./dist/cli.cjs",
     "fern:prod": "./dist/cli.cjs"
   },
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -11,22 +11,21 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "bin": {
     "fern:dev": "./dist/cli.cjs",
     "fern:local": "./dist/cli.cjs",
     "fern:prod": "./dist/cli.cjs"
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/cli/config/package.json
+++ b/packages/cli/config/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/config/package.json
+++ b/packages/cli/config/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/configuration-loader/package.json
+++ b/packages/cli/configuration-loader/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/configuration-loader/package.json
+++ b/packages/cli/configuration-loader/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-importers/commons/package.json
+++ b/packages/cli/docs-importers/commons/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-importers/commons/package.json
+++ b/packages/cli/docs-importers/commons/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-importers/mintlify/package.json
+++ b/packages/cli/docs-importers/mintlify/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-importers/mintlify/package.json
+++ b/packages/cli/docs-importers/mintlify/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-importers/readme/package.json
+++ b/packages/cli/docs-importers/readme/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-importers/readme/package.json
+++ b/packages/cli/docs-importers/readme/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-markdown-utils/package.json
+++ b/packages/cli/docs-markdown-utils/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-markdown-utils/package.json
+++ b/packages/cli/docs-markdown-utils/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-resolver/package.json
+++ b/packages/cli/docs-resolver/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/docs-resolver/package.json
+++ b/packages/cli/docs-resolver/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/fern-definition/formatter/package.json
+++ b/packages/cli/fern-definition/formatter/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/fern-definition/formatter/package.json
+++ b/packages/cli/fern-definition/formatter/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/fern-definition/ir-to-jsonschema/package.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/fern-definition/ir-to-jsonschema/package.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/fern-definition/schema/package.json
+++ b/packages/cli/fern-definition/schema/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/fern-definition/schema/package.json
+++ b/packages/cli/fern-definition/schema/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/fern-definition/validator/package.json
+++ b/packages/cli/fern-definition/validator/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/fern-definition/validator/package.json
+++ b/packages/cli/fern-definition/validator/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/ir-generator-tests/package.json
+++ b/packages/cli/generation/ir-generator-tests/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/ir-generator-tests/package.json
+++ b/packages/cli/generation/ir-generator-tests/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/ir-generator/package.json
+++ b/packages/cli/generation/ir-generator/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/ir-generator/package.json
+++ b/packages/cli/generation/ir-generator/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/ir-migrations/package.json
+++ b/packages/cli/generation/ir-migrations/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/ir-migrations/package.json
+++ b/packages/cli/generation/ir-migrations/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/local-generation/docker-utils/package.json
+++ b/packages/cli/generation/local-generation/docker-utils/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/local-generation/docker-utils/package.json
+++ b/packages/cli/generation/local-generation/docker-utils/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/local-generation/local-workspace-runner/package.json
+++ b/packages/cli/generation/local-generation/local-workspace-runner/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/local-generation/local-workspace-runner/package.json
+++ b/packages/cli/generation/local-generation/local-workspace-runner/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/protoc-gen-fern/package.json
+++ b/packages/cli/generation/protoc-gen-fern/package.json
@@ -11,15 +11,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "bin": {
     "protoc-gen-fern": "bin/protoc-gen-fern"

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/source-resolver/package.json
+++ b/packages/cli/generation/source-resolver/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/generation/source-resolver/package.json
+++ b/packages/cli/generation/source-resolver/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/init/package.json
+++ b/packages/cli/init/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/init/package.json
+++ b/packages/cli/init/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/library-docs-generator/package.json
+++ b/packages/cli/library-docs-generator/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/library-docs-generator/package.json
+++ b/packages/cli/library-docs-generator/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/logger/package.json
+++ b/packages/cli/logger/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/logger/package.json
+++ b/packages/cli/logger/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/login/package.json
+++ b/packages/cli/login/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/login/package.json
+++ b/packages/cli/login/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/mock/package.json
+++ b/packages/cli/mock/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/mock/package.json
+++ b/packages/cli/mock/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/project-loader/package.json
+++ b/packages/cli/project-loader/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/project-loader/package.json
+++ b/packages/cli/project-loader/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/register/package.json
+++ b/packages/cli/register/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/register/package.json
+++ b/packages/cli/register/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/semver-utils/package.json
+++ b/packages/cli/semver-utils/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/semver-utils/package.json
+++ b/packages/cli/semver-utils/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/source/package.json
+++ b/packages/cli/source/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/source/package.json
+++ b/packages/cli/source/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/task-context/package.json
+++ b/packages/cli/task-context/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/task-context/package.json
+++ b/packages/cli/task-context/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/browser-compatible-fern-workspace/package.json
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/browser-compatible-fern-workspace/package.json
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/commons/package.json
+++ b/packages/cli/workspace/commons/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/commons/package.json
+++ b/packages/cli/workspace/commons/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/lazy-fern-workspace/package.json
+++ b/packages/cli/workspace/lazy-fern-workspace/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/lazy-fern-workspace/package.json
+++ b/packages/cli/workspace/lazy-fern-workspace/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/loader/package.json
+++ b/packages/cli/workspace/loader/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/loader/package.json
+++ b/packages/cli/workspace/loader/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/oss-validator/package.json
+++ b/packages/cli/workspace/oss-validator/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/workspace/oss-validator/package.json
+++ b/packages/cli/workspace/oss-validator/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/yaml/generators-validator/package.json
+++ b/packages/cli/yaml/generators-validator/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/yaml/generators-validator/package.json
+++ b/packages/cli/yaml/generators-validator/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/yaml/loader/package.json
+++ b/packages/cli/yaml/loader/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/cli/yaml/loader/package.json
+++ b/packages/cli/yaml/loader/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/casings-generator/package.json
+++ b/packages/commons/casings-generator/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/casings-generator/package.json
+++ b/packages/commons/casings-generator/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/core-utils/package.json
+++ b/packages/commons/core-utils/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/core-utils/package.json
+++ b/packages/commons/core-utils/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/fs-utils/package.json
+++ b/packages/commons/fs-utils/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/fs-utils/package.json
+++ b/packages/commons/fs-utils/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/github/package.json
+++ b/packages/commons/github/package.json
@@ -18,9 +18,7 @@
   "main": "lib/index.js",
   "module": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/commons/github/package.json
+++ b/packages/commons/github/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
   "module": "src/index.ts",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/commons/ir-utils/package.json
+++ b/packages/commons/ir-utils/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/ir-utils/package.json
+++ b/packages/commons/ir-utils/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/loadable/package.json
+++ b/packages/commons/loadable/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/loadable/package.json
+++ b/packages/commons/loadable/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/logging-execa/package.json
+++ b/packages/commons/logging-execa/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/logging-execa/package.json
+++ b/packages/commons/logging-execa/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/mock-utils/package.json
+++ b/packages/commons/mock-utils/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/mock-utils/package.json
+++ b/packages/commons/mock-utils/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/path-utils/package.json
+++ b/packages/commons/path-utils/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/path-utils/package.json
+++ b/packages/commons/path-utils/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/test-utils/package.json
+++ b/packages/commons/test-utils/package.json
@@ -10,17 +10,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/commons/test-utils/package.json
+++ b/packages/commons/test-utils/package.json
@@ -17,9 +17,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -12,10 +12,7 @@
   "bin": {
     "generator-cli": "bin/cli"
   },
-  "files": [
-    "bin",
-    "dist"
-  ],
+  "files": ["bin", "dist"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "depcheck": "knip --config ../../knip.json --no-config-hints",

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -8,12 +8,14 @@
   },
   "type": "commonjs",
   "main": "dist/api.js",
-  "source": "src/index.ts",
   "types": "dist/api.d.ts",
   "bin": {
     "generator-cli": "bin/cli"
   },
-  "files": ["bin", "dist"],
+  "files": [
+    "bin",
+    "dist"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "depcheck": "knip --config ../../knip.json --no-config-hints",

--- a/packages/generator-migrations/package.json
+++ b/packages/generator-migrations/package.json
@@ -2,11 +2,7 @@
   "name": "@fern-api/generator-migrations",
   "version": "0.0.0",
   "description": "Unified migration package for all Fern generator configurations",
-  "keywords": [
-    "fern",
-    "generator",
-    "migration"
-  ],
+  "keywords": ["fern", "generator", "migration"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fern-api/fern.git",
@@ -24,9 +20,7 @@
   },
   "main": "lib/index.mjs",
   "types": "lib/index.d.mts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/generator-migrations/package.json
+++ b/packages/generator-migrations/package.json
@@ -2,7 +2,11 @@
   "name": "@fern-api/generator-migrations",
   "version": "0.0.0",
   "description": "Unified migration package for all Fern generator configurations",
-  "keywords": ["fern", "generator", "migration"],
+  "keywords": [
+    "fern",
+    "generator",
+    "migration"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fern-api/fern.git",
@@ -13,17 +17,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.mts",
       "import": "./lib/index.mjs",
       "default": "./lib/index.mjs"
     }
   },
   "main": "lib/index.mjs",
-  "source": "src/index.ts",
   "types": "lib/index.d.mts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/ir-sdk/package.json
+++ b/packages/ir-sdk/package.json
@@ -11,15 +11,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/packages/migrations-base/package.json
+++ b/packages/migrations-base/package.json
@@ -2,7 +2,12 @@
   "name": "@fern-api/migrations-base",
   "version": "0.0.0",
   "description": "Base types and utilities for Fern generator migrations",
-  "keywords": ["fern", "generator", "migration", "base"],
+  "keywords": [
+    "fern",
+    "generator",
+    "migration",
+    "base"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern.git",
@@ -13,17 +18,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/migrations-base/package.json
+++ b/packages/migrations-base/package.json
@@ -2,12 +2,7 @@
   "name": "@fern-api/migrations-base",
   "version": "0.0.0",
   "description": "Base types and utilities for Fern generator migrations",
-  "keywords": [
-    "fern",
-    "generator",
-    "migration",
-    "base"
-  ],
+  "keywords": ["fern", "generator", "migration", "base"],
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern.git",
@@ -25,9 +20,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -11,20 +11,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "bin": {
     "fern-scripts": "./lib/cli.js"
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -21,9 +21,7 @@
   "bin": {
     "fern-scripts": "./lib/cli.js"
   },
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/packages/seed/package.json
+++ b/packages/seed/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/seed/package.json
+++ b/packages/seed/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/snippets/core/package.json
+++ b/packages/snippets/core/package.json
@@ -11,17 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
-      "source": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
-  "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/packages/snippets/core/package.json
+++ b/packages/snippets/core/package.json
@@ -18,9 +18,7 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",


### PR DESCRIPTION
## Description

Refs: Performance investigation into vitest import resolution

Removes the `"development"` and `"source"` export conditions (and top-level `"source"` field) from 168 `package.json` files across `packages/` and `generators/`. This forces vitest to resolve workspace dependencies via the pre-compiled `lib/` output (`"import"` / `"default"` conditions) instead of raw TypeScript source.

Requested by: @Swimburger  
[Link to Devin run](https://app.devin.ai/sessions/5cbd7ad030694d6bb8011fe9b58759c3)

## Changes Made

- Removed `"development": "./src/index.ts"` from the `"exports"` map in 168 package.json files
- Removed `"source": "./src/index.ts"` from the `"exports"` map in those same files
- Removed top-level `"source": "src/index.ts"` field from those files
- Recompiled all packages with `pnpm compile` to ensure lib/ output matches current source
- (Side-effect) `json.dump` reformatted some single-line `"files"` arrays to multi-line

## Benchmark Results

| Package | Wall time (before) | Wall time (after) | Δ | Transform time | Tests |
|---|---|---|---|---|---|
| `core-utils` | 1.37s | 1.39s | +1% | 1.07s | ✓ 79/79 |
| `ir-utils` | 5.15s | 4.58s | **-11%** | 5.09s | ✓ 15/15 |
| `rust/codegen` | 1.19s | ~1.14s | -4% | — | ✓ |
| `csharp/codegen` | 10.8s | 9.94s | **-8%** | 30.55s (was 35.96s) | ✓ 594/594 |
| `docs-resolver` | 25.0s | 22.97s | **-8%** | 54.85s (was 63.55s) | 7 pre-existing failures |
| `fern-def/validator` | 21.0s | 19.45s | **-7%** | 71.61s (was 85.06s) | ✓ 69/69 |

**Summary:** Packages with deep cross-package dependency trees see modest wall-clock improvements (7-11%) and more significant transform-time reductions (14-16%). Leaf packages with few dependencies see negligible change. All tests pass except for pre-existing failures.

## CI Status

✅ **278 checks passing**  
⚠️ **1 check failing:** `@fern-api/register#test` — This is a **pre-existing failure on `main`** (same test fails there with identical error about missing `buf.lock`). Not caused by this PR.

## ⚠️ Reviewer Checklist

- [ ] **Verify no other tooling depends on the removed fields.** The `"development"` condition is also used by bundlers like Vite in dev mode, and the top-level `"source"` field may be used by some IDE integrations or build tools (e.g., Parcel). Confirm nothing else in the repo or CI relies on them.
- [ ] **Confirm the performance improvements justify the large diff.** This touches 168 files for a 7-11% speedup in test execution. Consider whether this tradeoff is worthwhile.
- [ ] **Cosmetic diff noise.** The script reformatted `"files": ["lib"]` to multi-line arrays across all 168 files. This is harmless but inflates the diff.

## Testing

- [x] Benchmarked vitest performance on 6 representative packages (before/after)
- [x] Verified all tests pass with recompiled lib/ output
- [x] Confirmed register test failure is pre-existing on main
- [x] CI passes (278/279 checks; 1 pre-existing failure)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->