### PR TITLE
feat(postman): add collection-description config option

### DIFF
--- a/generators/postman/src/config/schemas/PostmanGeneratorConfigSchema.ts
+++ b/generators/postman/src/config/schemas/PostmanGeneratorConfigSchema.ts
@@ -8,7 +8,8 @@ export const PostmanGeneratorConfigSchema = z.union([
     z.strictObject({
         publishing: PublishConfigSchema.optional(),
         filename: z.string().optional(),
-        "collection-name": z.string().optional()
+        "collection-name": z.string().optional(),
+        "collection-description": z.string().optional()
     })
 ]);
 

--- a/generators/postman/src/config/schemas/PostmanGeneratorConfigSchema.ts
+++ b/generators/postman/src/config/schemas/PostmanGeneratorConfigSchema.ts
@@ -9,7 +9,7 @@ export const PostmanGeneratorConfigSchema = z.union([
         publishing: PublishConfigSchema.optional(),
         filename: z.string().optional(),
         "collection-name": z.string().optional(),
-        "collection-description": z.string().optional()
+        description: z.string().optional()
     })
 ]);
 

--- a/generators/postman/src/config/schemas/PostmanGeneratorConfigSchema.ts
+++ b/generators/postman/src/config/schemas/PostmanGeneratorConfigSchema.ts
@@ -9,7 +9,7 @@ export const PostmanGeneratorConfigSchema = z.union([
         publishing: PublishConfigSchema.optional(),
         filename: z.string().optional(),
         "collection-name": z.string().optional(),
-        description: z.string().optional()
+        "collection-description": z.string().optional()
     })
 ]);
 

--- a/generators/postman/src/convertToPostmanCollection.ts
+++ b/generators/postman/src/convertToPostmanCollection.ts
@@ -15,10 +15,12 @@ import { ORIGIN_VARIABLE_NAME } from "./utils.js";
 
 export function convertToPostmanCollection({
     ir,
-    collectionName
+    collectionName,
+    collectionDescription
 }: {
     ir: FernIr.IntermediateRepresentation;
     collectionName: string;
+    collectionDescription: string | undefined;
 }): PostmanCollectionSchema {
     const authSchemes = filterAuthSchemes(ir.auth);
     const authHeaders = getAuthHeaders(authSchemes);
@@ -27,7 +29,7 @@ export function convertToPostmanCollection({
         info: {
             name: collectionName,
             schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-            description: ir.apiDocs ?? undefined
+            description: collectionDescription ?? ir.apiDocs ?? undefined
         },
         variable: [
             {

--- a/generators/postman/src/writePostmanCollection.ts
+++ b/generators/postman/src/writePostmanCollection.ts
@@ -61,7 +61,8 @@ export async function writePostmanCollection(pathToConfig: string): Promise<void
                 collectionName:
                     postmanGeneratorConfig?.["collection-name"] ??
                     ir.apiDisplayName ??
-                    startCase(ir.apiName.originalName)
+                    startCase(ir.apiName.originalName),
+                collectionDescription: postmanGeneratorConfig?.["collection-description"]
             });
             const rawCollectionDefinition = PostmanParsing.PostmanCollectionSchema.jsonOrThrow(_collectionDefinition, {
                 unrecognizedObjectKeys: "passthrough"

--- a/generators/postman/src/writePostmanCollection.ts
+++ b/generators/postman/src/writePostmanCollection.ts
@@ -62,7 +62,7 @@ export async function writePostmanCollection(pathToConfig: string): Promise<void
                     postmanGeneratorConfig?.["collection-name"] ??
                     ir.apiDisplayName ??
                     startCase(ir.apiName.originalName),
-                collectionDescription: postmanGeneratorConfig?.["collection-description"]
+                collectionDescription: postmanGeneratorConfig?.description
             });
             const rawCollectionDefinition = PostmanParsing.PostmanCollectionSchema.jsonOrThrow(_collectionDefinition, {
                 unrecognizedObjectKeys: "passthrough"

--- a/generators/postman/src/writePostmanCollection.ts
+++ b/generators/postman/src/writePostmanCollection.ts
@@ -62,7 +62,7 @@ export async function writePostmanCollection(pathToConfig: string): Promise<void
                     postmanGeneratorConfig?.["collection-name"] ??
                     ir.apiDisplayName ??
                     startCase(ir.apiName.originalName),
-                collectionDescription: postmanGeneratorConfig?.description
+                collectionDescription: postmanGeneratorConfig?.["collection-description"]
             });
             const rawCollectionDefinition = PostmanParsing.PostmanCollectionSchema.jsonOrThrow(_collectionDefinition, {
                 unrecognizedObjectKeys: "passthrough"

--- a/generators/postman/versions.yml
+++ b/generators/postman/versions.yml
@@ -1,5 +1,27 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
 
+- version: 0.6.0
+  changelogEntry:
+    - type: feat
+      summary: |
+        Add a `collection-description` configuration that allows you to set
+        the description of the generated Postman collection.
+
+        ```yml
+        groups:
+          generators:
+            postman:
+              - name: fernapi/fern-postman
+                version: 0.6.0
+                config:
+                  collection-description: My API description
+        ```
+
+        If not specified, the description falls back to the API-level docs
+        from the Fern definition.
+  createdAt: "2026-02-27"
+  irVersion: 53
+
 - version: 0.5.0
   changelogEntry:
     - type: feat

--- a/generators/postman/versions.yml
+++ b/generators/postman/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - type: feat
       summary: |
-        Add a `collection-description` configuration that allows you to set
+        Add a `description` configuration that allows you to set
         the description of the generated Postman collection.
 
         ```yml
@@ -14,7 +14,7 @@
               - name: fernapi/fern-postman
                 version: 0.6.0
                 config:
-                  collection-description: My API description
+                  description: My API description
         ```
 
         If not specified, the description falls back to the API-level docs

--- a/generators/postman/versions.yml
+++ b/generators/postman/versions.yml
@@ -4,7 +4,7 @@
   changelogEntry:
     - type: feat
       summary: |
-        Add a `description` configuration that allows you to set
+        Add a `collection-description` configuration that allows you to set
         the description of the generated Postman collection.
 
         ```yml
@@ -14,7 +14,7 @@
               - name: fernapi/fern-postman
                 version: 0.6.0
                 config:
-                  description: My API description
+                  collection-description: My API description
         ```
 
         If not specified, the description falls back to the API-level docs

--- a/seed/postman/imdb/collection-description/collection.json
+++ b/seed/postman/imdb/collection-description/collection.json
@@ -1,0 +1,233 @@
+{
+  "info": {
+    "name": "Api",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "The IMDb API allows you to search for movies and retrieve their details."
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "token",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "item": [
+    {
+      "_type": "container",
+      "description": null,
+      "name": "Imdb",
+      "item": [
+        {
+          "_type": "endpoint",
+          "name": "Create Movie",
+          "request": {
+            "description": "Add a movie to the database using the movies/* /... path.",
+            "url": {
+              "raw": "{{baseUrl}}/movies/create-movie",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "movies",
+                "create-movie"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "type": "text",
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"title\": \"title\",\n    \"rating\": 1.1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "status": "OK",
+              "code": 200,
+              "originalRequest": {
+                "description": "Add a movie to the database using the movies/* /... path.",
+                "url": {
+                  "raw": "{{baseUrl}}/movies/create-movie",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "movies",
+                    "create-movie"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "type": "text",
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "POST",
+                "auth": null,
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"title\": \"title\",\n    \"rating\": 1.1\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "description": null,
+              "body": "\"string\"",
+              "_postman_previewlanguage": "json"
+            }
+          ]
+        },
+        {
+          "_type": "endpoint",
+          "name": "Get Movie",
+          "request": {
+            "description": null,
+            "url": {
+              "raw": "{{baseUrl}}/movies/:movieId",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "movies",
+                ":movieId"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "key": "movieId",
+                  "description": null,
+                  "value": "movieId"
+                }
+              ]
+            },
+            "header": [
+              {
+                "type": "text",
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "auth": null,
+            "body": null
+          },
+          "response": [
+            {
+              "name": "Success",
+              "status": "OK",
+              "code": 200,
+              "originalRequest": {
+                "description": null,
+                "url": {
+                  "raw": "{{baseUrl}}/movies/:movieId",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "movies",
+                    ":movieId"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "key": "movieId",
+                      "description": null,
+                      "value": "movieId"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "type": "text",
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "GET",
+                "auth": null,
+                "body": null
+              },
+              "description": null,
+              "body": "{\n    \"id\": \"id\",\n    \"title\": \"title\",\n    \"rating\": 1.1\n}",
+              "_postman_previewlanguage": "json"
+            },
+            {
+              "name": "Movie Does Not Exist Error",
+              "status": "Movie Does Not Exist Error",
+              "code": 404,
+              "originalRequest": {
+                "description": null,
+                "url": {
+                  "raw": "{{baseUrl}}/movies/:movieId",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "movies",
+                    ":movieId"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "key": "movieId",
+                      "description": null,
+                      "value": "movieId"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "type": "text",
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "GET",
+                "auth": null,
+                "body": null
+              },
+              "description": null,
+              "body": "\"string\"",
+              "_postman_previewlanguage": "json"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/seed/postman/seed.yml
+++ b/seed/postman/seed.yml
@@ -20,5 +20,8 @@ fixtures:
     - customConfig:
         collection-name: GA Imdb Collection
       outputFolder: collection-name
+    - customConfig:
+        collection-description: The IMDb API allows you to search for movies and retrieve their details.
+      outputFolder: collection-description
 generatorType: Documentation
 defaultOutputMode: local_files


### PR DESCRIPTION
## Description

Closes https://github.com/fern-api/fern/issues/2751

Adds a `collection-description` configuration option to the Postman generator, allowing users to set the description on the generated Postman collection without manually editing it after each generation. The naming follows the existing `collection-name` convention.

## Changes Made

- Added `collection-description` optional string field to `PostmanGeneratorConfigSchema`
- Threaded the new config value through `writePostmanCollection` → `convertToPostmanCollection`
- Description precedence: config `collection-description` > `ir.apiDocs` > `undefined`
- Added `0.6.0` version entry in `versions.yml`
- Added seed test fixture (`imdb/collection-description`) verifying the description appears in the generated `collection.json`

Usage:
```yml
groups:
  generators:
    postman:
      - name: fernapi/fern-postman
        version: 0.6.0
        config:
          collection-description: My API description
```

## Human Review Checklist

- [ ] Verify the fallback chain (`collectionDescription ?? ir.apiDocs ?? undefined`) — config always overrides IR-level docs when set
- [ ] Confirm seed test output (`seed/postman/imdb/collection-description/collection.json`) has the description populated correctly at `info.description`
- [ ] Confirm 0.6.0 minor bump is appropriate

## Testing

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All postman seed tests passing locally (including new `collection-description` fixture)
- [x] Seed test added: `imdb/collection-description` output folder with `collection-description` custom config

---

Link to Devin run: https://app.devin.ai/sessions/732e37b96cb34ab4bb7df4007dae9129
Requested by: @Swimburger