### PR TITLE
feat(cli): add workspace validation caching and skipValidation flag

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.84.0
+  changelogEntry:
+    - summary: |
+        Add workspace validation caching and skipValidation flag to improve toFernWorkspace()
+        performance. A global validation cache eliminates redundant JSON schema validation and
+        Zod parsing when the same files are processed by multiple workspace instances. The
+        skipValidation option allows callers to bypass JSON schema validation for known-good files.
+      type: feat
+  createdAt: "2026-02-23"
+  irVersion: 65
 - version: 3.83.2
   changelogEntry:
     - summary: |

--- a/packages/cli/workspace/lazy-fern-workspace/src/LazyFernWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/LazyFernWorkspace.ts
@@ -39,7 +39,7 @@ export class LazyFernWorkspace extends AbstractAPIWorkspace<OSSWorkspace.Setting
     }
 
     public async toFernWorkspace(
-        { context }: { context?: TaskContext },
+        { context, skipValidation }: { context?: TaskContext; skipValidation?: boolean },
         settings?: OSSWorkspace.Settings
     ): Promise<FernWorkspace> {
         const key = hash(settings ?? {});
@@ -63,7 +63,8 @@ export class LazyFernWorkspace extends AbstractAPIWorkspace<OSSWorkspace.Setting
 
             const structuralValidationResult = validateStructureOfYamlFiles({
                 files: parseResult.files,
-                absolutePathToDefinition
+                absolutePathToDefinition,
+                skipValidation
             });
             if (!structuralValidationResult.didSucceed) {
                 handleFailedWorkspaceParserResultRaw(structuralValidationResult.failures, defaultedContext.logger);

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/validateStructureOfYamlFiles.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/validateStructureOfYamlFiles.ts
@@ -133,8 +133,7 @@ export function validateStructureOfYamlFiles({
                 // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
                 const result = validateAgainstJsonSchema(parsedFileContents, PackageMarkerFileJsonSchema as any);
                 if (result.success) {
-                    const contents =
-                        RawSchemas.serialization.PackageMarkerFileSchema.parseOrThrow(parsedFileContents);
+                    const contents = RawSchemas.serialization.PackageMarkerFileSchema.parseOrThrow(parsedFileContents);
                     packageMarkerParsedCache.set(file.rawContents, contents);
                     packageMarkers[relativeFilepath] = {
                         defaultUrl: typeof contents.export === "object" ? contents.export.url : undefined,
@@ -168,8 +167,7 @@ export function validateStructureOfYamlFiles({
                 // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
                 const result = validateAgainstJsonSchema(parsedFileContents, DefinitionFileJsonSchema as any);
                 if (result.success) {
-                    const contents =
-                        RawSchemas.serialization.DefinitionFileSchema.parseOrThrow(parsedFileContents);
+                    const contents = RawSchemas.serialization.DefinitionFileSchema.parseOrThrow(parsedFileContents);
                     definitionParsedCache.set(file.rawContents, contents);
                     namesDefinitionFiles[relativeFilepath] = {
                         defaultUrl: undefined,

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/validateStructureOfYamlFiles.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/validateStructureOfYamlFiles.ts
@@ -1,7 +1,12 @@
 import { OnDiskNamedDefinitionFile, ParsedFernFile } from "@fern-api/api-workspace-commons";
 import { FERN_PACKAGE_MARKER_FILENAME, ROOT_API_FILENAME } from "@fern-api/configuration-loader";
 import { entries, validateAgainstJsonSchema } from "@fern-api/core-utils";
-import { PackageMarkerFileSchema, RawSchemas, RootApiFileSchema } from "@fern-api/fern-definition-schema";
+import {
+    DefinitionFileSchema,
+    PackageMarkerFileSchema,
+    RawSchemas,
+    RootApiFileSchema
+} from "@fern-api/fern-definition-schema";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import path from "path";
 
@@ -9,6 +14,17 @@ import * as RootApiFileJsonSchema from "../api-yml.schema.json";
 import * as DefinitionFileJsonSchema from "../fern.schema.json";
 import * as PackageMarkerFileJsonSchema from "../package-yml.schema.json";
 import { WorkspaceLoader, WorkspaceLoaderFailureType } from "./Result.js";
+
+/**
+ * Module-level caches for validated/parsed file contents.
+ * Keyed on the raw YAML string (file contents), these caches avoid redundant
+ * JSON schema validation and schema parseOrThrow calls when the same file
+ * is processed by multiple workspace instances (e.g., multiple generators
+ * in a group, or multiple test runs against the same fixtures).
+ */
+const rootApiParsedCache = new Map<string, RootApiFileSchema>();
+const definitionParsedCache = new Map<string, DefinitionFileSchema>();
+const packageMarkerParsedCache = new Map<string, PackageMarkerFileSchema>();
 
 export declare namespace validateStructureOfYamlFiles {
     export type Return = SuccessfulResult | FailedResult;
@@ -31,10 +47,18 @@ export declare namespace validateStructureOfYamlFiles {
 
 export function validateStructureOfYamlFiles({
     files,
-    absolutePathToDefinition
+    absolutePathToDefinition,
+    skipValidation
 }: {
     files: Record<RelativeFilePath, ParsedFernFile<unknown>>;
     absolutePathToDefinition: AbsoluteFilePath;
+    /**
+     * When true, skips JSON schema validation (validateAgainstJsonSchema).
+     * Schema parsing (parseOrThrow) is still performed on cache miss to ensure
+     * type-safe output. Use this when files are known to be valid (e.g., test
+     * fixtures, or when re-generating IR for a second generator in the same group).
+     */
+    skipValidation?: boolean;
 }): validateStructureOfYamlFiles.Return {
     let rootApiFile: ParsedFernFile<RootApiFileSchema> | undefined = undefined;
     const namesDefinitionFiles: Record<RelativeFilePath, OnDiskNamedDefinitionFile> = {};
@@ -56,36 +80,84 @@ export function validateStructureOfYamlFiles({
         };
 
         if (relativeFilepath === ROOT_API_FILENAME) {
-            // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
-            const result = validateAgainstJsonSchema(parsedFileContents, RootApiFileJsonSchema as any);
-            if (result.success) {
+            // Check cache first
+            const cached = rootApiParsedCache.get(file.rawContents);
+            if (cached != null) {
+                rootApiFile = {
+                    defaultUrl: cached["default-url"],
+                    contents: cached,
+                    rawContents: file.rawContents
+                };
+            } else if (skipValidation) {
+                // Skip JSON schema validation, just run parseOrThrow
                 const contents = RawSchemas.serialization.RootApiFileSchema.parseOrThrow(parsedFileContents);
+                rootApiParsedCache.set(file.rawContents, contents);
                 rootApiFile = {
                     defaultUrl: contents["default-url"],
                     contents,
                     rawContents: file.rawContents
                 };
             } else {
-                addFailure(result);
+                // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
+                const result = validateAgainstJsonSchema(parsedFileContents, RootApiFileJsonSchema as any);
+                if (result.success) {
+                    const contents = RawSchemas.serialization.RootApiFileSchema.parseOrThrow(parsedFileContents);
+                    rootApiParsedCache.set(file.rawContents, contents);
+                    rootApiFile = {
+                        defaultUrl: contents["default-url"],
+                        contents,
+                        rawContents: file.rawContents
+                    };
+                } else {
+                    addFailure(result);
+                }
             }
         } else if (path.basename(relativeFilepath) === FERN_PACKAGE_MARKER_FILENAME) {
-            // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
-            const result = validateAgainstJsonSchema(parsedFileContents, PackageMarkerFileJsonSchema as any);
-            if (result.success) {
+            // Check cache first
+            const cached = packageMarkerParsedCache.get(file.rawContents);
+            if (cached != null) {
+                packageMarkers[relativeFilepath] = {
+                    defaultUrl: typeof cached.export === "object" ? cached.export.url : undefined,
+                    contents: cached,
+                    rawContents: file.rawContents
+                };
+            } else if (skipValidation) {
                 const contents = RawSchemas.serialization.PackageMarkerFileSchema.parseOrThrow(parsedFileContents);
+                packageMarkerParsedCache.set(file.rawContents, contents);
                 packageMarkers[relativeFilepath] = {
                     defaultUrl: typeof contents.export === "object" ? contents.export.url : undefined,
                     contents,
                     rawContents: file.rawContents
                 };
             } else {
-                addFailure(result);
+                // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
+                const result = validateAgainstJsonSchema(parsedFileContents, PackageMarkerFileJsonSchema as any);
+                if (result.success) {
+                    const contents =
+                        RawSchemas.serialization.PackageMarkerFileSchema.parseOrThrow(parsedFileContents);
+                    packageMarkerParsedCache.set(file.rawContents, contents);
+                    packageMarkers[relativeFilepath] = {
+                        defaultUrl: typeof contents.export === "object" ? contents.export.url : undefined,
+                        contents,
+                        rawContents: file.rawContents
+                    };
+                } else {
+                    addFailure(result);
+                }
             }
         } else {
-            // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
-            const result = validateAgainstJsonSchema(parsedFileContents, DefinitionFileJsonSchema as any);
-            if (result.success) {
+            // Check cache first
+            const cached = definitionParsedCache.get(file.rawContents);
+            if (cached != null) {
+                namesDefinitionFiles[relativeFilepath] = {
+                    defaultUrl: undefined,
+                    contents: cached,
+                    rawContents: file.rawContents,
+                    absoluteFilePath: join(absolutePathToDefinition, relativeFilepath)
+                };
+            } else if (skipValidation) {
                 const contents = RawSchemas.serialization.DefinitionFileSchema.parseOrThrow(parsedFileContents);
+                definitionParsedCache.set(file.rawContents, contents);
                 namesDefinitionFiles[relativeFilepath] = {
                     defaultUrl: undefined,
                     contents,
@@ -93,7 +165,21 @@ export function validateStructureOfYamlFiles({
                     absoluteFilePath: join(absolutePathToDefinition, relativeFilepath)
                 };
             } else {
-                addFailure(result);
+                // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
+                const result = validateAgainstJsonSchema(parsedFileContents, DefinitionFileJsonSchema as any);
+                if (result.success) {
+                    const contents =
+                        RawSchemas.serialization.DefinitionFileSchema.parseOrThrow(parsedFileContents);
+                    definitionParsedCache.set(file.rawContents, contents);
+                    namesDefinitionFiles[relativeFilepath] = {
+                        defaultUrl: undefined,
+                        contents,
+                        rawContents: file.rawContents,
+                        absoluteFilePath: join(absolutePathToDefinition, relativeFilepath)
+                    };
+                } else {
+                    addFailure(result);
+                }
             }
         }
     }

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/validateStructureOfYamlFiles.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/validateStructureOfYamlFiles.ts
@@ -134,10 +134,7 @@ export function validateStructureOfYamlFiles({
                     rawContents: file.rawContents
                 };
             } else {
-                const result = validateAgainstJsonSchema(
-                    parsedFileContents,
-                    asJsonSchema(PackageMarkerFileJsonSchema)
-                );
+                const result = validateAgainstJsonSchema(parsedFileContents, asJsonSchema(PackageMarkerFileJsonSchema));
                 if (result.success) {
                     const contents = RawSchemas.serialization.PackageMarkerFileSchema.parseOrThrow(parsedFileContents);
                     packageMarkerParsedCache.set(file.rawContents, contents);
@@ -170,10 +167,7 @@ export function validateStructureOfYamlFiles({
                     absoluteFilePath: join(absolutePathToDefinition, relativeFilepath)
                 };
             } else {
-                const result = validateAgainstJsonSchema(
-                    parsedFileContents,
-                    asJsonSchema(DefinitionFileJsonSchema)
-                );
+                const result = validateAgainstJsonSchema(parsedFileContents, asJsonSchema(DefinitionFileJsonSchema));
                 if (result.success) {
                     const contents = RawSchemas.serialization.DefinitionFileSchema.parseOrThrow(parsedFileContents);
                     definitionParsedCache.set(file.rawContents, contents);


### PR DESCRIPTION
## Description

Refs performance investigation in [Devin session](https://app.devin.ai/sessions/54b33b13824b484baa703e56a37c7416)
Requested by: @Swimburger

Profiling revealed that `toFernWorkspace()` accounts for ~97% of the IR generation pipeline time, with `validateStructureOfYamlFiles()` as the dominant cost (JSON schema validation + Zod `parseOrThrow` for every YAML file on every call). This PR adds two complementary optimizations:

1. **Global validation cache** — module-level `Map`s keyed on raw YAML file contents that store parsed schema results across workspace instances. Each cache entry tracks whether JSON schema validation was performed (`CachedEntry<T>.validated`), so entries cached via `skipValidation` are never returned to callers that request full validation.
2. **`skipValidation` flag** — optional parameter to bypass JSON schema validation on cache miss (still runs `parseOrThrow` for type safety)

### Measured Performance Impact

| Fixture | Cold (no cache) | Global cache (new instance) | Speedup |
|---|---|---|---|
| **trace** | 1590ms | 11.0ms | **145x** |
| **exhaustive** | 1854ms | 5.2ms | **353x** |
| **pagination** | 413ms | 3.6ms | **114x** |
| **examples** | 688ms | 3.9ms | **176x** |

Aggregate across all 139 test fixtures: **17,180ms → 241ms (71x faster)** on second pass with warm cache.

## Changes Made

- Added `asJsonSchema()` typed helper to replace pre-existing `as any` casts on JSON schema imports (uses `Parameters<typeof validateAgainstJsonSchema>[1]`)
- Added `CachedEntry<T>` interface with `value` and `validated` fields to track whether each cached entry was JSON-schema-validated
- Added three module-level caches (`rootApiParsedCache`, `definitionParsedCache`, `packageMarkerParsedCache`) in `validateStructureOfYamlFiles.ts` keyed on `file.rawContents`
- Cache lookup returns a hit only if the entry was fully validated OR the caller is skipping validation (`cached.validated || skipValidation`)
- Added `skipValidation?: boolean` parameter to `validateStructureOfYamlFiles()`
- Threaded `skipValidation` through `LazyFernWorkspace.toFernWorkspace()`
- [ ] Updated README.md generator (not applicable)

## Review Checklist for Humans

1. **Cached results are shared references** — `parseOrThrow` results are stored and returned directly from cache. If downstream code mutates these objects, it could affect other consumers. Verify parsed schemas are treated as immutable in practice.
2. **`skipValidation` doesn't affect `LazyFernWorkspace`-level cache key** — the instance-level `this.fernWorkspaces[key]` cache in `LazyFernWorkspace` does not account for `skipValidation`. The lower-level `validateStructureOfYamlFiles` cache correctly tracks validation state via `CachedEntry.validated`, but the workspace-level cache could still return a workspace that was built with `skipValidation=true` to a caller requesting full validation. Confirm this is acceptable.
3. **Caches are unbounded** — no eviction policy. Acceptable for CLI (short-lived process) but would need limits if used in a long-running context.
4. **No callers use `skipValidation` yet** — the cache provides immediate value; `skipValidation` is infrastructure for future use (tests, multi-generator scenarios).
5. **Validation failures are not cached** — only successful parses are cached, so invalid files are re-validated on each call (correct behavior).
6. **Unvalidated entries are re-validated on demand** — if a file was first cached with `validated: false` (via `skipValidation`), a subsequent caller with `skipValidation: false` will miss the cache, re-validate, and overwrite the entry with `validated: true`. Verify this re-validation + overwrite is acceptable (it should be, since the content is identical).

## Testing

- [x] Existing test suite passes (validates no regressions)
- [ ] Unit tests added/updated (no new tests; cache behavior is transparent to existing tests)
- [x] Manual testing completed (biome lint passes, TypeScript compiles, CLI builds successfully)
- [x] CI checks pass (biome, compile, lint, depcheck, all seed tests)

## Updates Since Last Revision

- Merged from `main` (resolved conflict in `versions.yml` with new 3.85.x entries)
- Replaced pre-existing `as any` casts with typed `asJsonSchema()` helper using `Parameters<typeof validateAgainstJsonSchema>[1]`
- Fixed biome formatting for single-line `validateAgainstJsonSchema` calls
- **Added `CachedEntry<T>` wrapper** to track whether each cached entry was JSON-schema-validated. Cache lookups now check `cached.validated || skipValidation` to ensure callers requesting full validation never receive unvalidated entries. This fixes the Devin Review finding that the cache could bypass validation for subsequent callers.