### PR TITLE
fix(cli): Replace global process timeout with per-request timeouts

### DIFF
--- a/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
+++ b/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
@@ -2,6 +2,7 @@ import { AbsoluteFilePath, doesPathExist, resolve } from "@fern-api/fs-utils";
 import { mkdtemp, readFile, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
+import { HTTP_REQUEST_TIMEOUT_MS } from "../../constants.js";
 import type { Context } from "../../context/Context.js";
 import type { ApiSpec, ApiSpecType } from "../config/ApiSpec.js";
 import { ApiSpecDetector } from "./ApiSpecDetector.js";
@@ -71,7 +72,7 @@ export class ApiSpecResolver {
     }
 
     private async fetchContent({ url }: { url: string }): Promise<{ content: string; contentType: string }> {
-        const response = await fetch(url);
+        const response = await fetch(url, { signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS) });
         if (!response.ok) {
             throw new Error(`Failed to fetch "${url}": HTTP ${response.status} ${response.statusText}`);
         }

--- a/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
+++ b/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
@@ -2,7 +2,7 @@ import { AbsoluteFilePath, doesPathExist, resolve } from "@fern-api/fs-utils";
 import { mkdtemp, readFile, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
-import { HTTP_REQUEST_TIMEOUT_MS } from "../../constants.js";
+import { FETCH_API_SPEC_REQUEST_TIMEOUT_MS } from "../../constants.js";
 import type { Context } from "../../context/Context.js";
 import type { ApiSpec, ApiSpecType } from "../config/ApiSpec.js";
 import { ApiSpecDetector } from "./ApiSpecDetector.js";
@@ -72,7 +72,7 @@ export class ApiSpecResolver {
     }
 
     private async fetchContent({ url }: { url: string }): Promise<{ content: string; contentType: string }> {
-        const response = await fetch(url, { signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS) });
+        const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_API_SPEC_REQUEST_TIMEOUT_MS) });
         if (!response.ok) {
             throw new Error(`Failed to fetch "${url}": HTTP ${response.status} ${response.statusText}`);
         }

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import type { Argv } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -11,19 +10,9 @@ import { addInitCommand } from "./commands/init/index.js";
 import { addSdkCommand } from "./commands/sdk/index.js";
 import { addTelemetryCommand } from "./commands/telemetry/index.js";
 import { GlobalArgs } from "./context/GlobalArgs.js";
-import { Icons } from "./ui/format.js";
 import { Version } from "./version.js";
 
-const TIMEOUT_MINUTES = 10;
-const TIMEOUT_MS = TIMEOUT_MINUTES * 60 * 1000;
-
 export async function runCliV2(argv?: string[]): Promise<void> {
-    const timeout = setTimeout(() => {
-        process.stderr.write(`${Icons.error} ${chalk.red(`Timed out after ${TIMEOUT_MINUTES} minutes.\n`)}`);
-        process.exit(1);
-    }, TIMEOUT_MS);
-    timeout.unref();
-
     const cli = createCliV2(argv);
     await cli.parse();
 }

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -22,6 +22,7 @@ import { SdkStageOverrides, SdkTaskGroup } from "../../../sdk/task/SdkTaskGroup.
 import type { TaskStageLabels } from "../../../ui/TaskStageLabels.js";
 import type { Workspace } from "../../../workspace/Workspace.js";
 import { WorkspaceBuilder } from "../../../workspace/WorkspaceBuilder.js";
+import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
 import { command } from "../../_internal/command.js";
 import { isGitUrl } from "../utils/gitUrl.js";
 
@@ -559,7 +560,15 @@ export function addGenerateCommand(cli: Argv<GlobalArgs>): void {
         cli,
         "generate",
         "Generate SDKs from fern.yml or directly from an API spec",
-        (context, args) => cmd.handle(context, args as GenerateCommand.Args),
+        async (context, args) => {
+            const timeout = new Promise<never>((_, reject) => {
+                setTimeout(
+                    () => reject(new CliError("Generation timed out after 10 minutes.")),
+                    GENERATE_COMMAND_TIMEOUT_MS
+                ).unref();
+            });
+            await Promise.race([cmd.handle(context, args as GenerateCommand.Args), timeout]);
+        },
         (yargs) =>
             yargs
                 .option("api", {

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -11,6 +11,7 @@ import type { Argv } from "yargs";
 import { ApiChecker } from "../../../api/checker/ApiChecker.js";
 import type { ApiDefinition } from "../../../api/config/ApiDefinition.js";
 import { ApiSpecResolver } from "../../../api/resolver/ApiSpecResolver.js";
+import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
@@ -22,7 +23,6 @@ import { SdkStageOverrides, SdkTaskGroup } from "../../../sdk/task/SdkTaskGroup.
 import type { TaskStageLabels } from "../../../ui/TaskStageLabels.js";
 import type { Workspace } from "../../../workspace/Workspace.js";
 import { WorkspaceBuilder } from "../../../workspace/WorkspaceBuilder.js";
-import { GENERATE_COMMAND_TIMEOUT_MS } from "../../../constants.js";
 import { command } from "../../_internal/command.js";
 import { isGitUrl } from "../utils/gitUrl.js";
 
@@ -563,7 +563,7 @@ export function addGenerateCommand(cli: Argv<GlobalArgs>): void {
         async (context, args) => {
             const timeout = new Promise<never>((_, reject) => {
                 setTimeout(
-                    () => reject(new CliError("Generation timed out after 10 minutes.")),
+                    () => reject(new CliError({ message: "Generation timed out after 10 minutes." })),
                     GENERATE_COMMAND_TIMEOUT_MS
                 ).unref();
             });

--- a/packages/cli/cli-v2/src/constants.ts
+++ b/packages/cli/cli-v2/src/constants.ts
@@ -1,2 +1,12 @@
 export const FERN_RC_FILENAME = ".fernrc";
 export const FERN_TOKEN_ENV_VAR = "FERN_TOKEN";
+
+/**
+ * Default timeout for individual HTTP requests (in milliseconds).
+ *
+ * This replaces the previous global process-level timeout. Instead of killing
+ * the entire CLI after a fixed duration (which breaks long-running commands
+ * like `fern docs dev` and interactive commands like `fern init`), we apply
+ * timeouts at the network request level.
+ */
+export const HTTP_REQUEST_TIMEOUT_MS = 60_000;

--- a/packages/cli/cli-v2/src/constants.ts
+++ b/packages/cli/cli-v2/src/constants.ts
@@ -2,20 +2,14 @@ export const FERN_RC_FILENAME = ".fernrc";
 export const FERN_TOKEN_ENV_VAR = "FERN_TOKEN";
 
 /**
- * Default timeout for individual HTTP requests (in milliseconds).
- *
- * This replaces the previous global process-level timeout. Instead of killing
- * the entire CLI after a fixed duration (which breaks long-running commands
- * like `fern docs dev` and interactive commands like `fern init`), we apply
- * timeouts at the network request level.
+ * Timeout for fetching API spec files over HTTP (in milliseconds).
  */
-export const HTTP_REQUEST_TIMEOUT_MS = 3_000;
+export const FETCH_API_SPEC_REQUEST_TIMEOUT_MS = 3_000;
 
 /**
  * Timeout for the `fern sdk generate` command (in milliseconds).
  *
  * Generation involves IR compilation, Docker container execution, and/or
- * remote API calls, so it gets a generous but bounded timeout to prevent
- * runaway processes.
+ * remote API calls, so it gets a generous but bounded timeout.
  */
 export const GENERATE_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;

--- a/packages/cli/cli-v2/src/constants.ts
+++ b/packages/cli/cli-v2/src/constants.ts
@@ -9,4 +9,13 @@ export const FERN_TOKEN_ENV_VAR = "FERN_TOKEN";
  * like `fern docs dev` and interactive commands like `fern init`), we apply
  * timeouts at the network request level.
  */
-export const HTTP_REQUEST_TIMEOUT_MS = 60_000;
+export const HTTP_REQUEST_TIMEOUT_MS = 3_000;
+
+/**
+ * Timeout for the `fern sdk generate` command (in milliseconds).
+ *
+ * Generation involves IR compilation, Docker container execution, and/or
+ * remote API calls, so it gets a generous but bounded timeout to prevent
+ * runaway processes.
+ */
+export const GENERATE_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;

--- a/packages/cli/cli-v2/src/init/Wizard.ts
+++ b/packages/cli/cli-v2/src/init/Wizard.ts
@@ -13,7 +13,7 @@ import { execSync } from "child_process";
 import inquirer from "inquirer";
 import path from "path";
 import type { FernYmlBuilder } from "../config/fern-yml/FernYmlBuilder";
-import { HTTP_REQUEST_TIMEOUT_MS } from "../constants";
+import { FETCH_API_SPEC_REQUEST_TIMEOUT_MS } from "../constants";
 import { TaskContextAdapter } from "../context/adapter/TaskContextAdapter";
 import type { Context } from "../context/Context";
 import { LANGUAGE_DISPLAY_NAMES, LANGUAGE_ORDER, type Language } from "../sdk/config/Language";
@@ -709,7 +709,7 @@ export class Wizard {
     }
 
     private async fetchApiFromUrl(url: string, specFormat: FernYmlBuilder.SpecFormat): Promise<Wizard.ApiSource> {
-        const response = await fetch(url, { signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS) });
+        const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_API_SPEC_REQUEST_TIMEOUT_MS) });
         if (!response.ok) {
             throw new Error(`HTTP ${response.status} ${response.statusText}`);
         }

--- a/packages/cli/cli-v2/src/init/Wizard.ts
+++ b/packages/cli/cli-v2/src/init/Wizard.ts
@@ -13,6 +13,7 @@ import { execSync } from "child_process";
 import inquirer from "inquirer";
 import path from "path";
 import type { FernYmlBuilder } from "../config/fern-yml/FernYmlBuilder";
+import { HTTP_REQUEST_TIMEOUT_MS } from "../constants";
 import { TaskContextAdapter } from "../context/adapter/TaskContextAdapter";
 import type { Context } from "../context/Context";
 import { LANGUAGE_DISPLAY_NAMES, LANGUAGE_ORDER, type Language } from "../sdk/config/Language";
@@ -708,7 +709,7 @@ export class Wizard {
     }
 
     private async fetchApiFromUrl(url: string, specFormat: FernYmlBuilder.SpecFormat): Promise<Wizard.ApiSource> {
-        const response = await fetch(url);
+        const response = await fetch(url, { signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS) });
         if (!response.ok) {
             throw new Error(`HTTP ${response.status} ${response.statusText}`);
         }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,15 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.88.1
-  changelogEntry:
-    - summary: |
-        Replace global 10-minute process timeout with per-request HTTP timeouts.
-        Long-running commands like `fern docs dev` and interactive commands like
-        `fern init` are no longer killed after 10 minutes. Individual HTTP requests
-        now have a 60-second timeout instead.
-      type: fix
-  createdAt: "2026-02-25"
-  irVersion: 65
-
 - version: 3.88.0
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.88.1
+  changelogEntry:
+    - summary: |
+        Replace global 10-minute process timeout with per-request HTTP timeouts.
+        Long-running commands like `fern docs dev` and interactive commands like
+        `fern init` are no longer killed after 10 minutes. Individual HTTP requests
+        now have a 60-second timeout instead.
+      type: fix
+  createdAt: "2026-02-25"
+  irVersion: 65
+
 - version: 3.88.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Linear ticket: Closes [FER-8657](https://linear.app/buildwithfern/issue/FER-8657/cli-v2-adjust-global-timeout-based-on-the-command)

Removes the global 10-minute process-level timeout from the CLI v2 entry point and replaces it with targeted timeouts.

* [Link to Devin run](https://app.devin.ai/sessions/26c1fbe503604035ac14cf97ce3f2582)