### PR TITLE
chore(ci): add GitHub Actions turbo cache, DO_NOT_TRACK=1, and improve ETE test resilience

### DIFF
--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -15,6 +15,15 @@ runs:
         registry-url: "https://registry.npmjs.org"
         cache: pnpm
 
+    - name: ⎔ Cache turbo build
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-${{ github.job }}-
+          ${{ runner.os }}-turbo-
+
     # Ensure npm 11.5.1 or later is installed
     - name: ⎔ Update npm
       shell: bash

--- a/.github/workflows/check-devin-pr-assignee.yml
+++ b/.github/workflows/check-devin-pr-assignee.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   pull-requests: write
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   check-assignee:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -17,10 +17,9 @@ permissions:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   test-typescript:

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   test-typescript:

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -15,10 +15,6 @@ on:
 permissions:
   contents: read
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   test-typescript:

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -16,9 +16,10 @@ permissions:
   contents: read
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   test-typescript:

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   compile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,19 +188,29 @@ jobs:
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
 
+      - name: Build CLI (dev)
+        timeout-minutes: 5
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli --filter=@fern-api/cli-v2
+
+      - name: Build seed CLI
+        timeout-minutes: 5
+        run: pnpm seed:build
+
       - name: Run ETE tests
         if: ${{ !github.event.inputs.update_snapshots }}
+        timeout-minutes: 10
         env:
           FERN_ORG_TOKEN_DEV: ${{ secrets.FERN_ORG_TOKEN_DEV }}
         run: |
-          FERN_TOKEN=${{ secrets.FERN_ORG_TOKEN_DEV }} pnpm test:ete
+          FERN_TOKEN=${{ secrets.FERN_ORG_TOKEN_DEV }} pnpm --filter @fern-api/ete-tests test
 
       - name: Run ETE tests with snapshot updates
         if: ${{ github.event.inputs.update_snapshots == 'true' }}
+        timeout-minutes: 10
         env:
           FERN_ORG_TOKEN_DEV: ${{ secrets.FERN_ORG_TOKEN_DEV }}
         run: |
-          FERN_TOKEN=${{ secrets.FERN_ORG_TOKEN_DEV }} pnpm test:ete:update
+          FERN_TOKEN=${{ secrets.FERN_ORG_TOKEN_DEV }} pnpm --filter @fern-api/ete-tests test -- -u
 
       - name: Commit and push updated snapshots
         if: ${{ github.event.inputs.update_snapshots == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   compile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,9 @@ concurrency:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   compile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   compile:

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -13,6 +13,7 @@ permissions:
   pull-requests: write
 
 env:
+  DO_NOT_TRACK: "1"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   run:

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -8,9 +8,10 @@ on:
       - main
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   run:

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -9,10 +9,9 @@ on:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   run:

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -8,6 +8,7 @@ on:
       - main
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -7,10 +7,6 @@ on:
     branches:
       - main
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   run:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,6 +10,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -10,10 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   fix-lint:

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -11,9 +11,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   fix-lint:

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   fix-lint:

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -12,10 +12,9 @@ concurrency:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   fix-lint:

--- a/.github/workflows/go-generator.yml
+++ b/.github/workflows/go-generator.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_call:
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - "packages/ir-sdk/fern/apis/ir-types-latest/VERSION"
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   node:
     runs-on: ubuntu-latest

--- a/.github/workflows/ir-validation.yml
+++ b/.github/workflows/ir-validation.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - main
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/java-generator.yml
+++ b/.github/workflows/java-generator.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_call:
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   pull-requests: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   run:
     name: Lint PR title

--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   trigger-seed-snapshot-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi-ir-validation.yml
+++ b/.github/workflows/openapi-ir-validation.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - main
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -25,10 +25,9 @@ permissions:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   detect-release-bump:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -23,10 +23,6 @@ permissions:
   contents: read # Required for checkout
   id-token: write # Required for OIDC
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   detect-release-bump:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -23,6 +23,10 @@ permissions:
   contents: read # Required for checkout
   id-token: write # Required for OIDC
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   detect-release-bump:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -24,6 +24,7 @@ permissions:
   id-token: write # Required for OIDC
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -24,9 +24,10 @@ permissions:
   id-token: write # Required for OIDC
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   detect-release-bump:

--- a/.github/workflows/publish-docs-parsers-sdk.yml
+++ b/.github/workflows/publish-docs-parsers-sdk.yml
@@ -3,6 +3,9 @@ name: Publish @fern-fern/docs-parsers-fern-definition
 on:
   workflow_dispatch:
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -9,9 +9,6 @@ on:
 
 env:
   PACKAGE_NAME: "@fern-api/generator-cli"
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
   FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
   NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -9,9 +9,10 @@ on:
 
 env:
   PACKAGE_NAME: "@fern-api/generator-cli"
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
   FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
   NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -9,6 +9,9 @@ on:
 
 env:
   PACKAGE_NAME: "@fern-api/generator-cli"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
   FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
   NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -10,10 +10,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
   PACKAGE_NAME: "@fern-api/generator-cli"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
   FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
   NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -8,6 +8,7 @@ on:
       - "packages/generator-cli/versions.yml"
 
 env:
+  DO_NOT_TRACK: "1"
   PACKAGE_NAME: "@fern-api/generator-cli"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"

--- a/.github/workflows/publish-generator-csharp-model.yml
+++ b/.github/workflows/publish-generator-csharp-model.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-csharp-sdk.yml
+++ b/.github/workflows/publish-generator-csharp-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-go-model.yml
+++ b/.github/workflows/publish-generator-go-model.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-go-sdk.yml
+++ b/.github/workflows/publish-generator-go-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-java-model.yml
+++ b/.github/workflows/publish-generator-java-model.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     permissions:

--- a/.github/workflows/publish-generator-java-spring.yml
+++ b/.github/workflows/publish-generator-java-spring.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -17,10 +17,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
   PACKAGE_NAME: "@fern-api/generator-migrations"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 permissions:
   id-token: write # Required for OIDC

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -16,9 +16,10 @@ on:
 
 env:
   PACKAGE_NAME: "@fern-api/generator-migrations"
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 permissions:
   id-token: write # Required for OIDC

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -16,9 +16,6 @@ on:
 
 env:
   PACKAGE_NAME: "@fern-api/generator-migrations"
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 permissions:
   id-token: write # Required for OIDC

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -15,6 +15,7 @@ on:
         type: string
 
 env:
+  DO_NOT_TRACK: "1"
   PACKAGE_NAME: "@fern-api/generator-migrations"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -16,6 +16,9 @@ on:
 
 env:
   PACKAGE_NAME: "@fern-api/generator-migrations"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 permissions:
   id-token: write # Required for OIDC

--- a/.github/workflows/publish-generator-openapi.yml
+++ b/.github/workflows/publish-generator-openapi.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-php-model.yml
+++ b/.github/workflows/publish-generator-php-model.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-php-sdk.yml
+++ b/.github/workflows/publish-generator-php-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-postman.yml
+++ b/.github/workflows/publish-generator-postman.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-python-fastapi.yml
+++ b/.github/workflows/publish-generator-python-fastapi.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-python-pydantic.yml
+++ b/.github/workflows/publish-generator-python-pydantic.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-python-sdk.yml
+++ b/.github/workflows/publish-generator-python-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-ruby-sdk.yml
+++ b/.github/workflows/publish-generator-ruby-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-rust-model.yml
+++ b/.github/workflows/publish-generator-rust-model.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-rust-sdk.yml
+++ b/.github/workflows/publish-generator-rust-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-swift-sdk.yml
+++ b/.github/workflows/publish-generator-swift-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-ts-express.yml
+++ b/.github/workflows/publish-generator-ts-express.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-ts-sdk.yml
+++ b/.github/workflows/publish-generator-ts-sdk.yml
@@ -18,6 +18,9 @@ permissions: # Required for OIDC
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -9,6 +9,7 @@ on:
         type: string
 
 env:
+  DO_NOT_TRACK: "1"
   PACKAGE_NAME: "@fern-api/snippets-core"
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-generator.yml
+++ b/.github/workflows/python-generator.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_call:
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   compile:
     runs-on: ubuntu-22.04

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -5,6 +5,9 @@ on:
     inputs:
       run_id:
         required: true
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   rerun:
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk-ete-tests.yml
+++ b/.github/workflows/sdk-ete-tests.yml
@@ -145,9 +145,10 @@ on:
       - 'generators/go/**'
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 permissions:
   contents: write

--- a/.github/workflows/sdk-ete-tests.yml
+++ b/.github/workflows/sdk-ete-tests.yml
@@ -144,6 +144,10 @@ on:
       - 'generators/php/**'
       - 'generators/go/**'
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 permissions:
   contents: write

--- a/.github/workflows/sdk-ete-tests.yml
+++ b/.github/workflows/sdk-ete-tests.yml
@@ -144,10 +144,6 @@ on:
       - 'generators/php/**'
       - 'generators/go/**'
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 permissions:
   contents: write

--- a/.github/workflows/sdk-ete-tests.yml
+++ b/.github/workflows/sdk-ete-tests.yml
@@ -145,6 +145,7 @@ on:
       - 'generators/go/**'
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/sdk-ete-tests.yml
+++ b/.github/workflows/sdk-ete-tests.yml
@@ -146,10 +146,9 @@ on:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 permissions:
   contents: write

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -31,9 +31,10 @@ on:
         type: boolean
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   create-dependabot-prs:

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -30,6 +30,10 @@ on:
         default: true
         type: boolean
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   create-dependabot-prs:

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -31,6 +31,7 @@ on:
         type: boolean
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -32,10 +32,9 @@ on:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   create-dependabot-prs:

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -30,10 +30,6 @@ on:
         default: true
         type: boolean
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   create-dependabot-prs:

--- a/.github/workflows/seed-dockers.yml
+++ b/.github/workflows/seed-dockers.yml
@@ -40,6 +40,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DO_NOT_TRACK: "1"
   DOCKER_BUILDKIT: 1
 
 jobs:

--- a/.github/workflows/seed-pr-comment.yml
+++ b/.github/workflows/seed-pr-comment.yml
@@ -16,6 +16,9 @@ concurrency:
   group: seed-pr-comment-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   post-seed-selector:
     name: Post Seed Selector Comment

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   setup:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -21,10 +21,9 @@ concurrency:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   setup:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -20,9 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   setup:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -20,6 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -19,10 +19,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   setup:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -8,6 +8,9 @@ permissions:
   pull-requests: write
   contents: write
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   stale-prs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -22,6 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -22,9 +22,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   run:

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -23,10 +23,9 @@ concurrency:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   run:

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -21,6 +21,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   run:

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -21,10 +21,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   run:

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -31,10 +31,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   # Determine which generator to test based on the triggering workflow

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -32,6 +32,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -31,6 +31,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   # Determine which generator to test based on the triggering workflow

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -33,10 +33,9 @@ concurrency:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   # Determine which generator to test based on the triggering workflow

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -32,9 +32,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   # Determine which generator to test based on the triggering workflow

--- a/.github/workflows/typescript-generator.yml
+++ b/.github/workflows/typescript-generator.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -51,9 +51,10 @@ permissions:
 
 env:
   DOCKER_BUILDKIT: 1
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   setup:

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -52,10 +52,9 @@ permissions:
 env:
   DO_NOT_TRACK: "1"
   DOCKER_BUILDKIT: 1
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   setup:

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -51,6 +51,9 @@ permissions:
 
 env:
   DOCKER_BUILDKIT: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   setup:

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -51,9 +51,6 @@ permissions:
 
 env:
   DOCKER_BUILDKIT: 1
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   setup:

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -50,6 +50,7 @@ permissions:
   contents: write
 
 env:
+  DO_NOT_TRACK: "1"
   DOCKER_BUILDKIT: 1
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -11,6 +11,9 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   update-test:
     if: github.repository == 'fern-api/fern' && github.ref != 'refs/heads/main'

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - "fern/docs/pages/**"
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   vale:
     name: runner / vale

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -23,9 +23,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
+  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # TURBO_TEAM: "buildwithfern"
+  # TURBO_REMOTE_CACHE_TIMEOUT: 60
+  TURBO_CACHE: "local:rw"
 
 jobs:
   validate-changelogs:

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -22,6 +22,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   validate-changelogs:

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -23,6 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DO_NOT_TRACK: "1"
   # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # TURBO_TEAM: "buildwithfern"
   # TURBO_REMOTE_CACHE_TIMEOUT: 60

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -22,10 +22,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: "buildwithfern"
-  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   validate-changelogs:

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -24,10 +24,9 @@ concurrency:
 
 env:
   DO_NOT_TRACK: "1"
-  # TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  # TURBO_TEAM: "buildwithfern"
-  # TURBO_REMOTE_CACHE_TIMEOUT: 60
-  TURBO_CACHE: "local:rw"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 60
 
 jobs:
   validate-changelogs:

--- a/.github/workflows/validate-ir-version-consistency.yml
+++ b/.github/workflows/validate-ir-version-consistency.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   validate-ir-versions:
     name: Validate IR Version Consistency

--- a/.github/workflows/validate-versions-files.yml
+++ b/.github/workflows/validate-versions-files.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   validate:
     name: Validate versions.yml files

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -10,6 +10,9 @@ permissions:
   pull-requests: write
   contents: write
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   copy-changelogs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Linear ticket: Refs N/A
<!-- No linear ticket — this is an operational fix for CI stability -->

Adds GitHub Actions-native caching for turbo's `.turbo` build cache via `actions/cache@v4` in the shared install composite action. This provides a fast, reliable primary cache layer for all CI jobs. Turbo's built-in remote caching (Vercel) remains enabled as a fallback for cache misses.

Additionally, `DO_NOT_TRACK: "1"` is added to all 59 workflow files to disable third-party CLI telemetry (primarily Turborepo's anonymous analytics to Vercel).

The `test-ete` job in `ci.yml` has been split into separate build and test steps with individual `timeout-minutes` to improve resilience and debuggability when turbo hangs during CI.

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/31c3e40d3a354dda94fd554c39d1f1f6)

## Changes Made

- Added `actions/cache@v4` to `.github/actions/install/action.yaml` to persist turbo's `.turbo` cache directory across CI runs, keyed per OS and job name (`${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}`) with prefix-based restore fallback. All workflows using the install action automatically get turbo build caching.
- Added `DO_NOT_TRACK: "1"` to all 59 `.github/workflows/*.yml` files to disable CLI telemetry across CI
- Split `test-ete` job's monolithic `pnpm test:ete` step into separate steps with individual timeouts:
  - **Build CLI (dev)** — `timeout-minutes: 5`
  - **Build seed CLI** — `timeout-minutes: 5`
  - **Run ETE tests** — `timeout-minutes: 10`
  - This gives clear visibility in the Actions UI about which step hangs and fails fast instead of waiting for the full 15-minute job timeout
- Turbo remote caching (`TURBO_TOKEN`, `TURBO_TEAM`, `TURBO_REMOTE_CACHE_TIMEOUT`) remains enabled in the 14 workflows that use it — it now serves as a fallback behind the GitHub Actions cache
- [ ] Updated README.md generator (if applicable) — N/A

### Affected Files

**GitHub Actions turbo cache added**: `.github/actions/install/action.yaml` (affects all workflows using the install action)

**DO_NOT_TRACK added**: All 59 `.github/workflows/*.yml` files

**ETE test resilience improved**: `ci.yml` (`test-ete` job)

## Testing

- [ ] Unit tests added/updated — N/A, CI configuration change only
- [x] Manual testing completed — verified `DO_NOT_TRACK: "1"` is present in all 59 workflow files
- [x] CI passed with the split test-ete steps and GitHub Actions cache

## Human Review Checklist

- [ ] Verify `.turbo` is the correct cache directory path for turbo v2.8.10 (defaults to `.turbo/cache` unless overridden by `cacheDir` in `turbo.jsonc`)
- [ ] Verify `github.job` context variable works correctly inside composite actions — if it doesn't, all jobs would share a single cache key prefix, causing only the first finishing job to save its cache per commit
- [ ] Consider cache size implications: GitHub Actions cache has a 10GB limit per repo with LRU eviction. Per-job turbo caches could grow large in a monorepo but should be manageable
- [ ] Verify the `test-ete` step split preserves the correct execution order: build CLI → build seed CLI → run tests
- [ ] Verify the timeout values are sufficient:
  - 5 minutes for "Build CLI (dev)" step
  - 5 minutes for "Build seed CLI" step
  - 10 minutes for "Run ETE tests" step
- [ ] Confirm the snapshot update path (`update_snapshots == 'true'`) still works correctly with the split steps (build steps run unconditionally, only the test step is conditional)
- [ ] Note: Turbo remote caching is still enabled as a fallback. If the original CI hang was caused by remote cache, it could recur, but the GitHub cache layer and step timeouts add resilience
- [ ] Note: Self-hosted runners (Seed, Test) may have persistent filesystems where the cache step provides consistency but could be partially redundant
- [ ] Confirm `DO_NOT_TRACK: "1"` is desired on *all* workflows (including non-turbo ones like `stale-bot.yml`, `lint-pr-title.yml`, etc.) — it's harmless but may be unnecessary for workflows that don't invoke turbo