### PR TITLE
fix(typescript): bump Docker base image Node version from 22.12 to 22.13

### DIFF
--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.13-alpine3.20 AS node
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.13-alpine3.20 AS node
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/go/model/Dockerfile
+++ b/generators/go/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.13-alpine3.20 AS node
 FROM golang:1.23.8-alpine3.20
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Node CLI
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.13-alpine3.20 AS node
 
 RUN apk --no-cache add git zip
 RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"

--- a/generators/openapi/Dockerfile
+++ b/generators/openapi/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:22.12-alpine3.20
+FROM node:22.13-alpine3.20
 COPY dist /dist
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs", "openapi"]

--- a/generators/php/model/Dockerfile
+++ b/generators/php/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.13-alpine3.20 AS node
 FROM composer:2.7.9
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.13-alpine3.20 AS node
 FROM composer:2.7.9
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/postman/Dockerfile
+++ b/generators/postman/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20
+FROM node:22.13-alpine3.20
 
 COPY dist /dist
 

--- a/generators/python-v2/fastapi/Dockerfile
+++ b/generators/python-v2/fastapi/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:22.12-alpine3.20
+FROM node:22.13-alpine3.20
 COPY generators/python-v2/fastapi/dist /dist
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs"]

--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20
+FROM node:22.13-alpine3.20
 
 # Install system dependencies and Rust toolchain
 RUN apk --no-cache add curl

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20
+FROM node:22.13-alpine3.20
 
 # Install system dependencies and Rust toolchain
 RUN apk --no-cache add bash curl git zip gcc musl-dev openssl-dev pkgconfig

--- a/generators/swift/model/Dockerfile
+++ b/generators/swift/model/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.13-alpine3.20 AS node
 
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs"]

--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.13-alpine3.20 AS node
 
 RUN apk --no-cache add bash curl git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \

--- a/generators/typescript/express/cli/Dockerfile
+++ b/generators/typescript/express/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-slim
+FROM node:22.13-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends git zip && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"

--- a/generators/typescript/express/versions.yml
+++ b/generators/typescript/express/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bump Docker base image from `node:22.12-slim` to `node:22.13-slim` to fix
+        `yarn install` failures caused by transitive dependencies (e.g. `eslint-visitor-keys@5.0.1`)
+        requiring Node `^20.19.0 || ^22.13.0 || >=24`.
+      type: fix
+  irVersion: 61
+  createdAt: "2026-02-25"
+  version: 0.19.4
+
+- changelogEntry:
+    - summary: |
         Update oxfmt to 0.35.0, oxlint to 1.50.0, and oxlint-tsgolint to 0.14.2.
       type: chore
   irVersion: 61

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-slim
+FROM node:22.13-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends git zip && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.49.4
+  changelogEntry:
+    - summary: |
+        Bump Docker base image from `node:22.12-slim` to `node:22.13-slim` to fix
+        `yarn install` failures caused by transitive dependencies (e.g. `eslint-visitor-keys@5.0.1`)
+        requiring Node `^20.19.0 || ^22.13.0 || >=24`.
+      type: fix
+  createdAt: "2026-02-25"
+  irVersion: 63
+
 - version: 3.49.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Customer report from Kunal Dawar — `yarn install` fails during TypeScript SDK generation because `eslint-visitor-keys@5.0.1` requires Node `^20.19.0 || ^22.13.0 || >=24`, but the generator image is pinned to Node 22.12.

Since the install runs without a lockfile (`--mode=update-lockfile`), Yarn resolves the latest dependency graph and pulls versions incompatible with Node 22.12.

[Link to Devin run](https://app.devin.ai/sessions/cf10e9b9b6634c7995eee26bc80bab24) | Requested by: @jon-fern

## Changes Made

- Bump TypeScript SDK Dockerfile from `node:22.12-slim` → `node:22.13-slim`
- Bump TypeScript Express Dockerfile from `node:22.12-slim` → `node:22.13-slim`
- Bump all other generator Dockerfiles from `node:22.12-alpine3.20` → `node:22.13-alpine3.20` (C#, Go, PHP, Python FastAPI, Rust, Swift, OpenAPI, Postman)
- Add `versions.yml` entries for TypeScript SDK (3.49.4) and Express (0.19.4)

## Human Review Checklist

- [ ] Verify `node:22.13-alpine3.20` exists as a Docker Hub tag (the `-slim` variant is confirmed)
- [ ] Confirm non-TypeScript generators don't need their own `versions.yml` bumps for this base image change
- [ ] Verify version increments (3.49.4, 0.19.4) are correct

## Testing

- [ ] No unit tests needed — Dockerfile base image change only
- [ ] CI should validate the version bump entries in `versions.yml`