### PR TITLE
fix(csharp): replace lodash-es template with Eta for template file processing

### DIFF
--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -43,5 +45,8 @@
     "lodash-es": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "dependencies": {
+    "eta": "^4.5.1"
   }
 }

--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -40,11 +40,9 @@
     "@fern-fern/ir-sdk": "^62.3.0",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
+    "eta": "^4.5.1",
     "lodash-es": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
-  },
-  "dependencies": {
-    "eta": "^4.5.1"
   }
 }

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -3,12 +3,14 @@ import { Generation, WithGeneration } from "@fern-api/csharp-codegen";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { access, mkdir, readFile, unlink, writeFile } from "fs/promises";
-import { template } from "lodash-es";
+import { Eta } from "eta";
 import path from "path";
 import { AsIsFiles } from "../AsIs.js";
 import { GeneratorContext } from "../context/GeneratorContext.js";
 import { findDotnetToolPath } from "../findDotNetToolPath.js";
 import { CSharpFile } from "./CSharpFile.js";
+
+const eta = new Eta({ autoEscape: false, useWith: true, autoTrim: false });
 
 export const CORE_DIRECTORY_NAME = "Core";
 export const PUBLIC_CORE_DIRECTORY_NAME = "Public";
@@ -285,7 +287,7 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
         }
 
         const githubWorkflowTemplate = (await readFile(getAsIsFilepath(AsIsFiles.CiYaml))).toString();
-        const githubWorkflow = template(githubWorkflowTemplate)({
+        const githubWorkflow = eta.renderString(githubWorkflowTemplate, {
             projectName: this.name,
             libraryPath: path.posix.join(libraryPath, this.name),
             libraryProjectFilePath: path.posix.join(libraryPath, this.name, `${this.name}.csproj`),
@@ -436,7 +438,7 @@ dotnet_diagnostic.IDE0005.severity = error
         const testCsProjTemplateContents = (
             await readFile(getAsIsFilepath(AsIsFiles.Test.TemplateTestCsProj))
         ).toString();
-        const testCsProjContents = template(testCsProjTemplateContents)({
+        const testCsProjContents = eta.renderString(testCsProjTemplateContents, {
             projectName: this.name,
             testProjectName
         });
@@ -699,7 +701,7 @@ dotnet_diagnostic.IDE0005.severity = error
 }
 
 function replaceTemplate({ contents, variables }: { contents: string; variables: Record<string, unknown> }): string {
-    return template(contents)(variables);
+    return eta.renderString(contents, variables);
 }
 
 function getAsIsFilepath(filename: string): string {

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -2,8 +2,8 @@ import { AbstractProject, FernGeneratorExec, File, SourceFetcher } from "@fern-a
 import { Generation, WithGeneration } from "@fern-api/csharp-codegen";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { access, mkdir, readFile, unlink, writeFile } from "fs/promises";
 import { Eta } from "eta";
+import { access, mkdir, readFile, unlink, writeFile } from "fs/promises";
 import path from "path";
 import { AsIsFiles } from "../AsIs.js";
 import { GeneratorContext } from "../context/GeneratorContext.js";
@@ -287,22 +287,24 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
         }
 
         const githubWorkflowTemplate = (await readFile(getAsIsFilepath(AsIsFiles.CiYaml))).toString();
-        const githubWorkflow = eta.renderString(githubWorkflowTemplate, {
-            projectName: this.name,
-            libraryPath: path.posix.join(libraryPath, this.name),
-            libraryProjectFilePath: path.posix.join(libraryPath, this.name, `${this.name}.csproj`),
-            testProjectFilePath: path.posix.join(
-                testPath,
-                this.names.files.testProject,
-                `${this.names.files.testProject}.csproj`
-            ),
-            shouldWritePublishBlock: this.context.publishConfig != null,
-            nugetTokenEnvvar:
-                this.context.publishConfig?.apiKeyEnvironmentVariable == null ||
-                this.context.publishConfig?.apiKeyEnvironmentVariable === ""
-                    ? "NUGET_API_TOKEN"
-                    : this.context.publishConfig.apiKeyEnvironmentVariable
-        }).replaceAll("\\{", "{");
+        const githubWorkflow = eta
+            .renderString(githubWorkflowTemplate, {
+                projectName: this.name,
+                libraryPath: path.posix.join(libraryPath, this.name),
+                libraryProjectFilePath: path.posix.join(libraryPath, this.name, `${this.name}.csproj`),
+                testProjectFilePath: path.posix.join(
+                    testPath,
+                    this.names.files.testProject,
+                    `${this.names.files.testProject}.csproj`
+                ),
+                shouldWritePublishBlock: this.context.publishConfig != null,
+                nugetTokenEnvvar:
+                    this.context.publishConfig?.apiKeyEnvironmentVariable == null ||
+                    this.context.publishConfig?.apiKeyEnvironmentVariable === ""
+                        ? "NUGET_API_TOKEN"
+                        : this.context.publishConfig.apiKeyEnvironmentVariable
+            })
+            .replaceAll("\\{", "{");
         const ghDir = join(this.absolutePathToOutputDirectory, RelativeFilePath.of(".github/workflows"));
         await mkdir(ghDir, { recursive: true });
         await writeFile(join(ghDir, RelativeFilePath.of("ci.yml")), githubWorkflow);

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.22.3
+  changelogEntry:
+    - summary: |
+        Replace lodash-es template engine with Eta for processing template files.
+        Eta is a modern, lightweight, TypeScript-native engine with zero dependencies
+        that uses the same `<% %>` / `<%= %>` syntax. This resolves crashes when
+        template files contain backticks (template literals).
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 62
+
 - version: 2.22.2
   changelogEntry:
     - summary: |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,6 +945,10 @@ importers:
         version: 4.0.18(@types/node@18.15.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.3.3)
 
   generators/csharp/base:
+    dependencies:
+      eta:
+        specifier: ^4.5.1
+        version: 4.5.1
     devDependencies:
       '@fern-api/base-generator':
         specifier: workspace:*
@@ -12140,6 +12144,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eta@4.5.1:
+    resolution: {integrity: sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==}
+    engines: {node: '>=20'}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -18990,6 +18998,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  eta@4.5.1: {}
 
   etag@1.8.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,10 +945,6 @@ importers:
         version: 4.0.18(@types/node@18.15.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.3.3)
 
   generators/csharp/base:
-    dependencies:
-      eta:
-        specifier: ^4.5.1
-        version: 4.5.1
     devDependencies:
       '@fern-api/base-generator':
         specifier: workspace:*
@@ -977,6 +973,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
+      eta:
+        specifier: ^4.5.1
+        version: 4.5.1
       lodash-es:
         specifier: 'catalog:'
         version: 4.17.23


### PR DESCRIPTION
## Description

Refs: [TypeScript equivalent PR #12696](https://github.com/fern-api/fern/pull/12696)
Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/9cb0154bf7944505b571dc5032d9f282)

Replaces `lodash-es`'s `template()` function with [Eta](https://eta.js.org/) for processing template files in the C# SDK generator (`@fern-api/csharp-base`). This mirrors the same change made for the TypeScript generator in #12696.

Lodash's template engine crashes on backticks because it internally uses `new Function()`, which interprets backticks as JS template literal syntax. Eta uses the identical `<% %>` / `<%= %>` syntax and is a modern, lightweight, TypeScript-native engine with zero dependencies.

## Changes Made

- **Engine swap (`CsharpProject.ts`)**: Replaced `import { template } from "lodash-es"` with `import { Eta } from "eta"`, instantiated with `{ autoEscape: false, useWith: true, autoTrim: false }`, and swapped all three call sites (`githubWorkflow`, `testCsProjContents`, `replaceTemplate` helper)
- **Dependency**: Added `eta` (`^4.5.1`) as a dev dependency to `@fern-api/csharp-base` (so it gets bundled into the generator CLI)
- **Versioning**: Added `2.22.3` changelog entry in `generators/csharp/sdk/versions.yml`
- `lodash-es` is **not** removed — it's still used by `PackageUtilities.ts` (`camelCase`, `upperFirst`)

## Testing

- [x] TypeScript compilation passes (`pnpm compile --filter @fern-api/csharp-base`)
- [x] CI checks all pass (biome, compile, lint, depcheck, test, test-ete, versions.yml validation)
- [x] No seed test snapshot changes — generated output is identical to lodash

## Human Review Checklist

- **`useWith: true`**: Uses JavaScript's `with(){}` under the hood to put template variables in scope (matching lodash's behavior). Same approach as the TypeScript PR. The alternative would be rewriting all template files to use `it.varName` syntax.
- **`autoTrim: false`**: Without this, Eta strips trailing newlines after `<% %>` tags, producing different whitespace than lodash. Confirmed by CI seed tests passing with no snapshot changes.
- **`.replaceAll("\\{", "{")` post-processing**: The `githubWorkflow` template still has this post-processing step. With lodash, escaped braces `\{` were needed because lodash used `${}` interpolation. With Eta using `<%= %>`, this is likely a no-op now but is harmless to keep. Worth verifying the CI YAML template doesn't contain literal `\{` sequences that should remain escaped.
- **Node version requirement**: Eta v4 requires Node ≥ 20. CI uses Node 22. Verify this aligns with the C# generator's Docker base image.