### PR TITLE
fix(typescript): add `cache: "no-store"` to streaming/SSE fetch requests for Next.js compatibility

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.51.4
+  changelogEntry:
+    - summary: |
+        Add `cache: "no-store"` to streaming and SSE fetch requests to prevent
+        Next.js from buffering streamed responses. The option is guarded by a
+        cached runtime feature-detection so it is safely skipped in runtimes
+        that do not support the `cache` RequestInit option (e.g. Cloudflare Workers).
+      type: fix
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 3.51.3
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/Fetcher.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/Fetcher.ts
@@ -282,6 +282,7 @@ export async function fetcherImpl<R = unknown>(args: Fetcher.Args): Promise<APIR
                     args.abortSignal,
                     args.withCredentials,
                     args.duplex,
+                    args.responseType === "streaming" || args.responseType === "sse",
                 ),
             args.maxRetries,
         );

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/makeRequest.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/makeRequest.ts
@@ -6,7 +6,7 @@ import { anySignal, getTimeoutSignal } from "./signals";
  * throw a TypeError when this option is used.
  */
 let _cacheNoStoreSupported: boolean | undefined;
-function isCacheNoStoreSupported(): boolean {
+export function isCacheNoStoreSupported(): boolean {
     if (_cacheNoStoreSupported != null) {
         return _cacheNoStoreSupported;
     }
@@ -17,6 +17,13 @@ function isCacheNoStoreSupported(): boolean {
         _cacheNoStoreSupported = false;
     }
     return _cacheNoStoreSupported;
+}
+
+/**
+ * Reset the cached result of `isCacheNoStoreSupported`. Exposed for testing only.
+ */
+export function resetCacheNoStoreSupported(): void {
+    _cacheNoStoreSupported = undefined;
 }
 
 export const makeRequest = async (

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/makeRequest.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/makeRequest.ts
@@ -1,5 +1,24 @@
 import { anySignal, getTimeoutSignal } from "./signals";
 
+/**
+ * Cached result of checking whether the current runtime supports
+ * the `cache` option in `Request`. Some runtimes (e.g. Cloudflare Workers)
+ * throw a TypeError when this option is used.
+ */
+let _cacheNoStoreSupported: boolean | undefined;
+function isCacheNoStoreSupported(): boolean {
+    if (_cacheNoStoreSupported != null) {
+        return _cacheNoStoreSupported;
+    }
+    try {
+        new Request("http://localhost", { cache: "no-store" });
+        _cacheNoStoreSupported = true;
+    } catch {
+        _cacheNoStoreSupported = false;
+    }
+    return _cacheNoStoreSupported;
+}
+
 export const makeRequest = async (
     fetchFn: (url: string, init: RequestInit) => Promise<Response>,
     url: string,
@@ -10,6 +29,7 @@ export const makeRequest = async (
     abortSignal?: AbortSignal,
     withCredentials?: boolean,
     duplex?: "half",
+    disableCache?: boolean,
 ): Promise<Response> => {
     const signals: AbortSignal[] = [];
 
@@ -32,6 +52,7 @@ export const makeRequest = async (
         credentials: withCredentials ? "include" : undefined,
         // @ts-ignore
         duplex,
+        ...(disableCache && isCacheNoStoreSupported() ? { cache: "no-store" as RequestCache } : {}),
     });
 
     if (timeoutAbortId != null) {

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/makeRequest.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/makeRequest.test.ts
@@ -1,4 +1,8 @@
-import { makeRequest } from "../../../src/core/fetcher/makeRequest";
+import {
+    makeRequest,
+    isCacheNoStoreSupported,
+    resetCacheNoStoreSupported,
+} from "../../../src/core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
     const mockPostUrl = "https://httpbin.org/post";
@@ -11,6 +15,7 @@ describe("Test makeRequest", () => {
     beforeEach(() => {
         mockFetch = jest.fn();
         mockFetch.mockResolvedValue(new Response(JSON.stringify({ test: "successful" }), { status: 200 }));
+        resetCacheNoStoreSupported();
     });
 
     it("should handle POST request correctly", async () => {
@@ -49,5 +54,66 @@ describe("Test makeRequest", () => {
         );
         expect(calledOptions.signal).toBeDefined();
         expect(calledOptions.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("should not include cache option when disableCache is not set", async () => {
+        await makeRequest(mockFetch, mockGetUrl, "GET", mockHeaders, undefined);
+        const [, calledOptions] = mockFetch.mock.calls[0];
+        expect(calledOptions.cache).toBeUndefined();
+    });
+
+    it("should not include cache option when disableCache is false", async () => {
+        await makeRequest(
+            mockFetch,
+            mockGetUrl,
+            "GET",
+            mockHeaders,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            false,
+        );
+        const [, calledOptions] = mockFetch.mock.calls[0];
+        expect(calledOptions.cache).toBeUndefined();
+    });
+
+    it("should include cache: no-store when disableCache is true and runtime supports it", async () => {
+        // In Node.js test environment, Request supports the cache option
+        expect(isCacheNoStoreSupported()).toBe(true);
+        await makeRequest(
+            mockFetch,
+            mockGetUrl,
+            "GET",
+            mockHeaders,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            true,
+        );
+        const [, calledOptions] = mockFetch.mock.calls[0];
+        expect(calledOptions.cache).toBe("no-store");
+    });
+
+    it("should cache the result of isCacheNoStoreSupported", () => {
+        const first = isCacheNoStoreSupported();
+        const second = isCacheNoStoreSupported();
+        expect(first).toBe(second);
+    });
+
+    it("should reset cache detection state with resetCacheNoStoreSupported", () => {
+        // First call caches the result
+        const first = isCacheNoStoreSupported();
+        expect(first).toBe(true);
+
+        // Reset clears the cache
+        resetCacheNoStoreSupported();
+
+        // After reset, it should re-detect (and still return true in Node.js)
+        const second = isCacheNoStoreSupported();
+        expect(second).toBe(true);
     });
 });

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/makeRequest.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/makeRequest.test.ts
@@ -116,4 +116,42 @@ describe("Test makeRequest", () => {
         const second = isCacheNoStoreSupported();
         expect(second).toBe(true);
     });
+
+    it("should not include cache option when runtime does not support it (e.g. Cloudflare Workers)", async () => {
+        // Mock Request constructor to throw when cache option is passed,
+        // simulating runtimes like Cloudflare Workers
+        const OriginalRequest = globalThis.Request;
+        globalThis.Request = class MockRequest {
+            constructor(_url: string, init?: RequestInit) {
+                if (init?.cache != null) {
+                    throw new TypeError("The 'cache' field on 'RequestInitializerDict' is not implemented.");
+                }
+            }
+        } as unknown as typeof Request;
+
+        try {
+            // Reset so the detection runs fresh with the mocked Request
+            resetCacheNoStoreSupported();
+            expect(isCacheNoStoreSupported()).toBe(false);
+
+            await makeRequest(
+                mockFetch,
+                mockGetUrl,
+                "GET",
+                mockHeaders,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                true,
+            );
+            const [, calledOptions] = mockFetch.mock.calls[0];
+            expect(calledOptions.cache).toBeUndefined();
+        } finally {
+            // Restore original Request
+            globalThis.Request = OriginalRequest;
+            resetCacheNoStoreSupported();
+        }
+    });
 });


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/2888

Next.js (v14 and below) caches `fetch()` responses by default, which buffers streaming/SSE responses and breaks real-time streaming in API route handlers. This PR adds `cache: "no-store"` to fetch calls for streaming and SSE response types, guarded by runtime feature detection to safely skip the option in runtimes that don't support it (e.g. Cloudflare Workers).

[Link to Devin run](https://app.devin.ai/sessions/2bf29dc2a3e1486f9e8efb597f10a8b0) | Requested by: @Swimburger

## Changes Made

- Added `isCacheNoStoreSupported()` in `makeRequest.ts` — a cached feature-detection function that probes `new Request("http://localhost", { cache: "no-store" })` once to determine runtime support for the `cache` RequestInit option
- Added `resetCacheNoStoreSupported()` — exported for test use only, resets the cached detection result
- Added `disableCache` parameter to `makeRequest()`, which conditionally spreads `{ cache: "no-store" }` into the fetch RequestInit when both `disableCache` is true and the runtime supports it
- In `Fetcher.ts`, passes `disableCache: true` when `responseType` is `"streaming"` or `"sse"`
- Added 6 unit tests covering happy path, negative path (mocked Cloudflare Workers runtime), and feature detection caching/reset
- Added `versions.yml` entry for v3.51.4

## Testing

- [x] Unit tests added — covers `disableCache` true/false/undefined, feature detection caching, reset, and a negative-path test that mocks `globalThis.Request` to throw (simulating Cloudflare Workers) and verifies `cache` is omitted
- [ ] Manual testing — not feasible to test Next.js streaming end-to-end in this environment

## Human Review Checklist

- **Feature detection reliability**: The detection probes `new Request(...)` as a proxy for `fetch()` support of `cache`. If any runtime accepts it in `Request` but rejects it in `fetch()`, this would still break. Worth verifying this assumption holds for target runtimes (Node.js, Deno, Cloudflare Workers, browsers).
- **Positional parameter growth**: `makeRequest` now has 10 positional parameters. The test cases show this pain with long chains of `undefined`. Consider whether this warrants a follow-up refactor to an options object.
- **Exported test helpers in production code**: `isCacheNoStoreSupported` and `resetCacheNoStoreSupported` are exported from production code for testability. `resetCacheNoStoreSupported` mutates module-level state — acceptable but worth noting.