### PR TITLE
chore(cli): Remove console.debug logs

### DIFF
--- a/packages/core/src/services/fdrGeneratorsSdk.ts
+++ b/packages/core/src/services/fdrGeneratorsSdk.ts
@@ -7,8 +7,6 @@ export function createFdrGeneratorsSdkService({
     environment?: string;
     token: (() => string) | string | undefined;
 }): FdrClient {
-    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-    console.debug(`[FDR] Creating generators SDK service with environment: ${environment}`);
     return new FdrClient({
         environment,
         token
@@ -22,42 +20,22 @@ export interface GeneratorInfo {
 
 export async function getIrVersionForGenerator(invocation: GeneratorInfo): Promise<number | undefined> {
     const fdr = createFdrGeneratorsSdkService({ token: undefined });
-    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-    console.debug(`[FDR] getIrVersionForGenerator: looking up generator by image: ${invocation.name}`);
     const generatorEntity = await fdr.generators.getGeneratorByImage({
         dockerImage: invocation.name
     });
     // Again, this is to allow for offline usage, and other transient errors
     if (!generatorEntity.ok || generatorEntity.body == null) {
-        // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-        console.debug(
-            `[FDR] getIrVersionForGenerator: getGeneratorByImage failed for ${invocation.name}`,
-            generatorEntity
-        );
         return undefined;
     }
-    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-    console.debug(
-        `[FDR] getIrVersionForGenerator: found generator id=${generatorEntity.body.id}, fetching release version=${invocation.version}`
-    );
     const generatorRelease = await fdr.generators.versions.getGeneratorRelease(
         generatorEntity.body.id,
         invocation.version
     );
 
     if (generatorRelease.ok) {
-        // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-        console.debug(
-            `[FDR] getIrVersionForGenerator: got release for ${invocation.name}@${invocation.version}, irVersion=${generatorRelease.body.irVersion}`
-        );
         // We've pulled the generator release, let's get it's IR version
         return generatorRelease.body.irVersion;
     }
 
-    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-    console.debug(
-        `[FDR] getIrVersionForGenerator: getGeneratorRelease failed for ${generatorEntity.body.id}@${invocation.version}`,
-        generatorRelease
-    );
     return undefined;
 }


### PR DESCRIPTION
## Description

The raw `console.debug` logs totally mess up the TTY-aware logging mechanism in the CLI. We should always use the `context.logger`. These logs don't seem required as-is, so this opts to remove them for now. If we need to restore them in the future, we can use a `context.logger`.