### PR TITLE
fix(internal): remove customization counts from PR body for replay

### DIFF
--- a/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
+++ b/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "child_process";
+import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "./github/constants";
 import { consolePipelineLogger, type PipelineLogger } from "./PipelineLogger";
 import { BaseStep } from "./steps/BaseStep";
 import { GithubStep } from "./steps/GithubStep";
@@ -51,6 +53,17 @@ export class PostGenerationPipeline {
     }
 
     async run(): Promise<PipelineResult> {
+        // Set git identity BEFORE any steps run, so all commits
+        // (including replay commits) are attributed to fern-bot.
+        if (this.config.github?.enabled) {
+            try {
+                execFileSync("git", ["config", "user.name", FERN_BOT_NAME], { cwd: this.config.outputDir });
+                execFileSync("git", ["config", "user.email", FERN_BOT_EMAIL], { cwd: this.config.outputDir });
+            } catch {
+                // pass
+            }
+        }
+
         const result: PipelineResult = {
             success: true,
             steps: {}

--- a/packages/generator-cli/src/pipeline/replay-summary.ts
+++ b/packages/generator-cli/src/pipeline/replay-summary.ts
@@ -43,10 +43,10 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
     );
 
     if (preserved > 0) {
-        const absorbedNote = absorbed > 0 ? ` (${plural(absorbed, "customization")} now part of generated code)` : "";
-        logger.info(`Replay: ${plural(preserved, "customization")} preserved${absorbedNote}`);
+        const absorbedNote = absorbed > 0 ? ` (some customizations now part of generated code)` : "";
+        logger.info(`Replay: customizations preserved${absorbedNote}`);
     } else if (absorbed > 0) {
-        logger.info(`Replay: ${plural(absorbed, "customization")} now part of generated code`);
+        logger.info(`Replay: customizations now part of generated code`);
     }
 
     if (conflicts > 0) {
@@ -87,10 +87,10 @@ export function formatReplayPrBody(
     const parts: string[] = [];
 
     if (preserved > 0 && conflicts === 0) {
-        parts.push(`\u2705 ${plural(preserved, "customization")} automatically preserved in this update.`);
+        parts.push(`\u2705 Customizations automatically preserved in this update.`);
     } else if (preserved > 0) {
         parts.push(
-            `\u2705 ${plural(preserved, "customization")} automatically preserved, but ${plural(conflicts, "file")} ${conflicts === 1 ? "needs" : "need"} your attention.`
+            `\u2705 Customizations automatically preserved, but ${plural(conflicts, "file")} ${conflicts === 1 ? "needs" : "need"} your attention.`
         );
     }
 

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -2,7 +2,6 @@ import { ClonedRepository, parseRepository } from "@fern-api/github";
 import { Octokit } from "@octokit/rest";
 import { access, writeFile } from "fs/promises";
 import { join } from "path";
-import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "../github/constants";
 import { createReplayBranch } from "../github/createReplayBranch";
 import type { ExistingPullRequest } from "../github/findExistingUpdatablePR";
 import { findExistingUpdatablePR } from "../github/findExistingUpdatablePR";
@@ -41,15 +40,6 @@ export class GithubStep extends BaseStep {
                 .replace("Z", "")
                 .replace(".", "_");
             const newPrBranch = `fern-bot/${formattedDate}`;
-
-            try {
-                await repository.setUserAndEmail({
-                    name: FERN_BOT_NAME,
-                    email: FERN_BOT_EMAIL
-                });
-            } catch {
-                // pass
-            }
 
             const mode = this.config.mode;
             switch (mode) {

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
+
+- changelogEntry:
+    - summary: |
+        Ensure commits are signed by fern-bot and remove specific customization counts from Replay PR descriptions in favor of generic messaging.
+      type: fix
+  createdAt: "2026-02-25"
+  version: 0.6.5
+
 - changelogEntry:
     - summary: |
         Update @fern-api/fern-replay to 0.6.1 which published as ESM and CJS.


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

- Remove specific customization counts from PR body and log messages since the
  count from @fern-api/replay can be inaccurate after squash merges

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
