### PR TITLE
fix(cli): remove unhelpful fallback changelog body when AI analysis fails

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.85.3
+  changelogEntry:
+    - summary: |
+        Remove unhelpful "Unable to analyze changes with AI" fallback message from
+        changelog entries when AI analysis fails during AUTO versioning. The changelog
+        now shows just the version header with no body instead.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 65
 - version: 3.85.2
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -185,8 +185,8 @@ export class LocalTaskHandler {
                 this.context.logger.warn(`AI analysis failed, falling back to PATCH increment: ${aiError}`);
                 const newVersion = this.incrementVersion(previousVersion, VersionBump.PATCH);
                 const fallbackMessage = this.isWhitelabel
-                    ? "SDK regeneration\n\nUnable to analyze changes with AI, incrementing PATCH version."
-                    : "SDK regeneration\n\nUnable to analyze changes with AI, incrementing PATCH version.\n\n🌿 Generated with Fern";
+                    ? "SDK regeneration"
+                    : "SDK regeneration\n\n🌿 Generated with Fern";
                 return {
                     version: newVersion,
                     commitMessage: fallbackMessage


### PR DESCRIPTION
## Description

<!-- Closes [ticket] -->

When AUTO versioning falls back to a PATCH increment because AI analysis fails, the generated changelog entry previously included the unhelpful message `"Unable to analyze changes with AI, incrementing PATCH version."`. This produced ugly changelog entries like:

```
## 0.0.44 - 2026-02-23
* SDK regeneration
* Unable to analyze changes with AI, incrementing PATCH version.
```

This PR removes that body text so the fallback produces a clean version entry with no extra noise.

[Link to Devin run](https://app.devin.ai/sessions/2a7b9b6d1737455aaf6f6a2496aab795) | Requested by: @Swimburger

## Changes Made

- Removed the `"Unable to analyze changes with AI, incrementing PATCH version."` body from the fallback commit message in `LocalTaskHandler.handleAutoVersioning()`
  - **Whitelabel**: message is now just `"SDK regeneration"` (no body)
  - **Non-whitelabel**: message is now `"SDK regeneration\n\n🌿 Generated with Fern"` (Fern branding only)
- Added CLI `versions.yml` entry for v3.85.3

## Review Checklist

- [x] Verify that the non-whitelabel fallback still including `"🌿 Generated with Fern"` as body text is the desired behavior (versus truly empty body for both cases)
- [x] Confirm the fallback message format works correctly with `parseCommitMessageForPR` — for whitelabel, the PR body will default to `"Automated SDK generation by Fern"` since there's no second line

## Testing

- [ ] Unit tests added/updated — no new tests; change is a string-only edit in an existing error-handling path
- [ ] Manual testing completed — not feasible to trigger AI failure path locally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
