### PR TITLE
fix(ci): add turbo-retry wrapper to auto-retry on remote cache hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,12 +144,12 @@ jobs:
       - name: Run tests
         if: ${{ !github.event.inputs.update_snapshots }}
         timeout-minutes: 20
-        run: pnpm test
+        run: ./scripts/turbo-retry.sh pnpm test
 
       - name: Run tests with snapshot updates
         if: ${{ github.event.inputs.update_snapshots == 'true' }}
         timeout-minutes: 20
-        run: pnpm test:update
+        run: ./scripts/turbo-retry.sh pnpm test:update
 
       - name: Commit and push updated snapshots
         if: ${{ github.event.inputs.update_snapshots == 'true' }}
@@ -200,7 +200,7 @@ jobs:
       - name: Build CLIs (dev + seed)
         timeout-minutes: 10
         run: |
-          pnpm turbo run dist:cli:dev dist:cli --filter=@fern-api/cli --filter=@fern-api/cli-v2 --filter=@fern-api/seed-cli
+          ./scripts/turbo-retry.sh pnpm turbo run dist:cli:dev dist:cli --filter=@fern-api/cli --filter=@fern-api/cli-v2 --filter=@fern-api/seed-cli
 
       - name: Run ETE tests
         if: ${{ !github.event.inputs.update_snapshots }}

--- a/scripts/turbo-retry.sh
+++ b/scripts/turbo-retry.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Retry wrapper for turbo commands that intermittently hang on remote cache initialization.
+#
+# Turbo has a known issue (https://github.com/vercel/turborepo/issues/8281) where it
+# hangs indefinitely after printing "Remote caching enabled" with zero further output.
+# This script monitors command output and retries if no output is produced for a
+# configurable timeout period.
+#
+# Usage: ./scripts/turbo-retry.sh <command...>
+# Example: ./scripts/turbo-retry.sh pnpm test
+#          ./scripts/turbo-retry.sh pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+#
+# Environment variables:
+#   TURBO_HANG_TIMEOUT  - seconds of silence before killing (default: 120)
+#   TURBO_RETRY_MAX     - max retry attempts (default: 3)
+
+set -uo pipefail
+
+HANG_TIMEOUT="${TURBO_HANG_TIMEOUT:-120}"
+MAX_RETRIES="${TURBO_RETRY_MAX:-3}"
+
+for attempt in $(seq 1 "$MAX_RETRIES"); do
+  echo "--- Attempt $attempt/$MAX_RETRIES: $* ---"
+
+  # Stop any stale turbo daemon before each attempt
+  pnpm turbo daemon stop 2>/dev/null || true
+
+  # Capture output to a temp file so we can monitor activity
+  OUTFILE=$(mktemp)
+  HUNG=false
+
+  # Run command with stdout+stderr redirected to file
+  "$@" > "$OUTFILE" 2>&1 &
+  CMD_PID=$!
+
+  LAST_SIZE=0
+  LAST_CHANGE=$(date +%s)
+
+  # Monitor loop: stream output and detect hangs
+  while kill -0 "$CMD_PID" 2>/dev/null; do
+    sleep 5
+
+    # Print any new output since last check
+    CURRENT_SIZE=$(stat -c%s "$OUTFILE" 2>/dev/null || echo 0)
+    if [ "$CURRENT_SIZE" -gt "$LAST_SIZE" ]; then
+      tail -c +"$((LAST_SIZE + 1))" "$OUTFILE"
+      LAST_SIZE=$CURRENT_SIZE
+      LAST_CHANGE=$(date +%s)
+    fi
+
+    # Check for hang
+    NOW=$(date +%s)
+    SILENT=$((NOW - LAST_CHANGE))
+    if [ "$SILENT" -ge "$HANG_TIMEOUT" ]; then
+      echo ""
+      echo "::warning::No output for ${SILENT}s — turbo appears hung. Killing process..."
+      kill -TERM "$CMD_PID" 2>/dev/null || true
+      sleep 3
+      kill -9 "$CMD_PID" 2>/dev/null || true
+      HUNG=true
+      break
+    fi
+  done
+
+  # Wait for process to fully exit and capture status
+  wait "$CMD_PID" 2>/dev/null
+  EXIT_CODE=$?
+
+  # Print any remaining output
+  FINAL_SIZE=$(stat -c%s "$OUTFILE" 2>/dev/null || echo 0)
+  if [ "$FINAL_SIZE" -gt "$LAST_SIZE" ]; then
+    tail -c +"$((LAST_SIZE + 1))" "$OUTFILE"
+  fi
+  rm -f "$OUTFILE"
+
+  if [ "$EXIT_CODE" -eq 0 ]; then
+    echo "--- Succeeded on attempt $attempt ---"
+    exit 0
+  fi
+
+  if $HUNG; then
+    echo "::warning::Turbo hung on attempt $attempt/$MAX_RETRIES"
+    if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+      echo "Retrying in 5s..."
+      sleep 5
+      continue
+    fi
+    echo "::error::All $MAX_RETRIES attempts failed due to turbo hanging"
+    exit 1
+  fi
+
+  # Real failure (not a hang) — don't retry
+  echo "::error::Command failed with exit code $EXIT_CODE"
+  exit "$EXIT_CODE"
+done


### PR DESCRIPTION
## Description

Refs: #12764, [vercel/turborepo#8281](https://github.com/vercel/turborepo/issues/8281)

After merging #12764 (reduced `TURBO_REMOTE_CACHE_TIMEOUT` + combined turbo invocations), the `test` job continues to intermittently hang after printing "Remote caching enabled" with zero further output. The per-request timeout doesn't prevent the hang because it occurs at the remote cache initialization/connection layer, not during individual cache requests.

This PR adds a retry wrapper script that detects the hang via output monitoring and automatically retries.

[Link to Devin run](https://app.devin.ai/sessions/22d5e7ddc0f9447c969de04990b9a21c) | Requested by: @Swimburger

## Changes Made

- **New `scripts/turbo-retry.sh`**: Bash wrapper that runs a command in the background, monitors output activity, and kills + retries if no output is produced for 120 seconds (configurable via `TURBO_HANG_TIMEOUT`). Real (non-hang) failures are passed through immediately without retrying.
- **Updated `ci.yml`**: Wrapped the three turbo-invoking steps (`test`, `test:update`, and the `test-ete` CLI build) with the retry script.

## Testing

- [ ] Manual testing completed — this is a CI-only change; the hang is intermittent and can only be validated by observing CI runs over time
- [ ] The retry script has not been tested against an actual turbo hang (only reproducible intermittently in CI)

## Human Review Checklist

- [ ] **Output buffering**: stdout/stderr is redirected to a file, so turbo is not writing to a TTY. Verify turbo doesn't buffer output in a way that could cause false-positive hang detection (e.g., large chunks written infrequently exceeding 120s gaps during normal operation).
- [ ] **Process cleanup on self-hosted runners**: `kill -TERM`/`kill -9` targets only the direct PID, not the process group. Could orphaned child processes (node/turbo) accumulate on the `Test` runner across retries?
- [ ] **120s default hang timeout**: Is this appropriate for all three wrapped steps? The `test` job runs 168 packages — could there be legitimate periods of >120s silence during normal execution (e.g., a single long-running test)?
- [ ] **5-second output streaming delay**: Output is polled and printed every 5s rather than streamed in real-time. Acceptable tradeoff for CI log readability?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
