### PR TITLE
fix(csharp): deep-copy request content in CloneRequestAsync to fix ObjectDisposedException on retry

### DIFF
--- a/generators/csharp/base/src/asIs/RawClient.Template.cs
+++ b/generators/csharp/base/src/asIs/RawClient.Template.cs
@@ -68,39 +68,52 @@ internal partial class RawClient(ClientOptions clientOptions)
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
         clonedRequest.Version = request.Version;
-        switch (request.Content)
+
+        if (request.Content != null)
         {
-            case MultipartContent oldMultipartFormContent:
-                var originalBoundary =
-                    oldMultipartFormContent
-                        .Headers.ContentType?.Parameters.First(p =>
-                            p.Name.Equals("boundary", StringComparison.OrdinalIgnoreCase)
-                        )
-                        .Value?.Trim('"') ?? Guid.NewGuid().ToString();
-                var newMultipartContent = oldMultipartFormContent switch
-                {
-                    MultipartFormDataContent => new MultipartFormDataContent(originalBoundary),
-                    _ => new MultipartContent(),
-                };
-                foreach (var content in oldMultipartFormContent)
-                {
-                    var ms = new MemoryStream();
-                    await content.CopyToAsync(ms).ConfigureAwait(false);
-                    ms.Position = 0;
-                    var newPart = new StreamContent(ms);
-                    foreach (var header in oldMultipartFormContent.Headers)
+            switch (request.Content)
+            {
+                case MultipartContent oldMultipartFormContent:
+                    var originalBoundary =
+                        oldMultipartFormContent
+                            .Headers.ContentType?.Parameters.First(p =>
+                                p.Name.Equals("boundary", StringComparison.OrdinalIgnoreCase)
+                            )
+                            .Value?.Trim('"') ?? Guid.NewGuid().ToString();
+                    var newMultipartContent = oldMultipartFormContent switch
                     {
-                        newPart.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                        MultipartFormDataContent => new MultipartFormDataContent(originalBoundary),
+                        _ => new MultipartContent(),
+                    };
+                    foreach (var content in oldMultipartFormContent)
+                    {
+                        var ms = new MemoryStream();
+                        await content.CopyToAsync(ms).ConfigureAwait(false);
+                        ms.Position = 0;
+                        var newPart = new StreamContent(ms);
+                        foreach (var header in content.Headers)
+                        {
+                            newPart.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                        }
+
+                        newMultipartContent.Add(newPart);
                     }
 
-                    newMultipartContent.Add(newPart);
-                }
+                    clonedRequest.Content = newMultipartContent;
+                    break;
+                default:
+                    var bodyStream = new MemoryStream();
+                    await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+                    bodyStream.Position = 0;
+                    var clonedContent = new StreamContent(bodyStream);
+                    foreach (var header in request.Content.Headers)
+                    {
+                        clonedContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
 
-                clonedRequest.Content = newMultipartContent;
-                break;
-            default:
-                clonedRequest.Content = request.Content;
-                break;
+                    clonedRequest.Content = clonedContent;
+                    break;
+            }
         }
 
         foreach (var header in request.Headers)

--- a/generators/csharp/base/src/asIs/test/RawClientTests/RetriesTests.Template.cs
+++ b/generators/csharp/base/src/asIs/test/RawClientTests/RetriesTests.Template.cs
@@ -318,6 +318,84 @@ public class RetriesTests
         });
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldPreserveJsonBody_OnRetry()
+    {
+        const string expectedBody = """{"key":"value"}""";
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("RetryWithBody")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("RetryWithBody")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await _rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            // Verify the retried request preserved the JSON body
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            Assert.That(retriedEntry.RequestMessage.Body, Is.EqualTo(expectedBody));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldPreserveMultipartBody_OnRetry()
+    {
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("RetryMultipart")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("RetryMultipart")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        var request = new <%= context.namespaces.core %>.MultipartFormRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+        };
+        request.AddJsonPart("object", new { key = "value" });
+
+        var response = await _rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            // Verify the retried request preserved the multipart body
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            Assert.That(retriedEntry.RequestMessage.Body, Does.Contain("""{"key":"value"}"""));
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.22.6
+  changelogEntry:
+    - summary: |
+        Fix `ObjectDisposedException` when retrying HTTP requests with a body. The
+        `CloneRequestAsync` method now deep-copies the request content into a new
+        `MemoryStream` instead of reusing the original (already-disposed) content
+        reference. Also fixes multipart retry cloning to preserve per-part headers
+        (e.g. `Content-Disposition`) instead of incorrectly copying the parent
+        multipart headers onto each part.
+      type: fix
+  createdAt: "2026-02-26"
+  irVersion: 62
+
 - version: 2.22.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/8191

Fixes an `ObjectDisposedException` thrown when the C# SDK retries an HTTP request that has a body (e.g. JSON POST). The `CloneRequestAsync` method's `default` case was assigning a reference to the original request's `HttpContent` rather than deep-copying it, so retried requests would attempt to read already-disposed content.

Also fixes a secondary bug in the multipart cloning path where parent-level multipart headers were being copied onto each individual part instead of each part's own headers (e.g. `Content-Disposition`).

[Link to Devin run](https://app.devin.ai/sessions/b1c47b6e5f5a4186ab6e7e3cc6281796) | Requested by: @Swimburger

## Changes Made

- **`RawClient.Template.cs`**: 
  - Added null check for `request.Content` before cloning
  - `default` case now deep-copies content bytes into a new `MemoryStream`/`StreamContent` and preserves content headers
  - Multipart path: changed `oldMultipartFormContent.Headers` → `content.Headers` so each part retains its own headers
- **`RetriesTests.Template.cs`**: Added two new tests:
  - `SendRequestAsync_ShouldPreserveJsonBody_OnRetry` — verifies JSON body survives a 500 → 200 retry
  - `SendRequestAsync_ShouldPreserveMultipartBody_OnRetry` — verifies multipart body survives a 500 → 200 retry
- **`versions.yml`**: Added 2.22.6 changelog entry

## Testing

- [x] Unit tests added (2 new retry body-preservation tests in `RetriesTests.Template.cs`)
- [x] Manual testing completed (compilation verified)

## Review Checklist

Key areas for review:
1. **Content cloning correctness**: Verify that `request.Content.CopyToAsync` works correctly for all content types (JSON, multipart, etc.) after `HttpClient.SendAsync` has already read the content on the first attempt. The original request content should remain readable for subsequent retry clones.
2. **Multipart header fix**: Confirm that copying `content.Headers` (per-part headers) instead of `oldMultipartFormContent.Headers` (parent container headers) is correct for preserving headers like `Content-Disposition` on each part.
3. **Test template variables**: Verify `<%= context.namespaces.core %>` usage in the new tests matches existing patterns in the file (it does — see line 187 for existing usage).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
