### PR TITLE
chore(ci): add generator-cli as valid PR title scope

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -54,6 +54,7 @@ jobs:
             ai-search
             swift
             rust
+            generator-cli
           requireScope: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Adds `generator-cli` as a valid scope for semantic PR title validation.

Requested by: @tstanmay13
[Link to Devin run](https://app.devin.ai/sessions/09eae79a1e39452d980be34d68ae2f88)

## Changes Made

- Added `generator-cli` to the list of allowed scopes in `.github/workflows/lint-pr-title.yml`
- This enables PR titles like `fix(generator-cli): ...` and `feat(generator-cli): ...` to pass the lint check

## Testing

- No tests needed — this is a CI configuration change
- Verified YAML indentation is consistent with existing entries