### PR TITLE
chore(internal): Add versions.yml entry for generator-cli 0.6.0

### DIFF
--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,17 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Add Replay step to post-generation pipeline. Introduces the PostGenerationPipeline
+        with ReplayStep that runs after SDK generation for self-hosted GitHub repos. Replay
+        preserves user customizations across SDK regenerations by detecting patches via
+        `.fern/replay.lock`, applying them with 3-way merge, and creating PRs with conflict
+        resolution guidance when needed.
+      type: feat
+  createdAt: "2026-02-25"
+  version: 0.6.0
+
+- changelogEntry:
+    - summary: |
         Regenerate generator-cli types with latest version of the TypeScript SDK generator.
       type: internal
   createdAt: "2026-01-29"


### PR DESCRIPTION
## Description

Adds the missing `versions.yml` changelog entry for the generator-cli package to track the Replay feature introduced in #12559.

[Link to Devin run](https://app.devin.ai/sessions/f642f748d2394e74b641c27d60eb7807) | Requested by: @tstanmay13

## Changes Made

- Added a new `0.6.0` entry (minor bump from `0.5.4`) to `packages/generator-cli/versions.yml` with type `feat` summarizing the PostGenerationPipeline / ReplayStep addition

## Review Checklist

- [ ] Confirm `0.6.0` is the intended next version (minor bump for a feature addition)
- [ ] Confirm the `createdAt` date — set to `2026-02-25` (today) rather than `2026-02-24` (when #12559 merged)
- [ ] Confirm the changelog summary accurately describes the Replay changes from #12559

## Testing

- No code logic changes; changelog entry only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
