### PR TITLE
feat(cli): Add `fern sdk update` command to CLI v2

### DIFF
--- a/packages/cli/cli-v2/src/commands/sdk/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/command.ts
@@ -3,7 +3,8 @@ import type { GlobalArgs } from "../../context/GlobalArgs.js";
 import { commandGroup } from "../_internal/commandGroup.js";
 import { addAddCommand } from "./add/index.js";
 import { addGenerateCommand } from "./generate/index.js";
+import { addUpdateCommand } from "./update/index.js";
 
 export function addSdkCommand(cli: Argv<GlobalArgs>): void {
-    commandGroup(cli, "sdk", "Configure and generate SDKs", [addAddCommand, addGenerateCommand]);
+    commandGroup(cli, "sdk", "Configure and generate SDKs", [addAddCommand, addGenerateCommand, addUpdateCommand]);
 }

--- a/packages/cli/cli-v2/src/commands/sdk/update/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/update/command.ts
@@ -1,18 +1,16 @@
-import { getLatestGeneratorVersion } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import chalk from "chalk";
-import { readFile, writeFile } from "fs/promises";
+import { readFile } from "fs/promises";
 import inquirer from "inquirer";
-import { type Document, type Pair, parseDocument, Scalar, YAMLMap } from "yaml";
+import { parseDocument } from "yaml";
 import type { Argv } from "yargs";
 import { FERN_YML_FILENAME, REF_KEY } from "../../../config/fern-yml/constants.js";
 import type { Context } from "../../../context/Context.js";
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { CliError } from "../../../errors/CliError.js";
 import { LANGUAGE_TO_DOCKER_IMAGE } from "../../../sdk/config/converter/constants.js";
-import { LANGUAGE_DISPLAY_NAMES, LANGUAGES, type Language } from "../../../sdk/config/Language.js";
+import { SdkUpdater } from "../../../sdk/updater/SdkUpdater.js";
 import { Icons } from "../../../ui/format.js";
-import { Version } from "../../../version.js";
 import { command } from "../../_internal/command.js";
 
 const CHANGELOG_URLS: Record<string, string> = {
@@ -26,37 +24,16 @@ const CHANGELOG_URLS: Record<string, string> = {
     "fernapi/fern-swift-sdk": "https://buildwithfern.com/learn/sdks/generators/swift/changelog"
 };
 
-interface TargetUpdate {
-    name: string;
-    language: Language;
-    image: string;
-    currentVersion: string;
-    latestVersion: string;
-}
-
-interface TargetUpToDate {
-    name: string;
-    language: Language;
-    version: string;
-}
-
-interface SkippedMajorUpgrade {
-    name: string;
-    language: Language;
-    currentVersion: string;
-    latestMajorVersion: string;
-}
-
 export declare namespace UpdateCommand {
     export interface Args extends GlobalArgs {
         /** The SDK target to update (e.g. typescript, python, go). */
         target?: string;
 
         /** Include major version upgrades. */
-        "include-major": boolean;
+        major: boolean;
 
-        /** Release channel (e.g. ga, rc). */
-        channel?: string;
+        /** Include pre-release versions (RC, alpha, beta, etc.). */
+        prerelease: boolean;
 
         /** Accept all defaults (non-interactive mode). */
         yes: boolean;
@@ -74,50 +51,32 @@ export class UpdateCommand {
             });
         }
 
-        const channel = this.parseChannel(args.channel);
-
-        const { targetsFilePath, document, targetsPath } = await this.resolveTargetsDocument(fernYmlPath);
-
-        const targetsNode = document.getIn(targetsPath);
-        if (targetsNode == null) {
+        const targets = workspace.sdks?.targets;
+        if (targets == null || targets.length === 0) {
             context.stderr.info(chalk.dim("No SDK targets found in configuration."));
             return;
         }
 
-        // Collect all target entries from the YAML document.
-        const targetEntries = this.collectTargetEntries({ document, targetsPath, targetFilter: args.target });
-        if (targetEntries.length === 0) {
+        const updater = new SdkUpdater({ context });
+
+        // Collect eligible target entries from the workspace.
+        const entries = updater.collectTargetEntries({ targets, targetFilter: args.target });
+        if (entries.length === 0) {
             if (args.target != null) {
                 throw new CliError({
                     message: `Target '${args.target}' not found in ${FERN_YML_FILENAME}.`
                 });
             }
-            context.stderr.info(chalk.dim("No SDK targets found in configuration."));
+            context.stderr.info(chalk.dim("No SDK targets with pinned versions found."));
             return;
         }
 
         // Resolve the latest versions for each target.
-        const updates: TargetUpdate[] = [];
-        const upToDate: TargetUpToDate[] = [];
-        const skippedMajorUpgrades: SkippedMajorUpgrade[] = [];
-
-        for (const entry of targetEntries) {
-            const result = await this.resolveTargetUpdate({
-                context,
-                entry,
-                includeMajor: args["include-major"],
-                channel
-            });
-            if (result.update != null) {
-                updates.push(result.update);
-            }
-            if (result.upToDate != null) {
-                upToDate.push(result.upToDate);
-            }
-            if (result.skippedMajor != null) {
-                skippedMajorUpgrades.push(result.skippedMajor);
-            }
-        }
+        const { updates, upToDate, skippedMajorUpgrades } = await updater.resolveUpdates({
+            entries,
+            includeMajor: args.major,
+            prerelease: args.prerelease
+        });
 
         if (updates.length === 0) {
             this.printUpToDate({ context, upToDate });
@@ -133,12 +92,11 @@ export class UpdateCommand {
             return;
         }
 
-        // Apply the selected updates to the YAML document.
-        for (const update of selectedUpdates) {
-            document.setIn([...targetsPath, update.name, "version"], update.latestVersion);
-        }
+        // Resolve the targets file path (handles $ref).
+        const { targetsFilePath, targetsPath } = await this.resolveTargetsFile(fernYmlPath);
 
-        await writeFile(targetsFilePath, document.toString(), "utf-8");
+        // Apply the selected updates atomically (all-or-nothing).
+        await updater.applyUpdates({ targetsFilePath, targetsPath, updates: selectedUpdates });
 
         // Print the results.
         this.printAppliedUpdates({ context, updates: selectedUpdates });
@@ -146,175 +104,21 @@ export class UpdateCommand {
         this.printSkippedMajorUpgrades({ context, skippedMajorUpgrades });
     }
 
-    private collectTargetEntries({
-        document,
-        targetsPath,
-        targetFilter
+    private async promptForUpdates({
+        updates
     }: {
-        document: Document;
-        targetsPath: string[];
-        targetFilter: string | undefined;
-    }): Array<{ name: string; language: Language; image: string; currentVersion: string }> {
-        const entries: Array<{ name: string; language: Language; image: string; currentVersion: string }> = [];
-        const targetsNode = document.getIn(targetsPath);
-        if (targetsNode == null || typeof targetsNode !== "object") {
-            return entries;
-        }
-
-        // targetsNode is a YAML map; iterate over its entries.
-        const targetsObj = document.getIn(targetsPath, true);
-        if (!(targetsObj instanceof YAMLMap)) {
-            return entries;
-        }
-        for (const item of targetsObj.items as Pair<Scalar<string>>[]) {
-            const name = item.key.value;
-
-            if (targetFilter != null && name !== targetFilter) {
-                continue;
-            }
-
-            const language = this.resolveLanguage(name, document, targetsPath);
-            if (language == null) {
-                continue;
-            }
-
-            const image = LANGUAGE_TO_DOCKER_IMAGE[language];
-            const currentVersion = this.resolveCurrentVersion(document, targetsPath, name);
-            if (currentVersion == null) {
-                // Skip targets without an explicit version (using "latest").
-                continue;
-            }
-
-            entries.push({ name, language, image, currentVersion });
-        }
-
-        return entries;
-    }
-
-    private resolveLanguage(name: string, document: Document, targetsPath: string[]): Language | undefined {
-        // Check explicit lang property first.
-        const lang = document.getIn([...targetsPath, name, "lang"]) as string | undefined;
-        if (lang != null && LANGUAGES.includes(lang as Language)) {
-            return lang as Language;
-        }
-
-        // Check explicit image property.
-        const image = document.getIn([...targetsPath, name, "image"]) as string | undefined;
-        if (image != null) {
-            for (const [language, dockerImage] of Object.entries(LANGUAGE_TO_DOCKER_IMAGE)) {
-                if (image === dockerImage || image.startsWith(`${dockerImage}:`)) {
-                    return language as Language;
-                }
-            }
-        }
-
-        // Fall back to name matching.
-        if (LANGUAGES.includes(name as Language)) {
-            return name as Language;
-        }
-
-        return undefined;
-    }
-
-    private resolveCurrentVersion(document: Document, targetsPath: string[], name: string): string | undefined {
-        const version = document.getIn([...targetsPath, name, "version"]) as string | undefined;
-        if (version == null || version === "latest") {
-            return undefined;
-        }
-        return version;
-    }
-
-    private async resolveTargetUpdate({
-        context,
-        entry,
-        includeMajor,
-        channel
-    }: {
-        context: Context;
-        entry: { name: string; language: Language; image: string; currentVersion: string };
-        includeMajor: boolean;
-        channel: "GA" | "RC" | undefined;
-    }): Promise<{
-        update?: TargetUpdate;
-        upToDate?: TargetUpToDate;
-        skippedMajor?: SkippedMajorUpgrade;
-    }> {
-        const latestVersion = await getLatestGeneratorVersion({
-            generatorName: entry.image,
-            cliVersion: Version,
-            currentGeneratorVersion: entry.currentVersion,
-            channel,
-            includeMajor
-        });
-
-        let update: TargetUpdate | undefined;
-        let upToDate: TargetUpToDate | undefined;
-        let skippedMajor: SkippedMajorUpgrade | undefined;
-
-        if (latestVersion != null && latestVersion !== entry.currentVersion) {
-            update = {
-                name: entry.name,
-                language: entry.language,
-                image: entry.image,
-                currentVersion: entry.currentVersion,
-                latestVersion
-            };
-        } else {
-            upToDate = {
-                name: entry.name,
-                language: entry.language,
-                version: entry.currentVersion
-            };
-        }
-
-        // Check for skipped major upgrades.
-        if (!includeMajor) {
-            const latestMajorVersion = await getLatestGeneratorVersion({
-                generatorName: entry.image,
-                cliVersion: Version,
-                currentGeneratorVersion: latestVersion ?? entry.currentVersion,
-                channel,
-                includeMajor: true
-            });
-
-            if (latestMajorVersion != null) {
-                const currentMajor = this.parseMajorVersion(latestVersion ?? entry.currentVersion);
-                const latestMajor = this.parseMajorVersion(latestMajorVersion);
-
-                if (currentMajor != null && latestMajor != null && latestMajor > currentMajor) {
-                    skippedMajor = {
-                        name: entry.name,
-                        language: entry.language,
-                        currentVersion: latestVersion ?? entry.currentVersion,
-                        latestMajorVersion
-                    };
-                }
-            }
-        }
-
-        return { update, upToDate, skippedMajor };
-    }
-
-    private parseMajorVersion(version: string): number | undefined {
-        const match = /^(\d+)\./.exec(version);
-        if (match?.[1] == null) {
-            return undefined;
-        }
-        return parseInt(match[1], 10);
-    }
-
-    private async promptForUpdates({ updates }: { updates: TargetUpdate[] }): Promise<TargetUpdate[]> {
+        updates: SdkUpdater.TargetUpdate[];
+    }): Promise<SdkUpdater.TargetUpdate[]> {
         if (updates.length === 1) {
             const update = updates[0];
             if (update == null) {
                 return [];
             }
-            const displayName = LANGUAGE_DISPLAY_NAMES[update.language] ?? update.name;
             const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
                 {
                     type: "confirm",
                     name: "confirm",
-                    message: `Update ${displayName} from ${chalk.dim(update.currentVersion)} to ${chalk.green(update.latestVersion)}?`,
+                    message: `Update ${update.name} from ${chalk.dim(update.currentVersion)} to ${chalk.green(update.latestVersion)}?`,
                     default: true
                 }
             ]);
@@ -326,21 +130,18 @@ export class UpdateCommand {
                 type: "checkbox",
                 name: "selected",
                 message: "Select targets to update:",
-                choices: updates.map((update) => {
-                    const displayName = LANGUAGE_DISPLAY_NAMES[update.language] ?? update.name;
-                    return {
-                        name: `${displayName}: ${chalk.dim(update.currentVersion)} ${chalk.white("→")} ${chalk.green(update.latestVersion)}`,
-                        value: update.name,
-                        checked: true
-                    };
-                })
+                choices: updates.map((update) => ({
+                    name: `${update.name}: ${chalk.dim(update.currentVersion)} ${chalk.white("\u2192")} ${chalk.green(update.latestVersion)}`,
+                    value: update.name,
+                    checked: true
+                }))
             }
         ]);
 
         return updates.filter((u) => selected.includes(u.name));
     }
 
-    private printAppliedUpdates({ context, updates }: { context: Context; updates: TargetUpdate[] }): void {
+    private printAppliedUpdates({ context, updates }: { context: Context; updates: SdkUpdater.TargetUpdate[] }): void {
         if (updates.length === 0) {
             return;
         }
@@ -349,9 +150,8 @@ export class UpdateCommand {
         context.stderr.info(`${Icons.success} ${chalk.green("Updated SDK targets:")}`);
 
         for (const update of updates) {
-            const displayName = LANGUAGE_DISPLAY_NAMES[update.language] ?? update.name;
             context.stderr.info(
-                chalk.green(`  ${displayName}: ${chalk.dim(update.currentVersion)} → ${update.latestVersion}`)
+                chalk.green(`  ${update.name}: ${chalk.dim(update.currentVersion)} \u2192 ${update.latestVersion}`)
             );
             const changelogUrl = CHANGELOG_URLS[update.image];
             if (changelogUrl != null) {
@@ -360,7 +160,7 @@ export class UpdateCommand {
         }
     }
 
-    private printUpToDate({ context, upToDate }: { context: Context; upToDate: TargetUpToDate[] }): void {
+    private printUpToDate({ context, upToDate }: { context: Context; upToDate: SdkUpdater.TargetUpToDate[] }): void {
         if (upToDate.length === 0) {
             return;
         }
@@ -369,8 +169,7 @@ export class UpdateCommand {
         context.stderr.info(chalk.dim("Already on latest version:"));
 
         for (const item of upToDate) {
-            const displayName = LANGUAGE_DISPLAY_NAMES[item.language] ?? item.name;
-            context.stderr.info(chalk.dim(`  ${displayName}: ${item.version} (latest)`));
+            context.stderr.info(chalk.dim(`  ${item.name}: ${item.version} (latest)`));
         }
     }
 
@@ -379,7 +178,7 @@ export class UpdateCommand {
         skippedMajorUpgrades
     }: {
         context: Context;
-        skippedMajorUpgrades: SkippedMajorUpgrade[];
+        skippedMajorUpgrades: SdkUpdater.SkippedMajorUpgrade[];
     }): void {
         if (skippedMajorUpgrades.length === 0) {
             return;
@@ -389,26 +188,34 @@ export class UpdateCommand {
         context.stderr.info(chalk.yellow("Major version upgrades available:"));
 
         for (const upgrade of skippedMajorUpgrades) {
-            const displayName = LANGUAGE_DISPLAY_NAMES[upgrade.language] ?? upgrade.name;
             context.stderr.info(
-                chalk.yellow(`  ${displayName}: ${upgrade.currentVersion} → ${upgrade.latestMajorVersion}`)
+                chalk.yellow(`  ${upgrade.name}: ${upgrade.currentVersion} \u2192 ${upgrade.latestMajorVersion}`)
             );
-            const changelogUrl = CHANGELOG_URLS[LANGUAGE_TO_DOCKER_IMAGE[upgrade.language]];
-            if (changelogUrl != null) {
-                context.stderr.info(chalk.yellow(`    Changelog: ${changelogUrl}`));
+            const image = this.findImageForTarget(upgrade.name);
+            if (image != null) {
+                const changelogUrl = CHANGELOG_URLS[image];
+                if (changelogUrl != null) {
+                    context.stderr.info(chalk.yellow(`    Changelog: ${changelogUrl}`));
+                }
             }
-            context.stderr.info(chalk.yellow(`    Run: fern sdk update --target ${upgrade.name} --include-major`));
+            context.stderr.info(chalk.yellow(`    Run: fern sdk update --target ${upgrade.name} --major`));
         }
     }
 
+    private findImageForTarget(name: string): string | undefined {
+        const language = name as keyof typeof LANGUAGE_TO_DOCKER_IMAGE;
+        return LANGUAGE_TO_DOCKER_IMAGE[language];
+    }
+
     /**
-     * Resolves the file that contains the `targets` key and the YAML path to it.
+     * Resolves the file that actually contains the `targets` key.
      *
-     * If the `sdks` value in fern.yml is a `$ref`, follows the reference.
+     * If the `sdks` value in fern.yml is a `$ref`, we follow it and return
+     * the referenced file's path instead.
      */
-    private async resolveTargetsDocument(
+    private async resolveTargetsFile(
         fernYmlPath: AbsoluteFilePath
-    ): Promise<{ targetsFilePath: AbsoluteFilePath; document: Document; targetsPath: string[] }> {
+    ): Promise<{ targetsFilePath: AbsoluteFilePath; targetsPath: string[] }> {
         const content = await readFile(fernYmlPath, "utf-8");
         const document = parseDocument(content);
         const doc = document.toJS() as Record<string, unknown>;
@@ -426,30 +233,12 @@ export class UpdateCommand {
             if (typeof refPath === "string") {
                 const resolvedPath = join(dirname(fernYmlPath), RelativeFilePath.of(refPath));
                 if (await doesPathExist(resolvedPath)) {
-                    const refContent = await readFile(resolvedPath, "utf-8");
-                    const refDocument = parseDocument(refContent);
-                    return { targetsFilePath: resolvedPath, document: refDocument, targetsPath: ["targets"] };
+                    return { targetsFilePath: resolvedPath, targetsPath: ["targets"] };
                 }
             }
         }
 
-        return { targetsFilePath: fernYmlPath, document, targetsPath: ["sdks", "targets"] };
-    }
-
-    private parseChannel(channel: string | undefined): "GA" | "RC" | undefined {
-        if (channel == null) {
-            return undefined;
-        }
-        switch (channel) {
-            case "ga":
-                return "GA";
-            case "rc":
-                return "RC";
-            default:
-                throw new CliError({
-                    message: `Unknown channel "${channel}". Supported: ga, rc`
-                });
-        }
+        return { targetsFilePath: fernYmlPath, targetsPath: ["sdks", "targets"] };
     }
 }
 
@@ -466,14 +255,15 @@ export function addUpdateCommand(cli: Argv<GlobalArgs>, parentPath?: string): vo
                     type: "string",
                     description: "The SDK target to update (e.g. typescript, python, go)"
                 })
-                .option("include-major", {
+                .option("major", {
                     type: "boolean",
                     default: false,
                     description: "Include major version upgrades"
                 })
-                .option("channel", {
-                    type: "string",
-                    description: "Release channel (ga, rc)"
+                .option("prerelease", {
+                    type: "boolean",
+                    default: false,
+                    description: "Include pre-release versions (RC, alpha, beta, etc.)"
                 })
                 .option("yes", {
                     type: "boolean",

--- a/packages/cli/cli-v2/src/commands/sdk/update/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/update/command.ts
@@ -3,7 +3,7 @@ import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath } from
 import chalk from "chalk";
 import { readFile, writeFile } from "fs/promises";
 import inquirer from "inquirer";
-import { type Document, parseDocument } from "yaml";
+import { type Document, type Pair, parseDocument, Scalar, YAMLMap } from "yaml";
 import type { Argv } from "yargs";
 import { FERN_YML_FILENAME, REF_KEY } from "../../../config/fern-yml/constants.js";
 import type { Context } from "../../../context/Context.js";
@@ -126,8 +126,7 @@ export class UpdateCommand {
         }
 
         // In interactive mode, let the user choose which targets to update.
-        const selectedUpdates =
-            !context.isTTY || args.yes ? updates : await this.promptForUpdates({ updates });
+        const selectedUpdates = !context.isTTY || args.yes ? updates : await this.promptForUpdates({ updates });
 
         if (selectedUpdates.length === 0) {
             context.stderr.info(chalk.dim("No targets selected for update."));
@@ -164,15 +163,11 @@ export class UpdateCommand {
 
         // targetsNode is a YAML map; iterate over its entries.
         const targetsObj = document.getIn(targetsPath, true);
-        if (targetsObj == null || !("items" in (targetsObj as object))) {
+        if (!(targetsObj instanceof YAMLMap)) {
             return entries;
         }
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const yamlMap = targetsObj as any;
-        for (const item of yamlMap.items) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const name = (item.key as any).value as string;
+        for (const item of targetsObj.items as Pair<Scalar<string>>[]) {
+            const name = item.key.value;
 
             if (targetFilter != null && name !== targetFilter) {
                 continue;
@@ -345,13 +340,7 @@ export class UpdateCommand {
         return updates.filter((u) => selected.includes(u.name));
     }
 
-    private printAppliedUpdates({
-        context,
-        updates
-    }: {
-        context: Context;
-        updates: TargetUpdate[];
-    }): void {
+    private printAppliedUpdates({ context, updates }: { context: Context; updates: TargetUpdate[] }): void {
         if (updates.length === 0) {
             return;
         }
@@ -371,13 +360,7 @@ export class UpdateCommand {
         }
     }
 
-    private printUpToDate({
-        context,
-        upToDate
-    }: {
-        context: Context;
-        upToDate: TargetUpToDate[];
-    }): void {
+    private printUpToDate({ context, upToDate }: { context: Context; upToDate: TargetUpToDate[] }): void {
         if (upToDate.length === 0) {
             return;
         }
@@ -414,9 +397,7 @@ export class UpdateCommand {
             if (changelogUrl != null) {
                 context.stderr.info(chalk.yellow(`    Changelog: ${changelogUrl}`));
             }
-            context.stderr.info(
-                chalk.yellow(`    Run: fern sdk update --target ${upgrade.name} --include-major`)
-            );
+            context.stderr.info(chalk.yellow(`    Run: fern sdk update --target ${upgrade.name} --include-major`));
         }
     }
 

--- a/packages/cli/cli-v2/src/commands/sdk/update/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/update/command.ts
@@ -1,0 +1,505 @@
+import { getLatestGeneratorVersion } from "@fern-api/configuration-loader";
+import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import chalk from "chalk";
+import { readFile, writeFile } from "fs/promises";
+import inquirer from "inquirer";
+import { type Document, parseDocument } from "yaml";
+import type { Argv } from "yargs";
+import { FERN_YML_FILENAME, REF_KEY } from "../../../config/fern-yml/constants.js";
+import type { Context } from "../../../context/Context.js";
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { CliError } from "../../../errors/CliError.js";
+import { LANGUAGE_TO_DOCKER_IMAGE } from "../../../sdk/config/converter/constants.js";
+import { LANGUAGE_DISPLAY_NAMES, LANGUAGES, type Language } from "../../../sdk/config/Language.js";
+import { Icons } from "../../../ui/format.js";
+import { Version } from "../../../version.js";
+import { command } from "../../_internal/command.js";
+
+const CHANGELOG_URLS: Record<string, string> = {
+    "fernapi/fern-typescript-sdk": "https://buildwithfern.com/learn/sdks/generators/typescript/changelog",
+    "fernapi/fern-python-sdk": "https://buildwithfern.com/learn/sdks/generators/python/changelog",
+    "fernapi/fern-go-sdk": "https://buildwithfern.com/learn/sdks/generators/go/changelog",
+    "fernapi/fern-java-sdk": "https://buildwithfern.com/learn/sdks/generators/java/changelog",
+    "fernapi/fern-csharp-sdk": "https://buildwithfern.com/learn/sdks/generators/csharp/changelog",
+    "fernapi/fern-php-sdk": "https://buildwithfern.com/learn/sdks/generators/php/changelog",
+    "fernapi/fern-ruby-sdk": "https://buildwithfern.com/learn/sdks/generators/ruby/changelog",
+    "fernapi/fern-swift-sdk": "https://buildwithfern.com/learn/sdks/generators/swift/changelog"
+};
+
+interface TargetUpdate {
+    name: string;
+    language: Language;
+    image: string;
+    currentVersion: string;
+    latestVersion: string;
+}
+
+interface TargetUpToDate {
+    name: string;
+    language: Language;
+    version: string;
+}
+
+interface SkippedMajorUpgrade {
+    name: string;
+    language: Language;
+    currentVersion: string;
+    latestMajorVersion: string;
+}
+
+export declare namespace UpdateCommand {
+    export interface Args extends GlobalArgs {
+        /** The SDK target to update (e.g. typescript, python, go). */
+        target?: string;
+
+        /** Include major version upgrades. */
+        "include-major": boolean;
+
+        /** Release channel (e.g. ga, rc). */
+        channel?: string;
+
+        /** Accept all defaults (non-interactive mode). */
+        yes: boolean;
+    }
+}
+
+export class UpdateCommand {
+    public async handle(context: Context, args: UpdateCommand.Args): Promise<void> {
+        const workspace = await context.loadWorkspaceOrThrow();
+
+        const fernYmlPath = workspace.absoluteFilePath;
+        if (fernYmlPath == null) {
+            throw new CliError({
+                message: `No ${FERN_YML_FILENAME} found. Run 'fern init' to initialize a project.`
+            });
+        }
+
+        const channel = this.parseChannel(args.channel);
+
+        const { targetsFilePath, document, targetsPath } = await this.resolveTargetsDocument(fernYmlPath);
+
+        const targetsNode = document.getIn(targetsPath);
+        if (targetsNode == null) {
+            context.stderr.info(chalk.dim("No SDK targets found in configuration."));
+            return;
+        }
+
+        // Collect all target entries from the YAML document.
+        const targetEntries = this.collectTargetEntries({ document, targetsPath, targetFilter: args.target });
+        if (targetEntries.length === 0) {
+            if (args.target != null) {
+                throw new CliError({
+                    message: `Target '${args.target}' not found in ${FERN_YML_FILENAME}.`
+                });
+            }
+            context.stderr.info(chalk.dim("No SDK targets found in configuration."));
+            return;
+        }
+
+        // Resolve the latest versions for each target.
+        const updates: TargetUpdate[] = [];
+        const upToDate: TargetUpToDate[] = [];
+        const skippedMajorUpgrades: SkippedMajorUpgrade[] = [];
+
+        for (const entry of targetEntries) {
+            const result = await this.resolveTargetUpdate({
+                context,
+                entry,
+                includeMajor: args["include-major"],
+                channel
+            });
+            if (result.update != null) {
+                updates.push(result.update);
+            }
+            if (result.upToDate != null) {
+                upToDate.push(result.upToDate);
+            }
+            if (result.skippedMajor != null) {
+                skippedMajorUpgrades.push(result.skippedMajor);
+            }
+        }
+
+        if (updates.length === 0) {
+            this.printUpToDate({ context, upToDate });
+            this.printSkippedMajorUpgrades({ context, skippedMajorUpgrades });
+            return;
+        }
+
+        // In interactive mode, let the user choose which targets to update.
+        const selectedUpdates =
+            !context.isTTY || args.yes ? updates : await this.promptForUpdates({ updates });
+
+        if (selectedUpdates.length === 0) {
+            context.stderr.info(chalk.dim("No targets selected for update."));
+            return;
+        }
+
+        // Apply the selected updates to the YAML document.
+        for (const update of selectedUpdates) {
+            document.setIn([...targetsPath, update.name, "version"], update.latestVersion);
+        }
+
+        await writeFile(targetsFilePath, document.toString(), "utf-8");
+
+        // Print the results.
+        this.printAppliedUpdates({ context, updates: selectedUpdates });
+        this.printUpToDate({ context, upToDate });
+        this.printSkippedMajorUpgrades({ context, skippedMajorUpgrades });
+    }
+
+    private collectTargetEntries({
+        document,
+        targetsPath,
+        targetFilter
+    }: {
+        document: Document;
+        targetsPath: string[];
+        targetFilter: string | undefined;
+    }): Array<{ name: string; language: Language; image: string; currentVersion: string }> {
+        const entries: Array<{ name: string; language: Language; image: string; currentVersion: string }> = [];
+        const targetsNode = document.getIn(targetsPath);
+        if (targetsNode == null || typeof targetsNode !== "object") {
+            return entries;
+        }
+
+        // targetsNode is a YAML map; iterate over its entries.
+        const targetsObj = document.getIn(targetsPath, true);
+        if (targetsObj == null || !("items" in (targetsObj as object))) {
+            return entries;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const yamlMap = targetsObj as any;
+        for (const item of yamlMap.items) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const name = (item.key as any).value as string;
+
+            if (targetFilter != null && name !== targetFilter) {
+                continue;
+            }
+
+            const language = this.resolveLanguage(name, document, targetsPath);
+            if (language == null) {
+                continue;
+            }
+
+            const image = LANGUAGE_TO_DOCKER_IMAGE[language];
+            const currentVersion = this.resolveCurrentVersion(document, targetsPath, name);
+            if (currentVersion == null) {
+                // Skip targets without an explicit version (using "latest").
+                continue;
+            }
+
+            entries.push({ name, language, image, currentVersion });
+        }
+
+        return entries;
+    }
+
+    private resolveLanguage(name: string, document: Document, targetsPath: string[]): Language | undefined {
+        // Check explicit lang property first.
+        const lang = document.getIn([...targetsPath, name, "lang"]) as string | undefined;
+        if (lang != null && LANGUAGES.includes(lang as Language)) {
+            return lang as Language;
+        }
+
+        // Check explicit image property.
+        const image = document.getIn([...targetsPath, name, "image"]) as string | undefined;
+        if (image != null) {
+            for (const [language, dockerImage] of Object.entries(LANGUAGE_TO_DOCKER_IMAGE)) {
+                if (image === dockerImage || image.startsWith(`${dockerImage}:`)) {
+                    return language as Language;
+                }
+            }
+        }
+
+        // Fall back to name matching.
+        if (LANGUAGES.includes(name as Language)) {
+            return name as Language;
+        }
+
+        return undefined;
+    }
+
+    private resolveCurrentVersion(document: Document, targetsPath: string[], name: string): string | undefined {
+        const version = document.getIn([...targetsPath, name, "version"]) as string | undefined;
+        if (version == null || version === "latest") {
+            return undefined;
+        }
+        return version;
+    }
+
+    private async resolveTargetUpdate({
+        context,
+        entry,
+        includeMajor,
+        channel
+    }: {
+        context: Context;
+        entry: { name: string; language: Language; image: string; currentVersion: string };
+        includeMajor: boolean;
+        channel: "GA" | "RC" | undefined;
+    }): Promise<{
+        update?: TargetUpdate;
+        upToDate?: TargetUpToDate;
+        skippedMajor?: SkippedMajorUpgrade;
+    }> {
+        const latestVersion = await getLatestGeneratorVersion({
+            generatorName: entry.image,
+            cliVersion: Version,
+            currentGeneratorVersion: entry.currentVersion,
+            channel,
+            includeMajor
+        });
+
+        let update: TargetUpdate | undefined;
+        let upToDate: TargetUpToDate | undefined;
+        let skippedMajor: SkippedMajorUpgrade | undefined;
+
+        if (latestVersion != null && latestVersion !== entry.currentVersion) {
+            update = {
+                name: entry.name,
+                language: entry.language,
+                image: entry.image,
+                currentVersion: entry.currentVersion,
+                latestVersion
+            };
+        } else {
+            upToDate = {
+                name: entry.name,
+                language: entry.language,
+                version: entry.currentVersion
+            };
+        }
+
+        // Check for skipped major upgrades.
+        if (!includeMajor) {
+            const latestMajorVersion = await getLatestGeneratorVersion({
+                generatorName: entry.image,
+                cliVersion: Version,
+                currentGeneratorVersion: latestVersion ?? entry.currentVersion,
+                channel,
+                includeMajor: true
+            });
+
+            if (latestMajorVersion != null) {
+                const currentMajor = this.parseMajorVersion(latestVersion ?? entry.currentVersion);
+                const latestMajor = this.parseMajorVersion(latestMajorVersion);
+
+                if (currentMajor != null && latestMajor != null && latestMajor > currentMajor) {
+                    skippedMajor = {
+                        name: entry.name,
+                        language: entry.language,
+                        currentVersion: latestVersion ?? entry.currentVersion,
+                        latestMajorVersion
+                    };
+                }
+            }
+        }
+
+        return { update, upToDate, skippedMajor };
+    }
+
+    private parseMajorVersion(version: string): number | undefined {
+        const match = /^(\d+)\./.exec(version);
+        if (match?.[1] == null) {
+            return undefined;
+        }
+        return parseInt(match[1], 10);
+    }
+
+    private async promptForUpdates({ updates }: { updates: TargetUpdate[] }): Promise<TargetUpdate[]> {
+        if (updates.length === 1) {
+            const update = updates[0];
+            if (update == null) {
+                return [];
+            }
+            const displayName = LANGUAGE_DISPLAY_NAMES[update.language] ?? update.name;
+            const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+                {
+                    type: "confirm",
+                    name: "confirm",
+                    message: `Update ${displayName} from ${chalk.dim(update.currentVersion)} to ${chalk.green(update.latestVersion)}?`,
+                    default: true
+                }
+            ]);
+            return confirm ? [update] : [];
+        }
+
+        const { selected } = await inquirer.prompt<{ selected: string[] }>([
+            {
+                type: "checkbox",
+                name: "selected",
+                message: "Select targets to update:",
+                choices: updates.map((update) => {
+                    const displayName = LANGUAGE_DISPLAY_NAMES[update.language] ?? update.name;
+                    return {
+                        name: `${displayName}: ${chalk.dim(update.currentVersion)} ${chalk.white("→")} ${chalk.green(update.latestVersion)}`,
+                        value: update.name,
+                        checked: true
+                    };
+                })
+            }
+        ]);
+
+        return updates.filter((u) => selected.includes(u.name));
+    }
+
+    private printAppliedUpdates({
+        context,
+        updates
+    }: {
+        context: Context;
+        updates: TargetUpdate[];
+    }): void {
+        if (updates.length === 0) {
+            return;
+        }
+
+        context.stderr.info("");
+        context.stderr.info(`${Icons.success} ${chalk.green("Updated SDK targets:")}`);
+
+        for (const update of updates) {
+            const displayName = LANGUAGE_DISPLAY_NAMES[update.language] ?? update.name;
+            context.stderr.info(
+                chalk.green(`  ${displayName}: ${chalk.dim(update.currentVersion)} → ${update.latestVersion}`)
+            );
+            const changelogUrl = CHANGELOG_URLS[update.image];
+            if (changelogUrl != null) {
+                context.stderr.info(chalk.dim(`    Changelog: ${changelogUrl}`));
+            }
+        }
+    }
+
+    private printUpToDate({
+        context,
+        upToDate
+    }: {
+        context: Context;
+        upToDate: TargetUpToDate[];
+    }): void {
+        if (upToDate.length === 0) {
+            return;
+        }
+
+        context.stderr.info("");
+        context.stderr.info(chalk.dim("Already on latest version:"));
+
+        for (const item of upToDate) {
+            const displayName = LANGUAGE_DISPLAY_NAMES[item.language] ?? item.name;
+            context.stderr.info(chalk.dim(`  ${displayName}: ${item.version} (latest)`));
+        }
+    }
+
+    private printSkippedMajorUpgrades({
+        context,
+        skippedMajorUpgrades
+    }: {
+        context: Context;
+        skippedMajorUpgrades: SkippedMajorUpgrade[];
+    }): void {
+        if (skippedMajorUpgrades.length === 0) {
+            return;
+        }
+
+        context.stderr.info("");
+        context.stderr.info(chalk.yellow("Major version upgrades available:"));
+
+        for (const upgrade of skippedMajorUpgrades) {
+            const displayName = LANGUAGE_DISPLAY_NAMES[upgrade.language] ?? upgrade.name;
+            context.stderr.info(
+                chalk.yellow(`  ${displayName}: ${upgrade.currentVersion} → ${upgrade.latestMajorVersion}`)
+            );
+            const changelogUrl = CHANGELOG_URLS[LANGUAGE_TO_DOCKER_IMAGE[upgrade.language]];
+            if (changelogUrl != null) {
+                context.stderr.info(chalk.yellow(`    Changelog: ${changelogUrl}`));
+            }
+            context.stderr.info(
+                chalk.yellow(`    Run: fern sdk update --target ${upgrade.name} --include-major`)
+            );
+        }
+    }
+
+    /**
+     * Resolves the file that contains the `targets` key and the YAML path to it.
+     *
+     * If the `sdks` value in fern.yml is a `$ref`, follows the reference.
+     */
+    private async resolveTargetsDocument(
+        fernYmlPath: AbsoluteFilePath
+    ): Promise<{ targetsFilePath: AbsoluteFilePath; document: Document; targetsPath: string[] }> {
+        const content = await readFile(fernYmlPath, "utf-8");
+        const document = parseDocument(content);
+        const doc = document.toJS() as Record<string, unknown>;
+
+        if (doc == null || typeof doc !== "object") {
+            throw new CliError({
+                message: `Invalid ${FERN_YML_FILENAME}: expected a YAML object; run 'fern init' to initialize a new file.`
+            });
+        }
+
+        // Check if sdks uses a $ref.
+        const sdksValue = doc.sdks;
+        if (sdksValue != null && typeof sdksValue === "object" && REF_KEY in sdksValue) {
+            const refPath = (sdksValue as Record<string, unknown>)[REF_KEY];
+            if (typeof refPath === "string") {
+                const resolvedPath = join(dirname(fernYmlPath), RelativeFilePath.of(refPath));
+                if (await doesPathExist(resolvedPath)) {
+                    const refContent = await readFile(resolvedPath, "utf-8");
+                    const refDocument = parseDocument(refContent);
+                    return { targetsFilePath: resolvedPath, document: refDocument, targetsPath: ["targets"] };
+                }
+            }
+        }
+
+        return { targetsFilePath: fernYmlPath, document, targetsPath: ["sdks", "targets"] };
+    }
+
+    private parseChannel(channel: string | undefined): "GA" | "RC" | undefined {
+        if (channel == null) {
+            return undefined;
+        }
+        switch (channel) {
+            case "ga":
+                return "GA";
+            case "rc":
+                return "RC";
+            default:
+                throw new CliError({
+                    message: `Unknown channel "${channel}". Supported: ga, rc`
+                });
+        }
+    }
+}
+
+export function addUpdateCommand(cli: Argv<GlobalArgs>, parentPath?: string): void {
+    const cmd = new UpdateCommand();
+    command(
+        cli,
+        "update",
+        "Update SDK targets to the latest version",
+        (context, args) => cmd.handle(context, args as UpdateCommand.Args),
+        (yargs) =>
+            yargs
+                .option("target", {
+                    type: "string",
+                    description: "The SDK target to update (e.g. typescript, python, go)"
+                })
+                .option("include-major", {
+                    type: "boolean",
+                    default: false,
+                    description: "Include major version upgrades"
+                })
+                .option("channel", {
+                    type: "string",
+                    description: "Release channel (ga, rc)"
+                })
+                .option("yes", {
+                    type: "boolean",
+                    alias: "y",
+                    description: "Accept all defaults (non-interactive mode)",
+                    default: false
+                }),
+        parentPath
+    );
+}

--- a/packages/cli/cli-v2/src/commands/sdk/update/index.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/update/index.ts
@@ -1,0 +1,1 @@
+export { addUpdateCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/sdk/updater/SdkUpdater.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/SdkUpdater.ts
@@ -1,0 +1,222 @@
+import { getLatestGeneratorVersion } from "@fern-api/configuration-loader";
+import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { readFile, writeFile } from "fs/promises";
+import { parseDocument } from "yaml";
+import type { Context } from "../../context/Context.js";
+import { Version } from "../../version.js";
+import type { Target } from "../config/Target.js";
+
+export namespace SdkUpdater {
+    export interface Config {
+        /** The CLI context. */
+        context: Context;
+    }
+
+    /** A target entry eligible for update resolution. */
+    export interface TargetEntry {
+        /** Target name from fern.yml (e.g. "typescript", "python"). */
+        name: string;
+        /** Resolved Docker image reference. */
+        image: string;
+        /** Current pinned version. */
+        currentVersion: string;
+    }
+
+    /** A target that has a newer version available. */
+    export interface TargetUpdate {
+        name: string;
+        image: string;
+        currentVersion: string;
+        latestVersion: string;
+    }
+
+    /** A target that is already on the latest version. */
+    export interface TargetUpToDate {
+        name: string;
+        version: string;
+    }
+
+    /** A target where a major version upgrade was skipped. */
+    export interface SkippedMajorUpgrade {
+        name: string;
+        currentVersion: string;
+        latestMajorVersion: string;
+    }
+
+    /** The result of resolving updates for all targets. */
+    export interface UpdateResult {
+        updates: TargetUpdate[];
+        upToDate: TargetUpToDate[];
+        skippedMajorUpgrades: SkippedMajorUpgrade[];
+    }
+}
+
+/**
+ * Resolves and applies SDK target version updates.
+ *
+ * The SdkUpdater is responsible for:
+ *  - Collecting eligible targets from the workspace
+ *  - Resolving the latest available version for each target
+ *  - Writing updated versions back to fern.yml (preserving formatting)
+ *
+ * The CLI command layer handles orchestration, interactive prompts, and output formatting.
+ */
+export class SdkUpdater {
+    private readonly context: Context;
+
+    constructor(config: SdkUpdater.Config) {
+        this.context = config.context;
+    }
+
+    /**
+     * Collects target entries from workspace targets that are eligible for update.
+     *
+     * Targets without an explicit version (or set to "latest") are skipped.
+     */
+    public collectTargetEntries({
+        targets,
+        targetFilter
+    }: {
+        targets: Target[];
+        targetFilter: string | undefined;
+    }): SdkUpdater.TargetEntry[] {
+        const entries: SdkUpdater.TargetEntry[] = [];
+        for (const target of targets) {
+            if (targetFilter != null && target.name !== targetFilter) {
+                continue;
+            }
+            if (target.version === "latest" || target.version == null) {
+                continue;
+            }
+            entries.push({
+                name: target.name,
+                image: target.image,
+                currentVersion: target.version
+            });
+        }
+        return entries;
+    }
+
+    /**
+     * Resolves the latest version for each target entry.
+     *
+     * If any target fails to resolve, the entire operation is aborted
+     * (partial failures are a no-op).
+     */
+    public async resolveUpdates({
+        entries,
+        includeMajor,
+        prerelease
+    }: {
+        entries: SdkUpdater.TargetEntry[];
+        includeMajor: boolean;
+        prerelease: boolean;
+    }): Promise<SdkUpdater.UpdateResult> {
+        const channel: "GA" | "RC" | undefined = prerelease ? "RC" : undefined;
+        const updates: SdkUpdater.TargetUpdate[] = [];
+        const upToDate: SdkUpdater.TargetUpToDate[] = [];
+        const skippedMajorUpgrades: SdkUpdater.SkippedMajorUpgrade[] = [];
+
+        for (const entry of entries) {
+            const latestVersion = await getLatestGeneratorVersion({
+                generatorName: entry.image,
+                cliVersion: Version,
+                currentGeneratorVersion: entry.currentVersion,
+                channel,
+                includeMajor
+            });
+
+            if (latestVersion != null && latestVersion !== entry.currentVersion) {
+                updates.push({
+                    name: entry.name,
+                    image: entry.image,
+                    currentVersion: entry.currentVersion,
+                    latestVersion
+                });
+            } else {
+                upToDate.push({
+                    name: entry.name,
+                    version: entry.currentVersion
+                });
+            }
+
+            // Check for skipped major upgrades when not including major.
+            if (!includeMajor) {
+                const latestMajorVersion = await getLatestGeneratorVersion({
+                    generatorName: entry.image,
+                    cliVersion: Version,
+                    currentGeneratorVersion: latestVersion ?? entry.currentVersion,
+                    channel,
+                    includeMajor: true
+                });
+
+                if (latestMajorVersion != null) {
+                    const currentMajor = this.parseMajorVersion(latestVersion ?? entry.currentVersion);
+                    const latestMajor = this.parseMajorVersion(latestMajorVersion);
+
+                    if (currentMajor != null && latestMajor != null && latestMajor > currentMajor) {
+                        skippedMajorUpgrades.push({
+                            name: entry.name,
+                            currentVersion: latestVersion ?? entry.currentVersion,
+                            latestMajorVersion
+                        });
+                    }
+                }
+            }
+        }
+
+        return { updates, upToDate, skippedMajorUpgrades };
+    }
+
+    /**
+     * Applies the given updates to the YAML document and writes it back.
+     *
+     * The document is only written if all updates can be applied successfully.
+     */
+    public async applyUpdates({
+        targetsFilePath,
+        targetsPath,
+        updates
+    }: {
+        targetsFilePath: AbsoluteFilePath;
+        targetsPath: string[];
+        updates: SdkUpdater.TargetUpdate[];
+    }): Promise<void> {
+        const content = await readFile(targetsFilePath, "utf-8");
+        const document = parseDocument(content);
+
+        for (const update of updates) {
+            document.setIn([...targetsPath, update.name, "version"], update.latestVersion);
+        }
+
+        await writeFile(targetsFilePath, document.toString(), "utf-8");
+    }
+
+    /**
+     * Resolves the file path and YAML path for the targets section.
+     *
+     * If the workspace's fern.yml uses a `$ref` for sdks, the targets
+     * live in the referenced file at ["targets"]. Otherwise they are
+     * at ["sdks", "targets"] in fern.yml itself.
+     */
+    public resolveTargetsPath({
+        fernYmlPath,
+        targetsFilePath
+    }: {
+        fernYmlPath: AbsoluteFilePath;
+        targetsFilePath: AbsoluteFilePath;
+    }): string[] {
+        if (targetsFilePath !== fernYmlPath) {
+            return ["targets"];
+        }
+        return ["sdks", "targets"];
+    }
+
+    private parseMajorVersion(version: string): number | undefined {
+        const match = /^(\d+)\./.exec(version);
+        if (match?.[1] == null) {
+            return undefined;
+        }
+        return Number.parseInt(match[1], 10);
+    }
+}

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,16 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 3.91.0
-  changelogEntry:
-    - summary: |
-        Add `fern sdk update` command to the CLI v2. Updates SDK target versions in
-        `fern.yml` to the latest available release from the Fern registry. Supports
-        interactive mode with target selection prompts, non-interactive mode via `--yes`,
-        filtering by `--target`, major version upgrades via `--include-major`, and
-        release channel selection via `--channel`.
-      type: feat
-  createdAt: "2026-02-26"
-  irVersion: 65
-
 - version: 3.90.1
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.91.0
+  changelogEntry:
+    - summary: |
+        Add `fern sdk update` command to the CLI v2. Updates SDK target versions in
+        `fern.yml` to the latest available release from the Fern registry. Supports
+        interactive mode with target selection prompts, non-interactive mode via `--yes`,
+        filtering by `--target`, major version upgrades via `--include-major`, and
+        release channel selection via `--channel`.
+      type: feat
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 3.90.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Closes [FER-8567](https://linear.app/buildwithfern/issue/FER-8567/cli-v2-implement-the-sdk-update-command)

Implements the `fern sdk update` command in the new CLI v2 (`@fern-api/cli-v2`). This is the CLI v2 equivalent of the existing `fern generator upgrade` command. It updates SDK target versions in `fern.yml` to the latest available release from the Fern registry.

Link to Devin run: https://app.devin.ai/sessions/3db1fbe8d39f4f2c9f8b90701507c7d9
Requested by: @amckinney

## Changes Made

- New `packages/cli/cli-v2/src/sdk/updater/SdkUpdater.ts` — Core updater class following the namespace + class pattern (à la `LegacyGeneratorInvocationAdapter`):
  - Namespaced interfaces: `Config`, `TargetEntry`, `TargetUpdate`, `TargetUpToDate`, `SkippedMajorUpgrade`, `UpdateResult`
  - `collectTargetEntries()` — filters `Workspace` `Target[]` by name and skips `"latest"` versions
  - `resolveUpdates()` — calls `getLatestGeneratorVersion` for each entry; detects skipped major upgrades
  - `applyUpdates()` — writes updated versions back to YAML atomically (all-or-nothing)
- New `packages/cli/cli-v2/src/commands/sdk/update/command.ts` — `UpdateCommand` orchestration layer:
  - Reads targets from `workspace.sdks.targets` (no manual YAML parsing for reading)
  - Interactive mode (TTY): confirm prompt for single update, checkbox for multiple
  - Non-interactive mode (`--yes` or non-TTY): applies all updates automatically
  - `--target` flag to filter to a specific SDK target (default: update all)
  - `--major` flag to include major version upgrades (default: minor/patch only)
  - `--prerelease` flag to include RC / pre-release versions
  - `$ref` resolution for targets defined in separate files
  - Output showing applied updates, up-to-date targets, skipped major upgrades, and changelog URLs
- Wired `addUpdateCommand` into the `sdk` command group
- [ ] Updated README.md generator (if applicable)

### Updates since last revision (addressing PR review comments)
- Extracted core logic into `SdkUpdater` class with namespaced interfaces per review feedback
- Refactored `command.ts` to read from `Workspace.sdks.targets` instead of manual YAML map iteration
- Replaced `--channel` / `--include-major` flags with `--prerelease` / `--major`
- Implemented all-or-nothing writes (all version resolutions succeed before any YAML is written)
- Removed `versions.yml` entry per review feedback

## Review Checklist for Humans

1. **`SdkUpdater.context` is stored but unused** — The `context` field is set in the constructor but none of the public methods reference `this.context`; all context-dependent work is in the command layer. Intentional or should methods like `resolveUpdates` log via context?
2. **`findImageForTarget` casts target name to language key** — `name as keyof typeof LANGUAGE_TO_DOCKER_IMAGE` assumes target names always match language keys; custom target names would silently return `undefined` (changelog URL omitted, not a crash).
3. **`target.version == null` is dead code** — `Target.version` is typed as `string` (non-optional), so the null check in `collectTargetEntries` never triggers. Harmless but worth noting.
4. **All-or-nothing is at resolution level, not file write level** — Version resolutions are collected before any writes, but if the YAML `writeFile` itself fails partway, partial state could occur (unlikely but not truly atomic).
5. **No manual end-to-end testing was performed** — Command was verified to compile and register (`fern sdk update --help`), but was not tested against a real workspace with pinned SDK versions and registry access.

## Testing

- [ ] Unit tests added/updated
- [x] Verified compilation produces no new errors
- [x] All CI checks passing (biome, lint, compile, test, test-ete, depcheck)
- [ ] Manual testing completed — requires a `fern.yml` workspace with pinned SDK versions and network access to the Fern registry