### PR TITLE
fix(cli): support `x-fern-server-name` extension on AsyncAPI server definitions

### DIFF
--- a/packages/cli/api-importers/asyncapi-to-ir/src/2.x/channel/ChannelConverter2_X.ts
+++ b/packages/cli/api-importers/asyncapi-to-ir/src/2.x/channel/ChannelConverter2_X.ts
@@ -12,6 +12,7 @@ import { camelCase, startCase } from "lodash-es";
 import { OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
 import { AsyncAPIConverterContext } from "../../AsyncAPIConverterContext.js";
 import { AbstractChannelConverter } from "../../converters/AbstractChannelConverter.js";
+import { AbstractServerConverter } from "../../converters/AbstractServerConverter.js";
 import { ParameterConverter } from "../../converters/ParameterConverter.js";
 import { ChannelAddressExtension } from "../../extensions/x-fern-channel-address.js";
 import { DisplayNameExtension } from "../../extensions/x-fern-display-name.js";
@@ -91,7 +92,8 @@ export class ChannelConverter2_X extends AbstractChannelConverter<AsyncAPIV2.Cha
         });
         const channelAddressExtensionValue = channelAddressExtension.convert();
         const channelAddress = this.transformToValidPath(channelAddressExtensionValue ?? this.channelPath);
-        const baseUrl = this.channel.servers?.[0] ?? Object.keys(this.context.spec.servers ?? {})[0];
+        const baseUrl = this.resolveServerName(this.channel.servers?.[0]) ??
+            this.resolveServerName(Object.keys(this.context.spec.servers ?? {})[0]);
         const path = constructHttpPath(channelAddress);
         const groupName = camelCase(this.channelPath);
 
@@ -296,6 +298,22 @@ export class ChannelConverter2_X extends AbstractChannelConverter<AsyncAPIV2.Cha
                 }
             }
         }
+    }
+
+    /**
+     * Resolves the effective server name by looking up the server in the spec
+     * and checking for x-fern-server-name extension.
+     */
+    private resolveServerName(serverKey: string | undefined): string | undefined {
+        if (serverKey == null) {
+            return undefined;
+        }
+        const specServers = this.context.spec.servers;
+        if (specServers != null && serverKey in specServers) {
+            const server = specServers[serverKey];
+            return AbstractServerConverter.getServerName(serverKey, server);
+        }
+        return serverKey;
     }
 
     private convertBindingQueryParameters({

--- a/packages/cli/api-importers/asyncapi-to-ir/src/2.x/channel/ChannelConverter2_X.ts
+++ b/packages/cli/api-importers/asyncapi-to-ir/src/2.x/channel/ChannelConverter2_X.ts
@@ -92,7 +92,8 @@ export class ChannelConverter2_X extends AbstractChannelConverter<AsyncAPIV2.Cha
         });
         const channelAddressExtensionValue = channelAddressExtension.convert();
         const channelAddress = this.transformToValidPath(channelAddressExtensionValue ?? this.channelPath);
-        const baseUrl = this.resolveServerName(this.channel.servers?.[0]) ??
+        const baseUrl =
+            this.resolveServerName(this.channel.servers?.[0]) ??
             this.resolveServerName(Object.keys(this.context.spec.servers ?? {})[0]);
         const path = constructHttpPath(channelAddress);
         const groupName = camelCase(this.channelPath);

--- a/packages/cli/api-importers/asyncapi-to-ir/src/3.0/channel/ChannelConverter3_0.ts
+++ b/packages/cli/api-importers/asyncapi-to-ir/src/3.0/channel/ChannelConverter3_0.ts
@@ -3,6 +3,7 @@ import { constructHttpPath } from "@fern-api/ir-utils";
 import { Converters } from "@fern-api/v3-importer-commons";
 import { OpenAPIV3 } from "openapi-types";
 import { AbstractChannelConverter } from "../../converters/AbstractChannelConverter.js";
+import { AbstractServerConverter } from "../../converters/AbstractServerConverter.js";
 import { ParameterConverter } from "../../converters/ParameterConverter.js";
 import { DisplayNameExtension } from "../../extensions/x-fern-display-name.js";
 import { AsyncAPIV3 } from "../index.js";
@@ -94,7 +95,7 @@ export class ChannelConverter3_0 extends AbstractChannelConverter<AsyncAPIV3.Cha
 
         const baseUrl =
             this.resolveChannelServersFromReference(this.channel.servers ?? []) ??
-            Object.keys(this.context.spec.servers ?? {})[0];
+            this.resolveFirstServerName();
 
         const channelAddress = this.transformToValidPath(this.channel.address ?? this.channelPath);
         const path = constructHttpPath(channelAddress);
@@ -242,15 +243,38 @@ export class ChannelConverter3_0 extends AbstractChannelConverter<AsyncAPIV3.Cha
             });
             return undefined;
         }
-        const serverName = serverRef.$ref.substring(SERVER_REFERENCE_PREFIX.length);
-        if (serverName == null) {
+        const serverKey = serverRef.$ref.substring(SERVER_REFERENCE_PREFIX.length);
+        if (serverKey == null) {
             this.context.errorCollector.collect({
-                message: `Failed to find server with name ${serverName}`,
+                message: `Failed to find server with name ${serverKey}`,
                 path: this.breadcrumbs
             });
             return undefined;
         }
-        return serverName;
+        // Check for x-fern-server-name extension on the referenced server
+        const specServers = this.context.spec.servers;
+        if (specServers != null && serverKey in specServers) {
+            const server = specServers[serverKey];
+            return AbstractServerConverter.getServerName(serverKey, server);
+        }
+        return serverKey;
+    }
+
+    /**
+     * Resolves the effective name of the first server in the spec,
+     * checking for x-fern-server-name extension.
+     */
+    private resolveFirstServerName(): string | undefined {
+        const specServers = this.context.spec.servers;
+        if (specServers == null) {
+            return undefined;
+        }
+        const firstServerKey = Object.keys(specServers)[0];
+        if (firstServerKey == null) {
+            return undefined;
+        }
+        const server = specServers[firstServerKey];
+        return AbstractServerConverter.getServerName(firstServerKey, server);
     }
 
     private getChannelPathFromOperation(operation: AsyncAPIV3.Operation): string {

--- a/packages/cli/api-importers/asyncapi-to-ir/src/3.0/channel/ChannelConverter3_0.ts
+++ b/packages/cli/api-importers/asyncapi-to-ir/src/3.0/channel/ChannelConverter3_0.ts
@@ -94,8 +94,7 @@ export class ChannelConverter3_0 extends AbstractChannelConverter<AsyncAPIV3.Cha
         }
 
         const baseUrl =
-            this.resolveChannelServersFromReference(this.channel.servers ?? []) ??
-            this.resolveFirstServerName();
+            this.resolveChannelServersFromReference(this.channel.servers ?? []) ?? this.resolveFirstServerName();
 
         const channelAddress = this.transformToValidPath(this.channel.address ?? this.channelPath);
         const path = constructHttpPath(channelAddress);

--- a/packages/cli/api-importers/asyncapi-to-ir/src/converters/AbstractServerConverter.ts
+++ b/packages/cli/api-importers/asyncapi-to-ir/src/converters/AbstractServerConverter.ts
@@ -4,6 +4,8 @@ import { AbstractConverter } from "@fern-api/v3-importer-commons";
 import { AsyncAPIConverter } from "../AsyncAPIConverter.js";
 import { AsyncAPIConverterContext } from "../AsyncAPIConverterContext.js";
 
+const X_FERN_SERVER_NAME = "x-fern-server-name";
+
 export declare namespace AbstractServerConverter {
     export interface Args<TServer> extends AsyncAPIConverter.AbstractArgs {
         servers?: Record<string, TServer>;
@@ -30,9 +32,10 @@ export abstract class AbstractServerConverter<TServer> extends AbstractConverter
         let defaultEnvironmentId: string | undefined;
 
         for (const [serverId, server] of Object.entries(this.servers)) {
+            const resolvedServerId = AbstractServerConverter.getServerName(serverId, server);
             const environment: SingleBaseUrlEnvironment = this.buildSingleBaseUrlEnvironment(
                 this.context,
-                serverId,
+                resolvedServerId,
                 server
             );
             environments.push(environment);
@@ -48,6 +51,20 @@ export abstract class AbstractServerConverter<TServer> extends AbstractConverter
                 environments
             })
         };
+    }
+
+    /**
+     * Resolves the effective server name by checking for x-fern-server-name extension,
+     * falling back to the original server ID (the key in the servers map).
+     */
+    public static getServerName<T>(serverId: string, server: T): string {
+        if (server != null && typeof server === "object") {
+            const extensionValue = (server as Record<string, unknown>)[X_FERN_SERVER_NAME];
+            if (typeof extensionValue === "string" && extensionValue.length > 0) {
+                return extensionValue;
+            }
+        }
+        return serverId;
     }
 
     protected abstract buildSingleBaseUrlEnvironment(

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/fernExtensions.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/fernExtensions.ts
@@ -117,7 +117,20 @@ export const FernAsyncAPIExtension = {
      *         description: The user ID
      *         x-fern-parameter-name: id
      */
-    FERN_PARAMETER_NAME: "x-fern-parameter-name"
+    FERN_PARAMETER_NAME: "x-fern-parameter-name",
+
+    /**
+     * Used to override the server name in AsyncAPI specs. This is useful when
+     * multiple APIs define servers with the same key (e.g. "uat") and you need
+     * to disambiguate them in the generated SDK's environment URLs.
+     *
+     * servers:
+     *   uat:
+     *     host: ws-gateway.uat.example.com
+     *     x-fern-server-name: market_data
+     *     protocol: wss
+     */
+    FERN_SERVER_NAME: "x-fern-server-name"
 } as const;
 
 export type FernAsyncAPIExtension = Values<typeof FernAsyncAPIExtension>;

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/parseAsyncAPIV2.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/parseAsyncAPIV2.ts
@@ -56,9 +56,9 @@ export function parseAsyncAPIV2({
 
     const servers: Record<string, ServerContext> = {};
     for (const [serverId, server] of Object.entries(document.servers ?? {})) {
+        const serverNameOverride = getExtension<string>(server, FernAsyncAPIExtension.FERN_SERVER_NAME);
         servers[serverId] = {
-            // Always preserve server names from AsyncAPI spec
-            name: serverId,
+            name: serverNameOverride ?? serverId,
             url: constructServerUrl(server.protocol, server.url)
         };
     }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -170,9 +170,9 @@ export function parseAsyncAPIV3({
 
     const servers: Record<string, ServerContext> = {};
     for (const [serverId, server] of Object.entries(document.servers ?? {})) {
+        const serverNameOverride = getExtension<string>(server, FernAsyncAPIExtension.FERN_SERVER_NAME);
         servers[serverId] = {
-            // Always preserve server names from AsyncAPI spec
-            name: serverId,
+            name: serverNameOverride ?? serverId,
             url: constructServerUrl(server.protocol, server.host)
         };
     }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.91.2
+  changelogEntry:
+    - summary: |
+        Fix `x-fern-server-name` extension being ignored on AsyncAPI server definitions.
+        When an AsyncAPI spec uses `x-fern-server-name` to override a server's name
+        (e.g. renaming `uat` to `market_data` to avoid naming conflicts with another API),
+        both the environment ID and channel base URL now use the overridden name. This
+        fixes SDK generation errors like "Expected environment UAT to contain url for uat"
+        when the generators.yml environment URLs reference the overridden server name.
+      type: fix
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 3.91.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs [Slack thread](https://buildwithfern.slack.com/archives/C0ACD0AC361/p1772124821042889)

Fixes `x-fern-server-name` extension being ignored on AsyncAPI server definitions, which caused SDK generation to fail with:
```
Encountered undefined server name undefined at channel marketData /. Expected environment UAT to contain url for uat
```

**Link to Devin run:** https://app.devin.ai/sessions/a5bc21c94b6b4f83a75353d58026201b
**Requested by:** @iamnamananand996

## Changes Made

The AsyncAPI-to-IR converter was ignoring `x-fern-server-name` in two places:

1. **`AbstractServerConverter.convert()`** — environment IDs were always the raw server map key (e.g. `uat`), never the overridden name (`market_data`). Added a static `getServerName()` helper that checks for `x-fern-server-name` on the server object and falls back to the map key.

2. **Channel converters (v2 + v3)** — when resolving which server a channel references, the raw key from `$ref: "#/servers/uat"` or the `servers: [uat]` array was used directly as `baseUrl`. Now both `ChannelConverter3_0` and `ChannelConverter2_X` look up the actual server object and apply the same `x-fern-server-name` resolution.

- Added `AbstractServerConverter.getServerName()` static method (used by both server and channel converters)
- Updated `ChannelConverter3_0.resolveChannelServersFromReference()` and added `resolveFirstServerName()` fallback
- Added `ChannelConverter2_X.resolveServerName()` private helper
- Added v3.90.1 changelog entry

## Testing

- [ ] No unit tests exist for the asyncapi-to-ir package (pre-existing). The fix is consistent with how the OpenAPI converter handles `x-fern-server-name` via `ServersConverter.getServerName()`.
- [ ] Pre-existing compile errors on `main` confirmed unrelated to this change.

## Review Checklist

- **Verify the `as Record<string, unknown>` cast approach** in `getServerName()` is acceptable vs reusing the `ServerNameExtension` class from `v3-importer-commons` (which expects `OpenAPIV3_1.ServerObject` types, not AsyncAPI server types).
- **Check for other callsites** that use raw server keys and may also need `x-fern-server-name` resolution.
- **Confirm v2 fallback path** — `resolveServerName(Object.keys(...)[0])` correctly propagates `undefined` when no servers exist (matches prior behavior).