### PR TITLE
fix(ruby): rename Union#member? to Union#type_member? to avoid rubocop-minitest autocorrect

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/types/union.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/types/union.Template.rb
@@ -21,7 +21,7 @@ module <%= gem_namespace %>
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 
@@ -162,4 +162,4 @@ module <%= gem_namespace %>
       end
     end
   end
-end                
+end                                

--- a/generators/ruby-v2/base/src/asIs/test/unit/internal/types/test_union.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/test/unit/internal/types/test_union.Template.rb
@@ -45,18 +45,18 @@ describe <%= gem_namespace %>::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.2
+  changelogEntry:
+    - summary: |
+        Rename `Union#member?` to `Union#type_member?` to avoid rubocop-minitest's
+        `Minitest/AssertIncludes` cop incorrectly autocorrecting `assert obj.member?(x)`
+        to `assert_includes obj, x`. The autocorrected form calls `Module#include?` which
+        raises `TypeError: wrong argument type Class (expected Module)` on union type tests.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 61
+
 - version: 1.0.1
   changelogEntry:
     - summary: |

--- a/seed/ruby-sdk-v2/accept-header/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/accept-header/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/accept-header/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/accept-header/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/alias-extends/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/alias-extends/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/alias-extends/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/alias-extends/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/alias/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/alias/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/alias/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/alias/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/any-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/any-auth/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/any-auth/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/any-auth/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/audiences/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/audiences/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/audiences/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/audiences/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/basic-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/basic-auth/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/basic-auth/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/basic-auth/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/bytes-download/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/bytes-download/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/bytes-download/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/bytes-download/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/bytes-upload/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/circular-references-advanced/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/circular-references-advanced/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/circular-references/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/circular-references/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/circular-references/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/circular-references/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/client-side-params/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/client-side-params/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/client-side-params/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/client-side-params/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/content-type/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/content-type/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/content-type/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/content-type/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/cross-package-type-names/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/dollar-string-examples/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/dollar-string-examples/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/dollar-string-examples/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/dollar-string-examples/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/empty-clients/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/empty-clients/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/empty-clients/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/empty-clients/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/endpoint-security-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/endpoint-security-auth/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/enum/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/enum/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/enum/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/error-property/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/error-property/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/error-property/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/error-property/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/errors/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/errors/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/errors/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/errors/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/examples/no-custom-config/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/examples/readme-config/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/examples/require-paths/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/examples/wire-tests/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/extends/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/extends/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/extends/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/extends/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/extra-properties/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/extra-properties/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/extra-properties/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/extra-properties/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/file-download/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/file-download/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/file-download/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/file-download/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/file-upload-openapi/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/file-upload-openapi/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/file-upload/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/file-upload/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/file-upload/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/file-upload/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/folders/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/folders/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/folders/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/header-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/header-auth/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/header-auth/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/header-auth/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/http-head/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/http-head/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/http-head/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/http-head/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/idempotency-headers/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/idempotency-headers/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/imdb/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/imdb/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/license/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/license/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/license/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/license/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/literal/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/literal/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/literal/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/literals-unions/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/literals-unions/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/literals-unions/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/literals-unions/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/mixed-case/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/mixed-case/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/mixed-case/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/mixed-case/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/mixed-file-directory/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/multi-line-docs/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/multi-line-docs/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/multi-url-environment/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/multiple-request-bodies/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/no-environment/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/no-environment/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/no-environment/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/no-environment/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/no-retries/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/no-retries/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/no-retries/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/no-retries/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/nullable-allof-extends/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/nullable-optional/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/nullable-optional/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/nullable-request-body/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/nullable-request-body/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/nullable/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/nullable/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/nullable/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/nullable/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/object/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/object/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/object/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/object/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/objects-with-imports/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/objects-with-imports/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/objects-with-imports/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/objects-with-imports/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/optional/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/optional/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/optional/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/optional/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/package-yml/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/package-yml/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/package-yml/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/package-yml/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/pagination-custom/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/pagination-custom/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/pagination-uri-path/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/pagination-uri-path/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/pagination-uri-path/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/pagination-uri-path/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/pagination/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/pagination/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/path-parameters/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/path-parameters/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/plain-text/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/plain-text/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/plain-text/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/plain-text/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/property-access/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/property-access/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/property-access/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/property-access/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/public-object/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/public-object/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/public-object/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/public-object/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/query-parameters-openapi/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/query-parameters/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/query-parameters/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/request-parameters/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/request-parameters/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/request-parameters/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/request-parameters/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/required-nullable/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/required-nullable/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/required-nullable/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/required-nullable/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/reserved-keywords/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/reserved-keywords/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/response-property/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/response-property/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/response-property/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/response-property/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/server-sent-event-examples/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/server-sent-events/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/server-sent-events/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/server-url-templating/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/server-url-templating/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/server-url-templating/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/server-url-templating/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/simple-api/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/simple-api/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/simple-api/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/simple-api/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/simple-fhir/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/simple-fhir/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/simple-fhir/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/simple-fhir/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/single-url-environment-default/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/streaming-parameter/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/streaming-parameter/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/streaming/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/streaming/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/streaming/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/streaming/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/trace/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/trace/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/trace/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/undiscriminated-unions/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/unions-with-local-date/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/unions/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/unions/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/unions/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/unknown/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/unknown/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/unknown/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/unknown/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/url-form-encoded/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/url-form-encoded/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/url-form-encoded/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/url-form-encoded/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/validation/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/validation/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/validation/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/validation/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/variables/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/variables/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/variables/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/variables/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/version-no-default/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/version-no-default/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/version-no-default/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/version-no-default/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/version/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/version/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/version/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/version/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/webhook-audience/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/webhook-audience/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/webhook-audience/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/webhook-audience/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end

--- a/seed/ruby-sdk-v2/websocket/lib/seed/internal/types/union.rb
+++ b/seed/ruby-sdk-v2/websocket/lib/seed/internal/types/union.rb
@@ -21,7 +21,7 @@ module Seed
           self
         end
 
-        def member?(type)
+        def type_member?(type)
           members.any? { |_key, type_fn| type == type_fn.call }
         end
 

--- a/seed/ruby-sdk-v2/websocket/test/unit/internal/types/test_union.rb
+++ b/seed/ruby-sdk-v2/websocket/test/unit/internal/types/test_union.rb
@@ -45,18 +45,18 @@ describe Seed::Internal::Types::Union do
     end
   end
 
-  describe "#member" do
+  describe "#type_member?" do
     it "defines Model members" do
-      assert Shape.member?(Rectangle)
-      assert Shape.member?(Circle)
-      refute Shape.member?(Pineapple)
+      assert Shape.type_member?(Rectangle)
+      assert Shape.type_member?(Circle)
+      refute Shape.type_member?(Pineapple)
     end
 
     it "defines other members" do
-      assert StringOrInteger.member?(String)
-      assert StringOrInteger.member?(Integer)
-      refute StringOrInteger.member?(Float)
-      refute StringOrInteger.member?(Pineapple)
+      assert StringOrInteger.type_member?(String)
+      assert StringOrInteger.type_member?(Integer)
+      refute StringOrInteger.type_member?(Float)
+      refute StringOrInteger.type_member?(Pineapple)
     end
   end
 end


### PR DESCRIPTION
## Description

Refs: Fixes all ruby-sdk-v2 seed test failures caused by `TypeError: wrong argument type Class (expected Module)` ([example CI failure](https://github.com/fern-api/fern/actions/runs/22355355455/job/64698895430?pr=12704)).

The Ruby SDK generator runs `rubocop -A` on generated output (`SdkGeneratorCli.ts:143`). The generated `.rubocop.yml` includes `rubocop-minitest` with `NewCops: enable`. A recently-enabled `Minitest/AssertIncludes` cop autocorrects `assert Shape.member?(Rectangle)` → `assert_includes Shape, Rectangle`. This calls `Module#include?` instead of the custom `Union#member?`, and `Module#include?` raises `TypeError` when given a Class argument instead of a Module.

Fix: rename `Union#member?` → `Union#type_member?` so rubocop no longer matches it against `Enumerable#member?`.

Link to Devin run: https://app.devin.ai/sessions/9ce5f097724340e18c3f9b32fcbd9860
Requested by: @patrickthornton

## Changes Made

- Renamed `def member?(type)` → `def type_member?(type)` in `union.Template.rb`
- Updated test assertions in `test_union.Template.rb` to use `type_member?`
- Propagated rename across all ~100 seed fixture `union.rb` and `test_union.rb` files
- Added `versions.yml` entry for v1.0.2

## Testing

- [x] Reproduced the failure locally by running `pnpm seed test --fixture alias-extends --generator ruby-sdk-v2` (fails before fix, passes after)
- [ ] Full CI seed test suite (pending)

## Review Checklist

- **Verify no other callers of `member?`**: The method is in `Internal::Types::Union` and appears only used in tests. Confirm no generated SDK runtime code calls `member?` (e.g., serialization paths). I did not find any, but a reviewer familiar with the codebase should double-check.
- **Public API surface**: `member?` lives under `Internal::Types`, so it should not be customer-facing. Confirm this is purely internal.
- **Alternative approach**: An alternative fix would be adding `Minitest/AssertIncludes: Enabled: false` to the generated `.rubocop.yml` in `RubocopFile.ts`, which would be more robust against future similar cops. The rename approach was chosen per the requester's preference.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
