### PR TITLE
feat(cli): auto-correct fern-api/ to fernapi/ in generator names

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -5,10 +5,10 @@ import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbui
 import { runCliV2 } from "@fern-api/cli-v2";
 import {
     correctIncorrectDockerOrg,
-    INCORRECT_DOCKER_ORG,
     GENERATORS_CONFIGURATION_FILENAME,
     generatorsYml,
     getFernDirectory,
+    INCORRECT_DOCKER_ORG,
     loadProjectConfig,
     PROJECT_CONFIG_FILENAME
 } from "@fern-api/configuration-loader";

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -717,9 +717,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
             if (argv.output != null && argv.docs != null) {
                 return cliContext.failWithoutThrowing("The --output flag is not supported for docs generation.");
             }
-            const correctedGeneratorFilter = argv.generator != null
-                ? warnAndCorrectDeprecatedDockerOrg(argv.generator, cliContext)
-                : undefined;
+            const correctedGeneratorFilter =
+                argv.generator != null ? warnAndCorrectDeprecatedDockerOrg(argv.generator, cliContext) : undefined;
             if (argv.api != null) {
                 return await generateAPIWorkspaces({
                     project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -4,8 +4,8 @@ import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbuild/protobuf/wkt";
 import { runCliV2 } from "@fern-api/cli-v2";
 import {
-    correctDeprecatedDockerOrg,
-    DEPRECATED_DOCKER_ORG,
+    correctIncorrectDockerOrg,
+    INCORRECT_DOCKER_ORG,
     GENERATORS_CONFIGURATION_FILENAME,
     generatorsYml,
     getFernDirectory,
@@ -552,7 +552,7 @@ function addAddCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     description: "Add the generator to the specified group"
                 }),
         async (argv) => {
-            const generatorName = warnAndCorrectDeprecatedDockerOrg(argv.generator, cliContext);
+            const generatorName = warnAndCorrectIncorrectDockerOrg(argv.generator, cliContext);
             await addGeneratorToWorkspaces({
                 project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
                     commandLineApiWorkspace: argv.api,
@@ -718,7 +718,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 return cliContext.failWithoutThrowing("The --output flag is not supported for docs generation.");
             }
             const correctedGeneratorFilter =
-                argv.generator != null ? warnAndCorrectDeprecatedDockerOrg(argv.generator, cliContext) : undefined;
+                argv.generator != null ? warnAndCorrectIncorrectDockerOrg(argv.generator, cliContext) : undefined;
             if (argv.api != null) {
                 return await generateAPIWorkspaces({
                     project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
@@ -1999,14 +1999,14 @@ function readBytes(stream: ReadStream): Promise<Uint8Array> {
 }
 
 /**
- * Corrects the deprecated "fern-api/" Docker org prefix to "fernapi/" and logs a warning.
+ * Corrects the incorrect "fern-api/" Docker org prefix to "fernapi/" and logs a warning.
  * Used for CLI arguments that accept generator names.
  */
-function warnAndCorrectDeprecatedDockerOrg(generatorName: string, cliContext: CliContext): string {
-    const corrected = correctDeprecatedDockerOrg(generatorName);
+function warnAndCorrectIncorrectDockerOrg(generatorName: string, cliContext: CliContext): string {
+    const corrected = correctIncorrectDockerOrg(generatorName);
     if (corrected !== generatorName) {
         cliContext.logger.warn(
-            `"${generatorName}" is deprecated. Use "${corrected}" instead — the Docker org is "fernapi", not "${DEPRECATED_DOCKER_ORG}".`
+            `"${generatorName}" is not a valid generator name. Using "${corrected}" instead — the Docker org is "fernapi", not "${INCORRECT_DOCKER_ORG}".`
         );
     }
     return corrected;

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -4,6 +4,8 @@ import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbuild/protobuf/wkt";
 import { runCliV2 } from "@fern-api/cli-v2";
 import {
+    correctDeprecatedDockerOrg,
+    DEPRECATED_DOCKER_ORG,
     GENERATORS_CONFIGURATION_FILENAME,
     generatorsYml,
     getFernDirectory,
@@ -550,12 +552,13 @@ function addAddCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     description: "Add the generator to the specified group"
                 }),
         async (argv) => {
+            const generatorName = warnAndCorrectDeprecatedDockerOrg(argv.generator, cliContext);
             await addGeneratorToWorkspaces({
                 project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
                     commandLineApiWorkspace: argv.api,
                     defaultToAllApiWorkspaces: false
                 }),
-                generatorName: argv.generator,
+                generatorName,
                 groupName: argv.group,
                 cliContext
             });
@@ -714,6 +717,9 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
             if (argv.output != null && argv.docs != null) {
                 return cliContext.failWithoutThrowing("The --output flag is not supported for docs generation.");
             }
+            const correctedGeneratorFilter = argv.generator != null
+                ? warnAndCorrectDeprecatedDockerOrg(argv.generator, cliContext)
+                : undefined;
             if (argv.api != null) {
                 return await generateAPIWorkspaces({
                     project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
@@ -723,7 +729,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     cliContext,
                     version: argv.version,
                     groupName: argv.group,
-                    generatorName: argv.generator,
+                    generatorName: correctedGeneratorFilter,
                     shouldLogS3Url: argv.printZipUrl,
                     keepDocker: argv.keepDocker,
                     useLocalDocker: argv.local || argv.runner != null,
@@ -776,7 +782,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 cliContext,
                 version: argv.version,
                 groupName: argv.group,
-                generatorName: argv.generator,
+                generatorName: correctedGeneratorFilter,
                 shouldLogS3Url: argv.printZipUrl,
                 keepDocker: argv.keepDocker,
                 useLocalDocker: argv.local,
@@ -1991,6 +1997,20 @@ function readBytes(stream: ReadStream): Promise<Uint8Array> {
             reject(err);
         });
     });
+}
+
+/**
+ * Corrects the deprecated "fern-api/" Docker org prefix to "fernapi/" and logs a warning.
+ * Used for CLI arguments that accept generator names.
+ */
+function warnAndCorrectDeprecatedDockerOrg(generatorName: string, cliContext: CliContext): string {
+    const corrected = correctDeprecatedDockerOrg(generatorName);
+    if (corrected !== generatorName) {
+        cliContext.logger.warn(
+            `"${generatorName}" is deprecated. Use "${corrected}" instead — the Docker org is "fernapi", not "${DEPRECATED_DOCKER_ORG}".`
+        );
+    }
+    return corrected;
 }
 
 function writeBytes(stream: WriteStream, data: Uint8Array): Promise<void> {

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -1,4 +1,4 @@
-import { GENERATORS_CONFIGURATION_FILENAME } from "@fern-api/configuration-loader";
+import { correctDeprecatedDockerOrg, DEPRECATED_DOCKER_ORG, GENERATORS_CONFIGURATION_FILENAME } from "@fern-api/configuration-loader";
 import { FernRegistry } from "@fern-fern/generators-sdk";
 import { writeFile } from "fs/promises";
 import { Argv } from "yargs";
@@ -11,6 +11,20 @@ import { GenerationModeFilter, getGeneratorList } from "./commands/generator-lis
 import { getGeneratorMetadata } from "./commands/generator-metadata/getGeneratorMetadata.js";
 import { getOrganization } from "./commands/organization/getOrganization.js";
 import { upgradeGenerator } from "./commands/upgrade/upgradeGenerator.js";
+
+/**
+ * Corrects the deprecated "fern-api/" Docker org prefix to "fernapi/" and logs a warning.
+ * Used for CLI arguments that accept generator names.
+ */
+function warnAndCorrectDeprecatedDockerOrgV2(generatorName: string, cliContext: CliContext): string {
+    const corrected = correctDeprecatedDockerOrg(generatorName);
+    if (corrected !== generatorName) {
+        cliContext.logger.warn(
+            `"${generatorName}" is deprecated. Use "${corrected}" instead — the Docker org is "fernapi", not "${DEPRECATED_DOCKER_ORG}".`
+        );
+    }
+    return corrected;
+}
 
 export function addGetOrganizationCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext): void {
     cli.command(
@@ -177,6 +191,9 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                         }
                     });
 
+                    const correctedGenerator = argv.generator != null
+                        ? warnAndCorrectDeprecatedDockerOrgV2(argv.generator, cliContext)
+                        : undefined;
                     const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
                         commandLineApiWorkspace: argv.api,
                         defaultToAllApiWorkspaces: true
@@ -188,7 +205,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                         const upgrades = await getProjectGeneratorUpgrades({
                             cliContext,
                             project,
-                            generatorFilter: argv.generator,
+                            generatorFilter: correctedGenerator,
                             groupFilter: argv.group,
                             includeMajor: argv.includeMajor,
                             channel: argv.channel
@@ -205,7 +222,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                     } else {
                         await upgradeGenerator({
                             cliContext,
-                            generator: argv.generator,
+                            generator: correctedGenerator,
                             group: argv.group,
                             project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
                                 commandLineApiWorkspace: argv.api,
@@ -259,10 +276,11 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                             description: "Get repository for the generator invocation, if one is specified."
                         }),
                 async (argv) => {
+                    const correctedGetGenerator = warnAndCorrectDeprecatedDockerOrgV2(argv.generator, cliContext);
                     await cliContext.instrumentPostHogEvent({
                         command: "fern generator get",
                         properties: {
-                            generator: argv.generator,
+                            generator: correctedGetGenerator,
                             version: argv.version,
                             api: argv.api,
                             group: argv.group,
@@ -271,7 +289,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                     });
                     const generator = await getGeneratorMetadata({
                         cliContext,
-                        generatorFilter: argv.generator,
+                        generatorFilter: correctedGetGenerator,
                         groupFilter: argv.group,
                         apiFilter: argv.api,
                         project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -1,4 +1,8 @@
-import { correctDeprecatedDockerOrg, DEPRECATED_DOCKER_ORG, GENERATORS_CONFIGURATION_FILENAME } from "@fern-api/configuration-loader";
+import {
+    correctDeprecatedDockerOrg,
+    DEPRECATED_DOCKER_ORG,
+    GENERATORS_CONFIGURATION_FILENAME
+} from "@fern-api/configuration-loader";
 import { FernRegistry } from "@fern-fern/generators-sdk";
 import { writeFile } from "fs/promises";
 import { Argv } from "yargs";
@@ -191,9 +195,10 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                         }
                     });
 
-                    const correctedGenerator = argv.generator != null
-                        ? warnAndCorrectDeprecatedDockerOrgV2(argv.generator, cliContext)
-                        : undefined;
+                    const correctedGenerator =
+                        argv.generator != null
+                            ? warnAndCorrectDeprecatedDockerOrgV2(argv.generator, cliContext)
+                            : undefined;
                     const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
                         commandLineApiWorkspace: argv.api,
                         defaultToAllApiWorkspaces: true

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -1,6 +1,6 @@
 import {
-    correctDeprecatedDockerOrg,
-    DEPRECATED_DOCKER_ORG,
+    correctIncorrectDockerOrg,
+    INCORRECT_DOCKER_ORG,
     GENERATORS_CONFIGURATION_FILENAME
 } from "@fern-api/configuration-loader";
 import { FernRegistry } from "@fern-fern/generators-sdk";
@@ -17,14 +17,14 @@ import { getOrganization } from "./commands/organization/getOrganization.js";
 import { upgradeGenerator } from "./commands/upgrade/upgradeGenerator.js";
 
 /**
- * Corrects the deprecated "fern-api/" Docker org prefix to "fernapi/" and logs a warning.
+ * Corrects the incorrect "fern-api/" Docker org prefix to "fernapi/" and logs a warning.
  * Used for CLI arguments that accept generator names.
  */
-function warnAndCorrectDeprecatedDockerOrgV2(generatorName: string, cliContext: CliContext): string {
-    const corrected = correctDeprecatedDockerOrg(generatorName);
+function warnAndCorrectIncorrectDockerOrgV2(generatorName: string, cliContext: CliContext): string {
+    const corrected = correctIncorrectDockerOrg(generatorName);
     if (corrected !== generatorName) {
         cliContext.logger.warn(
-            `"${generatorName}" is deprecated. Use "${corrected}" instead — the Docker org is "fernapi", not "${DEPRECATED_DOCKER_ORG}".`
+            `"${generatorName}" is not a valid generator name. Using "${corrected}" instead — the Docker org is "fernapi", not "${INCORRECT_DOCKER_ORG}".`
         );
     }
     return corrected;
@@ -197,7 +197,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
 
                     const correctedGenerator =
                         argv.generator != null
-                            ? warnAndCorrectDeprecatedDockerOrgV2(argv.generator, cliContext)
+                            ? warnAndCorrectIncorrectDockerOrgV2(argv.generator, cliContext)
                             : undefined;
                     const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
                         commandLineApiWorkspace: argv.api,
@@ -281,7 +281,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                             description: "Get repository for the generator invocation, if one is specified."
                         }),
                 async (argv) => {
-                    const correctedGetGenerator = warnAndCorrectDeprecatedDockerOrgV2(argv.generator, cliContext);
+                    const correctedGetGenerator = warnAndCorrectIncorrectDockerOrgV2(argv.generator, cliContext);
                     await cliContext.instrumentPostHogEvent({
                         command: "fern generator get",
                         properties: {

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -1,7 +1,7 @@
 import {
     correctIncorrectDockerOrg,
-    INCORRECT_DOCKER_ORG,
-    GENERATORS_CONFIGURATION_FILENAME
+    GENERATORS_CONFIGURATION_FILENAME,
+    INCORRECT_DOCKER_ORG
 } from "@fern-api/configuration-loader";
 import { FernRegistry } from "@fern-fern/generators-sdk";
 import { writeFile } from "fs/promises";

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,9 +2,9 @@
 - version: 3.85.0
   changelogEntry:
     - summary: |
-        Auto-correct deprecated `fern-api/` Docker org prefix to `fernapi/` in generator names.
-        When a generator is specified with the wrong prefix (e.g. `fern-api/fern-typescript-sdk`),
-        the CLI now automatically corrects it to `fernapi/fern-typescript-sdk` and prints a warning.
+        Auto-correct incorrect `fern-api/` Docker org prefix to `fernapi/` in generator names.
+        When a generator is specified with `fern-api/` (the GitHub/npm org) instead of `fernapi/`
+        (the Docker Hub org), the CLI now automatically corrects it and prints a warning.
         This applies to CLI commands (`--generator` flag) and `generators.yml` configuration files.
       type: feat
   createdAt: "2026-02-24"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.85.0
+  changelogEntry:
+    - summary: |
+        Auto-correct deprecated `fern-api/` Docker org prefix to `fernapi/` in generator names.
+        When a generator is specified with the wrong prefix (e.g. `fern-api/fern-typescript-sdk`),
+        the CLI now automatically corrects it to `fernapi/fern-typescript-sdk` and prints a warning.
+        This applies to CLI commands (`--generator` flag) and `generators.yml` configuration files.
+      type: feat
+  createdAt: "2026-02-24"
+  irVersion: 65
 - version: 3.84.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/__test__/getGeneratorName.test.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/__test__/getGeneratorName.test.ts
@@ -3,10 +3,10 @@ import { createMockTaskContext } from "@fern-api/task-context";
 import { GeneratorName } from "../GeneratorName.js";
 import {
     addDefaultDockerOrgIfNotPresent,
-    correctDeprecatedDockerOrg,
-    correctDeprecatedDockerOrgWithWarning,
+    correctIncorrectDockerOrg,
+    correctIncorrectDockerOrgWithWarning,
     DEFAULT_DOCKER_ORG,
-    DEPRECATED_DOCKER_ORG,
+    INCORRECT_DOCKER_ORG,
     getGeneratorNameOrThrow,
     normalizeGeneratorName,
     removeDefaultDockerOrgIfPresent
@@ -264,53 +264,53 @@ describe("real-world scenarios", () => {
     });
 });
 
-describe("correctDeprecatedDockerOrg", () => {
+describe("correctIncorrectDockerOrg", () => {
     it("corrects fern-api/ to fernapi/", () => {
-        expect(correctDeprecatedDockerOrg("fern-api/fern-typescript-sdk")).toBe("fernapi/fern-typescript-sdk");
-        expect(correctDeprecatedDockerOrg("fern-api/fern-python-sdk")).toBe("fernapi/fern-python-sdk");
-        expect(correctDeprecatedDockerOrg("fern-api/fern-java-sdk")).toBe("fernapi/fern-java-sdk");
+        expect(correctIncorrectDockerOrg("fern-api/fern-typescript-sdk")).toBe("fernapi/fern-typescript-sdk");
+        expect(correctIncorrectDockerOrg("fern-api/fern-python-sdk")).toBe("fernapi/fern-python-sdk");
+        expect(correctIncorrectDockerOrg("fern-api/fern-java-sdk")).toBe("fernapi/fern-java-sdk");
     });
 
     it("does not modify fernapi/ names", () => {
-        expect(correctDeprecatedDockerOrg("fernapi/fern-typescript-sdk")).toBe("fernapi/fern-typescript-sdk");
+        expect(correctIncorrectDockerOrg("fernapi/fern-typescript-sdk")).toBe("fernapi/fern-typescript-sdk");
     });
 
     it("does not modify shorthand names", () => {
-        expect(correctDeprecatedDockerOrg("fern-typescript-sdk")).toBe("fern-typescript-sdk");
+        expect(correctIncorrectDockerOrg("fern-typescript-sdk")).toBe("fern-typescript-sdk");
     });
 
     it("does not modify custom org names", () => {
-        expect(correctDeprecatedDockerOrg("myorg/my-generator")).toBe("myorg/my-generator");
+        expect(correctIncorrectDockerOrg("myorg/my-generator")).toBe("myorg/my-generator");
     });
 
     it("handles empty string", () => {
-        expect(correctDeprecatedDockerOrg("")).toBe("");
+        expect(correctIncorrectDockerOrg("")).toBe("");
     });
 });
 
-describe("correctDeprecatedDockerOrgWithWarning", () => {
+describe("correctIncorrectDockerOrgWithWarning", () => {
     it("corrects fern-api/ to fernapi/ and logs warning", () => {
         const context = createMockTaskContext();
-        const result = correctDeprecatedDockerOrgWithWarning("fern-api/fern-typescript-sdk", context);
+        const result = correctIncorrectDockerOrgWithWarning("fern-api/fern-typescript-sdk", context);
         expect(result).toBe("fernapi/fern-typescript-sdk");
     });
 
     it("does not log warning for correct names", () => {
         const context = createMockTaskContext();
-        const result = correctDeprecatedDockerOrgWithWarning("fernapi/fern-typescript-sdk", context);
+        const result = correctIncorrectDockerOrgWithWarning("fernapi/fern-typescript-sdk", context);
         expect(result).toBe("fernapi/fern-typescript-sdk");
     });
 
     it("does not log warning for shorthand names", () => {
         const context = createMockTaskContext();
-        const result = correctDeprecatedDockerOrgWithWarning("fern-typescript-sdk", context);
+        const result = correctIncorrectDockerOrgWithWarning("fern-typescript-sdk", context);
         expect(result).toBe("fern-typescript-sdk");
     });
 });
 
-describe("DEPRECATED_DOCKER_ORG constant", () => {
+describe("INCORRECT_DOCKER_ORG constant", () => {
     it("is set to 'fern-api'", () => {
-        expect(DEPRECATED_DOCKER_ORG).toBe("fern-api");
+        expect(INCORRECT_DOCKER_ORG).toBe("fern-api");
     });
 });
 

--- a/packages/cli/configuration-loader/src/generators-yml/__test__/getGeneratorName.test.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/__test__/getGeneratorName.test.ts
@@ -6,8 +6,8 @@ import {
     correctIncorrectDockerOrg,
     correctIncorrectDockerOrgWithWarning,
     DEFAULT_DOCKER_ORG,
-    INCORRECT_DOCKER_ORG,
     getGeneratorNameOrThrow,
+    INCORRECT_DOCKER_ORG,
     normalizeGeneratorName,
     removeDefaultDockerOrgIfPresent
 } from "../getGeneratorName.js";

--- a/packages/cli/configuration-loader/src/generators-yml/__test__/getGeneratorName.test.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/__test__/getGeneratorName.test.ts
@@ -3,7 +3,10 @@ import { createMockTaskContext } from "@fern-api/task-context";
 import { GeneratorName } from "../GeneratorName.js";
 import {
     addDefaultDockerOrgIfNotPresent,
+    correctDeprecatedDockerOrg,
+    correctDeprecatedDockerOrgWithWarning,
     DEFAULT_DOCKER_ORG,
+    DEPRECATED_DOCKER_ORG,
     getGeneratorNameOrThrow,
     normalizeGeneratorName,
     removeDefaultDockerOrgIfPresent
@@ -23,6 +26,11 @@ describe("addDefaultDockerOrgIfNotPresent", () => {
 
     it("preserves fernapi/ prefix if already present", () => {
         expect(addDefaultDockerOrgIfNotPresent("fernapi/fern-typescript-sdk")).toBe("fernapi/fern-typescript-sdk");
+    });
+
+    it("corrects deprecated fern-api/ prefix to fernapi/", () => {
+        expect(addDefaultDockerOrgIfNotPresent("fern-api/fern-typescript-sdk")).toBe("fernapi/fern-typescript-sdk");
+        expect(addDefaultDockerOrgIfNotPresent("fern-api/fern-python-sdk")).toBe("fernapi/fern-python-sdk");
     });
 
     it("preserves custom org prefixes", () => {
@@ -238,5 +246,78 @@ describe("real-world scenarios", () => {
 
         expect(fdrApiName).toBe("fernapi/fern-csharp-sdk");
         expect(fdrApiName).toContain("/");
+    });
+
+    it("handles deprecated fern-api/ org in generators.yml", () => {
+        // User accidentally uses fern-api/ (GitHub org) instead of fernapi/ (Docker org)
+        const yamlName = "fern-api/fern-typescript-sdk";
+        const normalized = addDefaultDockerOrgIfNotPresent(yamlName);
+        expect(normalized).toBe("fernapi/fern-typescript-sdk");
+    });
+
+    it("handles deprecated fern-api/ org in CLI --generator filter", () => {
+        // User passes fern-api/fern-typescript-sdk on CLI
+        const cliArg = "fern-api/fern-typescript-sdk";
+        const normalized = addDefaultDockerOrgIfNotPresent(cliArg);
+        const yamlNormalized = addDefaultDockerOrgIfNotPresent("fern-typescript-sdk");
+        expect(normalized).toBe(yamlNormalized);
+    });
+});
+
+describe("correctDeprecatedDockerOrg", () => {
+    it("corrects fern-api/ to fernapi/", () => {
+        expect(correctDeprecatedDockerOrg("fern-api/fern-typescript-sdk")).toBe("fernapi/fern-typescript-sdk");
+        expect(correctDeprecatedDockerOrg("fern-api/fern-python-sdk")).toBe("fernapi/fern-python-sdk");
+        expect(correctDeprecatedDockerOrg("fern-api/fern-java-sdk")).toBe("fernapi/fern-java-sdk");
+    });
+
+    it("does not modify fernapi/ names", () => {
+        expect(correctDeprecatedDockerOrg("fernapi/fern-typescript-sdk")).toBe("fernapi/fern-typescript-sdk");
+    });
+
+    it("does not modify shorthand names", () => {
+        expect(correctDeprecatedDockerOrg("fern-typescript-sdk")).toBe("fern-typescript-sdk");
+    });
+
+    it("does not modify custom org names", () => {
+        expect(correctDeprecatedDockerOrg("myorg/my-generator")).toBe("myorg/my-generator");
+    });
+
+    it("handles empty string", () => {
+        expect(correctDeprecatedDockerOrg("")).toBe("");
+    });
+});
+
+describe("correctDeprecatedDockerOrgWithWarning", () => {
+    it("corrects fern-api/ to fernapi/ and logs warning", () => {
+        const context = createMockTaskContext();
+        const result = correctDeprecatedDockerOrgWithWarning("fern-api/fern-typescript-sdk", context);
+        expect(result).toBe("fernapi/fern-typescript-sdk");
+    });
+
+    it("does not log warning for correct names", () => {
+        const context = createMockTaskContext();
+        const result = correctDeprecatedDockerOrgWithWarning("fernapi/fern-typescript-sdk", context);
+        expect(result).toBe("fernapi/fern-typescript-sdk");
+    });
+
+    it("does not log warning for shorthand names", () => {
+        const context = createMockTaskContext();
+        const result = correctDeprecatedDockerOrgWithWarning("fern-typescript-sdk", context);
+        expect(result).toBe("fern-typescript-sdk");
+    });
+});
+
+describe("DEPRECATED_DOCKER_ORG constant", () => {
+    it("is set to 'fern-api'", () => {
+        expect(DEPRECATED_DOCKER_ORG).toBe("fern-api");
+    });
+});
+
+describe("normalizeGeneratorName with deprecated org", () => {
+    it("normalizes fern-api/ prefixed names to valid GeneratorName", () => {
+        expect(normalizeGeneratorName("fern-api/fern-typescript-sdk")).toBe(GeneratorName.TYPESCRIPT_SDK);
+        expect(normalizeGeneratorName("fern-api/fern-python-sdk")).toBe(GeneratorName.PYTHON_SDK);
+        expect(normalizeGeneratorName("fern-api/fern-java-sdk")).toBe(GeneratorName.JAVA_SDK);
     });
 });

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -8,7 +8,7 @@ import { GithubPullRequestReviewer, OutputMetadata, PublishingMetadata, PypiMeta
 import { readFile } from "fs/promises";
 import path from "path";
 
-import { addDefaultDockerOrgIfNotPresent, correctDeprecatedDockerOrgWithWarning } from "./getGeneratorName.js";
+import { addDefaultDockerOrgIfNotPresent, correctIncorrectDockerOrgWithWarning } from "./getGeneratorName.js";
 
 /**
  * Union type representing any spec-level settings schema.
@@ -599,8 +599,8 @@ async function convertGenerator({
     readme: generatorsYml.ReadmeSchema | undefined;
     context: TaskContext;
 }): Promise<generatorsYml.GeneratorInvocation> {
-    // Warn and correct deprecated "fern-api/" org prefix in generators.yml
-    const correctedName = correctDeprecatedDockerOrgWithWarning(generator.name, context);
+    // Warn and correct incorrect "fern-api/" org prefix in generators.yml
+    const correctedName = correctIncorrectDockerOrgWithWarning(generator.name, context);
     // Normalize the generator name by adding the default Docker org prefix if not present
     const normalizedName = addDefaultDockerOrgIfNotPresent(correctedName);
     return {

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -8,7 +8,7 @@ import { GithubPullRequestReviewer, OutputMetadata, PublishingMetadata, PypiMeta
 import { readFile } from "fs/promises";
 import path from "path";
 
-import { addDefaultDockerOrgIfNotPresent } from "./getGeneratorName.js";
+import { addDefaultDockerOrgIfNotPresent, correctDeprecatedDockerOrgWithWarning } from "./getGeneratorName.js";
 
 /**
  * Union type representing any spec-level settings schema.
@@ -82,7 +82,8 @@ export async function convertGeneratorsConfiguration({
                               group,
                               maybeTopLevelMetadata,
                               maybeTopLevelReviewers: rawGeneratorsConfiguration.reviewers,
-                              readme
+                              readme,
+                              context
                           })
                       )
                   )
@@ -546,7 +547,8 @@ async function convertGroup({
     group,
     maybeTopLevelMetadata,
     maybeTopLevelReviewers,
-    readme
+    readme,
+    context
 }: {
     absolutePathToGeneratorsConfiguration: AbsoluteFilePath;
     groupName: string;
@@ -554,6 +556,7 @@ async function convertGroup({
     maybeTopLevelMetadata: OutputMetadata | undefined;
     maybeTopLevelReviewers: generatorsYml.ReviewersSchema | undefined;
     readme: generatorsYml.ReadmeSchema | undefined;
+    context: TaskContext;
 }): Promise<generatorsYml.GeneratorGroup> {
     const maybeGroupLevelMetadata = getOutputMetadata(group.metadata);
     return {
@@ -569,7 +572,8 @@ async function convertGroup({
                     maybeGroupLevelMetadata,
                     maybeTopLevelReviewers,
                     maybeGroupLevelReviewers: group.reviewers,
-                    readme
+                    readme,
+                    context
                 })
             )
         )
@@ -583,7 +587,8 @@ async function convertGenerator({
     maybeTopLevelMetadata,
     maybeGroupLevelReviewers,
     maybeTopLevelReviewers,
-    readme
+    readme,
+    context
 }: {
     absolutePathToGeneratorsConfiguration: AbsoluteFilePath;
     generator: generatorsYml.GeneratorInvocationSchema;
@@ -592,9 +597,12 @@ async function convertGenerator({
     maybeGroupLevelReviewers: generatorsYml.ReviewersSchema | undefined;
     maybeTopLevelReviewers: generatorsYml.ReviewersSchema | undefined;
     readme: generatorsYml.ReadmeSchema | undefined;
+    context: TaskContext;
 }): Promise<generatorsYml.GeneratorInvocation> {
+    // Warn and correct deprecated "fern-api/" org prefix in generators.yml
+    const correctedName = correctDeprecatedDockerOrgWithWarning(generator.name, context);
     // Normalize the generator name by adding the default Docker org prefix if not present
-    const normalizedName = addDefaultDockerOrgIfNotPresent(generator.name);
+    const normalizedName = addDefaultDockerOrgIfNotPresent(correctedName);
     return {
         raw: generator,
         name: normalizedName,

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorName.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorName.ts
@@ -3,6 +3,7 @@ import { TaskContext } from "@fern-api/task-context";
 import { GeneratorName } from "./GeneratorName.js";
 
 export const DEFAULT_DOCKER_ORG = "fernapi";
+export const DEPRECATED_DOCKER_ORG = "fern-api";
 
 /**
  * Adds the default Docker org prefix (fernapi/) to a generator name if no org is specified.
@@ -15,10 +16,46 @@ export const DEFAULT_DOCKER_ORG = "fernapi";
  * - "myorg/my-generator" -> "myorg/my-generator" (unchanged)
  */
 export function addDefaultDockerOrgIfNotPresent(generatorName: string): string {
+    // Correct deprecated "fern-api/" org to "fernapi/" silently
+    generatorName = correctDeprecatedDockerOrg(generatorName);
     if (generatorName.includes("/")) {
         return generatorName;
     }
     return `${DEFAULT_DOCKER_ORG}/${generatorName}`;
+}
+
+/**
+ * Corrects the deprecated Docker org prefix "fern-api/" to the correct "fernapi/".
+ * This handles a common user mistake where "fern-api" (the GitHub org) is used
+ * instead of "fernapi" (the Docker Hub org).
+ *
+ * Examples:
+ * - "fern-api/fern-typescript-sdk" -> "fernapi/fern-typescript-sdk"
+ * - "fernapi/fern-typescript-sdk" -> "fernapi/fern-typescript-sdk" (unchanged)
+ * - "myorg/my-generator" -> "myorg/my-generator" (unchanged)
+ */
+export function correctDeprecatedDockerOrg(generatorName: string): string {
+    const deprecatedPrefix = `${DEPRECATED_DOCKER_ORG}/`;
+    if (generatorName.startsWith(deprecatedPrefix)) {
+        return `${DEFAULT_DOCKER_ORG}/${generatorName.slice(deprecatedPrefix.length)}`;
+    }
+    return generatorName;
+}
+
+/**
+ * Corrects the deprecated Docker org prefix "fern-api/" to "fernapi/" and logs a warning.
+ * Use this variant when you have access to a TaskContext for user-visible warnings.
+ */
+export function correctDeprecatedDockerOrgWithWarning(generatorName: string, context: TaskContext): string {
+    const deprecatedPrefix = `${DEPRECATED_DOCKER_ORG}/`;
+    if (generatorName.startsWith(deprecatedPrefix)) {
+        const corrected = `${DEFAULT_DOCKER_ORG}/${generatorName.slice(deprecatedPrefix.length)}`;
+        context.logger.warn(
+            `"${generatorName}" is deprecated. Use "${corrected}" instead — the Docker org is "fernapi", not "fern-api".`
+        );
+        return corrected;
+    }
+    return generatorName;
 }
 
 /**

--- a/packages/cli/configuration-loader/src/generators-yml/getGeneratorName.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/getGeneratorName.ts
@@ -3,7 +3,7 @@ import { TaskContext } from "@fern-api/task-context";
 import { GeneratorName } from "./GeneratorName.js";
 
 export const DEFAULT_DOCKER_ORG = "fernapi";
-export const DEPRECATED_DOCKER_ORG = "fern-api";
+export const INCORRECT_DOCKER_ORG = "fern-api";
 
 /**
  * Adds the default Docker org prefix (fernapi/) to a generator name if no org is specified.
@@ -16,8 +16,8 @@ export const DEPRECATED_DOCKER_ORG = "fern-api";
  * - "myorg/my-generator" -> "myorg/my-generator" (unchanged)
  */
 export function addDefaultDockerOrgIfNotPresent(generatorName: string): string {
-    // Correct deprecated "fern-api/" org to "fernapi/" silently
-    generatorName = correctDeprecatedDockerOrg(generatorName);
+    // Correct incorrect "fern-api/" org to "fernapi/" silently
+    generatorName = correctIncorrectDockerOrg(generatorName);
     if (generatorName.includes("/")) {
         return generatorName;
     }
@@ -25,33 +25,33 @@ export function addDefaultDockerOrgIfNotPresent(generatorName: string): string {
 }
 
 /**
- * Corrects the deprecated Docker org prefix "fern-api/" to the correct "fernapi/".
- * This handles a common user mistake where "fern-api" (the GitHub org) is used
- * instead of "fernapi" (the Docker Hub org).
+ * Corrects the incorrect Docker org prefix "fern-api/" to the correct "fernapi/".
+ * This handles a common user mistake where "fern-api" (the GitHub/npm org) is
+ * confused with "fernapi" (the Docker Hub org for Fern generators).
  *
  * Examples:
  * - "fern-api/fern-typescript-sdk" -> "fernapi/fern-typescript-sdk"
  * - "fernapi/fern-typescript-sdk" -> "fernapi/fern-typescript-sdk" (unchanged)
  * - "myorg/my-generator" -> "myorg/my-generator" (unchanged)
  */
-export function correctDeprecatedDockerOrg(generatorName: string): string {
-    const deprecatedPrefix = `${DEPRECATED_DOCKER_ORG}/`;
-    if (generatorName.startsWith(deprecatedPrefix)) {
-        return `${DEFAULT_DOCKER_ORG}/${generatorName.slice(deprecatedPrefix.length)}`;
+export function correctIncorrectDockerOrg(generatorName: string): string {
+    const incorrectPrefix = `${INCORRECT_DOCKER_ORG}/`;
+    if (generatorName.startsWith(incorrectPrefix)) {
+        return `${DEFAULT_DOCKER_ORG}/${generatorName.slice(incorrectPrefix.length)}`;
     }
     return generatorName;
 }
 
 /**
- * Corrects the deprecated Docker org prefix "fern-api/" to "fernapi/" and logs a warning.
+ * Corrects the incorrect Docker org prefix "fern-api/" to "fernapi/" and logs a warning.
  * Use this variant when you have access to a TaskContext for user-visible warnings.
  */
-export function correctDeprecatedDockerOrgWithWarning(generatorName: string, context: TaskContext): string {
-    const deprecatedPrefix = `${DEPRECATED_DOCKER_ORG}/`;
-    if (generatorName.startsWith(deprecatedPrefix)) {
-        const corrected = `${DEFAULT_DOCKER_ORG}/${generatorName.slice(deprecatedPrefix.length)}`;
+export function correctIncorrectDockerOrgWithWarning(generatorName: string, context: TaskContext): string {
+    const incorrectPrefix = `${INCORRECT_DOCKER_ORG}/`;
+    if (generatorName.startsWith(incorrectPrefix)) {
+        const corrected = `${DEFAULT_DOCKER_ORG}/${generatorName.slice(incorrectPrefix.length)}`;
         context.logger.warn(
-            `"${generatorName}" is deprecated. Use "${corrected}" instead — the Docker org is "fernapi", not "fern-api".`
+            `"${generatorName}" is not a valid generator name. Using "${corrected}" instead — the Docker org is "fernapi", not "fern-api".`
         );
         return corrected;
     }

--- a/packages/cli/configuration-loader/src/generators-yml/index.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/index.ts
@@ -11,8 +11,8 @@ export {
     correctIncorrectDockerOrg,
     correctIncorrectDockerOrgWithWarning,
     DEFAULT_DOCKER_ORG,
-    INCORRECT_DOCKER_ORG,
     getGeneratorNameOrThrow,
+    INCORRECT_DOCKER_ORG,
     normalizeGeneratorName,
     removeDefaultDockerOrgIfPresent
 } from "./getGeneratorName.js";

--- a/packages/cli/configuration-loader/src/generators-yml/index.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/index.ts
@@ -8,10 +8,10 @@ export { GeneratorName } from "./GeneratorName.js";
 export { GENERATOR_INVOCATIONS } from "./generatorInvocations.js";
 export {
     addDefaultDockerOrgIfNotPresent,
-    correctDeprecatedDockerOrg,
-    correctDeprecatedDockerOrgWithWarning,
+    correctIncorrectDockerOrg,
+    correctIncorrectDockerOrgWithWarning,
     DEFAULT_DOCKER_ORG,
-    DEPRECATED_DOCKER_ORG,
+    INCORRECT_DOCKER_ORG,
     getGeneratorNameOrThrow,
     normalizeGeneratorName,
     removeDefaultDockerOrgIfPresent

--- a/packages/cli/configuration-loader/src/generators-yml/index.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/index.ts
@@ -8,6 +8,10 @@ export { GeneratorName } from "./GeneratorName.js";
 export { GENERATOR_INVOCATIONS } from "./generatorInvocations.js";
 export {
     addDefaultDockerOrgIfNotPresent,
+    correctDeprecatedDockerOrg,
+    correctDeprecatedDockerOrgWithWarning,
+    DEFAULT_DOCKER_ORG,
+    DEPRECATED_DOCKER_ORG,
     getGeneratorNameOrThrow,
     normalizeGeneratorName,
     removeDefaultDockerOrgIfPresent


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger

When users specify a generator with the wrong Docker org prefix (`fern-api/` instead of `fernapi/`), the CLI now automatically corrects it and prints a warning. This is a common mistake because Fern uses `fern-api` as its GitHub/npm org, but `fernapi` is the Docker Hub org where generators are published.

This applies to both CLI `--generator` flags and `generators.yml` configuration files.

[Link to Devin run](https://app.devin.ai/sessions/010b866416df43c696649a9596eb8db0)

## Changes Made

- Added `INCORRECT_DOCKER_ORG` constant (`"fern-api"`) to `getGeneratorName.ts`
- Added `correctIncorrectDockerOrg()` (silent) and `correctIncorrectDockerOrgWithWarning()` (with warning log) to `getGeneratorName.ts`
- Integrated silent correction into `addDefaultDockerOrgIfNotPresent()` so all normalization paths benefit
- Applied warning correction in `convertGeneratorsConfiguration.ts` when parsing `generators.yml` (required threading `context` through `convertGroup` → `convertGenerator`)
- Applied warning correction in `cli.ts` for `fern add` and `fern generate --generator` arguments
- Applied warning correction in `cliV2.ts` for `fern generator upgrade`, `fern generator get` arguments
- Added comprehensive unit tests for all new functions
- Added `versions.yml` entry for CLI v3.85.0
- Exported new functions and constants from the configuration-loader index

## Updates Since Last Revision

- Renamed all "deprecated" references to "incorrect" per reviewer feedback — `fern-api` is not a deprecated org, it's simply the GitHub/npm org commonly confused with the Docker Hub org `fernapi`
- Renamed `DEPRECATED_DOCKER_ORG` → `INCORRECT_DOCKER_ORG`, `correctDeprecatedDockerOrg` → `correctIncorrectDockerOrg`, `correctDeprecatedDockerOrgWithWarning` → `correctIncorrectDockerOrgWithWarning`
- Updated warning message from "is deprecated" to: `"fern-api/..." is not a valid generator name. Using "fernapi/..." instead — the Docker org is "fernapi", not "fern-api".`
- Updated `versions.yml` changelog wording accordingly
- Fixed biome import sorting issues

## Testing

- [x] Unit tests added for `correctIncorrectDockerOrg`, `correctIncorrectDockerOrgWithWarning`, and integration with `addDefaultDockerOrgIfNotPresent` and `normalizeGeneratorName`
- [x] All 49 tests passing
- [x] Biome checks passing locally

## Human Review Checklist

- **Warning message wording**: The warning says `"fern-api/..." is not a valid generator name` — verify this phrasing is clear and won't confuse users into thinking the generator itself doesn't exist (vs. just having the wrong org prefix).
- **`generator list` gap**: The `fern generator list --generators` flag in `cliV2.ts` accepts an array of generator names but these are **not** corrected. Verify whether this is acceptable or needs coverage.
- **Duplicate helpers**: `warnAndCorrectIncorrectDockerOrg` in `cli.ts` and `warnAndCorrectIncorrectDockerOrgV2` in `cliV2.ts` are near-identical. They exist because they use `cliContext.logger` rather than `TaskContext.logger`. Consider whether deduplication is worth it.
- **Double correction in convertGeneratorsConfiguration**: The code calls `correctIncorrectDockerOrgWithWarning` then `addDefaultDockerOrgIfNotPresent`, but the latter already calls `correctIncorrectDockerOrg` internally. This is functionally correct (warning fires, second correction is a no-op) but slightly redundant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
