### PR TITLE
fix(cli): restore deleted changelog entries for 3.82.0 and 3.81.1

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -103,6 +103,22 @@
         extension (in OpenAPI) with algorithm, encoding, header name, and payload format.
         SDK generators can use this to produce signature verification utilities.
       type: feat
+    - summary: |
+        Add `terminator` field support for SSE streaming throughout the OpenAPI to Fern pipeline.
+        The field was already present in the Fern definition schema but missing from the OpenAPI
+        extension parsing, OpenAPI-IR schema, and the OpenAPI-IR to Fern conversion layers.
+      type: feat
+  createdAt: "2026-02-19"
+  irVersion: 65
+- version: 3.81.1
+  changelogEntry:
+    - summary: |
+        Fix example object keys starting with `$` (e.g. `$ref`) not being unescaped when
+        generating the IR `jsonExample`. The Fern definition escapes `$`-prefixed keys with
+        a backslash to avoid collision with example references, but the backslash was not
+        removed when building the wire-format JSON example, causing generators to emit
+        invalid code (e.g. `"\$ref"` in Go).
+      type: fix
   createdAt: "2026-02-19"
   irVersion: 65
 - version: 3.81.0


### PR DESCRIPTION
## Description

Restores two changelog entries in `versions.yml` that were accidentally deleted by the 3.83.0 webhook signature verification PR ([fbc46d6](https://github.com/fern-api/fern/commit/fbc46d68477c0a3061ed0f0937865b45265e5555)).

Requested by: @aditya-arolkar-swe
[Link to Devin run](https://app.devin.ai/sessions/272014dd54bf404c8f07d1550512d9f3)

## Changes Made

- Adds back the **3.82.0** entry for `terminator` field support in SSE streaming as a second item under the existing 3.82.0 version
- Restores the missing **3.81.1** version entry for the `$ref` key unescaping fix in IR `jsonExample` generation

## Review Checklist

- [ ] Verify restored changelog text matches the [original entries](https://github.com/fern-api/fern/commit/fbc46d68477c0a3061ed0f0937865b45265e5555#diff-087338a5eeeec9afe2c1b0e01d8b82c619d17d5aa743bc22f4559a60c9f0ca3b) before deletion
- [ ] Note: the original 3.82.0 SSE terminator entry had `createdAt: "2026-02-20"`, but now shares `"2026-02-19"` with the webhook entry under the same version block — confirm this is acceptable

## Testing

- No code changes; changelog-only update