### PR TITLE
feat(internal): parse `x-fern-sdk-method-name` on asyncapi channel

### DIFF
--- a/fern.schema.json
+++ b/fern.schema.json
@@ -3960,6 +3960,16 @@
         "path": {
           "type": "string"
         },
+        "connect-method-name": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "headers": {
           "oneOf": [
             {

--- a/fern/apis/fern-definition/definition/websocket.yml
+++ b/fern/apis/fern-definition/definition/websocket.yml
@@ -13,6 +13,7 @@ types:
       auth: boolean
       url: optional<string>
       path: string
+      connect-method-name: optional<string>
       headers: optional<map<string, service.HttpHeaderSchema>>
       path-parameters: optional<map<string, service.HttpPathParameterSchema>>
       query-parameters: optional<map<string, service.HttpQueryParameterSchema>>

--- a/package-yml.schema.json
+++ b/package-yml.schema.json
@@ -3980,6 +3980,16 @@
         "path": {
           "type": "string"
         },
+        "connect-method-name": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "headers": {
           "oneOf": [
             {

--- a/packages/cli/api-importers/asyncapi-to-ir/src/2.x/channel/ChannelConverter2_X.ts
+++ b/packages/cli/api-importers/asyncapi-to-ir/src/2.x/channel/ChannelConverter2_X.ts
@@ -105,6 +105,7 @@ export class ChannelConverter2_X extends AbstractChannelConverter<AsyncAPIV2.Cha
             channel: {
                 name: this.context.casingsGenerator.generateName(groupName),
                 displayName,
+                connectMethodName: undefined, // AsyncAPI v2 doesn't support x-fern-sdk-method-name on channels
                 baseUrl,
                 path,
                 auth: false,

--- a/packages/cli/api-importers/asyncapi-to-ir/src/3.0/channel/ChannelConverter3_0.ts
+++ b/packages/cli/api-importers/asyncapi-to-ir/src/3.0/channel/ChannelConverter3_0.ts
@@ -109,6 +109,7 @@ export class ChannelConverter3_0 extends AbstractChannelConverter<AsyncAPIV3.Cha
             channel: {
                 name: this.context.casingsGenerator.generateName(displayName),
                 displayName,
+                connectMethodName: undefined, // This will be populated from OpenAPI IR layer
                 baseUrl,
                 path,
                 auth: false,

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/parseAsyncAPIV2.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/parseAsyncAPIV2.ts
@@ -367,6 +367,7 @@ export function parseAsyncAPIV2({
                         name: server.name as string
                     })),
                 summary: getExtension<string | undefined>(channel, FernAsyncAPIExtension.FERN_DISPLAY_NAME),
+                connectMethodName: getExtension<string>(channel, FernAsyncAPIExtension.FERN_SDK_METHOD_NAME),
                 path,
                 description: channel.description,
                 examples,

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -401,6 +401,9 @@ export function parseAsyncAPIV3({
                 FernAsyncAPIExtension.FERN_SDK_GROUP_NAME
             );
 
+            // Extract connect method name from x-fern-sdk-method-name extension
+            const connectMethodName = getExtension<string>(channel, FernAsyncAPIExtension.FERN_SDK_METHOD_NAME);
+
             const channelServers = (
                 channel.servers?.map((serverRef) => getServerNameFromServerRef(servers, serverRef)) ??
                 Object.values(servers)
@@ -435,6 +438,7 @@ export function parseAsyncAPIV3({
                 ),
                 messages,
                 summary: getExtension<string | undefined>(channel, FernAsyncAPIExtension.FERN_DISPLAY_NAME),
+                connectMethodName,
                 servers: channelServers,
                 path: parsedChannelPath,
                 description: channel.description,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/asyncapi-v3-x-fern-sdk-method-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/asyncapi-v3-x-fern-sdk-method-name.json
@@ -66,6 +66,7 @@
           }
         }
       ],
+      "connectMethodName": "createChatConnection",
       "servers": [
         {
           "name": "production",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-x-fern-sdk-method-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/asyncapi-v3-x-fern-sdk-method-name.json
@@ -84,6 +84,7 @@
       "contents": {
         "channel": {
           "auth": false,
+          "connect-method-name": "createChatConnection",
           "docs": "Chat channel for testing custom method names",
           "examples": [
             {
@@ -126,6 +127,7 @@
   path: /v1/ws/chat
   url: production
   auth: false
+  connect-method-name: createChatConnection
   docs: Chat channel for testing custom method names
   messages:
     serverNotification:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-x-fern-sdk-method-name/asyncapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/asyncapi-v3-x-fern-sdk-method-name/asyncapi.yml
@@ -15,6 +15,7 @@ channels:
   chat:
     address: /v1/ws/chat
     description: Chat channel for testing custom method names
+    x-fern-sdk-method-name: createChatConnection
     messages:
       userMessage:
         $ref: "#/components/messages/UserMessage"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildChannel.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildChannel.ts
@@ -60,6 +60,10 @@ export function buildChannel({
         convertedChannel["display-name"] = channel.summary;
     }
 
+    if (channel.connectMethodName != null) {
+        convertedChannel["connect-method-name"] = channel.connectMethodName;
+    }
+
     if (channel.description != null) {
         convertedChannel.docs = channel.description;
     }

--- a/packages/cli/api-importers/openapi/openapi-ir/fern/definition/finalIr.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir/fern/definition/finalIr.yml
@@ -137,6 +137,7 @@ types:
       path: string
       groupName: commons.SdkGroupName
       summary: optional<string>
+      connectMethodName: optional<string>
       handshake: WebsocketHandshake
       messages: list<WebsocketMessageSchema>
       servers: list<WebsocketServer>

--- a/packages/cli/api-importers/openapi/openapi-ir/src/sdk/api/resources/finalIr/types/WebsocketChannel.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir/src/sdk/api/resources/finalIr/types/WebsocketChannel.ts
@@ -7,6 +7,7 @@ export interface WebsocketChannel extends FernOpenapiIr.WithDescription, FernOpe
     path: string;
     groupName: FernOpenapiIr.SdkGroupName;
     summary: string | undefined;
+    connectMethodName: string | undefined;
     handshake: FernOpenapiIr.WebsocketHandshake;
     messages: FernOpenapiIr.WebsocketMessageSchema[];
     servers: FernOpenapiIr.WebsocketServer[];

--- a/packages/cli/api-importers/openapi/openapi-ir/src/sdk/serialization/resources/finalIr/types/WebsocketChannel.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir/src/sdk/serialization/resources/finalIr/types/WebsocketChannel.ts
@@ -20,6 +20,7 @@ export const WebsocketChannel: core.serialization.ObjectSchema<
         path: core.serialization.string(),
         groupName: SdkGroupName,
         summary: core.serialization.string().optional(),
+        connectMethodName: core.serialization.string().optional(),
         handshake: WebsocketHandshake,
         messages: core.serialization.list(WebsocketMessageSchema),
         servers: core.serialization.list(WebsocketServer),
@@ -34,6 +35,7 @@ export declare namespace WebsocketChannel {
         path: string;
         groupName: SdkGroupName.Raw;
         summary?: string | null;
+        connectMethodName?: string | null;
         handshake: WebsocketHandshake.Raw;
         messages: WebsocketMessageSchema.Raw[];
         servers: WebsocketServer.Raw[];

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.85.7
+- version: 3.86.0
   changelogEntry:
     - summary: |
         Add support for `x-fern-sdk-method-name` extension on AsyncAPI WebSocket channels

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,36 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.85.7
+  changelogEntry:
+    - summary: |
+        Add support for `x-fern-sdk-method-name` extension on AsyncAPI WebSocket channels
+        to customize the connection method name in generated SDKs. This field is now
+        available in both AsyncAPI v2 and v3 specifications.
+
+        **AsyncAPI example** — use `x-fern-sdk-method-name` to customize the WebSocket
+        connection method instead of the default "connect":
+
+        ```yaml
+        asyncapi: 3.0.0
+        info:
+          title: Chat API
+          version: 1.0.0
+        channels:
+          /chat:
+            x-fern-sdk-method-name: createChatConnection
+            messages:
+              userMessage:
+                payload:
+                  type: object
+                  properties:
+                    content:
+                      type: string
+        ```
+
+        This generates `client.createChatConnection()` instead of `client.connect()`,
+        avoiding confusing APIs where both wrapper creation and actual connection use "connect".
+      type: feat
+  createdAt: "2026-02-24"
+  irVersion: 65
 - version: 3.85.6
   changelogEntry:
     - summary: |

--- a/packages/cli/fern-definition/schema/src/schemas/api/resources/websocket/types/WebSocketChannelSchema.ts
+++ b/packages/cli/fern-definition/schema/src/schemas/api/resources/websocket/types/WebSocketChannelSchema.ts
@@ -6,6 +6,7 @@ export interface WebSocketChannelSchema extends FernDefinition.DeclarationSchema
     auth: boolean;
     url?: string;
     path: string;
+    "connect-method-name"?: string;
     headers?: Record<string, FernDefinition.HttpHeaderSchema>;
     "path-parameters"?: Record<string, FernDefinition.HttpPathParameterSchema>;
     "query-parameters"?: Record<string, FernDefinition.HttpQueryParameterSchema>;

--- a/packages/cli/fern-definition/schema/src/schemas/serialization/resources/websocket/types/WebSocketChannelSchema.ts
+++ b/packages/cli/fern-definition/schema/src/schemas/serialization/resources/websocket/types/WebSocketChannelSchema.ts
@@ -19,6 +19,7 @@ export const WebSocketChannelSchema: core.serialization.ObjectSchema<
         auth: core.serialization.boolean(),
         url: core.serialization.string().optional(),
         path: core.serialization.string(),
+        "connect-method-name": core.serialization.string().optional(),
         headers: core.serialization.record(core.serialization.string(), HttpHeaderSchema).optional(),
         "path-parameters": core.serialization.record(core.serialization.string(), HttpPathParameterSchema).optional(),
         "query-parameters": core.serialization.record(core.serialization.string(), HttpQueryParameterSchema).optional(),
@@ -33,6 +34,7 @@ export declare namespace WebSocketChannelSchema {
         auth: boolean;
         url?: string | null;
         path: string;
+        "connect-method-name"?: string | null;
         headers?: Record<string, HttpHeaderSchema.Raw> | null;
         "path-parameters"?: Record<string, HttpPathParameterSchema.Raw> | null;
         "query-parameters"?: Record<string, HttpQueryParameterSchema.Raw> | null;

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket-bearer-auth.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket-bearer-auth.json
@@ -1601,6 +1601,7 @@
                 }
             },
             "displayName": null,
+            "connectMethodName": null,
             "headers": [],
             "pathParameters": [
                 {
@@ -2318,6 +2319,7 @@
                 }
             },
             "displayName": null,
+            "connectMethodName": null,
             "headers": [],
             "pathParameters": [
                 {

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket-inferred-auth.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket-inferred-auth.json
@@ -3840,6 +3840,7 @@
                 }
             },
             "displayName": null,
+            "connectMethodName": null,
             "headers": [],
             "pathParameters": [
                 {

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket.json
@@ -1308,6 +1308,7 @@
                 }
             },
             "displayName": null,
+            "connectMethodName": null,
             "headers": [],
             "pathParameters": [],
             "queryParameters": [],
@@ -1362,6 +1363,7 @@
                 }
             },
             "displayName": null,
+            "connectMethodName": null,
             "headers": [],
             "pathParameters": [
                 {

--- a/packages/cli/generation/ir-generator/src/converters/convertChannel.ts
+++ b/packages/cli/generation/ir-generator/src/converters/convertChannel.ts
@@ -71,6 +71,7 @@ export function convertChannel({
         // since there's only 1 channel per file, we can use the file name as the channel's name
         name: file.fernFilepath.file ?? file.casingsGenerator.generateName(channel["display-name"] ?? channel.path),
         displayName: channel["display-name"],
+        connectMethodName: channel["connect-method-name"],
         headers:
             channel.headers != null
                 ? Object.entries(channel.headers).map(([headerKey, header]) =>

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/asyncapi-json-refs-ir.snap
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/__snapshots__/asyncapi-json-refs-ir.snap
@@ -699,6 +699,7 @@
       "auth": false,
       "availability": undefined,
       "baseUrl": "production",
+      "connectMethodName": undefined,
       "displayName": undefined,
       "docs": "Receive order status notifications",
       "examples": [
@@ -1103,6 +1104,7 @@
       "auth": false,
       "availability": undefined,
       "baseUrl": "production",
+      "connectMethodName": undefined,
       "displayName": undefined,
       "docs": "Receive real-time plant inventory updates",
       "examples": [

--- a/packages/cli/workspace/lazy-fern-workspace/src/fern.schema.json
+++ b/packages/cli/workspace/lazy-fern-workspace/src/fern.schema.json
@@ -3960,6 +3960,16 @@
         "path": {
           "type": "string"
         },
+        "connect-method-name": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "headers": {
           "oneOf": [
             {

--- a/packages/cli/workspace/lazy-fern-workspace/src/package-yml.schema.json
+++ b/packages/cli/workspace/lazy-fern-workspace/src/package-yml.schema.json
@@ -3980,6 +3980,16 @@
         "path": {
           "type": "string"
         },
+        "connect-method-name": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "headers": {
           "oneOf": [
             {

--- a/packages/ir-sdk/fern/apis/ir-types-latest/changelog/CHANGELOG.md
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/changelog/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v65.3.0] - 2026-02-24
+- Feature: Add optional `connectMethodName` field to `WebSocketChannel` for custom WebSocket connection method naming.
+  Supports `x-fern-sdk-method-name` extension on AsyncAPI channels to customize the generated connection method name instead of using the default "connect".
+  This addresses confusing APIs where both the client wrapper creation and actual connection use "connect".
+
 ## [v65.2.1] - 2026-02-24
 - Feature: Add document-level `webhook-signature` configuration to Fern definition files.
   Allows specifying a default signature verification config that applies to all webhooks in a file,

--- a/packages/ir-sdk/fern/apis/ir-types-latest/definition/websocket.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/definition/websocket.yml
@@ -13,6 +13,7 @@ types:
     properties:
       name: WebSocketName
       displayName: optional<string>
+      connectMethodName: optional<string>
       baseUrl: optional<environment.EnvironmentBaseUrlId>
       path: http.HttpPath
       auth: boolean

--- a/packages/ir-sdk/src/sdk/api/resources/websocket/types/WebSocketChannel.ts
+++ b/packages/ir-sdk/src/sdk/api/resources/websocket/types/WebSocketChannel.ts
@@ -5,6 +5,7 @@ import type * as FernIr from "../../../index.js";
 export interface WebSocketChannel extends FernIr.Declaration {
     name: FernIr.WebSocketName;
     displayName: string | undefined;
+    connectMethodName: string | undefined;
     baseUrl: FernIr.EnvironmentBaseUrlId | undefined;
     path: FernIr.HttpPath;
     auth: boolean;

--- a/packages/ir-sdk/src/sdk/serialization/resources/websocket/types/WebSocketChannel.ts
+++ b/packages/ir-sdk/src/sdk/serialization/resources/websocket/types/WebSocketChannel.ts
@@ -21,6 +21,7 @@ export const WebSocketChannel: core.serialization.ObjectSchema<
     .objectWithoutOptionalProperties({
         name: WebSocketName,
         displayName: core.serialization.string().optional(),
+        connectMethodName: core.serialization.string().optional(),
         baseUrl: EnvironmentBaseUrlId.optional(),
         path: HttpPath,
         auth: core.serialization.boolean(),
@@ -37,6 +38,7 @@ export declare namespace WebSocketChannel {
     export interface Raw extends Declaration.Raw {
         name: WebSocketName.Raw;
         displayName?: string | null;
+        connectMethodName?: string | null;
         baseUrl?: EnvironmentBaseUrlId.Raw | null;
         path: HttpPath.Raw;
         auth: boolean;


### PR DESCRIPTION
## Description
Parses `x-fern-sdk-method-name` on AsyncAPI channels; this allows for a custom name for the `connect` method instead of the default (which is `connect`). Certain APIs would have awkward or confusing name clashes where two or more related methods would both be called `connect`, which this resolves.

## Changes Made
Added a `connectMethodName` to channels; added parsing of the `x-fern-sdk-method-name` on channels.
- [X] Updated README.md generator (if applicable)

## Testing
Updated openapi-ir-to-fern-tests and an ETE test.
- [X] Unit tests added/updated
- [X] Manual testing completed
