### PR TITLE
fix(typescript): support custom AsyncAPI channel connect method name

### DIFF
--- a/generators/typescript/express/cli/package.json
+++ b/generators/typescript/express/cli/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript/express/cli/package.json
+++ b/generators/typescript/express/cli/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",
@@ -34,7 +36,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-generator-cli": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/express/express-endpoint-type-schemas-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/express/express-error-generator/package.json
+++ b/generators/typescript/express/express-error-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-error-generator/package.json
+++ b/generators/typescript/express/express-error-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-error-class-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/express/express-error-schema-generator/package.json
+++ b/generators/typescript/express/express-error-schema-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-error-schema-generator/package.json
+++ b/generators/typescript/express/express-error-schema-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/express/express-inlined-request-body-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-inlined-request-body-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*"
   },

--- a/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/express/express-inlined-request-body-schema-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/express/express-register-generator/package.json
+++ b/generators/typescript/express/express-register-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-register-generator/package.json
+++ b/generators/typescript/express/express-register-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/express/express-service-generator/package.json
+++ b/generators/typescript/express/express-service-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/express-service-generator/package.json
+++ b/generators/typescript/express/express-service-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/express/generator/package.json
+++ b/generators/typescript/express/generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/express/generator/package.json
+++ b/generators/typescript/express/generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -34,7 +36,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/express-endpoint-type-schemas-generator": "workspace:*",

--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/union-generator": "workspace:*",

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",
@@ -37,7 +39,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-api/typescript-base": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-generator-cli": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
@@ -810,7 +810,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
 
             const method: MethodDeclarationStructure = {
                 kind: StructureKind.Method,
-                name: "connect",
+                name: this.generatedWebsocketImplementation.channel.connectMethodName ?? "connect",
                 isAsync: true,
                 parameters: signature.parameters,
                 returnType: getTextOfTsNode(

--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -131,7 +131,7 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
         const statements = this.generateConnectMethodStatements(context);
 
         serviceClass.methods?.push({
-            name: "connect",
+            name: this.channel.connectMethodName ?? "connect",
             scope: Scope.Public,
             isAsync: true,
             parameters: [

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -38,7 +40,7 @@
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.5.0",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/endpoint-error-union-generator": "workspace:*",

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-error-class-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -32,7 +34,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.50.1
+  changelogEntry:
+    - summary: |
+        Support custom WebSocket connection method names via the `connectMethodName` IR field
+        (sourced from `x-fern-sdk-method-name` on AsyncAPI channels). When specified, the
+        generated client uses the custom name instead of the default `connect`.
+      type: fix
+  createdAt: "2026-02-25"
+  irVersion: 65
+
 - version: 3.50.0
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -37,7 +39,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "tmp-promise": "catalog:"

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -36,7 +38,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-api/typescript-base": "workspace:*",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "decompress": "catalog:",
     "esutils": "catalog:",
     "eta": "^4.5.1",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -35,7 +37,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*",
     "ts-morph": "catalog:"
   },

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -31,7 +33,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "^65.2.1",
+    "@fern-fern/ir-sdk": "^65.3.0",
     "@fern-typescript/commons": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,7 +962,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/logging-execa
       '@fern-fern/ir-sdk':
-        specifier: ^62.3.0
+        specifier: ^62.6.0
         version: 62.6.0
       '@types/lodash-es':
         specifier: 'catalog:'
@@ -995,7 +995,7 @@ importers:
         specifier: ^64.0.0
         version: 64.0.0
       '@fern-fern/ir-sdk':
-        specifier: ^62.3.0
+        specifier: ^62.6.0
         version: 62.6.0
       domhandler:
         specifier: 'catalog:'
@@ -1105,7 +1105,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
       '@fern-fern/ir-sdk':
-        specifier: ^62.3.0
+        specifier: ^62.6.0
         version: 62.6.0
       '@types/node':
         specifier: 'catalog:'
@@ -1153,7 +1153,7 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^62.3.0
+        specifier: ^62.6.0
         version: 62.6.0
       '@types/node':
         specifier: 'catalog:'
@@ -1593,7 +1593,7 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-fern/ir-sdk':
-        specifier: ^62.1.0
+        specifier: ^62.6.0
         version: 62.6.0
       '@types/lodash-es':
         specifier: 'catalog:'
@@ -1699,7 +1699,7 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-fern/ir-sdk':
-        specifier: ^62.1.0
+        specifier: ^62.6.0
         version: 62.6.0
       '@types/node':
         specifier: 'catalog:'
@@ -1753,7 +1753,7 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^62.1.0
+        specifier: ^62.6.0
         version: 62.6.0
       '@types/lodash-es':
         specifier: 'catalog:'
@@ -2822,8 +2822,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-generator-cli':
         specifier: workspace:*
         version: link:../../utils/abstract-generator-cli
@@ -2855,8 +2855,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -2886,8 +2886,8 @@ importers:
   generators/typescript/express/express-error-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-error-class-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-error-class-generator
@@ -2920,8 +2920,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -2951,8 +2951,8 @@ importers:
   generators/typescript/express/express-inlined-request-body-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2976,8 +2976,8 @@ importers:
   generators/typescript/express/express-inlined-request-body-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3007,8 +3007,8 @@ importers:
   generators/typescript/express/express-register-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3044,8 +3044,8 @@ importers:
   generators/typescript/express/express-service-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3084,8 +3084,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/cli/logger
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3179,8 +3179,8 @@ importers:
   generators/typescript/model/type-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3213,8 +3213,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3244,8 +3244,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3272,8 +3272,8 @@ importers:
   generators/typescript/model/type-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3309,8 +3309,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3337,8 +3337,8 @@ importers:
   generators/typescript/model/union-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3386,8 +3386,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/base
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-generator-cli':
         specifier: workspace:*
         version: link:../../utils/abstract-generator-cli
@@ -3413,8 +3413,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3453,8 +3453,8 @@ importers:
   generators/typescript/sdk/endpoint-error-union-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3487,8 +3487,8 @@ importers:
   generators/typescript/sdk/environments-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3536,8 +3536,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3649,8 +3649,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3680,8 +3680,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3717,8 +3717,8 @@ importers:
   generators/typescript/sdk/sdk-error-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-error-class-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-error-class-generator
@@ -3751,8 +3751,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3782,8 +3782,8 @@ importers:
   generators/typescript/sdk/sdk-inlined-request-body-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3813,8 +3813,8 @@ importers:
   generators/typescript/sdk/websocket-type-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3887,8 +3887,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -3955,8 +3955,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/base
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       decompress:
         specifier: 'catalog:'
         version: 4.2.1
@@ -4031,8 +4031,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -4056,8 +4056,8 @@ importers:
   generators/typescript/utils/resolvers:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: ^65.2.1
-        version: 65.2.1
+        specifier: ^65.3.0
+        version: 65.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -9700,8 +9700,8 @@ packages:
   '@fern-fern/ir-sdk@62.6.0':
     resolution: {integrity: sha512-UVSyKnIzcnvutyQ2tyIPqzG2uh+IEo8IZ3esGeULJdAKQ2fyCaDnFrpc/om08z6aCoEHRBuH+XYD/kmxODwm9A==}
 
-  '@fern-fern/ir-sdk@65.2.1':
-    resolution: {integrity: sha512-HpQaomQ0ZZPYQMrSxy7MbtrmA7wRuLNyNxn05CalOr3xpohiA87yECWubLyk12Ehcqc7A6h7gS9jR5T3FgYmqA==}
+  '@fern-fern/ir-sdk@65.3.0':
+    resolution: {integrity: sha512-Yt7BP8kL6dxtErzyMdM9jrW936GaxMsS1WDa7MiwzMPnOoOT96hN+yWP0CTysmTDKNoWR2VQPzESaoN6eN0Awg==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v1-model@0.0.2':
@@ -16500,7 +16500,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@fern-fern/ir-sdk@65.2.1': {}
+  '@fern-fern/ir-sdk@65.3.0': {}
 
   '@fern-fern/ir-v1-model@0.0.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,7 +962,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/logging-execa
       '@fern-fern/ir-sdk':
-        specifier: ^62.6.0
+        specifier: ^62.3.0
         version: 62.6.0
       '@types/lodash-es':
         specifier: 'catalog:'
@@ -995,7 +995,7 @@ importers:
         specifier: ^64.0.0
         version: 64.0.0
       '@fern-fern/ir-sdk':
-        specifier: ^62.6.0
+        specifier: ^62.3.0
         version: 62.6.0
       domhandler:
         specifier: 'catalog:'
@@ -1105,7 +1105,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
       '@fern-fern/ir-sdk':
-        specifier: ^62.6.0
+        specifier: ^62.3.0
         version: 62.6.0
       '@types/node':
         specifier: 'catalog:'
@@ -1153,7 +1153,7 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^62.6.0
+        specifier: ^62.3.0
         version: 62.6.0
       '@types/node':
         specifier: 'catalog:'
@@ -1593,7 +1593,7 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-fern/ir-sdk':
-        specifier: ^62.6.0
+        specifier: ^62.1.0
         version: 62.6.0
       '@types/lodash-es':
         specifier: 'catalog:'
@@ -1699,7 +1699,7 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-fern/ir-sdk':
-        specifier: ^62.6.0
+        specifier: ^62.1.0
         version: 62.6.0
       '@types/node':
         specifier: 'catalog:'
@@ -1753,7 +1753,7 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^62.6.0
+        specifier: ^62.1.0
         version: 62.6.0
       '@types/lodash-es':
         specifier: 'catalog:'

--- a/seed/ts-sdk/websocket/no-serde/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/api/resources/realtime/client/Client.ts
@@ -31,7 +31,7 @@ export class RealtimeClient {
         this._options = normalizeClientOptions(options);
     }
 
-    public async connect(args: RealtimeClient.ConnectArgs): Promise<RealtimeSocket> {
+    public async createRealtimeConnection(args: RealtimeClient.ConnectArgs): Promise<RealtimeSocket> {
         const {
             session_id: sessionId,
             model,

--- a/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Client.ts
@@ -31,7 +31,7 @@ export class RealtimeClient {
         this._options = normalizeClientOptions(options);
     }
 
-    public async connect(args: RealtimeClient.ConnectArgs): Promise<RealtimeSocket> {
+    public async createRealtimeConnection(args: RealtimeClient.ConnectArgs): Promise<RealtimeSocket> {
         const { sessionId, model, temperature, languageCode, queryParams, headers, debug, reconnectAttempts } = args;
         const _queryParams: Record<string, unknown> = {
             model,

--- a/test-definitions/fern/apis/websocket/definition/realtime.yml
+++ b/test-definitions/fern/apis/websocket/definition/realtime.yml
@@ -3,6 +3,7 @@
 channel:
   path: /realtime/{session_id}
   auth: true
+  connect-method-name: createRealtimeConnection
   path-parameters:
     session_id: string
   query-parameters:


### PR DESCRIPTION
## Description
Handle the IR field added in https://github.com/fern-api/fern/pull/12719 to customize a websocket channel's `connect` method name.

## Changes Made
Small change to websocket generator.

## Testing
One `connectMethodName` added to the `websocket` fixture to test new behavior.
- [X] Unit tests added/updated
- [X] Manual testing completed
