### PR TITLE
fix(docs): prefer default version slug when multiple versions share the same MDX file

### DIFF
--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -730,6 +730,8 @@ export class DocsDefinitionResolver {
             }
 
             const absoluteFilePath = join(this.docsWorkspace.absoluteFilePath, RelativeFilePath.of(pageId));
+            // Use ??= to preserve the first (default version) slug when multiple versions share the same MDX file.
+            // The NodeCollector processes the pruned default version first, so its slug (without version prefix) is kept.
             markdownFilesToPathName[absoluteFilePath] ??= slug;
         });
         return markdownFilesToPathName;

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -730,7 +730,7 @@ export class DocsDefinitionResolver {
             }
 
             const absoluteFilePath = join(this.docsWorkspace.absoluteFilePath, RelativeFilePath.of(pageId));
-            markdownFilesToPathName[absoluteFilePath] = slug;
+            markdownFilesToPathName[absoluteFilePath] ??= slug;
         });
         return markdownFilesToPathName;
     }


### PR DESCRIPTION
## Description

**Link to Devin run:** https://app.devin.ai/sessions/fda79e6a2ec84b498bdb6e6471099209
**Requested by:** @Ryan-Amirthan

### Problem

When versioned docs share the same MDX file across multiple versions (e.g., Square docs where `Invoice.mdx` is referenced by both "Latest" and "2023-01-19"), internal `.mdx` cross-links resolve to the **wrong version**.

For example, on the Latest version of the Square API docs, clicking an object type link like `Invoice` navigates to `/reference/square/2023-01-19/objects-enums/.../invoice` instead of `/reference/square/objects-enums/.../invoice` (the Latest/default version).

### Root Cause

In `getMarkdownFilesToFullyQualifiedPathNames`, the `slugMap` is iterated to build a mapping from MDX file paths to URL slugs. When multiple versions reference the same MDX file, each version writes its slug to the same key. With plain `=` assignment, the **last** version processed overwrites all previous ones.

The `NodeCollector` processes the **default version first** (its slug has no version prefix, e.g., `objects/.../invoice`), but subsequent older versions overwrite it (e.g., `2023-01-19/objects/.../invoice`). This corrupted mapping is then used by `replaceImagePathsAndUrls` and `resolveLinksInIrDocs` to resolve all `.mdx` links in page content and API descriptions.

### Fix

One-line change: `=` → `??=` (nullish coalescing assignment). Since `Map.forEach` follows insertion order and the default version is inserted first, `??=` preserves the default version's slug and ignores later overwrites.

## Changes Made

- Changed `markdownFilesToPathName[absoluteFilePath] = slug` to `markdownFilesToPathName[absoluteFilePath] ??= slug`
- Added inline comments explaining the ordering guarantee

## Testing

- [x] Built the CLI locally from this branch and ran `fern generate --docs --preview` against a versioned docs config (Latest + V2 sharing the same MDX pages with `.mdx` cross-links)
- [x] Verified resolved links in page content point to the default version (e.g., `[Key Concepts](/concepts)`) instead of the non-default version (`/v2/concepts`)
- [x] Confirmed that when viewing an older version, links correctly stay within that version's context
- [ ] Unit tests added/updated

## Human Review Checklist

> [!IMPORTANT]
> - **Ordering assumption**: This fix relies on the default version's pages being inserted into `slugMap` before non-default versions. `NodeCollector` processes the pruned default version first (see `isDefaultVersion` handling around lines 90-99). Confirm this ordering holds for all version configurations.
> - **Shared file resolution is version-unaware**: Since there's only one `markdownFilesToPathName` mapping (not per-version), all versions' page content resolves shared `.mdx` links to the same slug — the default version's. The docs renderer handles version-aware navigation separately, so links stay within the user's current version context. Verified working in local testing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
