### PR TITLE
fix(cli): capture untracked files in auto-versioning diff for namespace changes

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.90.3
+  changelogEntry:
+    - summary: |
+        Fix AUTO versioning incorrectly skipping SDK generation when the cleaned
+        diff is empty but the raw diff contains real changes. When all file sections
+        in a diff happen to be filtered out by the version-change cleaning logic
+        (e.g. when changes coincide with version bump patterns), the system now falls
+        back to a PATCH increment instead of reporting "no semantic changes detected".
+      type: fix
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 3.90.2
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -10,11 +10,6 @@
         diffing so that newly created files appear in the diff and are
         correctly analyzed by the AI as breaking changes.
       type: fix
-    - summary: |
-        Add safety net for AUTO versioning when the cleaned diff is empty but
-        the raw diff contains real changes. Falls back to a PATCH increment
-        instead of incorrectly skipping SDK generation.
-      type: fix
   createdAt: "2026-02-26"
   irVersion: 65
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -2,11 +2,18 @@
 - version: 3.90.3
   changelogEntry:
     - summary: |
-        Fix AUTO versioning incorrectly skipping SDK generation when the cleaned
-        diff is empty but the raw diff contains real changes. When all file sections
-        in a diff happen to be filtered out by the version-change cleaning logic
-        (e.g. when changes coincide with version bump patterns), the system now falls
-        back to a PATCH increment instead of reporting "no semantic changes detected".
+        Fix AUTO versioning missing namespace changes in the git diff. When
+        generated SDK files are copied without `.fernignore` (the
+        `copyGeneratedFilesNoFernIgnorePreservingGit` path), new files created
+        by namespace renames were untracked and invisible to `git diff HEAD`.
+        The diff generator now runs `git add -N .` (intent-to-add) before
+        diffing so that newly created files appear in the diff and are
+        correctly analyzed by the AI as breaking changes.
+      type: fix
+    - summary: |
+        Add safety net for AUTO versioning when the cleaned diff is empty but
+        the raw diff contains real changes. Falls back to a PATCH increment
+        instead of incorrectly skipping SDK generation.
       type: fix
   createdAt: "2026-02-26"
   irVersion: 65

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -510,9 +510,18 @@ export class LocalTaskHandler {
     /**
      * Generates a git diff file for automatic versioning analysis.
      * This compares the current state against HEAD to see what changes have been made.
+     *
+     * Uses `git add -N .` (intent-to-add) before diffing so that newly created files
+     * (e.g. from a namespace rename) appear in the diff. Without this, `git diff HEAD`
+     * silently ignores untracked files, which causes namespace changes to be invisible
+     * when the copy path does not stage files (copyGeneratedFilesNoFernIgnorePreservingGit).
      */
     private async generateDiffFile(): Promise<string> {
         const diffFile = pathJoin(tmpdir(), `git-diff-${Date.now()}.patch`);
+
+        // Mark any new untracked files as intent-to-add so they appear in the diff.
+        // This is a no-op for files that are already staged.
+        await this.runGitCommand(["add", "-N", "."], this.absolutePathToLocalOutput);
 
         await this.runGitCommand(["diff", "HEAD", "--output", diffFile], this.absolutePathToLocalOutput);
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -157,24 +157,11 @@ export class LocalTaskHandler {
 
             this.context.logger.debug(`Previous version detected: ${previousVersion}`);
 
-            // If the cleaned diff is empty but the raw diff was not, there are real changes
-            // that were all classified as version-only changes by the cleaning logic.
-            // Fall back to PATCH increment to avoid incorrectly skipping the commit.
             if (cleanedDiff.trim().length === 0) {
-                this.context.logger.warn(
-                    `Cleaned diff is empty but raw diff had ${diffContent.length} bytes. ` +
-                        `This may indicate the diff cleaning logic is too aggressive. ` +
-                        `Falling back to PATCH increment.`
+                this.context.logger.info(
+                    "No actual changes detected after filtering version-only changes. Cancelling generation."
                 );
-                const newVersion = this.incrementVersion(previousVersion, VersionBump.PATCH);
-                this.context.logger.info(`Fallback version bump: PATCH, new version: ${newVersion}`);
-                const fallbackMessage = this.isWhitelabel
-                    ? "SDK regeneration"
-                    : "SDK regeneration\n\n🌿 Generated with Fern";
-                return {
-                    version: newVersion,
-                    commitMessage: fallbackMessage
-                };
+                return null;
             }
 
             // Call AI to analyze the diff

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -157,6 +157,26 @@ export class LocalTaskHandler {
 
             this.context.logger.debug(`Previous version detected: ${previousVersion}`);
 
+            // If the cleaned diff is empty but the raw diff was not, there are real changes
+            // that were all classified as version-only changes by the cleaning logic.
+            // Fall back to PATCH increment to avoid incorrectly skipping the commit.
+            if (cleanedDiff.trim().length === 0) {
+                this.context.logger.warn(
+                    `Cleaned diff is empty but raw diff had ${diffContent.length} bytes. ` +
+                        `This may indicate the diff cleaning logic is too aggressive. ` +
+                        `Falling back to PATCH increment.`
+                );
+                const newVersion = this.incrementVersion(previousVersion, VersionBump.PATCH);
+                this.context.logger.info(`Fallback version bump: PATCH, new version: ${newVersion}`);
+                const fallbackMessage = this.isWhitelabel
+                    ? "SDK regeneration"
+                    : "SDK regeneration\n\n🌿 Generated with Fern";
+                return {
+                    version: newVersion,
+                    commitMessage: fallbackMessage
+                };
+            }
+
             // Call AI to analyze the diff
             try {
                 // TODO: Need to get project for BAML client configuration

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/AutoVersioningService.test.ts
@@ -1121,6 +1121,122 @@ describe("AutoVersioningService", () => {
         expect(cleaned).toContain("+    newMethod() { return true; }");
     });
 
+    it("testCleanDiffForAI_namespaceChangeWithVersionChanges", () => {
+        // Simulates namespace change from marketdata to market_data with version changes
+        const diff =
+            "diff --git a/pyproject.toml b/pyproject.toml\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/pyproject.toml\n" +
+            "+++ b/pyproject.toml\n" +
+            "@@ -1,5 +1,5 @@\n" +
+            " [tool.poetry]\n" +
+            ' name = "immix-sdk"\n' +
+            '-version = "0.0.46"\n' +
+            '+version = "505.503.4455"\n' +
+            ' description = ""\n' +
+            "diff --git a/src/immix/version.py b/src/immix/version.py\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/src/immix/version.py\n" +
+            "+++ b/src/immix/version.py\n" +
+            "@@ -1 +1 @@\n" +
+            '-__version__ = "0.0.46"\n' +
+            '+__version__ = "505.503.4455"\n' +
+            "diff --git a/src/immix/client.py b/src/immix/client.py\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/src/immix/client.py\n" +
+            "+++ b/src/immix/client.py\n" +
+            "@@ -1,5 +1,5 @@\n" +
+            "-from .marketdata import MarketDataClient\n" +
+            "+from .market_data import MarketDataClient\n" +
+            " from .trading import TradingClient\n" +
+            " \n" +
+            " class ImmixClient:\n" +
+            "diff --git a/src/immix/core/client_wrapper.py b/src/immix/core/client_wrapper.py\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/src/immix/core/client_wrapper.py\n" +
+            "+++ b/src/immix/core/client_wrapper.py\n" +
+            "@@ -5,7 +5,7 @@\n" +
+            " class ClientWrapper:\n" +
+            "     headers = {\n" +
+            '-        "X-Fern-SDK-Version": "0.0.46",\n' +
+            '+        "X-Fern-SDK-Version": "505.503.4455",\n' +
+            "     }\n" +
+            "diff --git a/src/immix/marketdata/__init__.py b/src/immix/marketdata/__init__.py\n" +
+            "deleted file mode 100644\n" +
+            "index abc123..0000000\n" +
+            "--- a/src/immix/marketdata/__init__.py\n" +
+            "+++ /dev/null\n" +
+            "@@ -1,3 +0,0 @@\n" +
+            "-from .market_data import MarketDataClient\n" +
+            "-from . import types\n" +
+            '-__all__ = ["MarketDataClient", "types"]\n' +
+            "diff --git a/src/immix/market_data/__init__.py b/src/immix/market_data/__init__.py\n" +
+            "new file mode 100644\n" +
+            "index 0000000..def456\n" +
+            "--- /dev/null\n" +
+            "+++ b/src/immix/market_data/__init__.py\n" +
+            "@@ -0,0 +1,3 @@\n" +
+            "+from .market_data import MarketDataClient\n" +
+            "+from . import types\n" +
+            '+__all__ = ["MarketDataClient", "types"]\n';
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(diff, "505.503.4455");
+
+        // Version-only changes should be removed
+        expect(cleaned).not.toContain("505.503.4455");
+        expect(cleaned).not.toContain("0.0.46");
+        // Namespace changes should be preserved
+        expect(cleaned).toContain("market_data");
+        expect(cleaned).toContain("marketdata");
+        // File sections with only version changes should be removed
+        expect(cleaned).not.toContain("pyproject.toml");
+        expect(cleaned).not.toContain("version.py");
+        // File sections with namespace changes should be preserved
+        expect(cleaned).toContain("client.py");
+        // Cleaned diff should be non-empty since there are real namespace changes
+        expect(cleaned.trim().length).toBeGreaterThan(0);
+    });
+
+    it("testCleanDiffForAI_versionOnlyChanges_returnsEmptyDiff", () => {
+        // Simulates a diff where ALL changes are version-related (no namespace or other changes)
+        // This is the scenario that was causing the bug: cleaned diff becomes empty
+        const diff =
+            "diff --git a/pyproject.toml b/pyproject.toml\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/pyproject.toml\n" +
+            "+++ b/pyproject.toml\n" +
+            "@@ -1,5 +1,5 @@\n" +
+            " [tool.poetry]\n" +
+            ' name = "immix-sdk"\n' +
+            '-version = "0.0.46"\n' +
+            '+version = "505.503.4455"\n' +
+            ' description = ""\n' +
+            "diff --git a/src/immix/version.py b/src/immix/version.py\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/src/immix/version.py\n" +
+            "+++ b/src/immix/version.py\n" +
+            "@@ -1 +1 @@\n" +
+            '-__version__ = "0.0.46"\n' +
+            '+__version__ = "505.503.4455"\n' +
+            "diff --git a/src/immix/core/client_wrapper.py b/src/immix/core/client_wrapper.py\n" +
+            "index abc123..def456 100644\n" +
+            "--- a/src/immix/core/client_wrapper.py\n" +
+            "+++ b/src/immix/core/client_wrapper.py\n" +
+            "@@ -5,7 +5,7 @@\n" +
+            " class ClientWrapper:\n" +
+            "     headers = {\n" +
+            '-        "X-Fern-SDK-Version": "0.0.46",\n' +
+            '+        "X-Fern-SDK-Version": "505.503.4455",\n' +
+            "     }\n";
+
+        const cleaned = new AutoVersioningService({ logger: mockLogger }).cleanDiffForAI(diff, "505.503.4455");
+
+        // All changes are version-related, so the cleaned diff should be empty
+        expect(cleaned.trim().length).toBe(0);
+        // Original diff was non-empty
+        expect(diff.trim().length).toBeGreaterThan(0);
+    });
+
     // TODO(tjb9dc): Reenable these tests, need to have them reference the LocalTaskHandler's gitDiff function (or refactor)
     // it("testAutoVersioningWorkflow_endToEnd", async () => {
     //     const tempDir = await fs.mkdtemp(path.join(require("os").tmpdir(), "test-"));


### PR DESCRIPTION
## Description

Refs: Reported by customer (fern-demo/immix-fern-config#16) — namespace change in `generators.yml` resulted in "no semantic changes detected" and no SDK PR was created.

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/832043ee87be4ffc94cc43c7fa0ddd5f)

**Root cause:** When generated SDK files are copied via the `copyGeneratedFilesNoFernIgnorePreservingGit` path (no `.fernignore` present), new files created by namespace renames are **untracked** and invisible to `git diff HEAD`. This means newly created namespace directories (e.g. `market_data/`) never appear in the diff, while the version-bump changes in existing files get cleaned away — resulting in an empty diff and "no semantic changes detected."

**Fix:** `generateDiffFile()` now runs `git add -N .` (intent-to-add) before `git diff HEAD`, which marks untracked files so they appear in the diff. This is a no-op for the fernignore path where files are already staged.

## Changes Made

- **`LocalTaskHandler.ts` — `generateDiffFile()`**: Added `git add -N .` before `git diff HEAD` so that newly created files (from namespace renames, new endpoints, etc.) appear in the diff and are correctly analyzed by the AI as breaking changes
- **`LocalTaskHandler.ts` — `handleAutoVersioning()`**: Added explicit early return when `cleanedDiff` is empty (all changes are version-only), short-circuiting before the AI call with a clear log message
- **`AutoVersioningService.test.ts`**: Added two test cases:
  - Namespace change scenario (`marketdata` → `market_data` with version changes) — verifies `cleanDiffForAI` preserves namespace changes correctly
  - Version-only changes scenario — verifies the cleaned diff IS empty when all changes are version-related (correctly skips generation)
- **`versions.yml`**: Added changelog entry for v3.90.3

## Testing

- [x] Unit tests added (2 new test cases, all 48 tests pass)
- [x] Lint checks pass (`pnpm run check`)
- [ ] Manual/integration testing — the `git add -N` fix depends on git operations in the generation pipeline that aren't directly unit-tested

## ⚠️ Review checklist — please verify

- [ ] **`git add -N .` side effects**: Does intent-to-add interfere with downstream git operations in `PostGenerationPipeline` (commit, push, PR creation)? In the fernignore path this is a no-op (files already staged). In the no-fernignore path, it creates empty index entries — does the pipeline properly `git add` before committing later?
- [ ] **Root cause confidence**: The diagnosis is based on code path analysis (the no-fernignore path doesn't run `git add`), not a full reproduction of the production incident. Does this match what you'd expect for the immix SDK setup?