### PR TITLE
fix(php): add hasDefaultValue() guard before getDefaultValue() for PHP 8.5 compatibility

### DIFF
--- a/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.1.4
+  changelogEntry:
+    - summary: |
+        Fix PHP 8.5 deprecation warning for `ReflectionProperty::getDefaultValue()` called on
+        properties without a default value. Now checks `hasDefaultValue()` before calling
+        `getDefaultValue()` in `JsonSerializableType::jsonDeserialize()`.
+      type: fix
+  createdAt: "2026-02-26"
+  irVersion: 62
+
 - version: 2.1.3
   changelogEntry:
     - summary: |

--- a/seed/php-model/accept-header/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/accept-header/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/alias-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/alias-extends/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/alias/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/alias/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/any-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/any-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/api-wide-base-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/api-wide-base-path/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/audiences/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/audiences/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/basic-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/basic-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/bytes-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/bytes-download/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/bytes-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/bytes-upload/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/circular-references-advanced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/circular-references-advanced/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/circular-references/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/circular-references/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/client-side-params/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/client-side-params/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/content-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/content-type/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/cross-package-type-names/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/cross-package-type-names/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/dollar-string-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/dollar-string-examples/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/empty-clients/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/empty-clients/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/enum/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/enum/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/error-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/error-property/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/errors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/errors/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/examples/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/exhaustive/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/exhaustive/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/extends/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/extra-properties/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/extra-properties/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/file-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/file-download/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/file-upload-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/file-upload-openapi/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/file-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/file-upload/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/folders/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/folders/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/header-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/header-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/http-head/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/http-head/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/idempotency-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/idempotency-headers/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/imdb/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/imdb/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/license/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/license/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/literal/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/literal/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/literals-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/literals-unions/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/mixed-case/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/mixed-case/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/mixed-file-directory/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/mixed-file-directory/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/multi-line-docs/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/multi-line-docs/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/multi-url-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/multi-url-environment/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/no-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/no-environment/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/no-retries/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/no-retries/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/nullable-optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/nullable-optional/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/nullable-request-body/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/nullable-request-body/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/nullable/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/object/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/objects-with-imports/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/objects-with-imports/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/optional/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/package-yml/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/package-yml/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/pagination-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/pagination-custom/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/pagination-uri-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/pagination-uri-path/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/pagination/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/pagination/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/path-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/path-parameters/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/plain-text/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/plain-text/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/property-access/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/property-access/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/public-object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/public-object/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/query-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/query-parameters/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/request-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/request-parameters/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/required-nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/required-nullable/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/reserved-keywords/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/reserved-keywords/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/response-property/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/server-sent-events/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/server-sent-events/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/server-url-templating/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/server-url-templating/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/simple-api/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/simple-api/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/simple-fhir/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/simple-fhir/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/single-url-environment-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/single-url-environment-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/streaming-parameter/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/streaming-parameter/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/streaming/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/streaming/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/trace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/trace/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/unions-with-local-date/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/unions-with-local-date/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/unions/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/unknown/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/unknown/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/url-form-encoded/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/url-form-encoded/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/validation/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/validation/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/variables/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/version-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/version-no-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/version/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/version/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/webhook-audience/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/webhook-audience/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/webhooks/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/webhooks/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-model/websocket/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-model/websocket/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/basic-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 

--- a/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
@@ -181,7 +181,7 @@ abstract class JsonSerializableType implements \JsonSerializable
         // Fill in any missing properties with defaults
         foreach ($properties as $property) {
             if (!isset($args[$property->getName()])) {
-                $args[$property->getName()] = $property->getDefaultValue() ?? null;
+                $args[$property->getName()] = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
             }
         }
 


### PR DESCRIPTION
## Description

Refs: Brevo PHP SDK bug report — PHP 8.5 deprecation warning in generated `JsonSerializableType.php`

Fixes a deprecation warning on PHP 8.5 where `ReflectionProperty::getDefaultValue()` is called on properties that have no default value. PHP 8.5 deprecates this usage and requires checking `hasDefaultValue()` first.

Reported by Brevo: their generated SDK throws:
```
Deprecated: ReflectionProperty::getDefaultValue() for a property without a default value is deprecated,
use ReflectionProperty::hasDefaultValue() to check if the default value exists
in .../src/Core/Json/JsonSerializableType.php on line 184
```

## Changes Made

- **`generators/php/base/src/asIs/Json/JsonSerializableType.Template.php`** (the source of truth): Changed `$property->getDefaultValue() ?? null` → `$property->hasDefaultValue() ? $property->getDefaultValue() : null` in `jsonDeserialize()`
- **`generators/php/sdk/versions.yml`**: Added version 2.1.4 changelog entry
- **`seed/php-model/*` and `seed/php-sdk/*`**: Updated all 229 generated seed copies with the same one-line fix

## Human Review Checklist

- [ ] Verify semantic equivalence: the old `getDefaultValue() ?? null` and new `hasDefaultValue() ? getDefaultValue() : null` should produce identical results — both return null for properties without defaults, but the new version avoids the deprecated call path
- [ ] Seed files were updated via `sed` rather than by re-running the generator — confirm this is acceptable or if a regeneration pass is needed to match generator output exactly

## Testing

- [ ] No new unit tests added — behavior is unchanged, only the code path to avoid a deprecation warning differs
- [ ] Existing seed test suite should validate no regressions

---

[Link to Devin run](https://app.devin.ai/sessions/1ddd305b0f454d408fc0f0a8b8d5ca10) | Requested by @jsklan