### PR TITLE
feat(cli): Surface task logs in console for CI/non-TTY environments

### DIFF
--- a/packages/cli/cli-v2/src/context/adapter/TaskContextLogger.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextLogger.ts
@@ -1,4 +1,5 @@
 import { LOG_LEVELS, Logger, LogLevel } from "@fern-api/logger";
+import chalk from "chalk";
 import type { Task } from "../../ui/Task.js";
 import type { Context } from "../Context.js";
 
@@ -31,6 +32,7 @@ export class TaskContextLogger implements Logger {
     public debug(...args: string[]): void {
         const message = args.join(" ");
         this.context.logs.write({ taskName: this.task.name, level: LogLevel.Debug, message });
+        this.writeToConsoleInCI(LogLevel.Debug, message);
 
         if (this.shouldLogToTask(LogLevel.Debug)) {
             if (this.task.logs == null) {
@@ -43,6 +45,7 @@ export class TaskContextLogger implements Logger {
     public info(...args: string[]): void {
         const message = args.join(" ");
         this.context.logs.write({ taskName: this.task.name, level: LogLevel.Info, message });
+        this.writeToConsoleInCI(LogLevel.Info, message);
 
         if (this.shouldLogToTask(LogLevel.Info)) {
             if (this.task.logs == null) {
@@ -56,6 +59,7 @@ export class TaskContextLogger implements Logger {
     public warn(...args: string[]): void {
         const message = args.join(" ");
         this.context.logs.write({ taskName: this.task.name, level: LogLevel.Warn, message });
+        this.writeToConsoleInCI(LogLevel.Warn, message);
 
         if (this.shouldLogToTask(LogLevel.Warn)) {
             if (this.task.logs == null) {
@@ -68,6 +72,7 @@ export class TaskContextLogger implements Logger {
     public error(...args: string[]): void {
         const message = args.join(" ");
         this.context.logs.write({ taskName: this.task.name, level: LogLevel.Error, message });
+        this.writeToConsoleInCI(LogLevel.Error, message);
 
         if (this.shouldLogToTask(LogLevel.Error)) {
             this.collectedErrors.push(message);
@@ -91,6 +96,31 @@ export class TaskContextLogger implements Logger {
                 break;
             case LogLevel.Error:
                 this.error(...args);
+                break;
+        }
+    }
+
+    /**
+     * In CI / non-TTY environments, write logs directly to stderr so they
+     * are visible in CI runner output rather than hidden in a log file.
+     */
+    private writeToConsoleInCI(level: LogLevel, message: string): void {
+        if (this.context.isTTY) {
+            return;
+        }
+        if (!this.enabled) {
+            return;
+        }
+        const prefix = chalk.dim(`[${this.task.name}]`);
+        switch (level) {
+            case LogLevel.Warn:
+                process.stderr.write(`${prefix}: ${chalk.yellow(message)}\n`);
+                break;
+            case LogLevel.Error:
+                process.stderr.write(`${prefix}: ${chalk.red(message)}\n`);
+                break;
+            default:
+                process.stderr.write(`${prefix}: ${message}\n`);
                 break;
         }
     }

--- a/packages/cli/cli-v2/src/context/adapter/TaskContextLogger.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextLogger.ts
@@ -31,8 +31,7 @@ export class TaskContextLogger implements Logger {
 
     public debug(...args: string[]): void {
         const message = args.join(" ");
-        this.context.logs.write({ taskName: this.task.name, level: LogLevel.Debug, message });
-        this.writeToConsoleInCI(LogLevel.Debug, message);
+        this.writeLog({ level: LogLevel.Debug, message });
 
         if (this.shouldLogToTask(LogLevel.Debug)) {
             if (this.task.logs == null) {
@@ -44,8 +43,7 @@ export class TaskContextLogger implements Logger {
 
     public info(...args: string[]): void {
         const message = args.join(" ");
-        this.context.logs.write({ taskName: this.task.name, level: LogLevel.Info, message });
-        this.writeToConsoleInCI(LogLevel.Info, message);
+        this.writeLog({ level: LogLevel.Info, message });
 
         if (this.shouldLogToTask(LogLevel.Info)) {
             if (this.task.logs == null) {
@@ -58,8 +56,7 @@ export class TaskContextLogger implements Logger {
 
     public warn(...args: string[]): void {
         const message = args.join(" ");
-        this.context.logs.write({ taskName: this.task.name, level: LogLevel.Warn, message });
-        this.writeToConsoleInCI(LogLevel.Warn, message);
+        this.writeLog({ level: LogLevel.Warn, message });
 
         if (this.shouldLogToTask(LogLevel.Warn)) {
             if (this.task.logs == null) {
@@ -71,8 +68,7 @@ export class TaskContextLogger implements Logger {
 
     public error(...args: string[]): void {
         const message = args.join(" ");
-        this.context.logs.write({ taskName: this.task.name, level: LogLevel.Error, message });
-        this.writeToConsoleInCI(LogLevel.Error, message);
+        this.writeLog({ level: LogLevel.Error, message });
 
         if (this.shouldLogToTask(LogLevel.Error)) {
             this.collectedErrors.push(message);
@@ -101,10 +97,12 @@ export class TaskContextLogger implements Logger {
     }
 
     /**
-     * In CI / non-TTY environments, write logs directly to stderr so they
-     * are visible in CI runner output rather than hidden in a log file.
+     * Write a log entry to the log file. In CI / non-TTY environments,
+     * also write directly to stderr so logs are visible in CI runner output.
      */
-    private writeToConsoleInCI(level: LogLevel, message: string): void {
+    private writeLog({ level, message }: { level: LogLevel; message: string }): void {
+        this.context.logs.write({ taskName: this.task.name, level, message });
+
         if (this.context.isTTY) {
             return;
         }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,15 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.91.0
-  changelogEntry:
-    - summary: |
-        Surface all task logs directly in the console in CI / non-TTY environments.
-        Previously, logs were only written to a cached log file. Now when running
-        in CI (e.g. `CI=true`), logs are streamed to stderr in real-time with the
-        format `[taskName]: message` for easier diagnosis in CI runners.
-      type: feat
-  createdAt: "2026-02-26"
-  irVersion: 65
-
 - version: 3.90.1
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.91.0
+  changelogEntry:
+    - summary: |
+        Surface all task logs directly in the console in CI / non-TTY environments.
+        Previously, logs were only written to a cached log file. Now when running
+        in CI (e.g. `CI=true`), logs are streamed to stderr in real-time with the
+        format `[taskName]: message` for easier diagnosis in CI runners.
+      type: feat
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 3.90.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Linear ticket: Closes [FER-8569](https://linear.app/buildwithfern/issue/FER-8569/cli-v2-the-cli-should-include-all-logs-in-the-console-in-ci)

In CI / non-TTY environments, the CLI v2 now streams all task logs directly to stderr in real-time with `[taskName]: message` format, rather than hiding them behind a cached log file path.

**Before (CI):**
```
◆ Generating SDK
  org: amckinney

✓ Successfully generated SDK in 12.3s

Logs written to: /Users/alex/.cache/fern/v1/logs/2026-02-10T22-32-13-400Z.log
```

**After (CI):**
```
◆ Generating SDK
  org: amckinney

[go]: Detecting air-gapped mode by checking connectivity to ...
[go]: fernapi/fern-go-sdk Network check succeeded
[go]: fernapi/fern-go-sdk Uploading source files ...
```

* Link to Devin run: https://app.devin.ai/sessions/cd6c71950e5941829c77b0c7f9796bc0