### PR TITLE
fix(cli): report broken AsyncAPI V3 message references as visible warnings

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
@@ -6,7 +6,22 @@ import { AsyncAPIV3 } from "../v3/index.js";
 
 export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<AsyncAPIV3.DocumentV3> {
     public getExampleMessageReference(message: WebsocketSessionExampleMessage): string {
-        return `#/channels/${message.channelId}/messages/${message.messageId}`;
+        const channelId = message.channelId ?? this.getDefaultChannelId();
+        if (channelId == null) {
+            throw new Error(
+                `Cannot resolve example message reference: no channelId provided and no channels found in document`
+            );
+        }
+        return `#/channels/${channelId}/messages/${message.messageId}`;
+    }
+
+    /**
+     * Returns the first channel ID from the document as a fallback when
+     * x-fern-examples messages omit `channelId`.
+     */
+    private getDefaultChannelId(): string | undefined {
+        const channelIds = Object.keys(this.document.channels ?? {});
+        return channelIds[0];
     }
 
     public resolveParameterReference(parameter: OpenAPIV3.ReferenceObject): AsyncAPIV3.ChannelParameter {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -355,39 +355,45 @@ export function parseAsyncAPIV3({
             const fernExamples: WebsocketSessionExampleExtension[] = getFernExamples(channel);
             const messages: WebsocketMessageSchema[] = channelEvents[channelPath]?.__parsedMessages ?? [];
             let examples: WebsocketSessionExample[] = [];
-            if (fernExamples.length > 0) {
-                examples = exampleFactory.buildWebsocketSessionExamplesForExtension({
-                    context,
-                    extensionExamples: fernExamples,
-                    handshake: {
-                        headers,
-                        queryParameters
-                    },
-                    source,
-                    namespace: context.namespace
-                });
-            } else {
-                const exampleBuilderInputs: SessionExampleBuilderInput[] = [];
-                const { examplePublishMessage, exampleSubscribeMessage } = getExampleSchemas({
-                    messages,
-                    messageSchemas: messageSchemas[channelPath] ?? {}
-                });
-                if (examplePublishMessage != null) {
-                    exampleBuilderInputs.push(examplePublishMessage);
+            try {
+                if (fernExamples.length > 0) {
+                    examples = exampleFactory.buildWebsocketSessionExamplesForExtension({
+                        context,
+                        extensionExamples: fernExamples,
+                        handshake: {
+                            headers,
+                            queryParameters
+                        },
+                        source,
+                        namespace: context.namespace
+                    });
+                } else {
+                    const exampleBuilderInputs: SessionExampleBuilderInput[] = [];
+                    const { examplePublishMessage, exampleSubscribeMessage } = getExampleSchemas({
+                        messages,
+                        messageSchemas: messageSchemas[channelPath] ?? {}
+                    });
+                    if (examplePublishMessage != null) {
+                        exampleBuilderInputs.push(examplePublishMessage);
+                    }
+                    if (exampleSubscribeMessage != null) {
+                        exampleBuilderInputs.push(exampleSubscribeMessage);
+                    }
+                    const autogenExample = exampleFactory.buildWebsocketSessionExample({
+                        handshake: {
+                            headers,
+                            queryParameters
+                        },
+                        messages: exampleBuilderInputs
+                    });
+                    if (autogenExample != null) {
+                        examples.push(autogenExample);
+                    }
                 }
-                if (exampleSubscribeMessage != null) {
-                    exampleBuilderInputs.push(exampleSubscribeMessage);
-                }
-                const autogenExample = exampleFactory.buildWebsocketSessionExample({
-                    handshake: {
-                        headers,
-                        queryParameters
-                    },
-                    messages: exampleBuilderInputs
-                });
-                if (autogenExample != null) {
-                    examples.push(autogenExample);
-                }
+            } catch (error) {
+                context.logger.warn(
+                    `Failed to build examples for channel ${channelPath}: ${error instanceof Error ? error.message : String(error)}`
+                );
             }
 
             const groupName = getExtension<string | string[] | undefined>(
@@ -546,21 +552,27 @@ function convertMessageReferencesToWebsocketSchemas({
     const results: WebsocketMessageSchema[] = [];
 
     messages.forEach((message, i) => {
-        const channelMessage = context.resolveMessageReference(message.ref, true);
-        let schemaId = channelMessage.name as string;
+        try {
+            const channelMessage = context.resolveMessageReference(message.ref, true);
+            let schemaId = channelMessage.name as string;
 
-        if (duplicatedMessageIds.includes(schemaId)) {
-            schemaId = `${channelPath}_${schemaId}`;
-        }
+            if (duplicatedMessageIds.includes(schemaId)) {
+                schemaId = `${channelPath}_${schemaId}`;
+            }
 
-        const schema = messageSchemas[schemaId];
-        if (schema != null) {
-            results.push({
-                origin,
-                name: schemaId ?? `${origin}Message${i + 1}`,
-                body: convertSchemaWithExampleToSchema(schema),
-                methodName: message.methodName
-            });
+            const schema = messageSchemas[schemaId];
+            if (schema != null) {
+                results.push({
+                    origin,
+                    name: schemaId ?? `${origin}Message${i + 1}`,
+                    body: convertSchemaWithExampleToSchema(schema),
+                    methodName: message.methodName
+                });
+            }
+        } catch (error) {
+            context.logger.warn(
+                `Skipping message reference ${message.ref.$ref} in channel ${channelPath}: ${error instanceof Error ? error.message : String(error)}`
+            );
         }
     });
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.85.4
+  changelogEntry:
+    - summary: |
+        Report broken AsyncAPI V3 message references as visible warnings instead
+        of silently dropping entire specs. When an operation references a
+        non-existent channel or message (e.g. `$ref: "#/channels/auth/messages/authenticate"`
+        when no `auth` channel exists), the parser now logs a warning with the
+        specific broken `$ref` and continues processing the remaining valid
+        messages and channels.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 65
 - version: 3.85.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Reported via [fern-demo/immix-fern-config](https://github.com/fern-demo/immix-fern-config) investigation

When an AsyncAPI V3 spec contains broken `$ref` pointers (e.g. `#/channels/auth/messages/authenticate` when no `auth` channel exists), the parser previously threw an unhandled exception that propagated up and silently dropped the **entire** AsyncAPI document. Users saw "No changes detected" with no indication their spec had issues.

This PR makes broken references visible by catching resolution failures at a granular level and emitting `context.logger.warn()` messages that appear in CLI output.

[Link to Devin run](https://app.devin.ai/sessions/32cd765e936f4a18832b60119a9bf9f4) | Requested by @Swimburger

## Changes Made

- **`convertMessageReferencesToWebsocketSchemas`**: Wrapped each per-message `resolveMessageReference` call in try/catch. A broken `$ref` now skips that single message with a warning like `Skipping message reference #/channels/auth/messages/authenticate in channel trading: Failed to resolve...` instead of killing the entire channel.
- **Example building block in `parseAsyncAPIV3`**: Wrapped the full example construction (both `x-fern-examples` extension path and auto-generated path) in try/catch. Example failures now log a warning and produce a channel with no examples rather than aborting the channel entirely.
- **`getExampleMessageReference`**: Added fallback to the first channel ID when `x-fern-examples` messages omit `channelId`, preventing `#/channels/undefined/messages/...` references. Throws a descriptive error if no channels exist at all.
- **`versions.yml`**: Added 3.85.4 changelog entry.

## Review Checklist for Humans

1. **`getDefaultChannelId()` fallback** picks the first channel arbitrarily. For single-channel specs this is correct; for multi-channel specs this could silently resolve to the wrong channel. Worth confirming this is acceptable vs. warning on fallback.
2. **The example try/catch is broad** — it wraps the entire example building block, not just reference resolution. Any bug in `buildWebsocketSessionExamplesForExtension` or `buildWebsocketSessionExample` would be swallowed as a warning rather than surfaced as a crash. Intentional (to prevent example failures from blocking channel emission) but worth confirming.
3. **Warning message assumes `message.ref.$ref` exists** in the catch block of `convertMessageReferencesToWebsocketSchemas`. The type guarantees this, but if `ref` were somehow malformed, the warning would show `undefined`.
4. **No unit tests added** — only manual local testing. Consider whether a snapshot test for broken-ref handling is desired.

## Testing

- [ ] Unit tests added/updated
- [x] Biome lint passes
- [x] Manual testing with broken AsyncAPI spec confirms warnings appear in CLI output

**Local test output** with a spec containing `$ref: '#/channels/auth/messages/authenticate'` and `$ref: '#/channels/nonexistent/messages/balance'` pointing to non-existent channels:

```
WARN  Skipping message reference #/channels/nonexistent/messages/balance in channel trading: Failed to resolve message reference #/channels/nonexistent/messages/balance in channel nonexistent
WARN  Skipping message reference #/channels/auth/messages/authenticate in channel trading: Failed to resolve message reference #/channels/auth/messages/authenticate in channel auth
DEBUG [buildChannel] Channel path="/ws/trading", server name="production", ...
```

The channel still gets generated with its valid messages — only the broken references are skipped with warnings.