### PR TITLE
fix(typescript): replace lodash-es template with Eta for template file processing

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.49.2
+  changelogEntry:
+    - summary: |
+        Replace lodash-es `template` with EJS for template file processing. The lodash
+        templating engine crashes on backticks (template literals) because it uses
+        `new Function()` internally. EJS properly handles backticks and uses the same
+        `<% %>` syntax, requiring no changes to existing template files.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 63
+
 - version: 3.49.1
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -2,10 +2,11 @@
 - version: 3.49.2
   changelogEntry:
     - summary: |
-        Replace lodash-es `template` with EJS for template file processing. The lodash
+        Replace lodash-es `template` with Eta for template file processing. The lodash
         templating engine crashes on backticks (template literals) because it uses
-        `new Function()` internally. EJS properly handles backticks and uses the same
-        `<% %>` syntax, requiring no changes to existing template files.
+        `new Function()` internally. Eta is a modern, lightweight, zero-dependency
+        templating engine that properly handles backticks and uses the same `<% %>`
+        syntax, requiring no changes to existing template files.
       type: fix
   createdAt: "2026-02-24"
   irVersion: 63

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -38,6 +40,7 @@
     "@fern-api/typescript-base": "workspace:*",
     "@fern-fern/ir-sdk": "^64.0.0",
     "decompress": "catalog:",
+    "ejs": "^4.0.1",
     "esutils": "catalog:",
     "glob": "catalog:",
     "immer": "^10.1.1",
@@ -49,6 +52,7 @@
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
     "@types/decompress": "catalog:",
+    "@types/ejs": "^3.1.5",
     "@types/esutils": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -38,8 +38,8 @@
     "@fern-api/typescript-base": "workspace:*",
     "@fern-fern/ir-sdk": "^64.0.0",
     "decompress": "catalog:",
-    "ejs": "^4.0.1",
     "esutils": "catalog:",
+    "eta": "^4.5.1",
     "glob": "catalog:",
     "immer": "^10.1.1",
     "lodash-es": "catalog:",
@@ -50,7 +50,6 @@
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
     "@types/decompress": "catalog:",
-    "@types/ejs": "^3.1.5",
     "@types/esutils": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",

--- a/generators/typescript/utils/commons/src/writeTemplateFiles.ts
+++ b/generators/typescript/utils/commons/src/writeTemplateFiles.ts
@@ -2,7 +2,7 @@ import { Eta } from "eta";
 import * as fs from "fs/promises";
 import * as path from "path";
 
-const eta = new Eta({ autoEscape: false, useWith: true });
+const eta = new Eta({ autoEscape: false, useWith: true, autoTrim: false });
 
 export async function writeTemplateFiles(directory: string, templateVariables: Record<string, unknown>): Promise<void> {
     const templateFiles = await findTemplateFiles(directory);

--- a/generators/typescript/utils/commons/src/writeTemplateFiles.ts
+++ b/generators/typescript/utils/commons/src/writeTemplateFiles.ts
@@ -1,5 +1,5 @@
+import ejs from "ejs";
 import * as fs from "fs/promises";
-import { template } from "lodash-es";
 import * as path from "path";
 
 export async function writeTemplateFiles(directory: string, templateVariables: Record<string, unknown>): Promise<void> {
@@ -36,8 +36,7 @@ async function processTemplateFile(
     templateVariables: Record<string, unknown>
 ): Promise<void> {
     const templateContent = await fs.readFile(templateFilePath, "utf8");
-    const compiledTemplate = template(templateContent);
-    const content = compiledTemplate(templateVariables);
+    const content = ejs.render(templateContent, templateVariables);
     const outputFilePath = templateFilePath.replace(/\.template\./, ".");
     await fs.writeFile(outputFilePath, content, "utf8");
     await fs.unlink(templateFilePath);

--- a/generators/typescript/utils/commons/src/writeTemplateFiles.ts
+++ b/generators/typescript/utils/commons/src/writeTemplateFiles.ts
@@ -2,7 +2,7 @@ import { Eta } from "eta";
 import * as fs from "fs/promises";
 import * as path from "path";
 
-const eta = new Eta({ autoEscape: false });
+const eta = new Eta({ autoEscape: false, useWith: true });
 
 export async function writeTemplateFiles(directory: string, templateVariables: Record<string, unknown>): Promise<void> {
     const templateFiles = await findTemplateFiles(directory);

--- a/generators/typescript/utils/commons/src/writeTemplateFiles.ts
+++ b/generators/typescript/utils/commons/src/writeTemplateFiles.ts
@@ -1,6 +1,8 @@
-import ejs from "ejs";
+import { Eta } from "eta";
 import * as fs from "fs/promises";
 import * as path from "path";
+
+const eta = new Eta({ autoEscape: false });
 
 export async function writeTemplateFiles(directory: string, templateVariables: Record<string, unknown>): Promise<void> {
     const templateFiles = await findTemplateFiles(directory);
@@ -36,7 +38,7 @@ async function processTemplateFile(
     templateVariables: Record<string, unknown>
 ): Promise<void> {
     const templateContent = await fs.readFile(templateFilePath, "utf8");
-    const content = ejs.render(templateContent, templateVariables);
+    const content = eta.renderString(templateContent, templateVariables);
     const outputFilePath = templateFilePath.replace(/\.template\./, ".");
     await fs.writeFile(outputFilePath, content, "utf8");
     await fs.unlink(templateFilePath);

--- a/generators/typescript/utils/core-utilities/src/core/form-data-utils/FormDataWrapper.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/form-data-utils/FormDataWrapper.template.ts
@@ -300,7 +300,7 @@ async function streamToBuffer(stream: unknown): Promise<Buffer> {
     }
 
     throw new Error(
-        "Unsupported stream type: " + typeof stream + ". Expected Node.js Readable stream or Web ReadableStream.",
+        `Unsupported stream type: ${typeof stream}. Expected Node.js Readable stream or Web ReadableStream.`,
     );
 }
 

--- a/generators/typescript/utils/core-utilities/tests/setup.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/setup.template.ts
@@ -53,27 +53,27 @@ expect.extend({
 
         if (pass) {
             return {
-                message: () => "expected " + actualType + " not to contain " + this.utils.printExpected(expectedHeaders),
+                message: () => `expected ${actualType} not to contain ${this.utils.printExpected(expectedHeaders)}`,
                 pass: true,
             };
         } else {
             const messages: string[] = [];
 
             if (missingHeaders.length > 0) {
-                messages.push("Missing headers: " + this.utils.printExpected(missingHeaders.join(", ")));
+                messages.push(`Missing headers: ${this.utils.printExpected(missingHeaders.join(", "))}`);
             }
 
             if (mismatchedHeaders.length > 0) {
                 const mismatches = mismatchedHeaders.map(
                     ({ key, expected, actual }) =>
-                        key + ": expected " + this.utils.printExpected(expected) + " but got " + this.utils.printReceived(actual),
+                        `${key}: expected ${this.utils.printExpected(expected)} but got ${this.utils.printReceived(actual)}`,
                 );
                 messages.push(mismatches.join("\n"));
             }
 
             return {
                 message: () =>
-                    "expected " + actualType + " to contain " + this.utils.printExpected(expectedHeaders) + "\n\n" + messages.join("\n"),
+                    `expected ${actualType} to contain ${this.utils.printExpected(expectedHeaders)}\n\n${messages.join("\n")}`,
                 pass: false,
             };
         }
@@ -125,27 +125,27 @@ expect.extend({
 
         if (pass) {
             return {
-                message: () => "expected " + actualType + " not to contain " + this.utils.printExpected(expectedHeaders),
+                message: () => `expected ${actualType} not to contain ${this.utils.printExpected(expectedHeaders)}`,
                 pass: true,
             };
         } else {
             const messages: string[] = [];
 
             if (missingHeaders.length > 0) {
-                messages.push("Missing headers: " + this.utils.printExpected(missingHeaders.join(", ")));
+                messages.push(`Missing headers: ${this.utils.printExpected(missingHeaders.join(", "))}`);
             }
 
             if (mismatchedHeaders.length > 0) {
                 const mismatches = mismatchedHeaders.map(
                     ({ key, expected, actual }) =>
-                        key + ": expected " + this.utils.printExpected(expected) + " but got " + this.utils.printReceived(actual),
+                        `${key}: expected ${this.utils.printExpected(expected)} but got ${this.utils.printReceived(actual)}`,
                 );
                 messages.push(mismatches.join("\n"));
             }
 
             return {
                 message: () =>
-                    "expected " + actualType + " to contain " + this.utils.printExpected(expectedHeaders) + "\n\n" + messages.join("\n"),
+                    `expected ${actualType} to contain ${this.utils.printExpected(expectedHeaders)}\n\n${messages.join("\n")}`,
                 pass: false,
             };
         }

--- a/generators/typescript/utils/core-utilities/tests/unit/form-data-utils/formDataWrapper.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/form-data-utils/formDataWrapper.test.template.ts
@@ -93,7 +93,7 @@ describe("CrossPlatformFormData", () => {
             for await (const chunk of request.body) {
                 data += decoder.decode(chunk);
             }
-            expect(data).toContain("Content-Disposition: form-data; name=\"file\"; filename=\"" + expectedFileName + "\"");
+            expect(data).toContain(`Content-Disposition: form-data; name="file"; filename="${expectedFileName}"`);
         });
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3960,12 +3960,12 @@ importers:
       decompress:
         specifier: 'catalog:'
         version: 4.2.1
-      ejs:
-        specifier: ^4.0.1
-        version: 4.0.1
       esutils:
         specifier: 'catalog:'
         version: 2.0.3
+      eta:
+        specifier: ^4.5.1
+        version: 4.5.1
       glob:
         specifier: 'catalog:'
         version: 11.1.0
@@ -3991,9 +3991,6 @@ importers:
       '@types/decompress':
         specifier: 'catalog:'
         version: 4.2.7
-      '@types/ejs':
-        specifier: ^3.1.5
-        version: 3.1.5
       '@types/esutils':
         specifier: 'catalog:'
         version: 2.0.2
@@ -10858,9 +10855,6 @@ packages:
   '@types/diff@5.2.3':
     resolution: {integrity: sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==}
 
-  '@types/ejs@3.1.5':
-    resolution: {integrity: sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==}
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -11293,9 +11287,6 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
-
-  async@3.2.6:
-    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -11970,11 +11961,6 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  ejs@4.0.1:
-    resolution: {integrity: sha512-krvQtxc0btwSm/nvnt1UpnaFDFVJpJ0fdckmALpCgShsr/iGYHTnJiUliZTgmzq/UxTX33TtOQVKaNigMQp/6Q==}
-    engines: {node: '>=0.12.18'}
-    hasBin: true
-
   electron-to-chromium@1.5.283:
     resolution: {integrity: sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==}
 
@@ -12157,6 +12143,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eta@4.5.1:
+    resolution: {integrity: sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==}
+    engines: {node: '>=20'}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -12298,10 +12288,6 @@ packages:
   file-type@6.2.0:
     resolution: {integrity: sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==}
     engines: {node: '>=4'}
-
-  filelist@1.0.5:
-    resolution: {integrity: sha512-ct/ckWBV/9Dg3MlvCXsLcSUyoWwv9mCKqlhLNB2DAuXR/NZolSXlQqP5dyy6guWlPXBhodZyZ5lGPQcbQDxrEQ==}
-    engines: {node: 20 || >=22}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -12880,11 +12866,6 @@ packages:
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
-
-  jake@10.9.4:
-    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
@@ -17642,8 +17623,6 @@ snapshots:
 
   '@types/diff@5.2.3': {}
 
-  '@types/ejs@3.1.5': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -18091,8 +18070,6 @@ snapshots:
   astral-regex@2.0.0: {}
 
   astring@1.9.0: {}
-
-  async@3.2.6: {}
 
   asynckit@0.4.0: {}
 
@@ -18792,10 +18769,6 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  ejs@4.0.1:
-    dependencies:
-      jake: 10.9.4
-
   electron-to-chromium@1.5.283: {}
 
   emoji-regex@10.6.0: {}
@@ -19025,6 +18998,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eta@4.5.1: {}
+
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
@@ -19214,10 +19189,6 @@ snapshots:
   file-type@5.2.0: {}
 
   file-type@6.2.0: {}
-
-  filelist@1.0.5:
-    dependencies:
-      minimatch: 10.2.1
 
   fill-range@7.1.1:
     dependencies:
@@ -19855,12 +19826,6 @@ snapshots:
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
-
-  jake@10.9.4:
-    dependencies:
-      async: 3.2.6
-      filelist: 1.0.5
-      picocolors: 1.1.1
 
   jest-diff@29.7.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3960,6 +3960,9 @@ importers:
       decompress:
         specifier: 'catalog:'
         version: 4.2.1
+      ejs:
+        specifier: ^4.0.1
+        version: 4.0.1
       esutils:
         specifier: 'catalog:'
         version: 2.0.3
@@ -3988,6 +3991,9 @@ importers:
       '@types/decompress':
         specifier: 'catalog:'
         version: 4.2.7
+      '@types/ejs':
+        specifier: ^3.1.5
+        version: 3.1.5
       '@types/esutils':
         specifier: 'catalog:'
         version: 2.0.2
@@ -10852,6 +10858,9 @@ packages:
   '@types/diff@5.2.3':
     resolution: {integrity: sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==}
 
+  '@types/ejs@3.1.5':
+    resolution: {integrity: sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -11284,6 +11293,9 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -11958,6 +11970,11 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  ejs@4.0.1:
+    resolution: {integrity: sha512-krvQtxc0btwSm/nvnt1UpnaFDFVJpJ0fdckmALpCgShsr/iGYHTnJiUliZTgmzq/UxTX33TtOQVKaNigMQp/6Q==}
+    engines: {node: '>=0.12.18'}
+    hasBin: true
+
   electron-to-chromium@1.5.283:
     resolution: {integrity: sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==}
 
@@ -12281,6 +12298,10 @@ packages:
   file-type@6.2.0:
     resolution: {integrity: sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==}
     engines: {node: '>=4'}
+
+  filelist@1.0.5:
+    resolution: {integrity: sha512-ct/ckWBV/9Dg3MlvCXsLcSUyoWwv9mCKqlhLNB2DAuXR/NZolSXlQqP5dyy6guWlPXBhodZyZ5lGPQcbQDxrEQ==}
+    engines: {node: 20 || >=22}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -12859,6 +12880,11 @@ packages:
   jackspeak@4.1.1:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
+
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
@@ -17616,6 +17642,8 @@ snapshots:
 
   '@types/diff@5.2.3': {}
 
+  '@types/ejs@3.1.5': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -18063,6 +18091,8 @@ snapshots:
   astral-regex@2.0.0: {}
 
   astring@1.9.0: {}
+
+  async@3.2.6: {}
 
   asynckit@0.4.0: {}
 
@@ -18762,6 +18792,10 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  ejs@4.0.1:
+    dependencies:
+      jake: 10.9.4
+
   electron-to-chromium@1.5.283: {}
 
   emoji-regex@10.6.0: {}
@@ -19180,6 +19214,10 @@ snapshots:
   file-type@5.2.0: {}
 
   file-type@6.2.0: {}
+
+  filelist@1.0.5:
+    dependencies:
+      minimatch: 10.2.1
 
   fill-range@7.1.1:
     dependencies:
@@ -19817,6 +19855,12 @@ snapshots:
   jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
+
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.5
+      picocolors: 1.1.1
 
   jest-diff@29.7.0:
     dependencies:


### PR DESCRIPTION
## Description

Refs: Requested by @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/7cba0a0a40634302b98d57cd48ba4790)

Replaces `lodash-es`'s `template()` function with [Eta](https://eta.js.org/) for processing `.template.*` files in the TypeScript SDK generator. The lodash templating engine crashes on backticks (template literals) because it internally uses `new Function()`, which interprets backticks as JS template literal syntax.

Eta uses the identical `<% %>` / `<%= %>` syntax and is a modern, lightweight, TypeScript-native engine with **zero dependencies** (vs. lodash-es or EJS which carry heavier transitive dependency trees).

## Changes Made

### Engine swap (`writeTemplateFiles.ts`)
- Replaced `import { template } from "lodash-es"` with `import { Eta } from "eta"`
- Instantiated `const eta = new Eta({ autoEscape: false, useWith: true, autoTrim: false })`
  - `autoEscape: false` — prevents HTML-escaping of generated TypeScript code
  - `useWith: true` — makes template variables available as top-level names (matching lodash's behavior; without this, Eta requires `it.varName` access)
  - `autoTrim: false` — preserves whitespace around `<% %>` tags identically to lodash (Eta's default trims trailing newlines after tags)
- Swapped `template(content)(vars)` → `eta.renderString(content, vars)`
- Added `eta` (`^4.5.1`) dependency to `@fern-typescript/commons`

### Template literal conversions (now possible with Eta)
Converted string concatenation to backtick template literals in 3 template files, demonstrating the backtick support that motivated this migration:
- `FormDataWrapper.template.ts` — error message string
- `setup.template.ts` — test matcher message strings (both vitest and jest branches)
- `formDataWrapper.test.template.ts` — test assertion string

### Versioning
- Added version `3.49.2` changelog entry in `generators/typescript/sdk/versions.yml`
- `lodash-es` is **not** removed — it's still used by other files in commons (`mergeExtraConfigs.ts`, `toCamelCase.ts`)

## Testing

- [x] TypeScript compilation passes (`pnpm compile --filter @fern-typescript/commons`)
- [x] Eta output verified identical to lodash output on all 9 template files (with `autoTrim: false` + `useWith: true`)
- [x] Backtick template literals render correctly through Eta
- [x] CI seed tests (ts-sdk, ts-express) validate generated output matches snapshots
- [x] `test-ete` passes
- **Note:** 2 of the ts-sdk seed test matrix batches were cancelled by GitHub Actions (not failed) — likely due to the rapid push cadence. All other ts-sdk and ts-express seed batches passed.

## Human Review Checklist

- **`useWith: true`**: This uses JavaScript's `with(){}` under the hood to put template variables in scope. This matches lodash's behavior but `with` is generally discouraged. Verify this is acceptable — the alternative would be rewriting all 9 template files to use `it.varName` syntax.
- **`autoTrim: false`**: Without this, Eta strips trailing newlines after `<% %>` tags, producing different whitespace than lodash. This was caught via seed test failures. Verify the generated output hasn't shifted.
- **Template literal changes**: The 3 files with backtick conversions change the actual generated SDK code (error messages, test assertions). These are semantically identical but produce different string literals in output.
- **Node version requirement**: Eta v4 requires Node ≥ 20. CI uses Node 22. Confirm this aligns with the generator's Docker base image.
- **Cancelled CI checks**: 2 ts-sdk seed test batches were cancelled (not failed). Consider re-running CI or manually verifying those test cases if needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->