### PR TITLE
fix(generator-cli): handle shallow git clones in generator-cli pipeline

### DIFF
--- a/packages/commons/github/src/ClonedRepository.ts
+++ b/packages/commons/github/src/ClonedRepository.ts
@@ -107,6 +107,11 @@ export class ClonedRepository {
         }
     }
 
+    public async fetch(args: string[]): Promise<void> {
+        await this.git.cwd(this.clonePath);
+        await this.git.fetch(args);
+    }
+
     public async pull(branch: string): Promise<void> {
         await this.git.cwd(this.clonePath);
         await this.git.pull("origin", branch);
@@ -255,12 +260,13 @@ export class ClonedRepository {
     }
 
     // Only used by replay's PR mode to push synthetic divergent commits to a fern-bot/ branch.
-    // Uses --force-with-lease (not --force) so we fail safely if the branch was updated
-    // by someone else since we cloned. Never targets main or user branches.
+    // These branches are exclusively owned by the pipeline — no human pushes to them.
+    // Uses --force (not --force-with-lease) because the lease check fails after
+    // git fetch --unshallow updates remote refs. Never targets main or user branches.
     public async forcePush(): Promise<void> {
         await this.git.cwd(this.clonePath);
         const currentBranch = await this.getCurrentBranch();
-        await this.git.push("origin", currentBranch, ["--force-with-lease"]);
+        await this.git.push("origin", currentBranch, ["--force"]);
     }
 
     public async createBranchFromHead(branchName: string): Promise<void> {

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -23,7 +23,7 @@
   },
   "files": ["bin", "dist", "lib"],
   "dependencies": {
-    "@fern-api/replay": "^0.6.1",
+    "@fern-api/replay": "^0.6.2",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -32,6 +32,16 @@ export class GithubStep extends BaseStep {
             this.logger.debug("Starting GitHub self-hosted flow in directory: " + this.outputDir);
             const repository = ClonedRepository.createAtPath(this.outputDir);
 
+            // Ensure full git history is available.
+            // Fiddle clones with --depth 1 for performance.
+            // Replay references historical SHAs from .fern/replay.lock that won't exist
+            // in a shallow clone.
+            try {
+                await repository.fetch(["--unshallow"]);
+            } catch {
+                // Not a shallow clone — already has full history. This is fine.
+            }
+
             const now = new Date();
             const formattedDate = now
                 .toISOString()

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -2,6 +2,16 @@
 
 - changelogEntry:
     - summary: |
+        Handle shallow git clones in the pipeline. Add `git fetch --unshallow`
+        at the start of GithubStep to ensure full history is available for
+        replay operations, and use `--force` instead of `--force-with-lease`
+        for fern-bot branch pushes to avoid stale ref failures.
+      type: fix
+  createdAt: "2026-02-25"
+  version: 0.6.6
+
+- changelogEntry:
+    - summary: |
         Ensure commits are signed by fern-bot and remove specific customization counts from Replay PR descriptions in favor of generic messaging.
       type: fix
   createdAt: "2026-02-25"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8156,8 +8156,8 @@ importers:
   packages/generator-cli:
     dependencies:
       '@fern-api/replay':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9658,6 +9658,11 @@ packages:
 
   '@fern-api/replay@0.6.1':
     resolution: {integrity: sha512-h3pRkz+i4IuWTR1usuRDNpCvk6Cv534VX76aXicE/L+u7ZcPbRAShNb08RLeFc9y3LeoEOK+s2JlvWqsvv1W/A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.6.2':
+    resolution: {integrity: sha512-AECUgZRIqU1XJneDRWkIB3YBAqJ4NdHqQ9CVx10abotGUtiGeoyoXNov79y4SgSrbKF+77CpmdjxTnwauNlPdQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16402,6 +16407,15 @@ snapshots:
       chalk: 5.6.2
 
   '@fern-api/replay@0.6.1':
+    dependencies:
+      minimatch: 10.2.2
+      node-diff3: 3.2.0
+      simple-git: 3.30.0
+      yaml: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.6.2':
     dependencies:
       minimatch: 10.2.2
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fiddle clones customer SDK repos with `--depth 1`. This causes two failures in GithubStep:

1. `git commit-tree -p <sha>` fails because the parent SHA from replay.lock doesn't exist in the shallow clone
2. `git push --force-with-lease` fails with "stale info" after unshallowing updates remote refs

Also includes a version bump of replay

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
