### PR TITLE
fix(cli): preserve array types in AI example enhancer for form data file fields

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.86.2
+  changelogEntry:
+    - summary: |
+        Fix AI example enhancer corrupting form data file array values. When the AI
+        returned a non-array value for file upload fields (filenames, filenamesWithData,
+        exploded), the enhancer would replace the original array with an object, causing
+        FDR registration to fail with "Expected array, received object" validation errors.
+        The enhancer now preserves the original wrapper when the AI returns an incompatible type.
+      type: fix
+  createdAt: "2026-02-25"
+  irVersion: 65
 - version: 3.86.1
   changelogEntry:
     - summary: |

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -1204,7 +1204,19 @@ function applyEnhancementResults(
                             // Update each field's value while preserving the FDR typed value wrapper structure
                             for (const [key, wrapper] of Object.entries(originalValue)) {
                                 if (key in enhancedReq) {
-                                    updatedValue[key] = { ...wrapper, value: enhancedReq[key] };
+                                    const enhancedValue = enhancedReq[key];
+                                    // For FormValue types that require array values (filenames, filenamesWithData, exploded),
+                                    // only apply the enhanced value if it's actually an array. If the AI returned a non-array
+                                    // (e.g., an object), keep the original wrapper to avoid type validation errors.
+                                    const requiresArrayValue =
+                                        wrapper.type === "filenames" ||
+                                        wrapper.type === "filenamesWithData" ||
+                                        wrapper.type === "exploded";
+                                    if (requiresArrayValue && !Array.isArray(enhancedValue)) {
+                                        updatedValue[key] = wrapper;
+                                    } else {
+                                        updatedValue[key] = { ...wrapper, value: enhancedValue };
+                                    }
                                 } else {
                                     updatedValue[key] = wrapper;
                                 }


### PR DESCRIPTION
## Description

Fixes FDR `registerApiDefinition` failing with "Expected array, received object" validation error for ElevenLabs docs (and any API with file array upload endpoints).

**Root cause**: In `applyEnhancementResults`, when re-wrapping form data after AI enhancement, the code blindly replaced each FormValue wrapper's `value` with whatever the AI returned. For file array fields (`filenames`, `filenamesWithData`, `exploded`), if the AI returned an object instead of an array, this produced `{ type: "filenames", value: { ... } }` — an object where the oRPC zod schema expects an array. The old FDR server silently accepted this; the new oRPC server properly validates and rejects it.

Link to Devin run: https://app.devin.ai/sessions/3f10a998e5154a91b06f5dc2ba739982
Requested by: @dsinghvi

## Changes Made

- Added type guard in `applyEnhancementResults` to check if a FormValue wrapper requires an array value (`filenames`, `filenamesWithData`, `exploded`)
- When the AI returns a non-array for an array-typed field, the original wrapper is preserved instead of being corrupted
- Added changelog entry in `versions.yml` (v3.86.2)

## Testing

- [ ] Unit tests added/updated
- [x] TypeScript compilation verified (no new errors introduced)
- [ ] Manual testing with ElevenLabs docs generation

## Review Checklist

- **Silent fallback**: When the AI returns an incompatible type, the enhancement is silently dropped for that field (falls back to original). Should a warning be logged instead?
- **Completeness of type list**: Verify that `filenames`, `filenamesWithData`, and `exploded` covers all FormValue variants that require array values (cross-reference with `FormValueSchema` in fern-platform's `shared.ts`)
- **Other type mismatches**: This fix only guards array-typed fields. Other mismatches (e.g., AI returning an array for a `filename` string field) are not handled — is that acceptable?