### PR TITLE
fix(python): skip path parameter deconfliction when body is not inlined

### DIFF
--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -489,9 +489,12 @@ export class EndpointSnippetGenerator {
         this.context.errors.scope(Scope.PathParameters);
         const pathParameters = [...(this.context.ir.pathParameters ?? []), ...(request.pathParameters ?? [])];
 
-        // Get body property names to check for collisions
+        // Get body property names to check for collisions.
+        // Only collect property names when the body is actually flattened into individual
+        // parameters (inline_request_params !== false). When the body is NOT flattened,
+        // it becomes a single "request" parameter and there is no collision with path params.
         let bodyPropertyNames: Set<string> = new Set();
-        if (request.body != null) {
+        if (request.body != null && this.context.customConfig.inline_request_params !== false) {
             const bodyArgs = this.getBodyRequestArgs({ body: request.body, value: snippet.requestBody });
             bodyPropertyNames = new Set(bodyArgs.map((arg) => arg.name));
 

--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -489,12 +489,9 @@ export class EndpointSnippetGenerator {
         this.context.errors.scope(Scope.PathParameters);
         const pathParameters = [...(this.context.ir.pathParameters ?? []), ...(request.pathParameters ?? [])];
 
-        // Get body property names to check for collisions.
-        // Only collect property names when the body is actually flattened into individual
-        // parameters (inline_request_params !== false). When the body is NOT flattened,
-        // it becomes a single "request" parameter and there is no collision with path params.
+        // Get body property names to check for collisions
         let bodyPropertyNames: Set<string> = new Set();
-        if (request.body != null && this.context.customConfig.inline_request_params !== false) {
+        if (request.body != null) {
             const bodyArgs = this.getBodyRequestArgs({ body: request.body, value: snippet.requestBody });
             bodyPropertyNames = new Set(bodyArgs.map((arg) => arg.name));
 

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -32,7 +32,6 @@ export class WireTestGenerator {
     private dynamicIr: FernIr.dynamic.DynamicIntermediateRepresentation;
     private wireMockConfigContent: Record<string, WireMockMapping>;
     private snippetGenerator: DynamicSnippetsGenerator;
-    private nonInlinedSnippetGenerator: DynamicSnippetsGenerator;
     constructor(context: SdkGeneratorContext, ir: FernIr.IntermediateRepresentation) {
         this.context = context;
         const dynamicIr = ir.dynamic;
@@ -49,20 +48,6 @@ export class WireTestGenerator {
                 organization: context.config.organization,
                 workspaceName: context.config.workspaceName,
                 customConfig: context.customConfig
-            } as FernGeneratorExec.GeneratorConfig
-        });
-
-        // A second snippet generator with inline_request_params forced to false.
-        // Used for endpoints whose SDK request shape is "justRequestBody" (i.e., the body
-        // is passed as a single `request` parameter and NOT flattened into individual args).
-        // Without this, the default generator would flatten body properties and incorrectly
-        // deconflict path parameter names that collide with body field names (e.g. task_name -> task_name_).
-        this.nonInlinedSnippetGenerator = new DynamicSnippetsGenerator({
-            ir: this.dynamicIr,
-            config: {
-                organization: context.config.organization,
-                workspaceName: context.config.workspaceName,
-                customConfig: { ...context.customConfig, inline_request_params: false }
             } as FernGeneratorExec.GeneratorConfig
         });
     }
@@ -572,21 +557,10 @@ export class WireTestGenerator {
             // file fields that are missing from the example request body.
             this.addPlaceholderFileUploadFields({ endpoint, snippetRequest });
 
-            // Choose the correct snippet generator based on whether the SDK inlines
-            // the request body. When the body is a referenced type passed as a single
-            // `request` parameter (sdkRequest.shape === "justRequestBody"), body field
-            // names are NOT top-level parameters and must not trigger path-parameter
-            // deconfliction (e.g. path param `task_name` should stay `task_name`, not
-            // become `task_name_` due to a body field with the same name).
-            const generator =
-                endpoint.sdkRequest?.shape.type === "justRequestBody"
-                    ? this.nonInlinedSnippetGenerator
-                    : this.snippetGenerator;
-
             // Generate just the method call AST using DynamicSnippetsGenerator
             // Pass endpointId to avoid path collision issues when multiple
             // namespaces have endpoints with the same HTTP method and path pattern
-            return generator.generateMethodCallSnippetAst({
+            return this.snippetGenerator.generateMethodCallSnippetAst({
                 request: snippetRequest,
                 options: { endpointId: endpoint.id }
             });

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -32,6 +32,7 @@ export class WireTestGenerator {
     private dynamicIr: FernIr.dynamic.DynamicIntermediateRepresentation;
     private wireMockConfigContent: Record<string, WireMockMapping>;
     private snippetGenerator: DynamicSnippetsGenerator;
+    private nonInlinedSnippetGenerator: DynamicSnippetsGenerator;
     constructor(context: SdkGeneratorContext, ir: FernIr.IntermediateRepresentation) {
         this.context = context;
         const dynamicIr = ir.dynamic;
@@ -48,6 +49,20 @@ export class WireTestGenerator {
                 organization: context.config.organization,
                 workspaceName: context.config.workspaceName,
                 customConfig: context.customConfig
+            } as FernGeneratorExec.GeneratorConfig
+        });
+
+        // A second snippet generator with inline_request_params forced to false.
+        // Used for endpoints whose SDK request shape is "justRequestBody" (i.e., the body
+        // is passed as a single `request` parameter and NOT flattened into individual args).
+        // Without this, the default generator would flatten body properties and incorrectly
+        // deconflict path parameter names that collide with body field names (e.g. task_name -> task_name_).
+        this.nonInlinedSnippetGenerator = new DynamicSnippetsGenerator({
+            ir: this.dynamicIr,
+            config: {
+                organization: context.config.organization,
+                workspaceName: context.config.workspaceName,
+                customConfig: { ...context.customConfig, inline_request_params: false }
             } as FernGeneratorExec.GeneratorConfig
         });
     }
@@ -557,10 +572,21 @@ export class WireTestGenerator {
             // file fields that are missing from the example request body.
             this.addPlaceholderFileUploadFields({ endpoint, snippetRequest });
 
+            // Choose the correct snippet generator based on whether the SDK inlines
+            // the request body. When the body is a referenced type passed as a single
+            // `request` parameter (sdkRequest.shape === "justRequestBody"), body field
+            // names are NOT top-level parameters and must not trigger path-parameter
+            // deconfliction (e.g. path param `task_name` should stay `task_name`, not
+            // become `task_name_` due to a body field with the same name).
+            const generator =
+                endpoint.sdkRequest?.shape.type === "justRequestBody"
+                    ? this.nonInlinedSnippetGenerator
+                    : this.snippetGenerator;
+
             // Generate just the method call AST using DynamicSnippetsGenerator
             // Pass endpointId to avoid path collision issues when multiple
             // namespaces have endpoints with the same HTTP method and path pattern
-            return this.snippetGenerator.generateMethodCallSnippetAst({
+            return generator.generateMethodCallSnippetAst({
                 request: snippetRequest,
                 options: { endpointId: endpoint.id }
             });

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.60.2
+  changelogEntry:
+    - summary: |
+        Fix wire test generation incorrectly appending underscore to path parameter names
+        when a referenced request body type has a field with the same name. When the SDK
+        request shape is "justRequestBody" (body passed as a single `request` parameter),
+        body field names no longer trigger path parameter deconfliction.
+      type: fix
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 4.60.1
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -3,9 +3,9 @@
 - version: 4.60.2
   changelogEntry:
     - summary: |
-        Fix wire test generation incorrectly appending underscore to path parameter names
-        when a referenced request body type has a field with the same name. When the SDK
-        request shape is "justRequestBody" (body passed as a single `request` parameter),
+        Fix dynamic snippet generation incorrectly appending underscore to path parameter names
+        when a referenced request body type has a field with the same name. When
+        `inline_request_params` is false (body passed as a single `request` parameter),
         body field names no longer trigger path parameter deconfliction.
       type: fix
   createdAt: "2026-02-26"


### PR DESCRIPTION
## Description

Fixes a bug where dynamic snippet generation (used by wire tests) incorrectly appends an underscore suffix to path parameter names when a referenced request body type has a property with the same name, but the body is **not** being flattened (i.e., `inline_request_params` is `false` and the SDK passes it as a single `request` parameter).

For example, an endpoint with path param `task_name` and body type `CreateUpdateTask` (which also has a `task_name` field) would incorrectly generate `task_name_="taskName"` instead of `task_name="taskName"` in the wire test snippet.

**Link to Devin run:** https://app.devin.ai/sessions/7ade4d1d54174254843d75f14a8a27c0
**Requested by:** @aditya-arolkar-swe

## Changes Made

### `EndpointSnippetGenerator.ts` (dynamic-snippets)
- In `getMethodArgsForBodyRequest()`, added a guard so body property names are only collected for path-parameter collision detection when `inline_request_params !== false`. When the body is NOT flattened into individual parameters, it is passed as a single `request` argument, so body field names cannot collide with path parameters.

### `versions.yml`
- Added version `4.60.2` changelog entry.

## How it works

`EndpointSnippetGenerator.getMethodArgsForBodyRequest()` collects body property names to detect collisions with path parameters (and appends `_` to resolve them). However, this deconfliction is only meaningful when body properties are actually flattened into top-level function parameters (`inline_request_params` is true/default). When `inline_request_params` is `false`, the body becomes a single `request` parameter and its internal field names never appear as top-level args — so no collision is possible.

The fix adds `&& this.context.customConfig.inline_request_params !== false` to the condition that triggers body property name collection. This also skips the schema-level property name collection (lines 500–513) which would otherwise pull in field names from the referenced type and cause false positives.

## Testing

- [x] TypeScript compilation passes
- [x] All 89 CI checks pass (including `exhaustive:wire-tests-custom-client-name` and all other seed tests)
- [ ] No new unit test added for the specific `inline_request_params=false` + path-param/body-property name collision scenario

## Human Review Checklist

- **Verify the `inline_request_params !== false` guard is correct**: When `inline_request_params` is `undefined` (default), the condition evaluates to `true` and collision detection still runs — this is correct since the SDK does inline body properties by default. When explicitly `false`, body is a single `request` param and no collision is possible. Confirm this matches the SDK's actual behavior in `getBodyRequestArgsForNamedTypeReference()` (line 637).
- **Schema-level property names are also skipped**: The guard also prevents schema-level property name collection (lines 500–513), which resolves the named type and adds all its property names to the collision set. Without this guard, these names would trigger false deconfliction even though `getBodyRequestArgs` returns only `[{name: "request"}]` when `inline_request_params` is `false`.
- **No test coverage for this edge case**: Consider whether a test should be added for the `inline_request_params=false` + path-param/body-property name collision scenario.