### PR TITLE
feat(cli): support collapsed-by-default for api reference layout sections

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -2025,6 +2025,26 @@
             }
           ]
         },
+        "collapsible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "collapsed-by-default": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "availability": {
           "oneOf": [
             {

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -1324,6 +1324,14 @@ types:
       icon: optional<string>
       hidden: optional<boolean>
       skip-slug: optional<boolean>
+      collapsible:
+        type: optional<boolean>
+        docs: |
+          Whether the section can be expanded/collapsed by the user.
+      collapsed-by-default:
+        type: optional<boolean>
+        docs: |
+          Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open).
       availability: optional<Availability>
       playground:
         type: optional<PlaygroundSettings>

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.89.0
+  changelogEntry:
+    - summary: |
+        Add `collapsible` and `collapsed-by-default` support for API Reference `layout` section items in `docs.yml`.
+      type: feat
+  createdAt: "2026-02-25"
+  irVersion: 65
+
 - version: 3.88.0
   changelogEntry:
     - summary: |

--- a/packages/cli/config/src/schemas/docs/navigation/ApiReferenceLayoutItemSchema.ts
+++ b/packages/cli/config/src/schemas/docs/navigation/ApiReferenceLayoutItemSchema.ts
@@ -39,6 +39,8 @@ export const ApiReferenceSectionConfigurationSchema = z.object({
     section: z.string(),
     slug: z.string().optional(),
     icon: z.string().optional(),
+    collapsible: z.boolean().optional(),
+    collapsedByDefault: z.boolean().optional(),
     contents: z.array(z.lazy((): z.ZodTypeAny => ApiReferenceLayoutItemSchema))
 });
 

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -1253,6 +1253,8 @@ function parseApiReferenceLayoutItem(
                 slug: item.slug,
                 hidden: item.hidden,
                 skipUrlSlug: item.skipSlug,
+                collapsible: item.collapsible,
+                collapsedByDefault: item.collapsedByDefault,
                 availability: item.availability,
                 icon: resolveIconPath(item.icon, absolutePathToConfig),
                 playground: item.playground,

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -420,6 +420,8 @@ export declare namespace ParsedApiReferenceLayoutItem {
         hidden: boolean | undefined;
         icon: string | AbsoluteFilePath | undefined;
         skipUrlSlug: boolean | undefined;
+        collapsible: boolean | undefined;
+        collapsedByDefault: boolean | undefined;
         availability: Availability | undefined;
         playground: PlaygroundSettings | undefined;
     }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ApiReferenceSectionConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ApiReferenceSectionConfiguration.ts
@@ -16,6 +16,8 @@ export interface ApiReferenceSectionConfiguration
     icon?: string;
     hidden?: boolean;
     skipSlug?: boolean;
+    collapsible?: boolean;
+    collapsedByDefault?: boolean;
     availability?: FernDocsConfig.Availability;
     /** Settings for the api playground that affects all endpoints. */
     playground?: FernDocsConfig.PlaygroundSettings;

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ApiReferenceSectionConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ApiReferenceSectionConfiguration.ts
@@ -24,6 +24,8 @@ export const ApiReferenceSectionConfiguration: core.serialization.ObjectSchema<
         icon: core.serialization.string().optional(),
         hidden: core.serialization.boolean().optional(),
         skipSlug: core.serialization.property("skip-slug", core.serialization.boolean().optional()),
+        collapsible: core.serialization.boolean().optional(),
+        collapsedByDefault: core.serialization.property("collapsed-by-default", core.serialization.boolean().optional()),
         availability: Availability.optional(),
         playground: PlaygroundSettings.optional(),
     })
@@ -40,6 +42,8 @@ export declare namespace ApiReferenceSectionConfiguration {
         icon?: string | null;
         hidden?: boolean | null;
         "skip-slug"?: boolean | null;
+        collapsible?: boolean | null;
+        "collapsed-by-default"?: boolean | null;
         availability?: Availability.Raw | null;
         playground?: PlaygroundSettings.Raw | null;
     }

--- a/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
+++ b/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
@@ -435,7 +435,7 @@ export class ApiReferenceNodeConverter {
             slug,
             sectionAvailability
         );
-        return {
+        const node: FernNavigation.V1.ApiPackageNode = {
             id: nodeId,
             type: "apiPackage",
             children: convertedItems,
@@ -454,6 +454,21 @@ export class ApiReferenceNodeConverter {
             orphaned: section.orphaned,
             featureFlags: section.featureFlags
         };
+
+        // `ApiPackageNode` (from `@fern-api/fdr-sdk`) may not yet include these properties at the type level.
+        // Assign via an intersection type to avoid excess-property errors while still emitting them in JSON.
+        const nodeWithCollapsing = node as FernNavigation.V1.ApiPackageNode & {
+            collapsible?: boolean;
+            collapsedByDefault?: boolean;
+        };
+        if (section.collapsible !== undefined) {
+            nodeWithCollapsing.collapsible = section.collapsible;
+        }
+        if (section.collapsedByDefault !== undefined) {
+            nodeWithCollapsing.collapsedByDefault = section.collapsedByDefault;
+        }
+
+        return node;
     }
 
     #convertUnknownIdentifier(

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -2025,6 +2025,26 @@
             }
           ]
         },
+        "collapsible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "collapsed-by-default": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "availability": {
           "oneOf": [
             {

--- a/packages/cli/yaml/docs-validator/src/docsAst/products-yml.schema.json
+++ b/packages/cli/yaml/docs-validator/src/docsAst/products-yml.schema.json
@@ -951,6 +951,26 @@
             }
           ]
         },
+        "collapsible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "collapsed-by-default": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "availability": {
           "oneOf": [
             {

--- a/packages/cli/yaml/docs-validator/src/docsAst/versions-yml.schema.json
+++ b/packages/cli/yaml/docs-validator/src/docsAst/versions-yml.schema.json
@@ -951,6 +951,26 @@
             }
           ]
         },
+        "collapsible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "collapsed-by-default": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "availability": {
           "oneOf": [
             {

--- a/product-yml.schema.json
+++ b/product-yml.schema.json
@@ -951,6 +951,26 @@
             }
           ]
         },
+        "collapsible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "collapsed-by-default": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "availability": {
           "oneOf": [
             {

--- a/version-yml.schema.json
+++ b/version-yml.schema.json
@@ -951,6 +951,26 @@
             }
           ]
         },
+        "collapsible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "collapsed-by-default": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "availability": {
           "oneOf": [
             {


### PR DESCRIPTION
## Description
Linear ticket: Closes  
Link to Devin run: https://app.devin.ai/sessions/284c091e988c429f886b89883749c2ba  
Requested by: @Ryan-Amirthan

Adds support for `collapsible` and `collapsed-by-default` on **API Reference `layout` section** items in `docs.yml`, so these sections can default to expanded/collapsed in the rendered navigation (emitted as `apiPackage` nodes).

Companion platform PR: https://github.com/fern-api/fern-platform/pull/7502

## Changes Made
- Added `collapsible` and `collapsed-by-default` fields to the Fern API definition for `ApiReferenceSectionConfiguration` (`fern/apis/docs-yml/definition/docs.yml`).
- Regenerated all JSON schema files from the updated API definition:
  - `docs-yml.schema.json` (root + `packages/cli/workspace/loader/src/`)
  - `products-yml.schema.json`, `versions-yml.schema.json` (in `packages/cli/yaml/docs-validator/src/docsAst/`)
  - `product-yml.schema.json`, `version-yml.schema.json` (root)
- Added `collapsible` and `collapsedByDefault` to:
  - Zod schema: `ApiReferenceSectionConfigurationSchema`
  - SDK type + serialization mapping (`collapsed-by-default` YAML key)
- Plumbed the fields through parsing into `ParsedApiReferenceLayoutItem.Section`.
- Emitted `collapsible` and `collapsedByDefault` on the generated `ApiPackageNode` for layout sections in `ApiReferenceNodeConverter`.
  - Note: uses an intersection-cast assignment to avoid TS excess-property errors until `@fern-api/fdr-sdk` updates land (platform PR #7502).
- Added CLI `versions.yml` entry (3.89.0) for the new feature.
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- All CI checks passing (compile, test, lint, biome, depcheck, test-ete, versions.yml validation, all seed tests)

## Reviewer Checklist
- SDK type/serialization files were **manually edited** (not regenerated via `fern generate --local`, which failed due to an unrelated IR migration issue). Verify the added fields in `ApiReferenceSectionConfiguration.ts` (api + serialization) are consistent with the API definition.
- Confirm the intersection-cast approach in `ApiReferenceNodeConverter` is acceptable given current `@fern-api/fdr-sdk` typing (will be unnecessary once platform PR #7502 merges).
- Verify the Zod schema field names (`collapsible`, `collapsedByDefault`) correctly map to the YAML keys (`collapsible`, `collapsed-by-default`) through the SDK serialization layer.
- Confirm `false` values for `collapsible`/`collapsedByDefault` are preserved (not dropped) on `apiPackage` nodes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
