### PR TITLE
fix(typescript): avoid Edge Runtime static analysis warning for process.versions.node

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.52.3
+  changelogEntry:
+    - summary: |
+        Fix Edge Runtime compatibility warning in Next.js. The runtime detection code
+        previously used `process.versions.node` directly, which caused Next.js bundlers
+        (Turbopack/webpack) to emit "A Node.js API is used which is not supported in
+        the Edge Runtime" warnings during static analysis, even though the code path was
+        guarded by an Edge Runtime check. The fix assigns `process` to a local variable
+        first, preventing bundlers from flagging the indirect property access.
+      type: fix
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 3.52.2
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/runtime/runtime.ts
+++ b/generators/typescript/utils/core-utilities/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/accept-header/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/accept-header/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/alias-extends/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/alias-extends/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/alias/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/alias/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/api-wide-base-path/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/basic-auth/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/basic-auth/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/bytes-download/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/bytes-download/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/bytes-upload/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/circular-references-advanced/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/circular-references/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/circular-references/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/client-side-params/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/client-side-params/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/content-type/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/content-type/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/dollar-string-examples/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/dollar-string-examples/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/empty-clients/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/empty-clients/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/endpoint-security-auth/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/enum/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/enum/serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/enum/serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/error-property/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/error-property/union-utils/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/errors/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/errors/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/bigint/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/local-files/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/output-src-only/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/extends/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/extends/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/extra-properties/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/extra-properties/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-download/stream-wrapper/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-upload-openapi/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-upload/inline/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-upload/serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-upload/use-jest/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/file-upload/wrapper/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/folders/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/folders/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/header-auth/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/header-auth/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/http-head/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/http-head/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/idempotency-headers/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/license/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/license/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/literal/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/literal/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/literals-unions/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/literals-unions/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/mixed-file-directory/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/multi-line-docs/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/multi-url-environment/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/multiple-request-bodies/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/no-environment/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/no-environment/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/no-retries/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/no-retries/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/nullable-allof-extends/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/nullable-optional/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/nullable-optional/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/nullable-request-body/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/nullable-request-body/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/nullable/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/nullable/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/object/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/object/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/objects-with-imports/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/optional/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/optional/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/package-yml/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/package-yml/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/pagination-custom/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/pagination-uri-path/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/plain-text/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/plain-text/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/property-access/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/public-object/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/public-object/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/query-parameters-openapi/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/query-parameters/serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/required-nullable/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/required-nullable/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/reserved-keywords/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/response-property/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/response-property/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/server-sent-event-examples/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/server-sent-events/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/server-url-templating/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/server-url-templating/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/bundle/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/jsr/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/use-oxc/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/simple-fhir/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/single-url-environment-default/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/streaming-parameter/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/streaming/serde-layer/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/streaming/wrapper/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/trace/exhaustive/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/trace/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/trace/serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/trace/serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/ts-express-casing/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/ts-extra-properties/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/unions-with-local-date/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/unions/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/unions/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/url-form-encoded/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/url-form-encoded/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/validation/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/validation/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/variables/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/variables/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/version-no-default/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/version-no-default/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/version/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/version/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/webhook-audience/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/webhook-audience/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/webhooks/no-custom-config/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/websocket/no-serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 

--- a/seed/ts-sdk/websocket/serde/src/core/runtime/runtime.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/runtime/runtime.ts
@@ -113,18 +113,20 @@ function evaluateRuntime(): Runtime {
 
     /**
      * A constant that indicates whether the environment the code is running is Node.JS.
+     *
+     * We assign `process` to a local variable first to avoid being flagged by
+     * bundlers that perform static analysis on `process.versions` (e.g. Next.js
+     * Edge Runtime warns about Node.js APIs even when they are guarded).
      */
+    const _process = typeof process !== "undefined" ? process : undefined;
     const isNode =
-        typeof process !== "undefined" &&
-        "version" in process &&
-        !!process.version &&
-        "versions" in process &&
-        !!process.versions?.node;
+        typeof _process !== "undefined" &&
+        typeof _process.versions?.node === "string";
     if (isNode) {
         return {
             type: "node",
-            version: process.versions.node,
-            parsedVersion: Number(process.versions.node.split(".")[0]),
+            version: _process.versions.node,
+            parsedVersion: Number(_process.versions.node.split(".")[0]),
         };
     }
 


### PR DESCRIPTION
## Description

Refs internal Slack thread re: Next.js Edge Runtime warnings during dev

Next.js bundlers (Turbopack/webpack) perform static AST analysis on imported files and flag direct `process.versions` usage as a Node.js API incompatible with Edge Runtime — even when the code path is guarded by an earlier `EdgeRuntime` check that returns before reaching the Node.js branch. This causes noisy log spam in local development.

This is a known ecosystem-wide problem affecting multiple libraries (see [graphql-js #4075](https://github.com/graphql/graphql-js/issues/4075) for thorough analysis, [supabase-js #1515](https://github.com/supabase/supabase-js/issues/1515) and [#1552](https://github.com/supabase/supabase-js/issues/1552) for the same `process.versions` issue).

[Link to Devin run](https://app.devin.ai/sessions/237335a28a2a4a2eb63f4ab58b66f577) | Requested by @Swimburger

## Changes Made

- Assign `process` to a local variable (`_process`) before accessing `.versions.node`, breaking the static `process.versions` pattern that bundlers detect
- Simplified the Node.js detection from 5 chained conditions to 2 (the extra `"version" in process` / `!!process.version` checks were redundant given we already check `process.versions.node` is a string)
- Updated all 192 seed test fixtures with the same change
- Added `versions.yml` entry for `3.52.5`

## Human Review Checklist

- [ ] **Verify the simplified Node.js check is equivalent**: The old check was `typeof process !== "undefined" && "version" in process && !!process.version && "versions" in process && !!process.versions?.node`. The new check is `typeof _process !== "undefined" && typeof _process.versions?.node === "string"`. The removed conditions should be redundant in any real Node.js environment, but confirm there are no edge cases.
- [ ] **Confirm the local variable trick suppresses the warning**: The fix relies on bundlers not tracing `process` through the `_process` intermediate variable. This is option F from the [graphql-js analysis](https://github.com/graphql/graphql-js/issues/4075), which notes some bundlers may still detect `process` as a local variable. The fix was **not verified** against an actual Next.js Edge Runtime setup that reproduces the warning (a minimal repro across Next.js 14/15/16 did not trigger the original warning).
- [ ] **`packages/` directory intentionally NOT updated**: Internal CLI SDK clients in `packages/` also contain `process.versions.node` but don't run in Edge Runtime, so they were left unchanged.

## Testing

- [ ] Unit tests — no new tests (behavioral equivalence, not a new feature)
- [ ] Manual testing — tested in minimal Next.js Edge Runtime setups (v14/15/16, Turbopack and webpack) but was unable to reproduce the original warning to confirm the fix. The original report was from a monorepo with compiled ESM output, which may have different bundler behavior.