### PR TITLE
fix(ci): use prod FDR registry for compatible-ir-versions tests

### DIFF
--- a/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/__test__/compatible-ir-versions.test.ts
+++ b/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/__test__/compatible-ir-versions.test.ts
@@ -5,7 +5,7 @@ import { CompatibleIrVersionsRule } from "../compatible-ir-versions.js";
 
 describe("compatible-ir-versions", () => {
     it("simple failure", async () => {
-        process.env.DEFAULT_FDR_ORIGIN = "https://registry-dev2.buildwithfern.com";
+        process.env.DEFAULT_FDR_ORIGIN = "https://registry.buildwithfern.com";
         const violations = await getViolationsForRule({
             rule: CompatibleIrVersionsRule,
             absolutePathToWorkspace: join(
@@ -30,7 +30,7 @@ describe("compatible-ir-versions", () => {
     }, 30_000);
 
     it("simple success", async () => {
-        process.env.DEFAULT_FDR_ORIGIN = "https://registry-dev2.buildwithfern.com";
+        process.env.DEFAULT_FDR_ORIGIN = "https://registry.buildwithfern.com";
         const violations = await getViolationsForRule({
             rule: CompatibleIrVersionsRule,
             absolutePathToWorkspace: join(


### PR DESCRIPTION
## Description

Fixes the failing `compatible-ir-versions > simple failure` test.

[Link to Devin run](https://app.devin.ai/sessions/7dd551f8cbc441bca3da685bf061a989) | Requested by: @Swimburger

## Changes Made

- Switched `DEFAULT_FDR_ORIGIN` in both `compatible-ir-versions` test cases from `registry-dev2.buildwithfern.com` to `registry.buildwithfern.com`

**Root cause:** The dev2 registry's `POST /generators/by-image` endpoint returns `500 Output validation failed`, causing `getIrVersionForGenerator` to return `undefined`. The rule then skips validation (by design, to tolerate transient/offline errors), so the "simple failure" test gets an empty violations array instead of the expected fatal violation.

This effectively re-applies the test portion of #12539, which was reverted in #12581.

## Review Checklist

- [ ] Confirm using the prod registry for these tests is acceptable (alternative: mock the FDR API)
- [ ] Note that the dev2 registry's `getGeneratorByImage` endpoint is still broken — this PR works around it rather than fixing the upstream issue

## Testing

- [x] Both `simple failure` and `simple success` tests pass locally against the prod registry
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
