### PR TITLE
fix(typescript): change [TIMING] logs from info to debug level

### DIFF
--- a/generators/base/src/AbstractGeneratorCli.ts
+++ b/generators/base/src/AbstractGeneratorCli.ts
@@ -47,11 +47,11 @@ export abstract class AbstractGeneratorCli<
                 generatorConfig: config,
                 generatorNotificationService
             });
-            context.logger.info(`[TIMING] parseIntermediateRepresentation took ${irElapsed}ms`);
-            context.logger.info(`[TIMING] constructContext took ${Date.now() - contextStartTime}ms`);
+            context.logger.debug(`[TIMING] parseIntermediateRepresentation took ${irElapsed}ms`);
+            context.logger.debug(`[TIMING] constructContext took ${Date.now() - contextStartTime}ms`);
             const metadataStartTime = Date.now();
             await this.generateMetadata(context);
-            context.logger.info(`[TIMING] generateMetadata took ${Date.now() - metadataStartTime}ms`);
+            context.logger.debug(`[TIMING] generateMetadata took ${Date.now() - metadataStartTime}ms`);
             const outputStartTime = Date.now();
             switch (config.output.mode.type) {
                 case "publish":
@@ -66,7 +66,7 @@ export abstract class AbstractGeneratorCli<
                 default:
                     assertNever(config.output.mode);
             }
-            context.logger.info(`[TIMING] output (${config.output.mode.type}) took ${Date.now() - outputStartTime}ms`);
+            context.logger.debug(`[TIMING] output (${config.output.mode.type}) took ${Date.now() - outputStartTime}ms`);
             await generatorNotificationService.sendUpdate(
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(FernGeneratorExec.ExitStatusUpdate.successful({}))
             );

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -215,26 +215,26 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
             libraryPath,
             solutionPath
         });
-        this.context.logger.info(`[TIMING] createProject took ${Date.now() - createProjectStartTime}ms`);
+        this.context.logger.debug(`[TIMING] createProject took ${Date.now() - createProjectStartTime}ms`);
         const createTestProjectStartTime = Date.now();
         const absolutePathToTestProjectDirectory = await this.createTestProject({
             absolutePathToTestDirectory,
             absolutePathToSolutionDirectory,
             absolutePathToProjectDirectory
         });
-        this.context.logger.info(`[TIMING] createTestProject took ${Date.now() - createTestProjectStartTime}ms`);
+        this.context.logger.debug(`[TIMING] createTestProject took ${Date.now() - createTestProjectStartTime}ms`);
 
         const writeSourceFilesStartTime = Date.now();
         for (const file of this.sourceFiles) {
             await file.write(absolutePathToProjectDirectory);
         }
-        this.context.logger.info(`[TIMING] writeSourceFiles took ${Date.now() - writeSourceFilesStartTime}ms`);
+        this.context.logger.debug(`[TIMING] writeSourceFiles took ${Date.now() - writeSourceFilesStartTime}ms`);
 
         const writeTestFilesStartTime = Date.now();
         for (const file of this.testFiles) {
             await file.write(absolutePathToTestProjectDirectory);
         }
-        this.context.logger.info(`[TIMING] writeTestFiles took ${Date.now() - writeTestFilesStartTime}ms`);
+        this.context.logger.debug(`[TIMING] writeTestFiles took ${Date.now() - writeTestFilesStartTime}ms`);
 
         await this.createRawFiles();
 
@@ -335,13 +335,13 @@ dotnet_diagnostic.IDE0005.severity = error
           `
             );
         }
-        this.context.logger.info(`[TIMING] dotnetFormat took ${Date.now() - dotnetFormatStartTime}ms`);
+        this.context.logger.debug(`[TIMING] dotnetFormat took ${Date.now() - dotnetFormatStartTime}ms`);
 
         // format the code cleanly using csharpier on the full output directory
         const csharpierStartTime = Date.now();
         await this.csharpier(this.absolutePathToOutputDirectory);
-        this.context.logger.info(`[TIMING] csharpier took ${Date.now() - csharpierStartTime}ms`);
-        this.context.logger.info(`[TIMING] persist took ${Date.now() - persistStartTime}ms`);
+        this.context.logger.debug(`[TIMING] csharpier took ${Date.now() - csharpierStartTime}ms`);
+        this.context.logger.debug(`[TIMING] persist took ${Date.now() - persistStartTime}ms`);
     }
 
     private async createProject({

--- a/generators/csharp/model/src/ModelGeneratorCli.ts
+++ b/generators/csharp/model/src/ModelGeneratorCli.ts
@@ -59,7 +59,7 @@ export class ModelGeneratorCLI extends AbstractCsharpGeneratorCli {
     private async generate(context: ModelGeneratorContext): Promise<void> {
         const generateStartTime = Date.now();
         const generatedTypes = generateModels({ context });
-        context.logger.info(`[TIMING] generateModels took ${Date.now() - generateStartTime}ms`);
+        context.logger.debug(`[TIMING] generateModels took ${Date.now() - generateStartTime}ms`);
         for (const file of generatedTypes) {
             context.project.addSourceFiles(file);
         }
@@ -73,7 +73,7 @@ export class ModelGeneratorCLI extends AbstractCsharpGeneratorCli {
             }
         }
 
-        context.logger.info(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);
+        context.logger.debug(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);
         await context.project.persist();
     }
 }

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.0.8
+  changelogEntry:
+    - summary: |
+        Change [TIMING] log statements from info to debug level so they are only
+        printed when debug logging is enabled.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 62
+
 - version: 0.0.7
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/src/SdkGeneratorCli.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorCli.ts
@@ -106,13 +106,13 @@ export class SdkGeneratorCLI extends AbstractCsharpGeneratorCli {
         // generate names for everything up front.
         const precalculateStartTime = Date.now();
         context.precalculate();
-        context.logger.info(`[TIMING] precalculate took ${Date.now() - precalculateStartTime}ms`);
+        context.logger.debug(`[TIMING] precalculate took ${Date.now() - precalculateStartTime}ms`);
 
         // before generating anything, generate the models first so that we
         // can identify collisions or ambiguities in the generated code.
         const modelsStartTime = Date.now();
         const models = generateModels({ context });
-        context.logger.info(`[TIMING] generateModels took ${Date.now() - modelsStartTime}ms`);
+        context.logger.debug(`[TIMING] generateModels took ${Date.now() - modelsStartTime}ms`);
 
         await context.snippetGenerator.populateSnippetsCache();
 
@@ -296,7 +296,7 @@ export class SdkGeneratorCLI extends AbstractCsharpGeneratorCli {
                 context.logger.warn("Failed to generate reference.md, this is OK.");
             }
         }
-        context.logger.info(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);
+        context.logger.debug(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);
         await context.project.persist();
     }
 

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.22.2
+  changelogEntry:
+    - summary: |
+        Change [TIMING] log statements from info to debug level so they are only
+        printed when debug logging is enabled.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 62
+
 - version: 2.22.1
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.49.1
+  changelogEntry:
+    - summary: |
+        Change [TIMING] log statements from info to debug level so they are only
+        printed when debug logging is enabled.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 63
+
 - version: 3.49.0
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -126,7 +126,7 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                 generatorContext,
                 intermediateRepresentation: ir
             });
-            logger.info(`[TIMING] code generation took ${Date.now() - codeGenStartTime}ms`);
+            logger.debug(`[TIMING] code generation took ${Date.now() - codeGenStartTime}ms`);
             if (!generatorContext.didSucceed()) {
                 throw new Error("Failed to generate TypeScript project.");
             }

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -81,7 +81,7 @@ export class PersistedTypescriptProject {
             logger.debug("Running npm pkg fix to normalize package.json");
             const startTime = Date.now();
             await npm(["pkg", "fix"]);
-            logger.info(`[TIMING] fixPackageJson took ${Date.now() - startTime}ms`);
+            logger.debug(`[TIMING] fixPackageJson took ${Date.now() - startTime}ms`);
         } catch (e) {
             logger.warn(`Failed to run npm pkg fix: ${e}`);
         }
@@ -111,7 +111,7 @@ export class PersistedTypescriptProject {
                       PNPM_FROZEN_LOCKFILE: "false"
                   }
               }));
-        logger.info(`[TIMING] generateLockfile took ${Date.now() - startTime}ms`);
+        logger.debug(`[TIMING] generateLockfile took ${Date.now() - startTime}ms`);
     }
 
     public async installDependencies(logger: Logger): Promise<void> {
@@ -138,7 +138,7 @@ export class PersistedTypescriptProject {
                       PNPM_FROZEN_LOCKFILE: "false"
                   }
               }));
-        logger.info(`[TIMING] installDependencies took ${Date.now() - startTime}ms`);
+        logger.debug(`[TIMING] installDependencies took ${Date.now() - startTime}ms`);
     }
 
     public async format(logger: Logger): Promise<void> {
@@ -153,7 +153,7 @@ export class PersistedTypescriptProject {
         try {
             const startTime = Date.now();
             await pm(this.formatCommand);
-            logger.info(`[TIMING] format took ${Date.now() - startTime}ms`);
+            logger.debug(`[TIMING] format took ${Date.now() - startTime}ms`);
         } catch (e) {
             logger.error(`Failed to format the generated project: ${e}`);
         }
@@ -172,7 +172,7 @@ export class PersistedTypescriptProject {
         try {
             const startTime = Date.now();
             await pm(this.checkFixCommand);
-            logger.info(`[TIMING] checkFix took ${Date.now() - startTime}ms`);
+            logger.debug(`[TIMING] checkFix took ${Date.now() - startTime}ms`);
         } catch (e) {
             logger.error(`Failed to format the generated project: ${e}`);
         }
@@ -189,7 +189,7 @@ export class PersistedTypescriptProject {
         });
         const startTime = Date.now();
         await pm(this.buildCommand);
-        logger.info(`[TIMING] build took ${Date.now() - startTime}ms`);
+        logger.debug(`[TIMING] build took ${Date.now() - startTime}ms`);
     }
 
     public async copyProjectTo({
@@ -370,7 +370,7 @@ export class PersistedTypescriptProject {
         await npm(publishCommand, {
             secrets: [publishInfo.registryUrl]
         });
-        logger.info(`[TIMING] publish took ${Date.now() - startTime}ms`);
+        logger.debug(`[TIMING] publish took ${Date.now() - startTime}ms`);
     }
 
     public async deleteGitIgnoredFiles(logger: Logger): Promise<void> {


### PR DESCRIPTION
## Description

Refs: Reported by @Swimburger

`[TIMING]` log statements (e.g. `[TIMING] code generation took 4174ms`) were always printed during generation, even when debug log level was not requested. This changes them from `logger.info` to `logger.debug` so they only appear when debug logging is enabled.

[Link to Devin run](https://app.devin.ai/sessions/7e22a1285df14dcbbeef9610a4ee6b46)

## Changes Made

- Changed all `[TIMING]` log calls from `.info()` to `.debug()` across:
  - `generators/base/src/AbstractGeneratorCli.ts` (4 calls — shared by C# generators)
  - `generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts` (1 call)
  - `generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts` (7 calls)
  - `generators/csharp/sdk/src/SdkGeneratorCli.ts` (3 calls)
  - `generators/csharp/base/src/project/CsharpProject.ts` (7 calls)
  - `generators/csharp/model/src/ModelGeneratorCli.ts` (2 calls)
- Bumped versions: TS SDK → 3.49.1, C# SDK → 2.22.2, C# model → 0.0.8

## Review Checklist

- [ ] Verify no `[TIMING]` info-level logs were missed (grep for `logger.info.*TIMING` across the repo)
- [ ] Confirm `generators/base` doesn't need its own version bump (it's an internal package consumed by C# generators)
- [ ] Confirm `debug` is the appropriate level (vs `trace`)

## Testing

- No unit tests needed — this is a log-level-only change with no behavioral impact