### PR TITLE
fix(cli): skip compatible IR version check for local dev (0.0.0)

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.85.4
+  changelogEntry:
+    - summary: |
+        Skip compatible IR version validation when running in local development
+        mode (CLI version 0.0.0). This prevents noisy 404 errors from the FDR
+        registry when the CLI version is not a real published release.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 65
 - version: 3.85.3
   changelogEntry:
     - summary: |

--- a/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
+++ b/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
@@ -31,10 +31,11 @@ export const CompatibleIrVersionsRule: Rule = {
         return {
             generatorsYml: {
                 generatorInvocation: async ({ invocation, cliVersion }) => {
-                    const fdr = createFdrGeneratorsSdkService({ token: undefined });
-                    if (cliVersion == null) {
+                    if (cliVersion == null || cliVersion === "0.0.0") {
                         return [];
                     }
+
+                    const fdr = createFdrGeneratorsSdkService({ token: undefined });
 
                     // Pull the CLI release to get the IR version
                     // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics


### PR DESCRIPTION
## Description

Refs: User-reported noisy `[FDR] compatible-ir-versions: getCliRelease failed for 0.0.0` log spam during local development.

When running the CLI locally (version `0.0.0`), the `compatible-ir-versions` validation rule calls the FDR registry to look up CLI release `0.0.0`, which doesn't exist, resulting in repeated 404 errors logged to the console for every generator invocation.

## Changes Made

- Skip the compatible IR version check early when `cliVersion` is `"0.0.0"` (local dev), matching the existing pattern used in `upgrade.ts`
- Move `createFdrGeneratorsSdkService` call below the guard clause to avoid unnecessary SDK client instantiation when skipping
- Added `versions.yml` changelog entry for 3.85.4

## Testing

- [ ] Unit tests added/updated — no new test added; the behavioral change is equivalent to the existing fallback (FDR call failure already returns `[]`)
- [x] Manual testing: ran `fern check` locally with `CLI_VERSION=0.0.0` and confirmed the noisy 404 logs no longer appear

## Human Review Checklist

- [ ] The `"0.0.0"` magic string is hardcoded, consistent with existing usage (e.g., `upgrade.ts:311`) — consider whether it should be extracted to a shared constant
- [ ] Confirm it's acceptable to skip IR version compatibility validation entirely during local development (note: the FDR call was already failing and returning `[]`, so effective behavior is unchanged)

---

Link to Devin run: https://app.devin.ai/sessions/d195b3c369a94de3b6038d8aa4ceeacd
Requested by: @Swimburger