### PR TITLE
chore(python): update > fern@ python:build /Users/aditya.arolkar/fern-api/fern > turbo run dist:cli --filter @fern-api/python-sdk && docker build . -f ./generators/python/sdk/Dockerfile -t fernapi/fern-python-sdk:latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "go:build": "turbo run dockerTagLatest --filter @fern-api/go-sdk",
     "java:build": "turbo run dockerTagLatest --filter @fern-api/java-sdk",
     "php:build": "turbo run dockerTagLatest --filter @fern-api/php-sdk",
-    "python:build": "turbo run dockerTagLatest --filter @fern-api/python-sdk",
+    "python:build": "turbo run dist:cli --filter @fern-api/python-sdk && docker build . -f ./generators/python/sdk/Dockerfile -t fernapi/fern-python-sdk:latest",
     "ruby:build": "turbo run dockerTagLatest --filter @fern-api/ruby-sdk",
     "rust:build": "turbo run dockerTagLatest --filter @fern-api/rust-sdk",
     "swift:build": "turbo run dockerTagLatest --filter @fern-api/swift-sdk",


### PR DESCRIPTION
• Packages in scope: @fern-api/python-sdk
• Running dist:cli in 1 packages
• Remote caching disabled
@fern-api/mock-utils:compile: cache miss, executing 90ec592953b16e8e
@fern-api/core-utils:compile: cache miss, executing a27af1afe8a1cc72
@fern-api/python-browser-compatible-base:compile: cache miss, executing 3d8b1898b4169892
@fern-api/ir-sdk:compile: cache miss, executing 57a82718074ab1b3
@fern-api/path-utils:compile: cache miss, executing f030988cce376a84
@fern-api/ir-sdk:compile:
@fern-api/ir-sdk:compile: > @fern-api/ir-sdk@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/packages/ir-sdk
@fern-api/ir-sdk:compile: > tsc
@fern-api/ir-sdk:compile:
@fern-api/python-browser-compatible-base:compile:
@fern-api/python-browser-compatible-base:compile: > @fern-api/python-browser-compatible-base@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/generators/python-v2/browser-compatible-base
@fern-api/python-browser-compatible-base:compile: > tsc
@fern-api/python-browser-compatible-base:compile:
@fern-api/mock-utils:compile:
@fern-api/mock-utils:compile: > @fern-api/mock-utils@0.0.1 compile /Users/aditya.arolkar/fern-api/fern/packages/commons/mock-utils
@fern-api/mock-utils:compile: > tsc
@fern-api/mock-utils:compile:
@fern-api/core-utils:compile:
@fern-api/core-utils:compile: > @fern-api/core-utils@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/packages/commons/core-utils
@fern-api/core-utils:compile: > tsc
@fern-api/core-utils:compile:
@fern-api/path-utils:compile:
@fern-api/path-utils:compile: > @fern-api/path-utils@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/packages/commons/path-utils
@fern-api/path-utils:compile: > tsc
@fern-api/path-utils:compile:
@fern-api/logger:compile: cache miss, executing 0b387fd13b3ff26c
@fern-api/fs-utils:compile: cache miss, executing 7560463471437e36
@fern-api/logger:compile:
@fern-api/logger:compile: > @fern-api/logger@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/packages/cli/logger
@fern-api/logger:compile: > tsc
@fern-api/logger:compile:
@fern-api/fs-utils:compile:
@fern-api/fs-utils:compile: > @fern-api/fs-utils@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/packages/commons/fs-utils
@fern-api/fs-utils:compile: > tsc
@fern-api/fs-utils:compile:
@fern-api/logging-execa:compile: cache miss, executing 7676c14387745e3c
@fern-api/logging-execa:compile:
@fern-api/logging-execa:compile: > @fern-api/logging-execa@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/packages/commons/logging-execa
@fern-api/logging-execa:compile: > tsc
@fern-api/logging-execa:compile:
@fern-api/fern-definition-schema:compile: cache miss, executing 95616ae13d265b55
@fern-api/fern-definition-schema:compile:
@fern-api/fern-definition-schema:compile: > @fern-api/fern-definition-schema@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/packages/cli/fern-definition/schema
@fern-api/fern-definition-schema:compile: > tsc
@fern-api/fern-definition-schema:compile:
@fern-api/browser-compatible-base-generator:compile: cache miss, executing d7a91bd43a4bb5fc
@fern-api/browser-compatible-base-generator:compile:
@fern-api/browser-compatible-base-generator:compile: > @fern-api/browser-compatible-base-generator@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/generators/browser-compatible-base
@fern-api/browser-compatible-base-generator:compile: > tsc
@fern-api/browser-compatible-base-generator:compile:
@fern-api/base-generator:compile: cache miss, executing fdef08133871d949
@fern-api/python-ast:compile: cache miss, executing c616e321af00547a
@fern-api/base-generator:compile:
@fern-api/base-generator:compile: > @fern-api/base-generator@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/generators/base
@fern-api/base-generator:compile: > tsc
@fern-api/base-generator:compile:
@fern-api/python-ast:compile:
@fern-api/python-ast:compile: > @fern-api/python-ast@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/generators/python-v2/ast
@fern-api/python-ast:compile: > tsc
@fern-api/python-ast:compile:
@fern-api/python-dynamic-snippets:compile: cache miss, executing 62cc4840e8e39cfa
@fern-api/base-generator:compile: src/GeneratorAgentClient.ts(9,8): error TS2307: Cannot find module '@fern-api/generator-cli' or its corresponding type declarations.
@fern-api/base-generator:compile:  ELIFECYCLE  Command failed with exit code 2.
@fern-api/python-dynamic-snippets:compile:
@fern-api/python-dynamic-snippets:compile: > @fern-api/python-dynamic-snippets@0.0.0 compile /Users/aditya.arolkar/fern-api/fern/generators/python-v2/dynamic-snippets
@fern-api/python-dynamic-snippets:compile: > tsc
@fern-api/python-dynamic-snippets:compile:
@fern-api/python-dynamic-snippets:compile:  ELIFECYCLE  Command failed.

 Tasks:    11 successful, 13 total
Cached:    0 cached, 13 total
  Time:    9.613s
Failed:    @fern-api/base-generator#compile

 ELIFECYCLE  Command failed with exit code 2. for correct build command

## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- 
- 
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
