### PR TITLE
fix(ts): add `cache: "no-store"` to streaming/SSE fetch requests for Next.js compatibility

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.51.4
+  changelogEntry:
+    - summary: |
+        Add `cache: "no-store"` to streaming and SSE fetch requests to prevent
+        Next.js from buffering streamed responses. The option is guarded by a
+        cached runtime feature-detection so it is safely skipped in runtimes
+        that do not support the `cache` RequestInit option (e.g. Cloudflare Workers).
+      type: fix
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 3.51.3
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/Fetcher.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/Fetcher.ts
@@ -282,6 +282,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                     args.abortSignal,
                     args.withCredentials,
                     args.duplex,
+                    args.responseType === "streaming" || args.responseType === "sse",
                 ),
             args.maxRetries,
         );

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/makeRequest.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/makeRequest.ts
@@ -1,5 +1,24 @@
 import { anySignal, getTimeoutSignal } from "./signals";
 
+/**
+ * Cached result of checking whether the current runtime supports
+ * the `cache` option in `Request`. Some runtimes (e.g. Cloudflare Workers)
+ * throw a TypeError when this option is used.
+ */
+let _cacheNoStoreSupported: boolean | undefined;
+function isCacheNoStoreSupported(): boolean {
+    if (_cacheNoStoreSupported != null) {
+        return _cacheNoStoreSupported;
+    }
+    try {
+        new Request("http://localhost", { cache: "no-store" });
+        _cacheNoStoreSupported = true;
+    } catch {
+        _cacheNoStoreSupported = false;
+    }
+    return _cacheNoStoreSupported;
+}
+
 export const makeRequest = async (
     fetchFn: (url: string, init: RequestInit) => Promise<Response>,
     url: string,
@@ -10,6 +29,7 @@ export const makeRequest = async (
     abortSignal?: AbortSignal,
     withCredentials?: boolean,
     duplex?: "half",
+    disableCache?: boolean,
 ): Promise<Response> => {
     const signals: AbortSignal[] = [];
 
@@ -32,6 +52,7 @@ export const makeRequest = async (
         credentials: withCredentials ? "include" : undefined,
         // @ts-ignore
         duplex,
+        ...(disableCache && isCacheNoStoreSupported() ? { cache: "no-store" as RequestCache } : {}),
     });
 
     if (timeoutAbortId != null) {


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/2888

Next.js (v14 and below) caches `fetch()` responses by default, which buffers streaming/SSE responses and breaks real-time streaming in API route handlers. This PR adds `cache: "no-store"` to fetch calls for streaming and SSE response types, guarded by runtime feature detection to avoid throwing in runtimes that don't support the option (e.g. Cloudflare Workers).

[Link to Devin run](https://app.devin.ai/sessions/2bf29dc2a3e1486f9e8efb597f10a8b0) | Requested by: @Swimburger

## Changes Made

- Added `isCacheNoStoreSupported()` in `makeRequest.ts` — a cached feature-detection function that probes `new Request("http://localhost", { cache: "no-store" })` once to determine if the runtime supports the `cache` RequestInit option
- Added `disableCache` parameter to `makeRequest()`, which conditionally spreads `{ cache: "no-store" }` into the fetch RequestInit when both `disableCache` is true and the runtime supports it
- In `Fetcher.ts`, passes `disableCache: true` when `responseType` is `"streaming"` or `"sse"`
- Added `versions.yml` entry for v3.51.4

## Testing

- [ ] Unit tests added/updated — **no new tests were added for the `disableCache` path**; existing tests still pass since the parameter is optional
- [ ] Manual testing completed — not feasible to test Next.js streaming end-to-end in this environment

## Human Review Checklist

- **Feature detection reliability**: The detection uses `new Request(...)` as a proxy for `fetch()` support of the `cache` option. Verify this is a safe assumption across target runtimes (Node.js, Deno, Cloudflare Workers, browsers).
- **Positional parameter growth**: `makeRequest` now has 10 positional parameters. Consider whether this should be refactored to an options object in a follow-up.
- **Test coverage**: No unit test covers the `disableCache=true` code path. Consider whether a test should be added that verifies `cache: "no-store"` appears in the RequestInit when `disableCache` is true.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
