### PR TITLE
chore(docs): add REVIEW.md for Devin Review guidelines

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,56 @@
+# Review Guidelines
+
+This file provides guidance to [Devin Review](https://docs.devin.ai/work-with-devin/devin-review) when analyzing pull requests in this repository.
+
+## Ignore
+
+- **Seed test output files** in `seed/*/` directories -- these are generated outputs. Focus review on the source-of-truth files (generator source code, template files, `seed.yml` configs) rather than the generated copies.
+- Lock files (`pnpm-lock.yaml`) unless dependency changes are the point of the PR.
+- Auto-generated files in `packages/ir-sdk/src/sdk/` -- these are generated from the Fern IR definition. Review the definition files in `packages/ir-sdk/fern/` instead.
+
+## Critical Areas
+
+### IR Schema Changes
+- Changes to `packages/ir-sdk/fern/apis/ir-types-latest/definition/` affect all generators. Verify that corresponding IR migration entries exist in `packages/cli/generation/ir-migrations/` for backward compatibility.
+- IR version bumps must be coordinated: update `irVersion` in the relevant `versions.yml` entry.
+
+### Version Management
+- Generator changes (bug fixes or features) should include a `versions.yml` entry in the appropriate generator directory (e.g., `generators/typescript/sdk/versions.yml`, `generators/python/sdk/versions.yml`).
+- CLI changes should include a `versions.yml` entry in `packages/cli/cli/versions.yml`.
+- The `type` field in changelog entries should match the PR type: `fix` for bug fixes, `feat` for new features.
+
+### Generator Template Files
+- Files matching `*.Template.*` or located under `asIs/` directories are the source of truth for generated code. Review these carefully for correctness -- seed output files are just copies.
+- When a template file changes, corresponding seed test outputs should also be updated (either via `seed test` or bulk update).
+
+## Conventions
+
+### TypeScript
+- No `any` type -- use `unknown` and narrow with type guards.
+- No `as X` type assertions unless the compiler genuinely cannot infer the type.
+- No default exports -- use named exports exclusively.
+- No `require()` -- use ES module `import` syntax.
+- Exported functions and public methods must have explicit return types.
+- Prefer `const` over `let`; never use `var`.
+- No `.then()` chains when `async/await` is available.
+- No empty `catch` blocks -- at minimum log the error.
+
+### PR Structure
+- PR titles must follow semantic commit format: `<type>(<scope>): <description>` where both type and scope are required.
+- Allowed types: `fix`, `feat`, `revert`, `break`, `chore`.
+- Allowed scopes: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `postman`, `ci`, `lint`, `fastapi`, `spring`, `express`, `openapi`, `deps`, `deps-dev`, `fiber`, `pydantic`, `ai-search`, `swift`, `rust`, `generator-cli`.
+
+### Cross-Package Type Safety
+- When importing types across packages, watch for name collisions -- use namespace imports (`import * as X`) rather than direct imports when multiple packages export types with the same name.
+- Serialization schema files are particularly susceptible to this (see `generators/typescript/`).
+
+## Performance
+
+- Flag any unbounded loops or recursive traversals over IR nodes without depth limits.
+- Watch for N+1 patterns when processing API definitions with many endpoints or types.
+- Docker-based generator tests (`seed test`) are expensive -- PRs should use `--fixture` to scope tests when possible rather than running all fixtures.
+
+## Security
+
+- Never expose or log secrets, API keys, or tokens in generated code or test fixtures.
+- Generator output that handles authentication (OAuth, bearer tokens, API keys) should be reviewed for secure defaults.


### PR DESCRIPTION
## Description

Adds a `REVIEW.md` file to give [Devin Review](https://docs.devin.ai/work-with-devin/devin-review) project-specific guidance when analyzing PRs in this repo. Devin Review automatically picks up `**/REVIEW.md` files and uses them to customize its analysis.

The repo already has extensive `CLAUDE.md` files for coding guidance, but nothing specifically tailored for *review*. Recent PRs (e.g., #12894 with 231 files, #12899 with 379 files) show that most of the diff is generated seed output, and Devin Review currently reports "No Issues Found" on most PRs — suggesting it could benefit from project-specific heuristics.

[Link to Devin run](https://app.devin.ai/sessions/d54f95401efd41f3ac2d9cb535ec0a48) | Requested by @jsklan

## Changes Made

- Added `REVIEW.md` at repository root with sections for:
  - **Ignore**: Seed test outputs (`seed/*/`), lock files, auto-generated IR SDK files
  - **Critical Areas**: IR schema changes requiring migrations, version management (`versions.yml`), generator template files
  - **Conventions**: TypeScript rules, PR title format, cross-package type safety
  - **Performance**: Unbounded IR traversals, N+1 patterns, seed test scoping
  - **Security**: Secret exposure in generated code, auth handler defaults
- [ ] Updated README.md generator (not applicable)

## Human Review Checklist

- [ ] **Verify directory paths are accurate**: The file references `packages/ir-sdk/fern/apis/ir-types-latest/definition/`, `packages/cli/generation/ir-migrations/`, `packages/ir-sdk/src/sdk/`, and various `versions.yml` locations. Confirm these are current.
- [ ] **TypeScript conventions overlap with CLAUDE.md**: The TypeScript section largely repeats rules from the root `CLAUDE.md`. Since Devin Review already reads `CLAUDE.md`, consider whether this section should be kept (for emphasis), trimmed, or removed to avoid drift between the two files.
- [ ] **Completeness of "Ignore" section**: Are there other high-churn generated directories that should be excluded from review focus? (e.g., any generated SDK output directories beyond `seed/*/` and `packages/ir-sdk/src/sdk/`)
- [ ] **Version management guidance**: Confirm the guidance about `versions.yml` entries matching PR types reflects actual team practice.

## Testing

- [ ] No unit tests — this is a documentation-only change
- [ ] Cannot be directly tested; effectiveness will be observed on future Devin Review runs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
