### PR TITLE
chore(internal): Simplify update tests workflow

### DIFF
--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -48,20 +48,11 @@ jobs:
       - name: Run test:update
         run: pnpm test:update
 
-      - name: Build CLI (dev)
-        timeout-minutes: 15
-        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli --filter=@fern-api/cli-v2
-
-      - name: Build seed CLI
-        timeout-minutes: 15
-        run: pnpm seed:build
-
       - name: Run test:ete:update
         timeout-minutes: 30
         env:
           FERN_ORG_TOKEN_DEV: ${{ secrets.FERN_ORG_TOKEN_DEV }}
-        run: |
-          FERN_TOKEN=${{ secrets.FERN_ORG_TOKEN_DEV }} pnpm --filter @fern-api/ete-tests test -- -u
+        run: FERN_TOKEN=${{ secrets.FERN_ORG_TOKEN_DEV }} pnpm test:ete:update
 
       - name: Commit and Push Changes
         run: |


### PR DESCRIPTION
## Description
Simplifies the update-test workflow by consolidating multiple build steps into a single command. This change fixes CI failures related to end-to-end test snapshot updates and reduces workflow complexity.

The previous approach used three separate steps (build CLI dev, build seed CLI, run tests) which could create race conditions and made the workflow harder to maintain. The consolidated approach uses the existing \`test:ete:update\` script that already includes all necessary dependencies in the correct order.

## Changes Made
- **Workflow consolidation**: Replaced three separate build/test steps with single \`pnpm test:ete:update\` command
- **Simplified command execution**: Changed from multi-line script to single-line command execution  
- **Maintained environment setup**: Preserved FERN_TOKEN environment variable configuration

## Testing
- [x] Manual testing completed
- [x] Verified workflow syntax and structure