### PR TITLE
fix(cli): per-spec settings ignored in multi-spec API configurations

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.90.5
+  changelogEntry:
+    - summary: |
+        Fix per-spec settings being ignored in multi-spec API configurations.
+        When `respect-nullable-schemas` (or other boolean settings) was set on
+        only a subset of specs, the setting was incorrectly collapsed to `false`
+        because `specs.every()` treated unset (`undefined`) the same as
+        explicitly disabled (`false`). Now, specs that don't define a setting
+        are treated as neutral ("don't care") so enabling a setting on a subset
+        of specs works correctly without affecting specs that don't set it.
+      type: fix
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 3.90.4
   changelogEntry:
     - summary: |

--- a/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
@@ -41,6 +41,30 @@ export declare namespace OSSWorkspace {
     export type Settings = BaseOpenAPIWorkspace.Settings;
 }
 
+/**
+ * Collapses a boolean per-spec setting into a single workspace-level value.
+ *
+ * - If no spec explicitly defines the setting (all undefined) → returns undefined (defaults apply)
+ * - If at least one spec defines it → returns true only if no spec explicitly sets it to false
+ *   (undefined specs are treated as neutral / "don't care")
+ *
+ * This ensures that enabling a setting on a subset of specs works correctly,
+ * without breaking users who don't set it at all. See https://github.com/fern-api/fern/issues/6408
+ */
+function collapseSpecBooleanSetting(
+    specs: (OpenAPISpec | ProtobufSpec)[],
+    getter: (settings: ParseOpenAPIOptions | undefined) => boolean | undefined
+): boolean | undefined {
+    const values = specs.map((spec) => getter(spec.settings));
+    const hasAnyExplicit = values.some((v) => v != null);
+    if (!hasAnyExplicit) {
+        return undefined;
+    }
+    // If at least one spec explicitly defines the setting, treat undefined as neutral.
+    // Only return false if a spec explicitly sets it to false.
+    return values.every((v) => v == null || v === true);
+}
+
 function convertRemoveDiscriminantsFromSchemas(
     specs: (OpenAPISpec | ProtobufSpec)[]
 ): generatorsYml.RemoveDiscriminantsFromSchemas {
@@ -71,34 +95,39 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
     private graphqlTypes: Record<FdrAPI.TypeId, FdrAPI.api.v1.register.TypeDefinition> = {};
 
     constructor({ allSpecs, specs, ...superArgs }: OSSWorkspace.Args) {
+        const openapiSpecs = specs.filter((spec) => spec.type === "openapi" && spec.source.type === "openapi");
         super({
             ...superArgs,
-            respectReadonlySchemas: specs.every((spec) => spec.settings?.respectReadonlySchemas),
-            respectNullableSchemas: specs.every((spec) => spec.settings?.respectNullableSchemas),
-            wrapReferencesToNullableInOptional: specs.every(
-                (spec) => spec.settings?.wrapReferencesToNullableInOptional
+            respectReadonlySchemas: collapseSpecBooleanSetting(specs, (s) => s?.respectReadonlySchemas),
+            respectNullableSchemas: collapseSpecBooleanSetting(specs, (s) => s?.respectNullableSchemas),
+            wrapReferencesToNullableInOptional: collapseSpecBooleanSetting(
+                specs,
+                (s) => s?.wrapReferencesToNullableInOptional
             ),
             removeDiscriminantsFromSchemas: convertRemoveDiscriminantsFromSchemas(specs),
-            coerceOptionalSchemasToNullable: specs.every((spec) => spec.settings?.coerceOptionalSchemasToNullable),
-            coerceEnumsToLiterals: specs.every((spec) => spec.settings?.coerceEnumsToLiterals),
-            onlyIncludeReferencedSchemas: specs.every((spec) => spec.settings?.onlyIncludeReferencedSchemas),
-            inlinePathParameters: specs.every((spec) => spec.settings?.inlinePathParameters),
-            objectQueryParameters: specs.every((spec) => spec.settings?.objectQueryParameters),
-            useBytesForBinaryResponse: specs
-                .filter((spec) => spec.type === "openapi" && spec.source.type === "openapi")
-
-                // TODO: Update this to '.every' once AsyncAPI sources are correctly recognized.
-                .some((spec) => spec.settings?.useBytesForBinaryResponse),
-            respectForwardCompatibleEnums: specs
-                .filter((spec) => spec.type === "openapi" && spec.source.type === "openapi")
-
-                // TODO: Update this to '.every' once AsyncAPI sources are correctly recognized.
-                .some((spec) => spec.settings?.respectForwardCompatibleEnums),
-            inlineAllOfSchemas: specs.every((spec) => spec.settings?.inlineAllOfSchemas),
+            coerceOptionalSchemasToNullable: collapseSpecBooleanSetting(
+                specs,
+                (s) => s?.coerceOptionalSchemasToNullable
+            ),
+            coerceEnumsToLiterals: collapseSpecBooleanSetting(specs, (s) => s?.coerceEnumsToLiterals),
+            onlyIncludeReferencedSchemas: collapseSpecBooleanSetting(specs, (s) => s?.onlyIncludeReferencedSchemas),
+            inlinePathParameters: collapseSpecBooleanSetting(specs, (s) => s?.inlinePathParameters),
+            objectQueryParameters: collapseSpecBooleanSetting(specs, (s) => s?.objectQueryParameters),
+            useBytesForBinaryResponse: collapseSpecBooleanSetting(openapiSpecs, (s) => s?.useBytesForBinaryResponse),
+            respectForwardCompatibleEnums: collapseSpecBooleanSetting(
+                openapiSpecs,
+                (s) => s?.respectForwardCompatibleEnums
+            ),
+            inlineAllOfSchemas: collapseSpecBooleanSetting(specs, (s) => s?.inlineAllOfSchemas),
             resolveAliases: (() => {
-                // Require that resolveAliases is true/provided for all specs
-                const allHaveResolveAliases = specs.every((spec) => spec.settings?.resolveAliases);
-                if (!allHaveResolveAliases) {
+                // Only collapse if at least one spec explicitly defines resolveAliases
+                const values = specs.map((spec) => spec.settings?.resolveAliases);
+                const hasAnyExplicit = values.some((v) => v != null);
+                if (!hasAnyExplicit) {
+                    return undefined;
+                }
+                // If any spec explicitly sets it to false, return false
+                if (values.some((v) => v === false)) {
                     return false;
                 }
 


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/6408

Fixes a bug where per-spec boolean settings (e.g. `respect-nullable-schemas`) were silently ignored when only a subset of specs in a multi-spec `generators.yml` defined them. The root cause is that `OSSWorkspace` collapsed per-spec settings using `specs.every()`, which treats `undefined` (not set) the same as `false` (explicitly disabled).

[Link to Devin run](https://app.devin.ai/sessions/b8d8188c97b247ddba27de4be9d9835a) | Requested by: @Swimburger

## Changes Made

- Added `collapseSpecBooleanSetting()` helper that distinguishes between "not set" (`undefined`) and "explicitly disabled" (`false`):
  - All specs undefined → returns `undefined` (defaults apply, **no behavior change**)
  - At least one spec sets `true`, others undefined → returns `true` (**bugfix**)
  - Explicit conflict (one `true`, one `false`) → returns `false` (same as before)
- Replaced all `specs.every(...)` / `specs.some(...)` boolean setting collapses in the `OSSWorkspace` constructor with the new helper
- Applied same "undefined = neutral" logic to `resolveAliases` (non-boolean setting)
- Added changelog entry in `versions.yml`

## ⚠️ Key Review Points

1. **`useBytesForBinaryResponse` and `respectForwardCompatibleEnums` changed from `.some()` to `collapseSpecBooleanSetting()`** — previously "any spec enables → all enabled", now "undefined specs are neutral". Both default to `false`, so when no spec sets them the result should be equivalent (`undefined` → default `false`). But the `.some()` → `collapseSpecBooleanSetting` switch is a subtle semantic change worth verifying.

2. **`resolveAliases` behavior change** — previously required ALL specs to have it set (via `.every()`); now returns `undefined` if no spec sets it, and merges `except` arrays if any spec enables it. A spec that doesn't set `resolveAliases` is now treated as neutral rather than as a vote against.

3. **No unit tests for `collapseSpecBooleanSetting`** — the function has specific edge-case behavior that should ideally be covered by tests.

## Testing
- [ ] Unit tests added/updated
- [x] Lint passes (`biome check` clean)
- [ ] Manual testing completed (no easy repro for multi-spec configs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
