### PR TITLE
chore(docs): improve README for non-contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![2023 Y Combinator Startup](https://img.shields.io/badge/Y%20Combinator-2023-orange)](https://www.ycombinator.com/companies/fern)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
 
-[![Slack](https://img.shields.io/badge/slack-pink.svg)](https://join.slack.com/t/fern-community/shared_invite/zt-2dpftfmif-MuAegl8AfP_PK8s2tx350Q)
+[![Slack](https://img.shields.io/badge/slack-pink.svg)](https://buildwithfern.com/contact/slack)
 [![Documentation](https://img.shields.io/badge/Read%20our%20Documentation-black?logo=book)](https://buildwithfern.com/learn/home?utm_source=fern-api/fern/readme-read-our-documentation)
 
 </div>
@@ -90,42 +90,42 @@ Get started [here](https://github.com/fern-api/docs-starter).
 
 ## 🌿 Generators
 
-Generators are process that take your API Definition as input and output artifacts (SDKs,
+Generators are processes that take your API Definition as input and output artifacts (SDKs,
 Postman Collections, Server boilerplate, etc.). To add a generator, run `fern add <generator id>`.
 
 ### SDK Generators
 
-| Generator ID                       | Latest Version                                                                                    | Entrypoint                                                                    |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `fernapi/fern-typescript-sdk`      | ![Typescript Generator Version](https://img.shields.io/docker/v/fernapi/fern-typescript-sdk)      | [cli.ts](./generators/typescript/sdk/cli/src/cli.ts)                      |
-| `fernapi/fern-python-sdk`          | ![Python Generator Version](https://img.shields.io/docker/v/fernapi/fern-python-sdk)              | [cli.py](./generators/python/src/fern_python/generators/sdk/cli.py)           |
-| `fernapi/fern-java-sdk`            | ![Java Generator Version](https://img.shields.io/docker/v/fernapi/fern-java-sdk)                  | [Cli.java](./generators/java/sdk/src/main/java/com/fern/java/client/Cli.java) |
-| `fernapi/fern-ruby-sdk`            | ![Ruby Generator Version](https://img.shields.io/docker/v/fernapi/fern-ruby-sdk)                  | [cli.ts](./generators/ruby-v2/sdk/src/cli.ts)                                 |
-| `fernapi/fern-go-sdk`              | ![Go Generator Version](https://img.shields.io/docker/v/fernapi/fern-go-sdk)                      | [main.go](./generators/go/cmd/fern-go-sdk/main.go)                            |
-| `fernapi/fern-csharp-sdk`          | ![C# Generator Version](https://img.shields.io/docker/v/fernapi/fern-csharp-sdk)                  | [cli.ts](./generators/csharp/sdk/src/cli.ts)                                  |
-| `fernapi/fern-php-sdk`             | ![PHP Generator Version](https://img.shields.io/docker/v/fernapi/fern-php-sdk)                    | [cli.ts](./generators/php/sdk/src/cli.ts)                                     |
-| `fernapi/fern-swift-sdk`           | ![Swift Generator Version](https://img.shields.io/docker/v/fernapi/fern-swift-sdk)                | [cli.ts](./generators/swift/sdk/src/cli.ts)                                   |
-| `fernapi/fern-rust-sdk`            | ![Rust Generator Version](https://img.shields.io/docker/v/fernapi/fern-rust-sdk)                  | [cli.ts](./generators/rust/sdk/src/cli.ts)                                  |
+| Generator ID                       | Latest Version                                                                                    | Changelog                                                                                                      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `fernapi/fern-typescript-sdk`      | ![Typescript Generator Version](https://img.shields.io/docker/v/fernapi/fern-typescript-sdk)      | [Changelog](https://buildwithfern.com/learn/sdks/generators/typescript/changelog)                               |
+| `fernapi/fern-python-sdk`          | ![Python Generator Version](https://img.shields.io/docker/v/fernapi/fern-python-sdk)              | [Changelog](https://buildwithfern.com/learn/sdks/generators/python/changelog)                                   |
+| `fernapi/fern-java-sdk`            | ![Java Generator Version](https://img.shields.io/docker/v/fernapi/fern-java-sdk)                  | [Changelog](https://buildwithfern.com/learn/sdks/generators/java/changelog)                                     |
+| `fernapi/fern-ruby-sdk`            | ![Ruby Generator Version](https://img.shields.io/docker/v/fernapi/fern-ruby-sdk)                  | [Changelog](https://buildwithfern.com/learn/sdks/generators/ruby/changelog)                                     |
+| `fernapi/fern-go-sdk`              | ![Go Generator Version](https://img.shields.io/docker/v/fernapi/fern-go-sdk)                      | [Changelog](https://buildwithfern.com/learn/sdks/generators/go/changelog)                                       |
+| `fernapi/fern-csharp-sdk`          | ![C# Generator Version](https://img.shields.io/docker/v/fernapi/fern-csharp-sdk)                  | [Changelog](https://buildwithfern.com/learn/sdks/generators/csharp/changelog)                                   |
+| `fernapi/fern-php-sdk`             | ![PHP Generator Version](https://img.shields.io/docker/v/fernapi/fern-php-sdk)                    | [Changelog](https://buildwithfern.com/learn/sdks/generators/php/changelog)                                      |
+| `fernapi/fern-swift-sdk`           | ![Swift Generator Version](https://img.shields.io/docker/v/fernapi/fern-swift-sdk)                | [Changelog](https://buildwithfern.com/learn/sdks/generators/swift/changelog)                                    |
+| `fernapi/fern-rust-sdk`            | ![Rust Generator Version](https://img.shields.io/docker/v/fernapi/fern-rust-sdk)                  | [Changelog](https://buildwithfern.com/learn/sdks/generators/rust/changelog)                                     |
 
 ### Server-side Generators
 
 Fern's server-side generators output boilerplate application code (models and networking logic). This is intended for spec-first or API-first developers, who write their API definition (as an OpenAPI spec or Fern definition) and want to generate backend code.
 
-| Generator ID                      | Latest Version                                                                                                  | Entrypoint                                                                       |
+| Generator ID                      | Latest Version                                                                                                  | Changelog                                                                        |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `fernapi/fern-typescript-express` | ![Typescript Express Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-typescript-express) | [cli.ts](./generators/typescript/express/cli/src/cli.ts)                         |
-| `fernapi/fern-fastapi-server`     | ![Python FastAPI Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-fastapi-server)         | [cli.py](./generators/python/src/fern_python/generators/sdk/cli.py)              |
-| `fernapi/fern-java-spring`        | ![Java Spring Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-java-spring)               | [Cli.java](./generators/java/spring/src/main/java/com/fern/java/spring/Cli.java) |
+| `fernapi/fern-typescript-express` | ![Typescript Express Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-typescript-express) | [versions.yml](./generators/typescript/express/versions.yml)                     |
+| `fernapi/fern-fastapi-server`     | ![Python FastAPI Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-fastapi-server)         | [versions.yml](./generators/python/fastapi/versions.yml)                         |
+| `fernapi/fern-java-spring`        | ![Java Spring Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-java-spring)               | [versions.yml](./generators/java/spring/versions.yml)                            |
 
 ### Model Generators
 
 Fern's model generators will output schemas or types defined in your OpenAPI spec or Fern Definition.
 
-| Generator ID                  | Latest Version                                                                                   | Entrypoint                                                                    |
+| Generator ID                  | Latest Version                                                                                   | Changelog                                                                     |
 | ----------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| `fernapi/fern-pydantic-model` | ![Pydantic Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-pydantic-model) | [cli.py](./generators/python/src/fern_python/generators/sdk/cli.py)           |
-| `fernapi/fern-java-model`     | ![Java Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-java-model)         | [Cli.java](./generators/java/sdk/src/main/java/com/fern/java/client/Cli.java) |
-| `fernapi/fern-go-model`       | ![Go Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-go-model)             | [main.go](./generators/go/cmd/fern-go-model/main.go)                          |
+| `fernapi/fern-pydantic-model` | ![Pydantic Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-pydantic-model) | [versions.yml](./generators/python/pydantic/versions.yml)                     |
+| `fernapi/fern-java-model`     | ![Java Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-java-model)         | [versions.yml](./generators/java/model/versions.yml)                          |
+| `fernapi/fern-go-model`       | ![Go Model Generator Version](https://img.shields.io/docker/v/fernapi/fern-go-model)             | [versions.yml](./generators/go/model/versions.yml)                            |
 
 ### Spec Generators
 
@@ -133,10 +133,10 @@ Fern's spec generators can output an OpenAPI spec or a Postman collection.
 
 > **Note**: The OpenAPI spec generator is primarily intended for Fern Definition users. This prevents lock-in so that one can always export to OpenAPI.
 
-| Generator ID           | Latest Version                                                                     | Entrypoint                                |
-| ---------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------- |
-| `fernapi/fern-openapi` | ![OpenAPI Generator Version](https://img.shields.io/docker/v/fernapi/fern-openapi) | [cli.ts](./generators/openapi/src/cli.ts) |
-| `fernapi/fern-postman` | ![Postman Generator Version](https://img.shields.io/docker/v/fernapi/fern-postman) | [cli.ts](./generators/postman/src/cli.ts) |
+| Generator ID           | Latest Version                                                                     | Changelog                                              |
+| ---------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `fernapi/fern-openapi` | ![OpenAPI Generator Version](https://img.shields.io/docker/v/fernapi/fern-openapi) | [versions.yml](./generators/openapi/versions.yml)      |
+| `fernapi/fern-postman` | ![Postman Generator Version](https://img.shields.io/docker/v/fernapi/fern-postman) | [versions.yml](./generators/postman/versions.yml)      |
 
 ## 🌿 CLI Commands
 
@@ -152,101 +152,13 @@ Here's a quick look at the most popular CLI commands. View the documentation for
 
 `fern add <generator>`: include a new generator in your `generators.yml`. For example, `fern add fern-python-sdk`.
 
-## Advanced
-
-### API First
-
-Fern supports developers and teams that want to be API-first or Spec-first.
-
-Define your API, and use Fern to generate models, networking code and boilerplate application code. The generated code adds
-type safety to your API implementation - if your backend doesn't implement the API correctly, it won't compile.
-
-Frameworks currently supported:
-
-- [Express](./generators/typescript)
-- [Spring Boot](./generators/java)
-- [FastAPI](./generators/python)
-
-### Fern Definition
-
-While we are big fans of OpenAPI, we know it isn't the _easiest_ format to read and write. If you're looking for an alternative,
-give the Fern Definition a try.
-
-Install the Fern CLI and initialize a Fern Project.
-
-```bash
-npm install -g fern-api
-fern init
-```
-
-This will create the following folder structure in your project:
-
-```yaml
-fern/
-├─ fern.config.json # root-level configuration
-├─ generators.yml # generators you're using
-└─ definition/
-  ├─ api.yml  # API-level configuration
-  └─ imdb.yml # endpoints, types, and errors
-```
-
-Here's what the `imdb.yml` starter file looks like:
-
-```yaml
-types:
-  MovieId: string
-
-  Movie:
-    properties:
-      id: MovieId
-      title: string
-      rating:
-        type: double
-        docs: The rating scale is one to five stars
-
-  CreateMovieRequest:
-    properties:
-      title: string
-      rating: double
-
-service:
-  auth: false
-  base-path: /movies
-  endpoints:
-    createMovie:
-      docs: Add a movie to the database
-      method: POST
-      path: /create-movie
-      request: CreateMovieRequest
-      response: MovieId
-
-    getMovie:
-      method: GET
-      path: /{movieId}
-      path-parameters:
-        movieId: MovieId
-      response: Movie
-      errors:
-        - MovieDoesNotExistError
-
-errors:
-  MovieDoesNotExistError:
-    status-code: 404
-    type: MovieId
-```
-
-Checkout open source projects that are using Fern Definitions:
-
-- [Metriport](https://github.com/metriport/metriport/tree/develop/fern/definition)
-- [Rivet](https://github.com/rivet-gg/rivet/tree/main/sdks/api/fern/definition)
-
 ## Inspiration
 
 Fern is inspired by internal tooling built to enhance the developer experience. We stand on the shoulders of giants. While teams were responsible for building the following tools, we want to give a shout out to Mark Elliot (creator of Conjure at Palantir), Michael Dowling (creator of Smithy at AWS), and Ian McCrystal (creator of Stripe Docs).
 
 ## Community
 
-[Join our Slack!](https://join.slack.com/t/fern-community/shared_invite/zt-2q7ev4mki-mhO5anKslwRowp4oExWf4A) We are here to answer questions and help you get the most out of Fern.
+[Join our Slack!](https://buildwithfern.com/contact/slack) We are here to answer questions and help you get the most out of Fern.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![2023 Y Combinator Startup](https://img.shields.io/badge/Y%20Combinator-2023-orange)](https://www.ycombinator.com/companies/fern)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
 
-[![Slack](https://img.shields.io/badge/slack-pink.svg)](https://buildwithfern.com/contact/slack)
+[![Slack](https://img.shields.io/badge/slack-pink.svg)](https://buildwithfern.com/slack)
 [![Documentation](https://img.shields.io/badge/Read%20our%20Documentation-black?logo=book)](https://buildwithfern.com/learn/home?utm_source=fern-api/fern/readme-read-our-documentation)
 
 </div>
@@ -107,16 +107,6 @@ Postman Collections, Server boilerplate, etc.). To add a generator, run `fern ad
 | `fernapi/fern-swift-sdk`           | ![Swift Generator Version](https://img.shields.io/docker/v/fernapi/fern-swift-sdk)                | [Changelog](https://buildwithfern.com/learn/sdks/generators/swift/changelog)                                    |
 | `fernapi/fern-rust-sdk`            | ![Rust Generator Version](https://img.shields.io/docker/v/fernapi/fern-rust-sdk)                  | [Changelog](https://buildwithfern.com/learn/sdks/generators/rust/changelog)                                     |
 
-### Server-side Generators
-
-Fern's server-side generators output boilerplate application code (models and networking logic). This is intended for spec-first or API-first developers, who write their API definition (as an OpenAPI spec or Fern definition) and want to generate backend code.
-
-| Generator ID                      | Latest Version                                                                                                  | Changelog                                                                        |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `fernapi/fern-typescript-express` | ![Typescript Express Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-typescript-express) | [versions.yml](./generators/typescript/express/versions.yml)                     |
-| `fernapi/fern-fastapi-server`     | ![Python FastAPI Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-fastapi-server)         | [versions.yml](./generators/python/fastapi/versions.yml)                         |
-| `fernapi/fern-java-spring`        | ![Java Spring Server Generator Version](https://img.shields.io/docker/v/fernapi/fern-java-spring)               | [versions.yml](./generators/java/spring/versions.yml)                            |
-
 ### Model Generators
 
 Fern's model generators will output schemas or types defined in your OpenAPI spec or Fern Definition.
@@ -158,7 +148,7 @@ Fern is inspired by internal tooling built to enhance the developer experience. 
 
 ## Community
 
-[Join our Slack!](https://buildwithfern.com/contact/slack) We are here to answer questions and help you get the most out of Fern.
+[Join our Slack!](https://buildwithfern.com/slack) We are here to answer questions and help you get the most out of Fern.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Improve the README to be more useful for non-contributors evaluating Fern, per user request.

Refs: https://app.devin.ai/sessions/12d8859a20c7412c8d036dd0ff86e653
Requested by: @Swimburger

## Changes Made

- **Replace "Entrypoint" column with "Changelog" in all generator tables.** SDK generators now link to published changelogs on buildwithfern.com. Model and spec generators fall back to linking their `versions.yml` files (no published changelog pages exist for these).
- **Remove the "Advanced" section** (API First + Fern Definition), which was contributor/power-user oriented and added ~88 lines of content not relevant to most visitors.
- **Remove the "Server-side Generators" table** per review feedback — not relevant for the target audience.
- **Consolidate Slack invite links** — both the badge and Community section now use `https://buildwithfern.com/slack` instead of direct `join.slack.com` invite tokens that can expire.
- **Fix typo**: "Generators are process" → "Generators are processes"

## Review Checklist

- [ ] Verify `https://buildwithfern.com/slack` resolves correctly (used for both Slack links)
- [ ] Verify `https://buildwithfern.com/learn/sdks/generators/php/changelog` exists (inferred from URL pattern of other generators, not explicitly confirmed)
- [ ] Confirm removal of Server-side Generators, Fern Definition, and API First sections is acceptable

## Testing

- [x] Manual review of rendered markdown
- No code changes; README-only update