### PR TITLE
fix(cli): wrap form data values with valid FormValue discriminator in AI example enhancer

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.88.2
+  changelogEntry:
+    - summary: |
+        Fix AI example enhancer producing invalid form data values when registering
+        API definitions. When the typed wrapper detection failed for form data requests
+        (e.g., filenameWithData wrappers with 3 keys), the raw AI output was set directly
+        without proper FormValue wrapping, causing FDR registration to reject the payload
+        with an invalid_union_discriminator error. Form values are now always wrapped with
+        a valid discriminator type, and the wrapper detection handles filenameWithData and
+        filenamesWithData variants.
+      type: fix
+  createdAt: "2026-02-25"
+  irVersion: 65
+
 - version: 3.88.1
   changelogEntry:
     - summary: |

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -183,7 +183,7 @@ class ConcurrentEndpointProcessor {
 }
 
 interface BodyV3 {
-    type?: "json" | "stream" | "sse" | "filename";
+    type?: "json" | "form" | "bytes" | "stream" | "sse" | "filename";
     value?: unknown;
 }
 
@@ -1183,9 +1183,12 @@ function applyEnhancementResults(
                 if (enhancementResult.enhancedReq !== undefined) {
                     enhancedExample.requestBody = enhancementResult.enhancedReq;
                     if (example.requestBodyV3) {
+                        // Check if this is a form data request (type === "form")
+                        const isFormType = example.requestBodyV3.type === "form";
+
                         // Check if the value contains FDR typed value wrappers (form data structure)
                         // Form data has a structure like: { "file": { "type": "filename", "value": "..." }, "text": { "type": "json", "value": "..." } }
-                        const isFormData =
+                        const hasTypedWrappers =
                             typeof example.requestBodyV3.value === "object" &&
                             example.requestBodyV3.value !== null &&
                             !Array.isArray(example.requestBodyV3.value) &&
@@ -1193,7 +1196,7 @@ function applyEnhancementResults(
                                 isFdrTypedValueWrapper(v)
                             );
 
-                        if (isFormData) {
+                        if (hasTypedWrappers) {
                             const enhancedReq = enhancementResult.enhancedReq as Record<string, unknown>;
                             const originalValue = example.requestBodyV3.value as Record<
                                 string,
@@ -1213,6 +1216,24 @@ function applyEnhancementResults(
                             enhancedExample.requestBodyV3 = {
                                 ...example.requestBodyV3,
                                 value: updatedValue
+                            };
+                        } else if (isFormType) {
+                            // Form data but typed wrapper detection failed (e.g., empty form value
+                            // or all values have 3+ keys like filenameWithData). Wrap each AI-generated
+                            // value as a JSON FormValue to ensure valid discriminator types.
+                            const enhancedReqObj =
+                                typeof enhancementResult.enhancedReq === "object" &&
+                                enhancementResult.enhancedReq !== null &&
+                                !Array.isArray(enhancementResult.enhancedReq)
+                                    ? (enhancementResult.enhancedReq as Record<string, unknown>)
+                                    : {};
+                            const wrappedValue: Record<string, { type: string; value: unknown }> = {};
+                            for (const [key, val] of Object.entries(enhancedReqObj)) {
+                                wrappedValue[key] = { type: "json", value: val };
+                            }
+                            enhancedExample.requestBodyV3 = {
+                                ...example.requestBodyV3,
+                                value: wrappedValue
                             };
                         } else {
                             enhancedExample.requestBodyV3 = {

--- a/packages/cli/register/src/ai-example-enhancer/filterHelpers.ts
+++ b/packages/cli/register/src/ai-example-enhancer/filterHelpers.ts
@@ -8,14 +8,32 @@ export function isFdrTypedValueWrapper(value: unknown): value is { type?: string
     }
     const obj = value as Record<string, unknown>;
     const keys = Object.keys(obj);
-    if (keys.length === 0 || keys.length > 2) {
+    if (keys.length === 0) {
         return false;
     }
     const hasType = "type" in obj && typeof obj.type === "string";
     const hasValue = "value" in obj;
-    return (
-        (hasType && keys.length === 1) || (hasType && hasValue && keys.length === 2) || (hasValue && keys.length === 1)
-    );
+
+    // Standard wrappers: { type, value } or { type } or { value }
+    if (keys.length <= 2) {
+        return (
+            (hasType && keys.length === 1) ||
+            (hasType && hasValue && keys.length === 2) ||
+            (hasValue && keys.length === 1)
+        );
+    }
+
+    // filenameWithData wrapper: { type: "filenameWithData", filename: string, data: string }
+    if (hasType && obj.type === "filenameWithData" && "filename" in obj && "data" in obj) {
+        return true;
+    }
+
+    // filenamesWithData wrapper: { type: "filenamesWithData", value: [...] }
+    if (hasType && hasValue && obj.type === "filenamesWithData") {
+        return true;
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes the AI example enhancer producing invalid form data values that cause `registerApiDefinition` to fail with `invalid_union_discriminator` errors. This is the CLI-side fix complementing the server-side relaxation in [fern-platform#7505](https://github.com/fern-api/fern-platform/pull/7505).

## Changes Made

### 1. `applyEnhancementResults` — new fallback for form-type requests (`enhanceExamplesWithAI.ts`)
- When `requestBodyV3.type === "form"` but the typed-wrapper heuristic (`isFdrTypedValueWrapper`) fails to detect any wrappers, the AI-enhanced values are now wrapped as `{ type: "json", value: val }` instead of being set as raw values. Previously this path produced form values without a valid `type` discriminator, breaking FDR registration.
- Added `"form"` and `"bytes"` to the `BodyV3` type union (was missing, causing a TS error).

### 2. `isFdrTypedValueWrapper` — handle 3+-key wrappers (`filterHelpers.ts`)
- Previously rejected any object with >2 keys, missing `filenameWithData` wrappers (`{ type, filename, data }` — 3 keys).
- Now recognizes `filenameWithData` and `filenamesWithData` variants explicitly.

### 3. `versions.yml` — changelog entry for 3.88.2

## Key review points

- [ ] **JSON fallback correctness**: The `isFormType` fallback wraps *all* values as `type: "json"`. If the original form had file-type fields, those would be downgraded to JSON wrappers. This is intentional as a safe fallback (better than crashing registration), but worth confirming this is acceptable behavior.
- [ ] **`isFdrTypedValueWrapper` specificity**: The function now checks for literal `"filenameWithData"` and `"filenamesWithData"` type strings. If new FormValue variants are added in the future, this function would need updating. Consider whether a more general heuristic would be safer.
- [ ] No unit tests added for the new branches.

## Testing

- [x] `pnpm compile --filter @fern-api/register` passes
- [ ] No automated tests added (the fix is best verified by re-running docs generation for affected customer repos like Deel)

---

[Link to Devin run](https://app.devin.ai/sessions/927047f8ea174373acf093ab47042342) | Requested by @dsinghvi