### PR TITLE
fix(cli): handle new SDK repos in AUTO versioning

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.84.1
+  changelogEntry:
+    - summary: |
+        Fix AUTO versioning failing for new SDK repositories. When generating an SDK
+        into an empty or newly initialized repository, the version extraction would fail
+        because all files are new additions with no previous version lines in the diff.
+        Now returns 0.0.1 as the initial version instead of throwing an error.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 65
 - version: 3.84.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/AutoVersioningService.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/AutoVersioningService.ts
@@ -47,10 +47,10 @@ export class AutoVersioningService {
      *
      * @param diffContent The git diff content
      * @param mappedMagicVersion The magic version after language transformations (e.g., "v505.503.4455" for Go)
-     * @return The previous version if found
-     * @throws AutoVersioningException if no previous version can be extracted from the diff
+     * @return The previous version if found, or undefined if all magic version occurrences are in new files
+     * @throws AutoVersioningException if the magic version is not found at all in the diff
      */
-    public extractPreviousVersion(diffContent: string, mappedMagicVersion: string): string {
+    public extractPreviousVersion(diffContent: string, mappedMagicVersion: string): string | undefined {
         const lines = diffContent.split("\n");
 
         let currentFile = "unknown";
@@ -89,10 +89,11 @@ export class AutoVersioningService {
         }
 
         if (magicVersionOccurrences > 0) {
-            throw new AutoVersioningException(
+            this.logger.info(
                 `Found placeholder version in the diff but no matching previous version lines were found in any hunk. ` +
-                    `This may indicate new files or a format change. occurrences=${magicVersionOccurrences}, pairsFound=0`
+                    `This indicates a new SDK repository with no previous version. occurrences=${magicVersionOccurrences}`
             );
+            return undefined;
         }
 
         throw new AutoVersioningException(

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -139,6 +139,22 @@ export class LocalTaskHandler {
 
             this.context.logger.debug(`Generated diff size: ${diffContent.length} bytes`);
             this.context.logger.debug(`Cleaned diff size: ${cleanedDiff.length} bytes`);
+
+            // Handle new SDK repository with no previous version
+            if (previousVersion == null) {
+                this.context.logger.info(
+                    "No previous version found (new SDK repository). Using 0.0.1 as initial version."
+                );
+                const initialVersion = "0.0.1";
+                const commitMessage = this.isWhitelabel
+                    ? "Initial SDK generation"
+                    : "Initial SDK generation\n\n🌿 Generated with Fern";
+                return {
+                    version: initialVersion,
+                    commitMessage
+                };
+            }
+
             this.context.logger.debug(`Previous version detected: ${previousVersion}`);
 
             // Call AI to analyze the diff

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -145,7 +145,7 @@ export class LocalTaskHandler {
                 this.context.logger.info(
                     "No previous version found (new SDK repository). Using 0.0.1 as initial version."
                 );
-                const initialVersion = "0.0.1";
+                const initialVersion = this.version?.startsWith("v") ? "v0.0.1" : "0.0.1";
                 const commitMessage = this.isWhitelabel
                     ? "Initial SDK generation"
                     : "Initial SDK generation\n\n🌿 Generated with Fern";

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
@@ -773,9 +773,9 @@ describe("AutoVersioningService", () => {
     });
 
     it("testExtractPreviousVersion_emptyDiff_throws", () => {
-        expect(() => new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion("", "505.503.4455")).toThrow(
-            AutoVersioningException
-        );
+        expect(() =>
+            new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion("", "505.503.4455")
+        ).toThrow(AutoVersioningException);
     });
 
     it("testExtractPreviousVersion_magicVersionOnlyInContextLines_throws", () => {
@@ -818,7 +818,7 @@ describe("AutoVersioningService", () => {
             "+package sdk\n" +
             "+\n" +
             "+type Client struct {\n" +
-            '+    version string // v505.503.4455\n' +
+            "+    version string // v505.503.4455\n" +
             "+}\n";
 
         const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "v505.503.4455");

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
@@ -2,7 +2,7 @@ import { execSync } from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { describe, expect, it } from "vitest";
-import { AutoVersioningService } from "../AutoVersioningService.js";
+import { AutoVersioningException, AutoVersioningService } from "../AutoVersioningService.js";
 
 // Mock logger for tests
 const mockLogger = {
@@ -751,6 +751,374 @@ describe("AutoVersioningService", () => {
         } finally {
             await fs.rm(tempDir, { recursive: true, force: true });
         }
+    });
+
+    // --- Tests for extractPreviousVersion: exception path ---
+
+    it("testExtractPreviousVersion_noMagicVersionInDiff_throws", () => {
+        // When the magic version is not found at all in the diff, it should throw
+        const diff =
+            "diff --git a/README.md b/README.md\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/README.md\n" +
+            "+++ b/README.md\n" +
+            "@@ -1,3 +1,4 @@\n" +
+            " # My Project\n" +
+            "+Some new content\n" +
+            " ## Installation\n";
+
+        expect(() =>
+            new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455")
+        ).toThrow(AutoVersioningException);
+    });
+
+    it("testExtractPreviousVersion_emptyDiff_throws", () => {
+        expect(() => new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion("", "505.503.4455")).toThrow(
+            AutoVersioningException
+        );
+    });
+
+    it("testExtractPreviousVersion_magicVersionOnlyInContextLines_throws", () => {
+        // Magic version appears in context lines (no + or - prefix), should not count
+        const diff =
+            "diff --git a/config.txt b/config.txt\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/config.txt\n" +
+            "+++ b/config.txt\n" +
+            "@@ -1,3 +1,4 @@\n" +
+            " version = 505.503.4455\n" +
+            "+new line added\n" +
+            " other content\n";
+
+        expect(() =>
+            new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455")
+        ).toThrow(AutoVersioningException);
+    });
+
+    // --- Tests for extractPreviousVersion: new repo with v prefix ---
+
+    it("testExtractPreviousVersion_newRepoWithVPrefixMagicVersion_returnsUndefined", () => {
+        // Go SDK new repo: all files are new, magic version has v prefix
+        const diff =
+            "diff --git a/version.go b/version.go\n" +
+            "new file mode 100644\n" +
+            "index 0000000..abc123\n" +
+            "--- /dev/null\n" +
+            "+++ b/version.go\n" +
+            "@@ -0,0 +1,3 @@\n" +
+            "+package sdk\n" +
+            '+const Version = "v505.503.4455"\n' +
+            "+\n" +
+            "diff --git a/client.go b/client.go\n" +
+            "new file mode 100644\n" +
+            "index 0000000..def456\n" +
+            "--- /dev/null\n" +
+            "+++ b/client.go\n" +
+            "@@ -0,0 +1,5 @@\n" +
+            "+package sdk\n" +
+            "+\n" +
+            "+type Client struct {\n" +
+            '+    version string // v505.503.4455\n' +
+            "+}\n";
+
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "v505.503.4455");
+        expect(result).toBeUndefined();
+    });
+
+    it("testExtractPreviousVersion_singleNewFileWithVPrefix_returnsUndefined", () => {
+        const diff =
+            "diff --git a/version.go b/version.go\n" +
+            "new file mode 100644\n" +
+            "index 0000000..abc123\n" +
+            "--- /dev/null\n" +
+            "+++ b/version.go\n" +
+            "@@ -0,0 +1 @@\n" +
+            '+const Version = "v505.503.4455"\n';
+
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "v505.503.4455");
+        expect(result).toBeUndefined();
+    });
+
+    // --- Tests for extractPreviousVersion: mixed scenario ---
+
+    it("testExtractPreviousVersion_mixedNewAndExistingFiles_returnsVersionFromExisting", () => {
+        // Some files are new (no matching minus lines), but one existing file has a version pair
+        const diff =
+            "diff --git a/src/newFile.ts b/src/newFile.ts\n" +
+            "new file mode 100644\n" +
+            "index 0000000..abc123\n" +
+            "--- /dev/null\n" +
+            "+++ b/src/newFile.ts\n" +
+            "@@ -0,0 +1,3 @@\n" +
+            '+export const SDK_VERSION = "505.503.4455";\n' +
+            "+export const name = 'test';\n" +
+            "diff --git a/package.json b/package.json\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/package.json\n" +
+            "+++ b/package.json\n" +
+            "@@ -1,5 +1,5 @@\n" +
+            " {\n" +
+            '-  "version": "2.3.4",\n' +
+            '+  "version": "505.503.4455",\n' +
+            '   "name": "test"\n' +
+            " }\n";
+
+        const previousVersion = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
+            diff,
+            "505.503.4455"
+        );
+        expect(previousVersion).toBe("2.3.4");
+    });
+
+    it("testExtractPreviousVersion_mixedNewAndExistingFiles_newFileFirst_returnsVersionFromExisting", () => {
+        // New file appears first in the diff, followed by existing file with version pair.
+        // The new file's magic version occurrence should be skipped, then find match in existing file.
+        const diff =
+            "diff --git a/src/version.ts b/src/version.ts\n" +
+            "new file mode 100644\n" +
+            "index 0000000..abc123\n" +
+            "--- /dev/null\n" +
+            "+++ b/src/version.ts\n" +
+            "@@ -0,0 +1,1 @@\n" +
+            '+export const VERSION = "505.503.4455";\n' +
+            "diff --git a/src/Client.ts b/src/Client.ts\n" +
+            "new file mode 100644\n" +
+            "index 0000000..def456\n" +
+            "--- /dev/null\n" +
+            "+++ b/src/Client.ts\n" +
+            "@@ -0,0 +1,2 @@\n" +
+            '+import { VERSION } from "./version";\n' +
+            '+const v = "505.503.4455";\n' +
+            "diff --git a/package.json b/package.json\n" +
+            "index 111111..222222 100644\n" +
+            "--- a/package.json\n" +
+            "+++ b/package.json\n" +
+            "@@ -2,3 +2,3 @@\n" +
+            '   "name": "my-sdk",\n' +
+            '-  "version": "1.0.0",\n' +
+            '+  "version": "505.503.4455",\n' +
+            '   "private": false\n';
+
+        const previousVersion = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
+            diff,
+            "505.503.4455"
+        );
+        expect(previousVersion).toBe("1.0.0");
+    });
+
+    // --- Tests for cleanDiffForAI: new file scenarios ---
+
+    it("testCleanDiffForAI_allNewFiles_removesAllVersionLines", () => {
+        // Simulates a new SDK repo where all files are new (all + lines)
+        const diff =
+            "diff --git a/package.json b/package.json\n" +
+            "new file mode 100644\n" +
+            "index 0000000..abc123\n" +
+            "--- /dev/null\n" +
+            "+++ b/package.json\n" +
+            "@@ -0,0 +1,5 @@\n" +
+            "+{\n" +
+            '+    "name": "test-sdk",\n' +
+            '+    "version": "505.503.4455",\n' +
+            '+    "private": false\n' +
+            "+}\n" +
+            "diff --git a/src/Client.ts b/src/Client.ts\n" +
+            "new file mode 100644\n" +
+            "index 0000000..def456\n" +
+            "--- /dev/null\n" +
+            "+++ b/src/Client.ts\n" +
+            "@@ -0,0 +1,3 @@\n" +
+            "+export class Client {\n" +
+            "+    constructor() {}\n" +
+            "+}\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(diff, "505.503.4455");
+
+        // The version line should be removed
+        expect(cleaned).not.toContain("505.503.4455");
+        // Other new file content should be preserved
+        expect(cleaned).toContain('+    "name": "test-sdk"');
+        expect(cleaned).toContain("+export class Client");
+    });
+
+    it("testCleanDiffForAI_newFileWithVPrefixMagicVersion", () => {
+        // Go SDK new file scenario with v-prefixed magic version
+        const diff =
+            "diff --git a/version.go b/version.go\n" +
+            "new file mode 100644\n" +
+            "index 0000000..abc123\n" +
+            "--- /dev/null\n" +
+            "+++ b/version.go\n" +
+            "@@ -0,0 +1,3 @@\n" +
+            "+package sdk\n" +
+            '+const Version = "v505.503.4455"\n' +
+            "+\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(diff, "v505.503.4455");
+
+        expect(cleaned).not.toContain("v505.503.4455");
+        expect(cleaned).toContain("+package sdk");
+    });
+
+    // --- Tests for replaceMagicVersion: initial version scenarios ---
+
+    it("testReplaceMagicVersion_withVPrefixInitialVersion", async () => {
+        // Simulates Go SDK initial generation: replacing v505.503.4455 with v0.0.1
+        const tempDir = await fs.mkdtemp(path.join(require("os").tmpdir(), "test-"));
+        try {
+            const versionFile = path.join(tempDir, "version.go");
+            await fs.writeFile(versionFile, 'package sdk\n\nconst Version = "v505.503.4455"\n');
+
+            const clientFile = path.join(tempDir, "client.go");
+            await fs.writeFile(clientFile, 'package sdk\n\nvar sdkVersion = "v505.503.4455"\n');
+
+            await new AutoVersioningService({ logger: mockLogger }).replaceMagicVersion(
+                tempDir,
+                "v505.503.4455",
+                "v0.0.1"
+            );
+
+            const versionContent = await fs.readFile(versionFile, "utf-8");
+            expect(versionContent).not.toContain("v505.503.4455");
+            expect(versionContent).toContain("v0.0.1");
+            expect(versionContent).toBe('package sdk\n\nconst Version = "v0.0.1"\n');
+
+            const clientContent = await fs.readFile(clientFile, "utf-8");
+            expect(clientContent).not.toContain("v505.503.4455");
+            expect(clientContent).toContain("v0.0.1");
+        } finally {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it("testReplaceMagicVersion_withNonVPrefixInitialVersion", async () => {
+        // Simulates TS/Python SDK initial generation: replacing 505.503.4455 with 0.0.1
+        const tempDir = await fs.mkdtemp(path.join(require("os").tmpdir(), "test-"));
+        try {
+            const packageJson = path.join(tempDir, "package.json");
+            await fs.writeFile(packageJson, '{\n  "name": "test-sdk",\n  "version": "505.503.4455"\n}');
+
+            const clientFile = path.join(tempDir, "src");
+            await fs.mkdir(clientFile, { recursive: true });
+            const versionTs = path.join(clientFile, "version.ts");
+            await fs.writeFile(versionTs, 'export const SDK_VERSION = "505.503.4455";\n');
+
+            await new AutoVersioningService({ logger: mockLogger }).replaceMagicVersion(
+                tempDir,
+                "505.503.4455",
+                "0.0.1"
+            );
+
+            const packageContent = await fs.readFile(packageJson, "utf-8");
+            expect(packageContent).not.toContain("505.503.4455");
+            expect(packageContent).toContain("0.0.1");
+            expect(packageContent).toBe('{\n  "name": "test-sdk",\n  "version": "0.0.1"\n}');
+
+            const versionContent = await fs.readFile(versionTs, "utf-8");
+            expect(versionContent).not.toContain("505.503.4455");
+            expect(versionContent).toContain("0.0.1");
+        } finally {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    // --- Tests for extractPreviousVersion: edge cases ---
+
+    it("testExtractPreviousVersion_magicVersionInDeletedLine_throws", () => {
+        // Magic version appears only in a deleted line (not added), should not count
+        const diff =
+            "diff --git a/package.json b/package.json\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/package.json\n" +
+            "+++ b/package.json\n" +
+            "@@ -1,5 +1,4 @@\n" +
+            " {\n" +
+            '-  "version": "505.503.4455",\n' +
+            '   "name": "test"\n' +
+            " }\n";
+
+        expect(() =>
+            new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455")
+        ).toThrow(AutoVersioningException);
+    });
+
+    it("testExtractPreviousVersion_multipleExistingFilesWithVersions_returnsFirst", () => {
+        // Multiple files with version pairs - should return the first match
+        const diff =
+            "diff --git a/package.json b/package.json\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/package.json\n" +
+            "+++ b/package.json\n" +
+            "@@ -1,5 +1,5 @@\n" +
+            " {\n" +
+            '-  "version": "3.2.1",\n' +
+            '+  "version": "505.503.4455",\n' +
+            '   "name": "test"\n' +
+            " }\n" +
+            "diff --git a/src/version.ts b/src/version.ts\n" +
+            "index 111111..222222 100644\n" +
+            "--- a/src/version.ts\n" +
+            "+++ b/src/version.ts\n" +
+            "@@ -1 +1 @@\n" +
+            '-export const VERSION = "3.2.1";\n' +
+            '+export const VERSION = "505.503.4455";\n';
+
+        const previousVersion = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
+            diff,
+            "505.503.4455"
+        );
+        expect(previousVersion).toBe("3.2.1");
+    });
+
+    it("testExtractPreviousVersion_versionWithBuildMetadata", () => {
+        const diff =
+            "diff --git a/setup.py b/setup.py\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/setup.py\n" +
+            "+++ b/setup.py\n" +
+            "@@ -1,3 +1,3 @@\n" +
+            " setup(\n" +
+            "-    version='1.0.0+build.123',\n" +
+            "+    version='505.503.4455',\n" +
+            " )\n";
+
+        const previousVersion = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
+            diff,
+            "505.503.4455"
+        );
+        expect(previousVersion).toBe("1.0.0+build.123");
+    });
+
+    // --- Tests for cleanDiffForAI: mixed new and existing files ---
+
+    it("testCleanDiffForAI_mixedNewAndExistingFiles_preservesNonVersionContent", () => {
+        const diff =
+            "diff --git a/src/newFile.ts b/src/newFile.ts\n" +
+            "new file mode 100644\n" +
+            "index 0000000..abc123\n" +
+            "--- /dev/null\n" +
+            "+++ b/src/newFile.ts\n" +
+            "@@ -0,0 +1,3 @@\n" +
+            "+export function hello() {\n" +
+            '+    return "505.503.4455";\n' +
+            "+}\n" +
+            "diff --git a/src/existing.ts b/src/existing.ts\n" +
+            "index 111111..222222 100644\n" +
+            "--- a/src/existing.ts\n" +
+            "+++ b/src/existing.ts\n" +
+            "@@ -1,3 +1,4 @@\n" +
+            " export class Existing {\n" +
+            "+    newMethod() { return true; }\n" +
+            " }\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(diff, "505.503.4455");
+
+        // Version line removed from new file
+        expect(cleaned).not.toContain("505.503.4455");
+        // Non-version new file content preserved
+        expect(cleaned).toContain("+export function hello()");
+        // Existing file changes preserved
+        expect(cleaned).toContain("+    newMethod() { return true; }");
     });
 
     // TODO(tjb9dc): Reenable these tests, need to have them reference the LocalTaskHandler's gitDiff function (or refactor)

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
@@ -109,10 +109,7 @@ describe("AutoVersioningService", () => {
             "@@ -0,0 +1 @@\n" +
             "+version = 505.503.4455\n";
 
-        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
-            diff,
-            "505.503.4455"
-        );
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455");
         expect(result).toBeUndefined();
     });
 
@@ -147,12 +144,9 @@ describe("AutoVersioningService", () => {
             "+++ b/src/core/index.ts\n" +
             "@@ -0,0 +1,3 @@\n" +
             '+export const SDK_VERSION = "505.503.4455";\n' +
-            "+export const SDK_NAME = \"test-sdk\";\n";
+            '+export const SDK_NAME = "test-sdk";\n';
 
-        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
-            diff,
-            "505.503.4455"
-        );
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455");
         expect(result).toBeUndefined();
     });
 
@@ -276,10 +270,7 @@ describe("AutoVersioningService", () => {
 
         // The minus line doesn't form a version pair, so no previous version can be extracted.
         // This is treated like a new file scenario - returns undefined instead of throwing.
-        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
-            diff,
-            "505.503.4455"
-        );
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455");
         expect(result).toBeUndefined();
     });
 
@@ -348,10 +339,7 @@ describe("AutoVersioningService", () => {
             " # Changelog\n" +
             "+## 505.503.4455\n";
 
-        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
-            diff,
-            "505.503.4455"
-        );
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455");
         expect(result).toBeUndefined();
     });
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
@@ -2,7 +2,7 @@ import { execSync } from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { describe, expect, it } from "vitest";
-import { AutoVersioningException, AutoVersioningService } from "../AutoVersioningService.js";
+import { AutoVersioningService } from "../AutoVersioningService.js";
 
 // Mock logger for tests
 const mockLogger = {
@@ -99,7 +99,7 @@ describe("AutoVersioningService", () => {
         expect(previousVersion).toBe("3.0.0-beta.2");
     });
 
-    it("testExtractPreviousVersion_noPreviousVersion", () => {
+    it("testExtractPreviousVersion_noPreviousVersion_returnsUndefined", () => {
         const diff =
             "diff --git a/new-file.txt b/new-file.txt\n" +
             "new file mode 100644\n" +
@@ -109,9 +109,51 @@ describe("AutoVersioningService", () => {
             "@@ -0,0 +1 @@\n" +
             "+version = 505.503.4455\n";
 
-        expect(() => {
-            new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455");
-        }).toThrow(AutoVersioningException);
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
+            diff,
+            "505.503.4455"
+        );
+        expect(result).toBeUndefined();
+    });
+
+    it("testExtractPreviousVersion_newRepoWithMultipleNewFiles_returnsUndefined", () => {
+        // Simulates a new SDK repo where all files are new (like immix-ts-sdk initial generation)
+        const diff =
+            "diff --git a/package.json b/package.json\n" +
+            "new file mode 100644\n" +
+            "index 0000000..abc123\n" +
+            "--- /dev/null\n" +
+            "+++ b/package.json\n" +
+            "@@ -0,0 +1,6 @@\n" +
+            "+{\n" +
+            '+    "name": "test-sdk",\n' +
+            '+    "version": "505.503.4455",\n' +
+            '+    "private": false\n' +
+            "+}\n" +
+            "diff --git a/src/Client.ts b/src/Client.ts\n" +
+            "new file mode 100644\n" +
+            "index 0000000..def456\n" +
+            "--- /dev/null\n" +
+            "+++ b/src/Client.ts\n" +
+            "@@ -0,0 +1,5 @@\n" +
+            "+export class Client {\n" +
+            '+    private readonly version = "505.503.4455";\n' +
+            "+    constructor() {}\n" +
+            "+}\n" +
+            "diff --git a/src/core/index.ts b/src/core/index.ts\n" +
+            "new file mode 100644\n" +
+            "index 0000000..789abc\n" +
+            "--- /dev/null\n" +
+            "+++ b/src/core/index.ts\n" +
+            "@@ -0,0 +1,3 @@\n" +
+            '+export const SDK_VERSION = "505.503.4455";\n' +
+            "+export const SDK_NAME = \"test-sdk\";\n";
+
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
+            diff,
+            "505.503.4455"
+        );
+        expect(result).toBeUndefined();
     });
 
     it("testCleanDiffForAI_removesMagicVersionLines", () => {
@@ -222,7 +264,7 @@ describe("AutoVersioningService", () => {
         expect(cleaned).not.toContain("version.go");
     });
 
-    it("testExtractPreviousVersion_invalidVersionFormat", () => {
+    it("testExtractPreviousVersion_invalidVersionFormat_returnsUndefined", () => {
         const diff =
             "diff --git a/config.txt b/config.txt\n" +
             "index abc123..def456 100644\n" +
@@ -232,9 +274,13 @@ describe("AutoVersioningService", () => {
             "-some random text\n" +
             "+magic version is 505.503.4455\n";
 
-        expect(() => {
-            new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455");
-        }).toThrow(AutoVersioningException);
+        // The minus line doesn't form a version pair, so no previous version can be extracted.
+        // This is treated like a new file scenario - returns undefined instead of throwing.
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
+            diff,
+            "505.503.4455"
+        );
+        expect(result).toBeUndefined();
     });
 
     it("testExtractPreviousVersion_withNonVersionLinesInBetween", () => {
@@ -285,7 +331,7 @@ describe("AutoVersioningService", () => {
         expect(previousVersion).toBe("1.5.0");
     });
 
-    it("testExtractPreviousVersion_noMatchingMinusLines_throwsException", () => {
+    it("testExtractPreviousVersion_noMatchingMinusLines_returnsUndefined", () => {
         const diff =
             "diff --git a/README.md b/README.md\n" +
             "index abc123..def456 100644\n" +
@@ -302,14 +348,11 @@ describe("AutoVersioningService", () => {
             " # Changelog\n" +
             "+## 505.503.4455\n";
 
-        try {
-            new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(diff, "505.503.4455");
-            expect.fail("Should have thrown AutoVersioningException");
-        } catch (error) {
-            expect(error).toBeInstanceOf(AutoVersioningException);
-            expect((error as Error).message).toContain("no matching previous version lines were found");
-            expect((error as Error).message).toContain("occurrences=2");
-        }
+        const result = new AutoVersioningService({ logger: mockLogger }).extractPreviousVersion(
+            diff,
+            "505.503.4455"
+        );
+        expect(result).toBeUndefined();
     });
 
     it("testCleanDiffForAI_removesFileWithOnlyVersionChanges", () => {


### PR DESCRIPTION
## Description

Refs [fern-demo/immix-fern-config@dc98ec1](https://github.com/fern-demo/immix-fern-config/commit/dc98ec1ef5f7c656cfacc76b676c36a8f5d73416)

When `fern generate --version AUTO` targets a new/empty SDK repository (e.g. `fern-demo/immix-ts-sdk` which only had an initial README commit), `extractPreviousVersion` threw `AutoVersioningException` because the git diff contained only `+` lines (new files) with no corresponding `-` lines carrying the old version. This caused the entire TS SDK generation to fail with:

```
AUTO versioning failed: Found magic version in the diff but no matching previous version lines were found in any hunk. occurrences=5, pairsFound=0
```

## Changes Made

- **`AutoVersioningService.extractPreviousVersion`**: Changed return type from `string` → `string | undefined`. When magic version occurrences exist in the diff but no matching deletion lines are found (new repo), returns `undefined` instead of throwing.
- **`LocalTaskHandler.handleAutoVersioning`**: When `previousVersion` is `undefined`, skips AI analysis and returns `0.0.1` as the initial version with an "Initial SDK generation" commit message. Respects the `v` prefix for Go SDKs (returns `v0.0.1` when `this.version` starts with `"v"`).
- Updated 3 existing tests (changed from expecting throws to expecting `undefined`) and added 16 new tests covering:
  - `AutoVersioningException` throw paths (no magic version in diff, empty diff, magic version only in context lines, magic version only in deleted lines)
  - New repo with `v` prefix magic version (Go SDK scenario)
  - Mixed new + existing files (version extracted from existing file)
  - `cleanDiffForAI` with all-new-file diffs and `v`-prefixed magic versions
  - `replaceMagicVersion` with initial versions (`0.0.1` and `v0.0.1`)
  - Edge cases: multiple files with versions (returns first), build metadata versions
- Added `versions.yml` entry for CLI 3.85.1.

## Testing

- [x] Unit tests added/updated (46/46 passing locally)
- [x] Biome lint passing
- [x] CI: biome, lint, compile, depcheck, test-ete, all seed-test-results, versions.yml validation passing
- [x] CI: `test` check was cancelled (not a failure — likely workflow scheduling artifact)
- [ ] Manual testing against actual immix-fern-config not performed

## Human Review Checklist

- **Hardcoded `0.0.1`**: New repos get `0.0.1` (or `v0.0.1` for Go) and skip AI diff analysis entirely. Is this the desired starting version, or should it be configurable / default to `0.1.0`?
- **Broader behavioral change**: The `invalidVersionFormat` case (magic version in `+` line but `-` line has no version-like content) previously threw but now also returns `undefined` → `0.0.1`. This could mask errors in existing repos with genuinely unsupported version formats. Worth deciding if this path should remain an error for non-new-file diffs.
- **`cleanedDiff` computed before null check**: `cleanDiffForAI` runs before the `previousVersion == null` early return, so it does wasted work for new repos. Minor, but easy to reorder if desired.
- **`handleAutoVersioning` is private**: The `v` prefix logic and commit message generation in `LocalTaskHandler` are not directly unit-tested — they are covered indirectly via `AutoVersioningService` and `replaceMagicVersion` tests, but the branching logic itself (`this.version?.startsWith("v")`) has no direct test.

---


Link to Devin run: https://app.devin.ai/sessions/514a39ef05794ad9b25300b4b8c2b24e
Requested by: @Swimburger