### PR TITLE
fix(python): omit `bytes` wire tests

### DIFF
--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -702,7 +702,7 @@ export class EndpointSnippetGenerator {
         }
         return [
             {
-                name: this.context.getPropertyName(body.bodyKey),
+                name: REQUEST_BODY_ARG_NAME,
                 value: typeInstantiation
             }
         ];

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -205,6 +205,12 @@ export class WireTestGenerator {
                 continue;
             }
 
+            // Skip bytes request body endpoints — the IR example system has no
+            // ExampleRequestBody variant for bytes, so we can't produce a proper example.
+            if (endpoint.requestBody?.type === "bytes") {
+                continue;
+            }
+
             // Always use static IR examples to match WireMock mappings
             // WireMock mappings are generated from static IR examples, so we must use the same examples
             const staticExample = this.getStaticIrExample(endpoint);

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.59.3
+  changelogEntry:
+    - summary: Fix bytes body snippet generation to use `request` parameter name instead of dynamic IR body key.
+      type: fix
+    - summary: Skip wire test generation for bytes request body endpoints, which lack IR example support.
+      type: fix
+  createdAt: "2026-02-24"
+  irVersion: 65
+
 - version: 4.59.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Drops wire tests with `bytes` type parameters until we actually implement that in the IR.
