### PR TITLE
fix(typescript): use JSON.parse + skipValidation for IR parsing under 500MB

### DIFF
--- a/generators/base/src/utils/parseIR.ts
+++ b/generators/base/src/utils/parseIR.ts
@@ -1,4 +1,5 @@
 import { AbsoluteFilePath, streamObjectFromFile } from "@fern-api/fs-utils";
+import { readFile, stat } from "fs/promises";
 
 export declare namespace parseIR {
     export interface Args<IntermediateRepresentation> {
@@ -62,14 +63,37 @@ export declare namespace parseIR {
     }
 }
 
+/**
+ * Files under this threshold are parsed with JSON.parse (faster for
+ * most real-world IRs). Larger files fall back to streaming to avoid
+ * allocating the entire string in memory at once.
+ *
+ * Benchmarks show JSON.parse is 3-8x faster than stream-json at all
+ * sizes.  The hard ceiling is V8's MAX_STRING_LENGTH (~512 MB) — we
+ * stay below that with a margin so the utf-8 string never exceeds
+ * the limit.
+ */
+const STREAM_THRESHOLD_BYTES = 500 * 1024 * 1024; // 500 MB
+
 export async function parseIR<IR>({ absolutePathToIR, parse }: parseIR.Args<IR>): Promise<IR> {
-    const irJson = await streamObjectFromFile(absolutePathToIR);
+    const fileStat = await stat(absolutePathToIR);
+    const useStreaming = fileStat.size >= STREAM_THRESHOLD_BYTES;
+
+    let irJson: unknown;
+    if (useStreaming) {
+        irJson = await streamObjectFromFile(absolutePathToIR);
+    } else {
+        const raw = await readFile(absolutePathToIR, "utf-8");
+        irJson = JSON.parse(raw);
+    }
     // biome-ignore lint/suspicious/noConsole: allow console
-    console.log(`Parsed ${absolutePathToIR}`);
+    console.log(`Parsed ${absolutePathToIR} (${useStreaming ? "streamed" : "JSON.parse"}, ${fileStat.size} bytes)`);
+
     const parsedIR = await parse(irJson, {
         unrecognizedObjectKeys: "passthrough",
         allowUnrecognizedEnumValues: true,
-        allowUnrecognizedUnionMembers: true
+        allowUnrecognizedUnionMembers: true,
+        skipValidation: true
     });
 
     if (!parsedIR.ok) {


### PR DESCRIPTION
## Description

Refs: Performance optimization for IR parsing across all generators.

Optimizes `parseIR` with two changes: (1) use V8's native `JSON.parse` instead of `stream-json` for files under 500 MB, and (2) skip schema validation since the IR is a trusted internal format generated by fern.

Link to Devin run: https://app.devin.ai/sessions/3e1c651017e8452591d37dc4bcaa323b
Requested by: @Swimburger

## Changes Made

- **Fast-path JSON.parse for files < 500 MB**: Checks file size via `fs.stat`, then uses `readFile` + `JSON.parse` for most real-world IRs. Falls back to `streamObjectFromFile` for files ≥ 500 MB to avoid hitting V8's `MAX_STRING_LENGTH` (~512 MB) limit.
- **`skipValidation: true`**: Skips the per-field schema validation in the IR SDK `parse()` call, treating the IR as trusted input.
- Enhanced console log to show which parsing strategy was used and the file size.

Benchmarks (synthetic JSON on this VM):

| Size | JSON.parse | stream-json | Speedup |
|------|-----------|-------------|---------|
| 1 MB | 4 ms | 35 ms | 8.1x |
| 10 MB | 44 ms | 263 ms | 5.9x |
| 50 MB | 327 ms | 1,274 ms | 3.9x |
| 100 MB | 736 ms | 2,667 ms | 3.6x |
| 400 MB | 3,842 ms | 10,882 ms | 2.8x |

## Important Review Items

- **`skipValidation: true` affects ALL generators** (TypeScript, Python, Go, Java, C#, PHP, Ruby, Swift, OpenAPI, Postman) since `parseIR` is shared in `@fern-api/base-generator`. If the IR ever has an unexpected shape (e.g., during version migrations or fern CLI bugs), errors will no longer be caught at parse time and will surface as confusing downstream failures instead.
- **500 MB threshold vs V8 limit**: `MAX_STRING_LENGTH` is 536,870,888 bytes (~512 MB). The 500 MB threshold gives ~12 MB of margin. JSON IR files are mostly ASCII so byte count ≈ character count, but worth confirming this margin is sufficient.
- **No unit tests for the threshold/fallback logic** — tested indirectly via CI seed tests only.

## Testing

- [x] `pnpm turbo run compile --filter @fern-api/base-generator` passes
- [x] `pnpm turbo run depcheck --filter @fern-api/base-generator` passes
- [x] `pnpm turbo run test --filter @fern-api/base-generator` passes (1 test)
- [x] `pnpm turbo run dist:cli --filter @fern-typescript/sdk-generator-cli` passes
- [ ] Unit tests added/updated — no direct tests for `parseIR`; relies on CI seed tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
