### PR TITLE
fix(python): respect package_name config in wire test imports

### DIFF
--- a/generators/python-v2/sdk/src/SdkCustomConfig.ts
+++ b/generators/python-v2/sdk/src/SdkCustomConfig.ts
@@ -50,6 +50,7 @@ export const SdkCustomConfigSchema = z.object({
     /** @deprecated Use `wire_tests.enabled` instead */
     enable_wire_tests: z.boolean().optional(),
     package_path: relativePathSchema.optional(),
+    package_name: z.string().optional(),
     client: ClientConfigSchema.optional(),
     client_class_name: z.string().optional(),
     inline_request_params: z.boolean().optional(),

--- a/generators/python-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/python-v2/sdk/src/SdkGeneratorContext.ts
@@ -32,4 +32,23 @@ export class SdkGeneratorContext extends AbstractPythonGeneratorContext<SdkCusto
     public isSelfHosted(): boolean {
         return this.ir.selfHosted ?? false;
     }
+
+    /**
+     * Gets the full module path, prioritizing package_name from custom config.
+     */
+    public getModulePath(): string {
+        // First priority: Use package_name if set
+        if (this.customConfig.package_name != null) {
+            return this.customConfig.package_name;
+        }
+
+        // Fallback: Use organization + package_path logic
+        const orgName = this.config.organization;
+        const packagePath = this.customConfig.package_path;
+        if (packagePath) {
+            const packagePathDotted = packagePath.replace(/\//g, ".");
+            return `${orgName}.${packagePathDotted}`;
+        }
+        return orgName;
+    }
 }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -648,7 +648,7 @@ export class WireTestGenerator {
     private getClientModulePath(): string[] {
         // The client is imported from the root package module
         // e.g., "from seed import SeedExhaustive" -> modulePath is ["seed"]
-        return [this.context.config.organization];
+        return [this.context.getModulePath()];
     }
 
     private getClientClassName(): string {

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -394,27 +394,8 @@ def pytest_unconfigure(config: pytest.Config) -> None:
      */
     private getClientImport(): string {
         const clientClassName = this.getClientClassName();
-        const modulePath = this.getModulePath();
+        const modulePath = this.context.getModulePath();
         return `from ${modulePath}.client import ${clientClassName}`;
-    }
-
-    /**
-     * Gets the full module path, prioritizing package_name from custom config.
-     */
-    private getModulePath(): string {
-        // First priority: Use package_name if set
-        if (this.context.customConfig.package_name != null) {
-            return this.context.customConfig.package_name;
-        }
-
-        // Fallback: Use organization + package_path logic
-        const orgName = this.context.config.organization;
-        const packagePath = this.context.customConfig.package_path;
-        if (packagePath) {
-            const packagePathDotted = packagePath.replace(/\//g, ".");
-            return `${orgName}.${packagePathDotted}`;
-        }
-        return orgName;
     }
 
     /**
@@ -440,7 +421,7 @@ def pytest_unconfigure(config: pytest.Config) -> None:
         if (environments?.environments.type === "multipleBaseUrls") {
             const envConfig = environments.environments;
             const environmentClassName = this.getEnvironmentClassName();
-            const modulePath = this.getModulePath();
+            const modulePath = this.context.getModulePath();
 
             // Build kwargs for all base URLs using dynamic base_url variable
             const baseUrlKwargsDynamic = envConfig.baseUrls

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -399,9 +399,15 @@ def pytest_unconfigure(config: pytest.Config) -> None:
     }
 
     /**
-     * Gets the full module path including package_path if set.
+     * Gets the full module path, prioritizing package_name from custom config.
      */
     private getModulePath(): string {
+        // First priority: Use package_name if set
+        if (this.context.customConfig.package_name != null) {
+            return this.context.customConfig.package_name;
+        }
+
+        // Fallback: Use organization + package_path logic
         const orgName = this.context.config.organization;
         const packagePath = this.context.customConfig.package_path;
         if (packagePath) {

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.59.1
+  changelogEntry:
+    - summary: Fix wire test imports to respect package_name custom config, preventing import errors when users specify custom package names
+      type: fix
+  createdAt: "2026-02-23"
+  irVersion: 65
 - version: 4.59.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

Fixes an issue where wire tests weren't respecting the `package_name` custom config, causing import errors when users specify custom package names. This change centralizes the module path logic and ensures consistent import behavior across all wire test components.

## Changes Made
- **Config Schema**: Added `package_name` option to `SdkCustomConfig` for explicit package naming
- **Context Centralization**: Added `getModulePath()` method to `SdkGeneratorContext` that prioritizes `package_name` config over organization-based paths
- **Wire Test Generator**: Updated to use centralized module path logic instead of hardcoded organization name
- **Wire Test Setup**: Removed duplicate module path logic and unified import generation
- **Version Update**: Bumped to 4.59.1 with changelog entry documenting the fix

## Testing
- [x] Manual testing completed
- [x] Verified wire tests generate correct imports with custom package names
- [x] Confirmed backward compatibility with existing configurations