### PR TITLE
fix(generator-cli): force push when updating existing fern-bot PR

### DIFF
--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -152,7 +152,9 @@ export class GithubStep extends BaseStep {
         };
 
         if (!this.config.previewMode) {
-            if (skipCommit && isUpdatingExistingPR) {
+            if (isUpdatingExistingPR) {
+                // Force push is safe: fern-bot/* branches are exclusively owned by this pipeline,
+                // and required when the clone lacks remote tracking refs (e.g., shallow clone from fiddle).
                 await repository.forcePush();
             } else {
                 await repository.push();

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -2,6 +2,13 @@
 
 - changelogEntry:
     - summary: |
+        Fix non-fast-forward push error when updating an existing fern-bot PR from a shallow clone.
+      type: fix
+  createdAt: "2026-02-26"
+  version: 0.6.8
+
+- changelogEntry:
+    - summary: |
         `pipeline run --config` now accepts inline JSON, "-" for stdin,
         or a file path. Result JSON is written to stdout.
       type: feat


### PR DESCRIPTION
## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Shallow clones (--depth 1) from fiddle lack remote refs for fern-bot/* branches, causing `checkoutRemoteBranch` to silently create a new branch from main. The subsequent push fails with non-fast-forward since the local and remote branches have different ancestry.

Fix: always force push when updating an existing PR, not only when replay committed. This is safe because fern-bot/* branches are exclusively pipeline-owned.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
