### PR TITLE
fix(generator-cli): allow pipeline run to accept inline JSON config and output result to stdout

### DIFF
--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -18,6 +18,8 @@ import { loadReadmeConfig } from "./configuration/loadReadmeConfig.js";
 import { loadReferenceConfig } from "./configuration/loadReferenceConfig.js";
 import { type PipelineConfig, PostGenerationPipeline } from "./pipeline/index.js";
 
+const STDIN_MARKER = "-";
+
 void yargs(hideBin(process.argv))
     // eslint-disable-next-line turbo/no-undeclared-env-vars
     .scriptName(process.env.CLI_NAME ?? "generator-cli")
@@ -172,17 +174,12 @@ void yargs(hideBin(process.argv))
                         .option("config", {
                             string: true,
                             required: true,
-                            description: "Pipeline config as inline JSON string or path to JSON file"
+                            description: "The file or data to use for pipeline configuration"
                         })
                         .option("output-dir", {
                             string: true,
                             required: true,
                             description: "Path to SDK output directory"
-                        })
-                        .option("result-file", {
-                            string: true,
-                            required: false,
-                            description: "Path to write result JSON"
                         });
                 },
                 async (argv) => {
@@ -196,12 +193,21 @@ void yargs(hideBin(process.argv))
                     try {
                         const wd = cwd();
 
-                        // Read pipeline config from inline JSON or file
+                        // Read pipeline config: "-" = stdin, starts with "{" = inline JSON, otherwise file path
                         const configValue = argv.config;
-                        const configContent = configValue.trimStart().startsWith("{")
-                            ? configValue
-                            : await readFile(resolve(wd, configValue), "utf-8");
-                        const config: PipelineConfig = JSON.parse(configContent);
+                        const configContent =
+                            configValue === STDIN_MARKER
+                                ? await readStdin()
+                                : configValue.trimStart().startsWith("{")
+                                  ? configValue
+                                  : await readFile(resolve(wd, configValue), "utf-8");
+                        let config: PipelineConfig;
+                        try {
+                            config = JSON.parse(configContent);
+                        } catch (parseError) {
+                            const parseMessage = parseError instanceof Error ? parseError.message : String(parseError);
+                            throw new Error(`Failed to parse pipeline config as JSON: ${parseMessage}`);
+                        }
 
                         // Override outputDir from CLI arg
                         config.outputDir = resolve(wd, argv["output-dir"]);
@@ -209,13 +215,6 @@ void yargs(hideBin(process.argv))
                         // Run pipeline
                         const pipeline = new PostGenerationPipeline(config);
                         const result = await pipeline.run();
-
-                        // Write result if specified
-                        if (argv["result-file"] != null) {
-                            const resultPath = resolve(wd, argv["result-file"]);
-                            await mkdir(path.dirname(resultPath), { recursive: true });
-                            await fs.promises.writeFile(resultPath, JSON.stringify(result, null, 2));
-                        }
 
                         // Log summary to stderr
                         process.stderr.write(`Pipeline ${result.success ? "succeeded" : "failed"}\n`);
@@ -244,12 +243,12 @@ void yargs(hideBin(process.argv))
                         // Write result JSON to stdout for programmatic consumption
                         process.stdout.write(JSON.stringify(result) + "\n");
 
-                        // Exit with appropriate code
-                        process.exit(result.success ? 0 : 1);
+                        // Use process.exitCode instead of process.exit() to allow stdout to drain
+                        process.exitCode = result.success ? 0 : 1;
                     } catch (error) {
                         const errorMessage = error instanceof Error ? error.message : String(error);
                         process.stderr.write(`Pipeline failed: ${errorMessage}\n`);
-                        process.exit(1);
+                        process.exitCode = 1;
                     }
                 }
             )
@@ -443,6 +442,14 @@ void yargs(hideBin(process.argv))
     .demandCommand()
     .showHelpOnFail(true)
     .parse();
+
+async function readStdin(): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf-8");
+}
 
 async function createWriteStream(outputPath: string | undefined): Promise<fs.WriteStream | NodeJS.Process["stdout"]> {
     return outputPath != null ? await createWriteStreamFromFile(resolve(cwd(), outputPath)) : process.stdout;

--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -172,7 +172,7 @@ void yargs(hideBin(process.argv))
                         .option("config", {
                             string: true,
                             required: true,
-                            description: "Path to pipeline config JSON"
+                            description: "Pipeline config as inline JSON string or path to JSON file"
                         })
                         .option("output-dir", {
                             string: true,
@@ -196,8 +196,11 @@ void yargs(hideBin(process.argv))
                     try {
                         const wd = cwd();
 
-                        // Read pipeline config from file
-                        const configContent = await readFile(resolve(wd, argv.config), "utf-8");
+                        // Read pipeline config from inline JSON or file
+                        const configValue = argv.config;
+                        const configContent = configValue.trimStart().startsWith("{")
+                            ? configValue
+                            : await readFile(resolve(wd, configValue), "utf-8");
                         const config: PipelineConfig = JSON.parse(configContent);
 
                         // Override outputDir from CLI arg
@@ -237,6 +240,9 @@ void yargs(hideBin(process.argv))
                         if (result.errors != null && result.errors.length > 0) {
                             process.stderr.write(`Errors:\n${result.errors.map((e) => `  - ${e}`).join("\n")}\n`);
                         }
+
+                        // Write result JSON to stdout for programmatic consumption
+                        process.stdout.write(JSON.stringify(result) + "\n");
 
                         // Exit with appropriate code
                         process.exit(result.success ? 0 : 1);

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -2,6 +2,14 @@
 
 - changelogEntry:
     - summary: |
+        `pipeline run --config` accepts inline JSON (in addition to file paths)
+        and writes the result JSON to stdout.
+      type: feat
+  createdAt: "2026-02-26"
+  version: 0.6.7
+
+- changelogEntry:
+    - summary: |
         Handle shallow git clones in the pipeline. Add `git fetch --unshallow`
         at the start of GithubStep to ensure full history is available for
         replay operations, and use `--force` instead of `--force-with-lease`

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -2,8 +2,8 @@
 
 - changelogEntry:
     - summary: |
-        `pipeline run --config` accepts inline JSON (in addition to file paths)
-        and writes the result JSON to stdout.
+        `pipeline run --config` now accepts inline JSON, "-" for stdin,
+        or a file path. Result JSON is written to stdout.
       type: feat
   createdAt: "2026-02-26"
   version: 0.6.7


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

- `--config` now accepts inline JSON (detected by `{` prefix) in addition to file paths
- Result JSON always written to stdout; logs remain on stderr

This lets fiddle pass config inline and capture the result from stdout, eliminating the temp files that caused path resolution bugs in Docker. The entire temp file dance (serialize -> write to disk -> pass path -> read from disk -> parse) is replaced by (serialize -> pass as arg) for config and (write to stdout -> capture) for result

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
