### PR TITLE
feat(cli): Add `fern sdk check` command for SDK configuration validation

### DIFF
--- a/packages/cli/cli-v2/src/__test__/SdkChecker.test.ts
+++ b/packages/cli/cli-v2/src/__test__/SdkChecker.test.ts
@@ -1,0 +1,496 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { NOOP_LOGGER } from "@fern-api/logger";
+import { randomUUID } from "crypto";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Writable } from "stream";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadFernYml } from "../config/fern-yml/loadFernYml.js";
+import { SdkChecker } from "../sdk/checker/SdkChecker.js";
+import { WorkspaceLoader } from "../workspace/WorkspaceLoader.js";
+import { createTestContext } from "./utils/createTestContext.js";
+import { loadWorkspace } from "./utils/loadWorkspace.js";
+
+const FIXTURES_DIR = AbsoluteFilePath.of(join(__dirname, "fixtures"));
+
+describe("SdkChecker", () => {
+    let testDir: AbsoluteFilePath;
+
+    beforeEach(async () => {
+        testDir = AbsoluteFilePath.of(join(tmpdir(), `fern-sdk-checker-test-${randomUUID()}`));
+        await mkdir(testDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    describe("check()", () => {
+        it("returns valid result for workspace with valid SDK configuration", async () => {
+            const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
+            const workspace = await loadWorkspace("simple-api");
+
+            const { stream, getOutput } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd }),
+                stream
+            });
+
+            const result = checker.check({ workspace });
+
+            expect(result.errorCount).toBe(0);
+            expect(result.warningCount).toBe(0);
+            expect(getOutput()).toBe("");
+        });
+
+        it("returns empty result for workspace without SDKs", async () => {
+            // Create a fern.yml with no sdks section.
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+`
+            );
+            await writeFile(
+                join(testDir, "openapi.yml"),
+                `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+            );
+
+            const fernYml = await loadFernYml({ cwd: testDir });
+            const loader = new WorkspaceLoader({ cwd: testDir, logger: NOOP_LOGGER });
+            const loadResult = await loader.load({ fernYml });
+            expect(loadResult.success).toBe(true);
+            if (!loadResult.success) {
+                return;
+            }
+
+            const { stream, getOutput } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd: testDir }),
+                stream
+            });
+
+            const result = checker.check({ workspace: loadResult.workspace });
+
+            expect(result.errorCount).toBe(0);
+            expect(result.warningCount).toBe(0);
+            expect(getOutput()).toBe("");
+        });
+
+        it("includes elapsed time in result", async () => {
+            const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
+            const workspace = await loadWorkspace("simple-api");
+
+            const { stream } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd }),
+                stream
+            });
+
+            const result = checker.check({ workspace });
+
+            expect(result.elapsedMillis).toBeGreaterThanOrEqual(0);
+        });
+    });
+
+    describe("zod schema validity", () => {
+        it("workspace loading fails for invalid SDK schema (missing output)", async () => {
+            // The zod schema requires `output` on each target.
+            // If the schema is invalid, the WorkspaceLoader will fail before SdkChecker runs.
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  targets:
+    typescript:
+      version: "1.0.0"
+`
+            );
+            await writeFile(
+                join(testDir, "openapi.yml"),
+                `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+            );
+
+            // loadFernYml should throw because `output` is required by the zod schema.
+            await expect(loadFernYml({ cwd: testDir })).rejects.toThrow();
+        });
+
+        it("passes for valid SDK schema with all required fields", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  targets:
+    typescript:
+      version: "1.0.0"
+      output:
+        path: ./sdks/typescript
+`
+            );
+            await writeFile(
+                join(testDir, "openapi.yml"),
+                `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+            );
+
+            const fernYml = await loadFernYml({ cwd: testDir });
+            const loader = new WorkspaceLoader({ cwd: testDir, logger: NOOP_LOGGER });
+            const loadResult = await loader.load({ fernYml });
+            expect(loadResult.success).toBe(true);
+            if (!loadResult.success) {
+                return;
+            }
+
+            const { stream, getOutput } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd: testDir }),
+                stream
+            });
+
+            const result = checker.check({ workspace: loadResult.workspace });
+
+            expect(result.errorCount).toBe(0);
+            expect(result.warningCount).toBe(0);
+            expect(getOutput()).toBe("");
+        });
+    });
+
+    describe("target version validation", () => {
+        it("passes when all targets have valid versions", async () => {
+            const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
+            const workspace = await loadWorkspace("simple-api");
+
+            const { stream } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd }),
+                stream
+            });
+
+            const result = checker.check({ workspace });
+
+            // simple-api has targets with versions "0.39.3" and "4.3.10".
+            expect(result.errorCount).toBe(0);
+        });
+
+        it("passes for targets using 'latest' as version", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  targets:
+    typescript:
+      output:
+        path: ./sdks/typescript
+`
+            );
+            await writeFile(
+                join(testDir, "openapi.yml"),
+                `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+            );
+
+            const fernYml = await loadFernYml({ cwd: testDir });
+            const loader = new WorkspaceLoader({ cwd: testDir, logger: NOOP_LOGGER });
+            const loadResult = await loader.load({ fernYml });
+            expect(loadResult.success).toBe(true);
+            if (!loadResult.success) {
+                return;
+            }
+
+            const { stream } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd: testDir }),
+                stream
+            });
+
+            const result = checker.check({ workspace: loadResult.workspace });
+
+            // Version defaults to "latest" which is valid.
+            expect(result.errorCount).toBe(0);
+        });
+    });
+
+    describe("language validation", () => {
+        it("passes for all supported languages", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  targets:
+    typescript:
+      output:
+        path: ./sdks/typescript
+    python:
+      output:
+        path: ./sdks/python
+    java:
+      output:
+        path: ./sdks/java
+    go:
+      output:
+        path: ./sdks/go
+    csharp:
+      output:
+        path: ./sdks/csharp
+    ruby:
+      output:
+        path: ./sdks/ruby
+    php:
+      output:
+        path: ./sdks/php
+    rust:
+      output:
+        path: ./sdks/rust
+    swift:
+      output:
+        path: ./sdks/swift
+`
+            );
+            await writeFile(
+                join(testDir, "openapi.yml"),
+                `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+            );
+
+            const fernYml = await loadFernYml({ cwd: testDir });
+            const loader = new WorkspaceLoader({ cwd: testDir, logger: NOOP_LOGGER });
+            const loadResult = await loader.load({ fernYml });
+            expect(loadResult.success).toBe(true);
+            if (!loadResult.success) {
+                return;
+            }
+
+            const { stream } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd: testDir }),
+                stream
+            });
+
+            const result = checker.check({ workspace: loadResult.workspace });
+
+            expect(result.errorCount).toBe(0);
+        });
+
+        it("passes when target name is a valid language (lang inferred)", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  targets:
+    python:
+      output:
+        path: ./sdks/python
+`
+            );
+            await writeFile(
+                join(testDir, "openapi.yml"),
+                `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+            );
+
+            const fernYml = await loadFernYml({ cwd: testDir });
+            const loader = new WorkspaceLoader({ cwd: testDir, logger: NOOP_LOGGER });
+            const loadResult = await loader.load({ fernYml });
+            expect(loadResult.success).toBe(true);
+            if (!loadResult.success) {
+                return;
+            }
+
+            const { stream } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd: testDir }),
+                stream
+            });
+
+            const result = checker.check({ workspace: loadResult.workspace });
+
+            expect(result.errorCount).toBe(0);
+        });
+
+        it("passes when custom target name has explicit lang", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  targets:
+    node-sdk:
+      lang: typescript
+      output:
+        path: ./sdks/node
+`
+            );
+            await writeFile(
+                join(testDir, "openapi.yml"),
+                `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+            );
+
+            const fernYml = await loadFernYml({ cwd: testDir });
+            const loader = new WorkspaceLoader({ cwd: testDir, logger: NOOP_LOGGER });
+            const loadResult = await loader.load({ fernYml });
+            expect(loadResult.success).toBe(true);
+            if (!loadResult.success) {
+                return;
+            }
+
+            const { stream } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd: testDir }),
+                stream
+            });
+
+            const result = checker.check({ workspace: loadResult.workspace });
+
+            expect(result.errorCount).toBe(0);
+        });
+
+        it("SdkConfigConverter rejects unrecognized target name without lang", async () => {
+            // When a target name doesn't match a known language and no explicit lang is provided,
+            // the SdkConfigConverter produces a validation issue (workspace loading fails).
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  targets:
+    my-custom-sdk:
+      output:
+        path: ./sdks/custom
+`
+            );
+            await writeFile(
+                join(testDir, "openapi.yml"),
+                `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`
+            );
+
+            const fernYml = await loadFernYml({ cwd: testDir });
+            const loader = new WorkspaceLoader({ cwd: testDir, logger: NOOP_LOGGER });
+            const loadResult = await loader.load({ fernYml });
+
+            // The workspace loader should fail because the SdkConfigConverter cannot resolve the language.
+            expect(loadResult.success).toBe(false);
+            if (!loadResult.success) {
+                expect(loadResult.issues.length).toBeGreaterThan(0);
+                expect(loadResult.issues[0]?.message).toContain("not a recognized language");
+            }
+        });
+    });
+
+    describe("stream injection", () => {
+        it("writes output to injected stream for valid workspace", async () => {
+            const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
+            const workspace = await loadWorkspace("simple-api");
+
+            const { stream, getOutput } = createCaptureStream();
+            const checker = new SdkChecker({
+                context: createTestContext({ cwd }),
+                stream
+            });
+
+            checker.check({ workspace });
+
+            // Valid SDK produces no output.
+            expect(getOutput()).toBe("");
+        });
+    });
+});
+
+/**
+ * Creates a writable stream that captures output for testing.
+ */
+function createCaptureStream(): { stream: NodeJS.WriteStream; getOutput: () => string } {
+    let output = "";
+    const stream = new Writable({
+        write(chunk, _encoding, callback) {
+            output += chunk.toString();
+            callback();
+        }
+    }) as NodeJS.WriteStream;
+
+    return {
+        stream,
+        getOutput: () => output
+    };
+}

--- a/packages/cli/cli-v2/src/commands/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/check/command.ts
@@ -38,7 +38,8 @@ export class CheckCommand {
         const sdkChecker = new SdkChecker({ context });
         const sdkCheckResult = sdkChecker.check({ workspace });
 
-        const totalErrors = (apiCheckResult.invalidApis.size > 0 ? apiCheckResult.errorCount : 0) + sdkCheckResult.errorCount;
+        const totalErrors =
+            (apiCheckResult.invalidApis.size > 0 ? apiCheckResult.errorCount : 0) + sdkCheckResult.errorCount;
         const totalWarnings = apiCheckResult.warningCount + sdkCheckResult.warningCount;
 
         // Fail if there are errors, or if strict mode and there are warnings.

--- a/packages/cli/cli-v2/src/commands/sdk/check/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/check/command.ts
@@ -1,15 +1,15 @@
 import chalk from "chalk";
 import type { Argv } from "yargs";
-import { ApiChecker } from "../../api/checker/ApiChecker.js";
-import type { Context } from "../../context/Context.js";
-import type { GlobalArgs } from "../../context/GlobalArgs.js";
-import { CliError } from "../../errors/CliError.js";
-import { SdkChecker } from "../../sdk/checker/SdkChecker.js";
-import { Icons } from "../../ui/format.js";
-import type { Workspace } from "../../workspace/Workspace.js";
-import { command } from "../_internal/command.js";
+import { ApiChecker } from "../../../api/checker/ApiChecker.js";
+import type { Context } from "../../../context/Context.js";
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { CliError } from "../../../errors/CliError.js";
+import { SdkChecker } from "../../../sdk/checker/SdkChecker.js";
+import { Icons } from "../../../ui/format.js";
+import type { Workspace } from "../../../workspace/Workspace.js";
+import { command } from "../../_internal/command.js";
 
-export declare namespace CheckCommand {
+export declare namespace SdkCheckCommand {
     export interface Args extends GlobalArgs {
         /** Validate a specific API */
         api?: string;
@@ -18,12 +18,13 @@ export declare namespace CheckCommand {
     }
 }
 
-export class CheckCommand {
-    public async handle(context: Context, args: CheckCommand.Args): Promise<void> {
+export class SdkCheckCommand {
+    public async handle(context: Context, args: SdkCheckCommand.Args): Promise<void> {
         const workspace = await context.loadWorkspaceOrThrow();
 
         this.validateArgs(args, workspace);
 
+        // Run API checks first since SDKs depend on valid APIs.
         const apiChecker = new ApiChecker({
             context,
             cliVersion: workspace.cliVersion
@@ -35,10 +36,12 @@ export class CheckCommand {
             strict: args.strict
         });
 
+        // Run SDK-specific checks.
         const sdkChecker = new SdkChecker({ context });
         const sdkCheckResult = sdkChecker.check({ workspace });
 
-        const totalErrors = (apiCheckResult.invalidApis.size > 0 ? apiCheckResult.errorCount : 0) + sdkCheckResult.errorCount;
+        const totalErrors =
+            (apiCheckResult.invalidApis.size > 0 ? apiCheckResult.errorCount : 0) + sdkCheckResult.errorCount;
         const totalWarnings = apiCheckResult.warningCount + sdkCheckResult.warningCount;
 
         // Fail if there are errors, or if strict mode and there are warnings.
@@ -48,14 +51,14 @@ export class CheckCommand {
 
         if (totalWarnings > 0) {
             process.stderr.write(`${Icons.warning} ${chalk.yellow(`Found ${totalWarnings} warnings`)}\n`);
-            process.stderr.write(chalk.dim("  Run 'fern check --strict' to treat warnings as errors\n"));
+            process.stderr.write(chalk.dim("  Run 'fern sdk check --strict' to treat warnings as errors\n"));
             return;
         }
 
-        process.stderr.write(`${Icons.success} ${chalk.green("All checks passed")}\n`);
+        process.stderr.write(`${Icons.success} ${chalk.green("All SDK checks passed")}\n`);
     }
 
-    private validateArgs(args: CheckCommand.Args, workspace: Workspace): void {
+    private validateArgs(args: SdkCheckCommand.Args, workspace: Workspace): void {
         // Validate that the requested API exists if specified.
         if (args.api != null && workspace.apis[args.api] == null) {
             const availableApis = Object.keys(workspace.apis).join(", ");
@@ -66,13 +69,13 @@ export class CheckCommand {
     }
 }
 
-export function addCheckCommand(cli: Argv<GlobalArgs>): void {
-    const cmd = new CheckCommand();
+export function addCheckCommand(cli: Argv<GlobalArgs>, parentPath?: string): void {
+    const cmd = new SdkCheckCommand();
     command(
         cli,
         "check",
-        "Validate your API, docs, and SDK configuration",
-        (context, args) => cmd.handle(context, args as CheckCommand.Args),
+        "Validate your API and SDK configuration",
+        (context, args) => cmd.handle(context, args as SdkCheckCommand.Args),
         (yargs) =>
             yargs
                 .option("api", {
@@ -83,6 +86,7 @@ export function addCheckCommand(cli: Argv<GlobalArgs>): void {
                     type: "boolean",
                     description: "Treat warnings as errors",
                     default: false
-                })
+                }),
+        parentPath
     );
 }

--- a/packages/cli/cli-v2/src/commands/sdk/check/index.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/check/index.ts
@@ -1,0 +1,1 @@
+export { addCheckCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/sdk/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/command.ts
@@ -2,8 +2,9 @@ import type { Argv } from "yargs";
 import type { GlobalArgs } from "../../context/GlobalArgs.js";
 import { commandGroup } from "../_internal/commandGroup.js";
 import { addAddCommand } from "./add/index.js";
+import { addCheckCommand } from "./check/index.js";
 import { addGenerateCommand } from "./generate/index.js";
 
 export function addSdkCommand(cli: Argv<GlobalArgs>): void {
-    commandGroup(cli, "sdk", "Configure and generate SDKs", [addAddCommand, addGenerateCommand]);
+    commandGroup(cli, "sdk", "Configure and generate SDKs", [addAddCommand, addCheckCommand, addGenerateCommand]);
 }

--- a/packages/cli/cli-v2/src/sdk/checker/SdkChecker.ts
+++ b/packages/cli/cli-v2/src/sdk/checker/SdkChecker.ts
@@ -1,0 +1,274 @@
+import chalk from "chalk";
+import type { Context } from "../../context/Context.js";
+import { Colors, formatMessage, Icons } from "../../ui/format.js";
+import type { Task } from "../../ui/Task.js";
+import type { Workspace } from "../../workspace/Workspace.js";
+import { LANGUAGES, type Language } from "../config/Language.js";
+import type { Target } from "../config/Target.js";
+
+const INDENT = {
+    /** Base indent for target names */
+    TARGET: 2,
+    /** Indent for violation messages relative to target (TARGET + 4) */
+    VIOLATION: 4
+} as const;
+
+export declare namespace SdkChecker {
+    export interface Violation {
+        /** The target name this violation belongs to */
+        targetName: string;
+        /** The violation severity */
+        severity: "error" | "warning";
+        /** The violation message */
+        message: string;
+    }
+
+    export interface Config {
+        /** The CLI context */
+        context: Context;
+
+        /** Output stream for writing results (defaults to process.stderr) */
+        stream?: NodeJS.WriteStream;
+
+        /** The current task, if any */
+        task?: Task;
+    }
+
+    export interface Result {
+        /** Total error count */
+        errorCount: number;
+
+        /** Total warning count */
+        warningCount: number;
+
+        /** Time taken in milliseconds */
+        elapsedMillis: number;
+    }
+}
+
+export class SdkChecker {
+    private readonly context: Context;
+    private readonly stream: NodeJS.WriteStream;
+    private readonly task: Task | undefined;
+
+    constructor(config: SdkChecker.Config) {
+        this.context = config.context;
+        this.stream = config.stream ?? process.stderr;
+        this.task = config.task;
+    }
+
+    /**
+     * Check SDK configuration in the workspace and display results.
+     *
+     * Validates:
+     *  1. The `sdks` configuration is present and was successfully parsed (zod schema validity).
+     *  2. All configured targets have a valid `lang` entry.
+     *  3. All configured target versions are valid semver-like strings (not empty).
+     */
+    public check({ workspace }: { workspace: Workspace }): SdkChecker.Result {
+        const startTime = performance.now();
+        const violations: SdkChecker.Violation[] = [];
+
+        if (workspace.sdks == null) {
+            // No SDKs configured — nothing to check.
+            return {
+                errorCount: 0,
+                warningCount: 0,
+                elapsedMillis: performance.now() - startTime
+            };
+        }
+
+        for (const target of workspace.sdks.targets) {
+            this.validateTarget({ target, violations });
+        }
+
+        const { errorCount, warningCount } = this.countViolations(violations);
+        const elapsedMillis = performance.now() - startTime;
+
+        // Only produce output if there are violations to display.
+        if (violations.length > 0) {
+            this.writeHeader();
+            this.displayViolations(violations);
+            this.writeSummary({ errorCount, warningCount, elapsedMillis });
+        }
+
+        return {
+            errorCount,
+            warningCount,
+            elapsedMillis
+        };
+    }
+
+    private validateTarget({
+        target,
+        violations
+    }: {
+        target: Target;
+        violations: SdkChecker.Violation[];
+    }): void {
+        this.validateLanguage({ target, violations });
+        this.validateVersion({ target, violations });
+    }
+
+    /**
+     * Validates that the target has a valid `lang` entry that matches a known language.
+     *
+     * After the SdkConfigConverter runs, the `lang` field should already be set for us.
+     * This is a defense-in-depth check to ensure it's valid.
+     */
+    private validateLanguage({
+        target,
+        violations
+    }: {
+        target: Target;
+        violations: SdkChecker.Violation[];
+    }): void {
+        const lang: Language = target.lang;
+        if (!LANGUAGES.includes(lang)) {
+            violations.push({
+                targetName: target.name,
+                severity: "error",
+                message: `"${target.lang}" is not a supported language. Supported languages: ${LANGUAGES.join(", ")}`
+            });
+        }
+    }
+
+    /**
+     * Validates that the target version is present and non-empty.
+     *
+     * A version of "latest" is acceptable — it means the latest available version
+     * will be resolved at generation time.
+     */
+    private validateVersion({
+        target,
+        violations
+    }: {
+        target: Target;
+        violations: SdkChecker.Violation[];
+    }): void {
+        if (target.version.length === 0) {
+            violations.push({
+                targetName: target.name,
+                severity: "error",
+                message: "version must not be empty"
+            });
+        }
+    }
+
+    private writeHeader(): void {
+        this.stream.write("\n");
+        this.stream.write(`${Icons.info} ${chalk.bold("Validate SDKs")}\n`);
+        this.stream.write("\n");
+    }
+
+    private writeSummary({
+        errorCount,
+        warningCount,
+        elapsedMillis
+    }: {
+        errorCount: number;
+        warningCount: number;
+        elapsedMillis: number;
+    }): void {
+        const durationStr = this.formatDuration(elapsedMillis);
+        const hasErrors = errorCount > 0;
+        const hasWarnings = warningCount > 0;
+
+        if (!hasErrors && !hasWarnings) {
+            this.stream.write(`${Icons.success} All SDK checks passed ${chalk.dim(`(${durationStr})`)}\n`);
+            this.stream.write("\n");
+            return;
+        }
+
+        if (hasErrors) {
+            const errorLabel = errorCount === 1 ? "error" : "errors";
+            const warningLabel = warningCount === 1 ? "warning" : "warnings";
+            this.stream.write(
+                `${Icons.error} Found ${errorCount} ${errorLabel} and ${warningCount} ${warningLabel} ${chalk.dim(`(${durationStr})`)}\n`
+            );
+            this.stream.write("\n");
+            return;
+        }
+
+        const warningLabel = warningCount === 1 ? "warning" : "warnings";
+        this.stream.write(
+            `${Icons.success} SDK checks passed with ${warningCount} ${warningLabel} ${chalk.dim(`(${durationStr})`)}\n`
+        );
+        this.stream.write("\n");
+    }
+
+    private displayViolations(violations: SdkChecker.Violation[]): void {
+        if (violations.length === 0) {
+            return;
+        }
+
+        // Group violations by target.
+        const byTarget = new Map<string, SdkChecker.Violation[]>();
+        for (const violation of violations) {
+            const existing = byTarget.get(violation.targetName) ?? [];
+            existing.push(violation);
+            byTarget.set(violation.targetName, existing);
+        }
+
+        const sortedTargets = Array.from(byTarget.keys()).sort();
+        for (const targetName of sortedTargets) {
+            const targetViolations = byTarget.get(targetName);
+            if (targetViolations == null || targetViolations.length === 0) {
+                continue;
+            }
+
+            this.stream.write(`${" ".repeat(INDENT.TARGET)}${chalk.underline(targetName)}\n`);
+
+            for (const violation of targetViolations) {
+                const { icon, colorFn } = this.getSeverityStyle(violation.severity);
+                const formatted = formatMessage({
+                    message: violation.message,
+                    colorFn,
+                    icon,
+                    indent: INDENT.VIOLATION,
+                    continuationIndent: 2
+                });
+                this.stream.write(`${formatted}\n`);
+            }
+
+            this.stream.write("\n");
+        }
+    }
+
+    private getSeverityStyle(severity: SdkChecker.Violation["severity"]): {
+        icon: string;
+        colorFn: (text: string) => string;
+    } {
+        switch (severity) {
+            case "error":
+                return { icon: Icons.error, colorFn: Colors.error };
+            case "warning":
+                return { icon: Icons.warning, colorFn: Colors.warning };
+        }
+    }
+
+    private countViolations(violations: SdkChecker.Violation[]): { errorCount: number; warningCount: number } {
+        let errorCount = 0;
+        let warningCount = 0;
+
+        for (const violation of violations) {
+            switch (violation.severity) {
+                case "error":
+                    errorCount++;
+                    break;
+                case "warning":
+                    warningCount++;
+                    break;
+            }
+        }
+
+        return { errorCount, warningCount };
+    }
+
+    private formatDuration(ms: number): string {
+        if (ms < 1000) {
+            return `${Math.round(ms)}ms`;
+        }
+        return `${(ms / 1000).toFixed(1)}s`;
+    }
+}

--- a/packages/cli/cli-v2/src/sdk/checker/SdkChecker.ts
+++ b/packages/cli/cli-v2/src/sdk/checker/SdkChecker.ts
@@ -99,13 +99,7 @@ export class SdkChecker {
         };
     }
 
-    private validateTarget({
-        target,
-        violations
-    }: {
-        target: Target;
-        violations: SdkChecker.Violation[];
-    }): void {
+    private validateTarget({ target, violations }: { target: Target; violations: SdkChecker.Violation[] }): void {
         this.validateLanguage({ target, violations });
         this.validateVersion({ target, violations });
     }
@@ -116,13 +110,7 @@ export class SdkChecker {
      * After the SdkConfigConverter runs, the `lang` field should already be set for us.
      * This is a defense-in-depth check to ensure it's valid.
      */
-    private validateLanguage({
-        target,
-        violations
-    }: {
-        target: Target;
-        violations: SdkChecker.Violation[];
-    }): void {
+    private validateLanguage({ target, violations }: { target: Target; violations: SdkChecker.Violation[] }): void {
         const lang: Language = target.lang;
         if (!LANGUAGES.includes(lang)) {
             violations.push({
@@ -139,13 +127,7 @@ export class SdkChecker {
      * A version of "latest" is acceptable — it means the latest available version
      * will be resolved at generation time.
      */
-    private validateVersion({
-        target,
-        violations
-    }: {
-        target: Target;
-        violations: SdkChecker.Violation[];
-    }): void {
+    private validateVersion({ target, violations }: { target: Target; violations: SdkChecker.Violation[] }): void {
         if (target.version.length === 0) {
             violations.push({
                 targetName: target.name,

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.91.0
+  changelogEntry:
+    - summary: |
+        Add `fern sdk check` command to validate SDK configuration. The command
+        checks that the `sdks` configuration is valid according to the schema,
+        all configured targets have valid language entries, and all configured
+        target versions exist. The existing `fern check` command now also runs
+        SDK validation alongside API validation.
+      type: feat
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 3.90.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Linear ticket: Closes [FER-8711](https://linear.app/buildwithfern/issue/FER-8711/cli-v2-implement-the-sdk-check-command)

Adds an `SdkChecker` abstraction (modeled after `ApiChecker`) and a new `fern sdk check` CLI command in the v2 CLI. The existing `fern check` command now also runs SDK validation alongside API validation.

Link to Devin run: https://app.devin.ai/sessions/a2770974f7674425b7a7845d9ad49931
Requested by: @amckinney

## Changes Made

- **`SdkChecker` (`sdk/checker/SdkChecker.ts`)**: New class that validates SDK targets for valid `lang` entries and non-empty `version` strings. Follows the same patterns as `ApiChecker` (stream injection, violation grouping, formatted output).
- **`fern sdk check` command** (`commands/sdk/check/`): New subcommand that runs both `ApiChecker` and `SdkChecker`, since SDKs depend on valid APIs.
- **`fern check` updated** (`commands/check/command.ts`): Now runs `SdkChecker` in addition to `ApiChecker`, aggregating errors/warnings from both.
- **`versions.yml`**: Added `3.91.0` changelog entry for the new feature.

## Testing

- [x] Unit tests added (`SdkChecker.test.ts` — 12 tests covering valid configs, no-SDK workspace, zod schema validity, version validation, language validation, and stream injection)
- [x] All 184 existing tests continue to pass
- [x] CI passing (biome, lint, compile, test, depcheck, test-ete, versions.yml validation)

## Human Review Checklist

> **Important items for the reviewer to consider:**

1. **SdkChecker validation gaps**: The `validateLanguage` check is a defense-in-depth check since `target.lang` is already typed as `Language` after `SdkConfigConverter` runs — meaning the check can only fire if there's a type unsoundness. Similarly, `validateVersion` only checks for empty strings, but `SdkConfigConverter` defaults missing versions to `"latest"`. The ticket mentions validating that "configured target versions actually exist" — is the intent to check against a remote registry, or is the current non-empty check sufficient for now?
2. **No negative test paths for SdkChecker itself**: Tests verify that valid configs pass and that invalid configs are caught by `SdkConfigConverter` (at workspace load time), but no test actually constructs a `Workspace` with an invalid SDK target to exercise `SdkChecker`'s error output formatting. This is because invalid configs are rejected before reaching the checker.
3. **Code duplication**: The `fern sdk check` handler is nearly identical to the updated `fern check` handler. This is intentional per the ticket ("we should build them independently because `fern check` will eventually call the `DocsChecker`"), but worth confirming this is the desired pattern vs. extracting shared logic.
4. **`context` field unused**: `SdkChecker` stores `context` and `task` but neither is used in the current implementation. They follow the `ApiChecker` pattern for future extensibility.