### PR TITLE
fix(internal): `respect-readonly-schemas` correctly resolves references

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly-schema-references.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/readonly-schema-references.json
@@ -1,0 +1,773 @@
+{
+  "title": "Readonly Schema References API",
+  "description": "Test schema reference resolution when respect-readonly-schemas causes schema renaming",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "Create configuration",
+      "audiences": [],
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "PostConfigRequest",
+      "request": {
+        "schema": {
+          "generatedName": "PostConfigRequest",
+          "schema": "ConfigCreateRequest",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Configuration created successfully",
+        "schema": {
+          "generatedName": "PostConfigResponse",
+          "schema": "ConfigResponse",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/config",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {},
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "provisioning": {
+                  "properties": {
+                    "enabled": {
+                      "value": {
+                        "value": true,
+                        "type": "boolean"
+                      },
+                      "type": "primitive"
+                    },
+                    "mappings": {
+                      "value": [
+                        {
+                          "properties": {},
+                          "type": "object"
+                        }
+                      ],
+                      "type": "array"
+                    },
+                    "createdAt": {
+                      "value": {
+                        "value": "2024-01-15T09:30:00Z",
+                        "type": "datetime"
+                      },
+                      "type": "primitive"
+                    },
+                    "lastModified": {
+                      "value": {
+                        "value": "2024-01-15T09:30:00Z",
+                        "type": "datetime"
+                      },
+                      "type": "primitive"
+                    },
+                    "syncStatus": {
+                      "value": "active",
+                      "type": "enum"
+                    }
+                  },
+                  "type": "object"
+                },
+                "metadata": {
+                  "properties": {
+                    "version": {
+                      "value": {
+                        "value": 1,
+                        "type": "int"
+                      },
+                      "type": "primitive"
+                    },
+                    "owner": {
+                      "value": {
+                        "value": "owner",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    },
+                    "tags": {
+                      "value": [
+                        {
+                          "value": {
+                            "value": "tags",
+                            "type": "string"
+                          },
+                          "type": "primitive"
+                        }
+                      ],
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "summary": "Get configuration",
+      "audiences": [],
+      "tags": [],
+      "pathParameters": [
+        {
+          "name": "configId",
+          "schema": {
+            "schema": {
+              "type": "string"
+            },
+            "generatedName": "GetConfigConfigIdRequestConfigId",
+            "groupName": [],
+            "type": "primitive"
+          },
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          }
+        }
+      ],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetConfigConfigIdRequest",
+      "response": {
+        "description": "Configuration retrieved successfully",
+        "schema": {
+          "generatedName": "GetConfigConfigIdResponse",
+          "schema": "ConfigResponse",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "GET",
+      "path": "/config/{configId}",
+      "examples": [
+        {
+          "pathParameters": [
+            {
+              "name": "configId",
+              "value": {
+                "value": {
+                  "value": "configId",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            }
+          ],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "provisioning": {
+                  "properties": {
+                    "enabled": {
+                      "value": {
+                        "value": true,
+                        "type": "boolean"
+                      },
+                      "type": "primitive"
+                    },
+                    "mappings": {
+                      "value": [
+                        {
+                          "properties": {},
+                          "type": "object"
+                        }
+                      ],
+                      "type": "array"
+                    },
+                    "createdAt": {
+                      "value": {
+                        "value": "2024-01-15T09:30:00Z",
+                        "type": "datetime"
+                      },
+                      "type": "primitive"
+                    },
+                    "lastModified": {
+                      "value": {
+                        "value": "2024-01-15T09:30:00Z",
+                        "type": "datetime"
+                      },
+                      "type": "primitive"
+                    },
+                    "syncStatus": {
+                      "value": "active",
+                      "type": "enum"
+                    }
+                  },
+                  "type": "object"
+                },
+                "metadata": {
+                  "properties": {
+                    "version": {
+                      "value": {
+                        "value": 1,
+                        "type": "int"
+                      },
+                      "type": "primitive"
+                    },
+                    "owner": {
+                      "value": {
+                        "value": "owner",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    },
+                    "tags": {
+                      "value": [
+                        {
+                          "value": {
+                            "value": "tags",
+                            "type": "string"
+                          },
+                          "type": "primitive"
+                        }
+                      ],
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "IdpProvisioningConfig": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "idpProvisioningConfigEnabled",
+            "key": "enabled",
+            "schema": {
+              "generatedName": "IdpProvisioningConfigEnabled",
+              "description": "Whether provisioning is enabled",
+              "value": {
+                "description": "Whether provisioning is enabled",
+                "schema": {
+                  "type": "boolean"
+                },
+                "generatedName": "IdpProvisioningConfigEnabled",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "idpProvisioningConfigMappings",
+            "key": "mappings",
+            "schema": {
+              "generatedName": "IdpProvisioningConfigMappings",
+              "value": {
+                "value": {
+                  "generatedName": "IdpProvisioningConfigMappingsItem",
+                  "schema": "AttributeMapping",
+                  "source": {
+                    "file": "../openapi.yml",
+                    "type": "openapi"
+                  },
+                  "type": "reference"
+                },
+                "generatedName": "IdpProvisioningConfigMappings",
+                "groupName": [],
+                "type": "array"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "idpProvisioningConfigCreatedAt",
+            "key": "createdAt",
+            "schema": {
+              "generatedName": "IdpProvisioningConfigCreatedAt",
+              "description": "When the config was created",
+              "value": {
+                "description": "When the config was created",
+                "schema": {
+                  "type": "datetime"
+                },
+                "generatedName": "IdpProvisioningConfigCreatedAt",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": true
+          },
+          {
+            "conflict": {},
+            "generatedName": "idpProvisioningConfigLastModified",
+            "key": "lastModified",
+            "schema": {
+              "generatedName": "IdpProvisioningConfigLastModified",
+              "description": "When the config was last modified",
+              "value": {
+                "description": "When the config was last modified",
+                "schema": {
+                  "type": "datetime"
+                },
+                "generatedName": "IdpProvisioningConfigLastModified",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": true
+          },
+          {
+            "conflict": {},
+            "generatedName": "idpProvisioningConfigSyncStatus",
+            "key": "syncStatus",
+            "schema": {
+              "generatedName": "IdpProvisioningConfigSyncStatus",
+              "description": "Current sync status",
+              "value": {
+                "description": "Current sync status",
+                "generatedName": "IdpProvisioningConfigSyncStatus",
+                "values": [
+                  {
+                    "generatedName": "active",
+                    "value": "active",
+                    "casing": {}
+                  },
+                  {
+                    "generatedName": "pending",
+                    "value": "pending",
+                    "casing": {}
+                  },
+                  {
+                    "generatedName": "failed",
+                    "value": "failed",
+                    "casing": {}
+                  }
+                ],
+                "groupName": [],
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "enum"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": true
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "IdpProvisioningConfig",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ConfigResponse": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "configResponseId",
+            "key": "id",
+            "schema": {
+              "generatedName": "ConfigResponseId",
+              "description": "Configuration ID",
+              "value": {
+                "description": "Configuration ID",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ConfigResponseId",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "configResponseProvisioning",
+            "key": "provisioning",
+            "schema": {
+              "generatedName": "ConfigResponseProvisioning",
+              "value": {
+                "description": "Provisioning configuration",
+                "generatedName": "ConfigResponseProvisioning",
+                "schema": "IdpProvisioningConfig",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          },
+          {
+            "conflict": {},
+            "generatedName": "configResponseMetadata",
+            "key": "metadata",
+            "schema": {
+              "generatedName": "ConfigResponseMetadata",
+              "value": {
+                "generatedName": "ConfigResponseMetadata",
+                "schema": "ConfigMetadata",
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "reference"
+              },
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": false,
+            "writeonly": false
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ConfigResponse",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ConfigCreateRequest": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "configCreateRequestEnabled",
+            "key": "enabled",
+            "schema": {
+              "generatedName": "ConfigCreateRequestEnabled",
+              "description": "Whether provisioning is enabled",
+              "value": {
+                "description": "Whether provisioning is enabled",
+                "schema": {
+                  "type": "boolean"
+                },
+                "generatedName": "ConfigCreateRequestEnabled",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "configCreateRequestMappings",
+            "key": "mappings",
+            "schema": {
+              "generatedName": "ConfigCreateRequestMappings",
+              "value": {
+                "value": {
+                  "generatedName": "ConfigCreateRequestMappingsItem",
+                  "schema": "AttributeMapping",
+                  "source": {
+                    "file": "../openapi.yml",
+                    "type": "openapi"
+                  },
+                  "type": "reference"
+                },
+                "generatedName": "ConfigCreateRequestMappings",
+                "groupName": [],
+                "type": "array"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ConfigCreateRequest",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "AttributeMapping": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "attributeMappingSource",
+            "key": "source",
+            "schema": {
+              "generatedName": "AttributeMappingSource",
+              "description": "Source attribute name",
+              "value": {
+                "description": "Source attribute name",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "AttributeMappingSource",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "attributeMappingTarget",
+            "key": "target",
+            "schema": {
+              "generatedName": "AttributeMappingTarget",
+              "description": "Target attribute name",
+              "value": {
+                "description": "Target attribute name",
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "AttributeMappingTarget",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "attributeMappingRequired",
+            "key": "required",
+            "schema": {
+              "generatedName": "AttributeMappingRequired",
+              "value": {
+                "schema": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "generatedName": "AttributeMappingRequired",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "AttributeMapping",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ConfigMetadata": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "configMetadataVersion",
+            "key": "version",
+            "schema": {
+              "generatedName": "ConfigMetadataVersion",
+              "value": {
+                "schema": {
+                  "type": "int"
+                },
+                "generatedName": "ConfigMetadataVersion",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": true
+          },
+          {
+            "conflict": {},
+            "generatedName": "configMetadataOwner",
+            "key": "owner",
+            "schema": {
+              "generatedName": "ConfigMetadataOwner",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ConfigMetadataOwner",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": [],
+            "readonly": true
+          },
+          {
+            "conflict": {},
+            "generatedName": "configMetadataTags",
+            "key": "tags",
+            "schema": {
+              "generatedName": "ConfigMetadataTags",
+              "value": {
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "ConfigMetadataTagsItem",
+                  "groupName": [],
+                  "type": "primitive"
+                },
+                "generatedName": "ConfigMetadataTags",
+                "groupName": [],
+                "type": "array"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ConfigMetadata",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-schema-references.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly-schema-references.json
@@ -1,0 +1,384 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createConfiguration": {
+              "auth": undefined,
+              "display-name": "Create configuration",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {},
+                  "response": {
+                    "body": {
+                      "id": "id",
+                      "metadata": {
+                        "owner": "owner",
+                        "tags": [
+                          "tags",
+                        ],
+                        "version": 1,
+                      },
+                      "provisioning": {
+                        "createdAt": "2024-01-15T09:30:00Z",
+                        "enabled": true,
+                        "lastModified": "2024-01-15T09:30:00Z",
+                        "mappings": [
+                          {},
+                        ],
+                        "syncStatus": "active",
+                      },
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/config",
+              "request": {
+                "body": {
+                  "properties": {
+                    "enabled": {
+                      "docs": "Whether provisioning is enabled",
+                      "type": "optional<boolean>",
+                    },
+                    "mappings": "optional<list<AttributeMapping>>",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "ConfigCreateRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "Configuration created successfully",
+                "status-code": 200,
+                "type": "ConfigResponse",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+            "getConfiguration": {
+              "auth": undefined,
+              "display-name": "Get configuration",
+              "docs": undefined,
+              "examples": [
+                {
+                  "path-parameters": {
+                    "configId": "configId",
+                  },
+                  "response": {
+                    "body": {
+                      "id": "id",
+                      "metadata": {
+                        "owner": "owner",
+                        "tags": [
+                          "tags",
+                        ],
+                        "version": 1,
+                      },
+                      "provisioning": {
+                        "createdAt": "2024-01-15T09:30:00Z",
+                        "enabled": true,
+                        "lastModified": "2024-01-15T09:30:00Z",
+                        "mappings": [
+                          {},
+                        ],
+                        "syncStatus": "active",
+                      },
+                    },
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/config/{configId}",
+              "request": {
+                "name": "GetConfigConfigIdRequest",
+                "path-parameters": {
+                  "configId": "string",
+                },
+              },
+              "response": {
+                "docs": "Configuration retrieved successfully",
+                "status-code": 200,
+                "type": "ConfigResponse",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "AttributeMapping": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "required": {
+                "default": false,
+                "type": "optional<boolean>",
+              },
+              "source": {
+                "docs": "Source attribute name",
+                "type": "optional<string>",
+              },
+              "target": {
+                "docs": "Target attribute name",
+                "type": "optional<string>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ConfigMetadataRead": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "owner": {
+                "access": "read-only",
+                "type": "optional<string>",
+              },
+              "tags": "optional<list<string>>",
+              "version": {
+                "access": "read-only",
+                "type": "optional<integer>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ConfigResponse": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "id": {
+                "docs": "Configuration ID",
+                "type": "optional<string>",
+              },
+              "metadata": "optional<ConfigMetadataRead>",
+              "provisioning": {
+                "docs": "Provisioning configuration",
+                "type": "optional<IdpProvisioningConfigRead>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "IdpProvisioningConfigRead": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "createdAt": {
+                "access": "read-only",
+                "docs": "When the config was created",
+                "type": "optional<datetime>",
+              },
+              "enabled": {
+                "docs": "Whether provisioning is enabled",
+                "type": "optional<boolean>",
+              },
+              "lastModified": {
+                "access": "read-only",
+                "docs": "When the config was last modified",
+                "type": "optional<datetime>",
+              },
+              "mappings": "optional<list<AttributeMapping>>",
+              "syncStatus": {
+                "access": "read-only",
+                "docs": "Current sync status",
+                "type": "optional<IdpProvisioningConfigSyncStatus>",
+              },
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "IdpProvisioningConfigSyncStatus": {
+            "docs": "Current sync status",
+            "enum": [
+              "active",
+              "pending",
+              "failed",
+            ],
+            "inline": true,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    createConfiguration:
+      path: /config
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      display-name: Create configuration
+      request:
+        name: ConfigCreateRequest
+        body:
+          properties:
+            enabled:
+              type: optional<boolean>
+              docs: Whether provisioning is enabled
+            mappings: optional<list<AttributeMapping>>
+        content-type: application/json
+      response:
+        docs: Configuration created successfully
+        type: ConfigResponse
+        status-code: 200
+      examples:
+        - request: {}
+          response:
+            body:
+              id: id
+              provisioning:
+                enabled: true
+                mappings:
+                  - {}
+                createdAt: '2024-01-15T09:30:00Z'
+                lastModified: '2024-01-15T09:30:00Z'
+                syncStatus: active
+              metadata:
+                version: 1
+                owner: owner
+                tags:
+                  - tags
+    getConfiguration:
+      path: /config/{configId}
+      method: GET
+      source:
+        openapi: ../openapi.yml
+      display-name: Get configuration
+      request:
+        name: GetConfigConfigIdRequest
+        path-parameters:
+          configId: string
+      response:
+        docs: Configuration retrieved successfully
+        type: ConfigResponse
+        status-code: 200
+      examples:
+        - path-parameters:
+            configId: configId
+          response:
+            body:
+              id: id
+              provisioning:
+                enabled: true
+                mappings:
+                  - {}
+                createdAt: '2024-01-15T09:30:00Z'
+                lastModified: '2024-01-15T09:30:00Z'
+                syncStatus: active
+              metadata:
+                version: 1
+                owner: owner
+                tags:
+                  - tags
+  source:
+    openapi: ../openapi.yml
+types:
+  IdpProvisioningConfigSyncStatus:
+    enum:
+      - active
+      - pending
+      - failed
+    docs: Current sync status
+    inline: true
+    source:
+      openapi: ../openapi.yml
+  IdpProvisioningConfigRead:
+    properties:
+      enabled:
+        type: optional<boolean>
+        docs: Whether provisioning is enabled
+      mappings: optional<list<AttributeMapping>>
+      createdAt:
+        type: optional<datetime>
+        docs: When the config was created
+        access: read-only
+      lastModified:
+        type: optional<datetime>
+        docs: When the config was last modified
+        access: read-only
+      syncStatus:
+        type: optional<IdpProvisioningConfigSyncStatus>
+        docs: Current sync status
+        access: read-only
+    source:
+      openapi: ../openapi.yml
+  ConfigResponse:
+    properties:
+      id:
+        type: optional<string>
+        docs: Configuration ID
+      provisioning:
+        type: optional<IdpProvisioningConfigRead>
+        docs: Provisioning configuration
+      metadata: optional<ConfigMetadataRead>
+    source:
+      openapi: ../openapi.yml
+  AttributeMapping:
+    properties:
+      source:
+        type: optional<string>
+        docs: Source attribute name
+      target:
+        type: optional<string>
+        docs: Target attribute name
+      required:
+        type: optional<boolean>
+        default: false
+    source:
+      openapi: ../openapi.yml
+  ConfigMetadataRead:
+    properties:
+      version:
+        type: optional<integer>
+        access: read-only
+      owner:
+        type: optional<string>
+        access: read-only
+      tags: optional<list<string>>
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Readonly Schema References API",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Readonly Schema References API
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/readonly.json
@@ -129,8 +129,8 @@
                 "type": "optional<string>",
               },
               "name": "optional<string>",
-              "settings": "optional<UserSettings>",
-              "stats": "optional<UserStats>",
+              "settings": "optional<UserSettingsRead>",
+              "stats": "optional<UserStatsRead>",
             },
             "source": {
               "openapi": "../openapi.yml",
@@ -264,8 +264,8 @@ types:
       createdAt:
         type: optional<datetime>
         access: read-only
-      settings: optional<UserSettings>
-      stats: optional<UserStats>
+      settings: optional<UserSettingsRead>
+      stats: optional<UserStatsRead>
     source:
       openapi: ../openapi.yml
   UserSettingsRead:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-schema-references/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-schema-references/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "test",
+  "version": "0.0.0"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-schema-references/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-schema-references/fern/generators.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings:
+        respect-readonly-schemas: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-schema-references/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/readonly-schema-references/openapi.yml
@@ -1,0 +1,122 @@
+openapi: 3.1.0
+info:
+  title: Readonly Schema References API
+  description: Test schema reference resolution when respect-readonly-schemas causes schema renaming
+  version: 1.0.0
+
+paths:
+  /config:
+    post:
+      summary: Create configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConfigCreateRequest"
+      responses:
+        "200":
+          description: Configuration created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConfigResponse"
+
+  /config/{configId}:
+    get:
+      summary: Get configuration
+      parameters:
+        - name: configId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Configuration retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConfigResponse"
+
+components:
+  schemas:
+    # Schema with readonly properties that will be renamed to IdpProvisioningConfigRead
+    IdpProvisioningConfig:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Whether provisioning is enabled
+        mappings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttributeMapping"
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+          description: When the config was created
+        lastModified:
+          type: string
+          format: date-time
+          readOnly: true
+          description: When the config was last modified
+        syncStatus:
+          type: string
+          enum: [active, pending, failed]
+          readOnly: true
+          description: Current sync status
+
+    # Schema that references the renamed schema
+    ConfigResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Configuration ID
+        provisioning:
+          $ref: "#/components/schemas/IdpProvisioningConfig"
+          description: Provisioning configuration
+        metadata:
+          $ref: "#/components/schemas/ConfigMetadata"
+
+    # Request schema for creation (no readonly properties)
+    ConfigCreateRequest:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Whether provisioning is enabled
+        mappings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttributeMapping"
+
+    # Supporting schemas
+    AttributeMapping:
+      type: object
+      properties:
+        source:
+          type: string
+          description: Source attribute name
+        target:
+          type: string
+          description: Target attribute name
+        required:
+          type: boolean
+          default: false
+
+    ConfigMetadata:
+      type: object
+      properties:
+        version:
+          type: integer
+          readOnly: true
+        owner:
+          type: string
+          readOnly: true
+        tags:
+          type: array
+          items:
+            type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
@@ -307,6 +307,10 @@ export class OpenApiIrConverterContext {
      * Gets the final name for a schema, or the original name if no mapping exists.
      */
     public getSchemaFinalName(schemaId: string): string {
+        // Fast path: if respect-readonly-schemas is disabled, no schema renaming occurs
+        if (!this.options.respectReadonlySchemas) {
+            return schemaId;
+        }
         return this.schemaNameMapping.get(schemaId) ?? schemaId;
     }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
@@ -68,6 +68,12 @@ export class OpenApiIrConverterContext {
      */
     private state: Set<State> = new Set();
 
+    /**
+     * Maps original schema IDs to their final names after readonly processing.
+     * Used to resolve schema references correctly when respect-readonly-schemas is enabled.
+     */
+    private schemaNameMapping: Map<string, string> = new Map();
+
     constructor({
         taskContext,
         ir,
@@ -288,5 +294,19 @@ export class OpenApiIrConverterContext {
 
     private isInAnyState(...states: State[]): boolean {
         return states.some((state) => this.isInState(state));
+    }
+
+    /**
+     * Records the final name for a schema after readonly processing.
+     */
+    public setSchemaFinalName(schemaId: string, finalName: string): void {
+        this.schemaNameMapping.set(schemaId, finalName);
+    }
+
+    /**
+     * Gets the final name for a schema, or the original name if no mapping exists.
+     */
+    public getSchemaFinalName(schemaId: string): string {
+        return this.schemaNameMapping.get(schemaId) ?? schemaId;
     }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
@@ -35,17 +35,20 @@ function addSchemas({
     context: OpenApiIrConverterContext;
 }): void {
     // Phase 1: Pre-compute all final schema names to handle readonly renaming
-    for (const [id, schema] of Object.entries(schemas)) {
-        if (schemaIdsToExclude.includes(id) || schema.type !== "object") {
-            continue;
-        }
+    // Skip this phase entirely if respect-readonly-schemas is disabled
+    if (context.options.respectReadonlySchemas) {
+        for (const [id, schema] of Object.entries(schemas)) {
+            if (schemaIdsToExclude.includes(id) || schema.type !== "object") {
+                continue;
+            }
 
-        const originalName = schema.nameOverride ?? schema.generatedName;
-        const hasReadonlyProperties = schema.properties.some((prop) => prop.readonly);
+            const originalName = schema.nameOverride ?? schema.generatedName;
+            const hasReadonlyProperties = schema.properties.some((prop) => prop.readonly);
 
-        if (hasReadonlyProperties && context.options.respectReadonlySchemas) {
-            const finalName = `${originalName}Read`;
-            context.setSchemaFinalName(originalName, finalName);
+            if (hasReadonlyProperties) {
+                const finalName = `${originalName}Read`;
+                context.setSchemaFinalName(originalName, finalName);
+            }
         }
     }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
@@ -34,6 +34,22 @@ function addSchemas({
     namespace: string | undefined;
     context: OpenApiIrConverterContext;
 }): void {
+    // Phase 1: Pre-compute all final schema names to handle readonly renaming
+    for (const [id, schema] of Object.entries(schemas)) {
+        if (schemaIdsToExclude.includes(id) || schema.type !== "object") {
+            continue;
+        }
+
+        const originalName = schema.nameOverride ?? schema.generatedName;
+        const hasReadonlyProperties = schema.properties.some((prop) => prop.readonly);
+
+        if (hasReadonlyProperties && context.options.respectReadonlySchemas) {
+            const finalName = `${originalName}Read`;
+            context.setSchemaFinalName(originalName, finalName);
+        }
+    }
+
+    // Phase 2: Build type declarations using final names
     for (const [id, schema] of Object.entries(schemas)) {
         if (schemaIdsToExclude.includes(id)) {
             continue;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeDeclaration.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeDeclaration.ts
@@ -144,12 +144,12 @@ export function buildObjectTypeDeclaration({
     namespace: string | undefined;
     declarationDepth: number;
 }): ConvertedTypeDeclaration {
-    const shouldSkipReadonly =
-        context.isInState(State.Request) &&
-        context.options.respectReadonlySchemas &&
-        (context.getEndpointMethod() === "POST" ||
-            context.getEndpointMethod() === "PUT" ||
-            context.getEndpointMethod() === "PATCH");
+    const isInRequestState = context.isInState(State.Request);
+    const respectReadonlySchemas = context.options.respectReadonlySchemas;
+    const endpointMethod = context.getEndpointMethod();
+    const isWriteMethod = endpointMethod === "POST" || endpointMethod === "PUT" || endpointMethod === "PATCH";
+
+    const shouldSkipReadonly = isInRequestState && respectReadonlySchemas && isWriteMethod;
 
     let readOnlyPropertyPresent = false;
     const properties: Record<string, RawSchemas.ObjectPropertySchema> = {};
@@ -300,11 +300,16 @@ export function buildObjectTypeDeclaration({
     objectTypeDeclaration.inline = getInline(schema, declarationDepth);
 
     const name = schema.nameOverride ?? schema.generatedName;
+    const finalName =
+        readOnlyPropertyPresent && context.options.respectReadonlySchemas && !shouldSkipReadonly ? `${name}Read` : name;
+
+    // Record the final name mapping for reference resolution
+    if (finalName !== name) {
+        context.setSchemaFinalName(name, finalName);
+    }
+
     return {
-        name:
-            readOnlyPropertyPresent && context.options.respectReadonlySchemas && !shouldSkipReadonly
-                ? `${name}Read`
-                : name,
+        name: finalName,
         schema: objectTypeDeclaration
     };
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
@@ -462,7 +462,9 @@ export function buildReferenceTypeReference({
     }
 
     const originalSchemaName = getSchemaName(resolvedSchema) ?? schema.schema;
-    const schemaName = context.getSchemaFinalName(originalSchemaName);
+    const schemaName = context.options.respectReadonlySchemas
+        ? context.getSchemaFinalName(originalSchemaName)
+        : originalSchemaName;
     const groupName = getGroupNameForSchema(resolvedSchema);
     const displayName = getDisplayName(resolvedSchema);
     // Use the reference's namespace (schema.namespace) to determine the declaration file,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
@@ -461,7 +461,8 @@ export function buildReferenceTypeReference({
         return "unknown";
     }
 
-    const schemaName = getSchemaName(resolvedSchema) ?? schema.schema;
+    const originalSchemaName = getSchemaName(resolvedSchema) ?? schema.schema;
+    const schemaName = context.getSchemaFinalName(originalSchemaName);
     const groupName = getGroupNameForSchema(resolvedSchema);
     const displayName = getDisplayName(resolvedSchema);
     // Use the reference's namespace (schema.namespace) to determine the declaration file,

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.90.5
+  changelogEntry:
+    - summary: |
+        Fix schema reference resolution when `respect-readonly-schemas: true` is enabled.
+        Previously, when schemas containing readonly properties were renamed with "Read"
+        suffixes (e.g., `UserConfig` → `UserConfigRead`), other schemas that referenced
+        them would still point to the original names, causing validation failures.
+        Implemented two-phase processing to pre-compute final schema names before
+        building type declarations, ensuring references resolve correctly.
+      type: fix
+  createdAt: "2026-02-26"
+  irVersion: 65
+
 - version: 3.90.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
When `respect-readonly-schemas: true`, schemas would be renamed to `{name}Read`, but not universally, which caused references to break:
```yml
# generators.yml
  api:
    specs:
      - openapi: spec.yml
        settings:
          respect-readonly-schemas: true

---
# spec.yml
  components:
    schemas:
      # Schema with readonly properties (gets renamed to "ProvisioningConfigRead")
      ProvisioningConfig:
        type: object
        properties:
          enabled:
            type: boolean
          createdAt:
            type: string
            format: date-time
            readOnly: true
          lastModified:
            type: string
            format: date-time
            readOnly: true

      # Schema that references the above (this reference would break)
      ConfigResponse:
        type: object
        properties:
          id:
            type: string
          provisioning:
            $ref: "#/components/schemas/ProvisioningConfig"  # ← This reference breaks!
```
Now there's a 2-stage pass of schema names to complete their potential renaming before resolving references.

## Changes Made
To the `openapi-ir-to-fern` parser.

## Testing
Added a case to `openapi-ir-to-fern-tests` to test this behavior; this test will fail when this behavior isn't present.
- [X] Unit tests added/updated
- [X] Manual testing completed
