### PR TITLE
fix(typescript): dynamically calculate expected hasNextPage in pagination tests

### DIFF
--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -2212,7 +2212,6 @@ function isPaginationResultsPathMissingInExample({
     return cursor === undefined;
 }
 
-
 /**
  * Extracts a property value from a JSON object by following a property path.
  * Used for walking response/request JSON examples using wire values.
@@ -2265,9 +2264,7 @@ function getRequestPropertyValueFromExample(
         return value;
     } else if (propValue.type === "query") {
         // Query parameter - find matching query param in example
-        const queryParam = example.queryParameters.find(
-            (qp) => qp.name.wireValue === propValue.name.wireValue
-        );
+        const queryParam = example.queryParameters.find((qp) => qp.name.wireValue === propValue.name.wireValue);
         return queryParam?.value.jsonExample;
     }
     return undefined;

--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -1281,8 +1281,8 @@ describe("${serviceName}", () => {
         }
 
         // hasPagination determines if we need { once: false } for multiple mock requests
-        // This is set after isCursorMissing is computed to ensure we don't allow multiple
-        // requests when cursor is missing (since there's no next page to request)
+        // This is set after expectedHasNextPage is computed to ensure we don't allow multiple
+        // requests when there's no next page to request
         const supportsPaginatedResponse =
             endpoint.pagination !== undefined && paginationGeneratesPageObject(endpoint.pagination);
         let hasPagination = supportsPaginatedResponse;
@@ -1305,15 +1305,19 @@ describe("${serviceName}", () => {
                 endpoint
             });
 
-        const isCursorMissing =
-            endpoint.pagination !== undefined &&
-            isPaginationCursorMissingInExample({
-                example,
-                endpoint
-            });
+        // Dynamically calculate the expected hasNextPage() value based on pagination type and example data,
+        // mirroring the SDK's actual pagination heuristic logic
+        const expectedHasNextPage =
+            endpoint.pagination !== undefined && paginationGeneratesPageObject(endpoint.pagination)
+                ? calculateExpectedHasNextPage({
+                      example,
+                      endpoint,
+                      pagination: endpoint.pagination
+                  })
+                : undefined;
 
-        // If cursor is missing, we won't be making getNextPage() calls, so don't need { once: false }
-        if (isCursorMissing) {
+        // If hasNextPage is false, we won't be making getNextPage() calls, so don't need { once: false }
+        if (expectedHasNextPage !== true) {
             hasPagination = false;
         }
 
@@ -1346,16 +1350,21 @@ describe("${serviceName}", () => {
                 const page = ${getTextOfTsNode(generatedExample.endpointInvocation)};
                 ${
                     endpoint.pagination !== undefined && paginationGeneratesPageObject(endpoint.pagination)
-                        ? isCursorMissing
+                        ? expectedHasNextPage === true
                             ? code`
-                            expect(${expectedName}).toEqual(${pageName}.data);
-                            `
-                            : code`
                             expect(${expectedName}).toEqual(${pageName}.data);
                             expect(${pageName}.hasNextPage()).toBe(true);
                             const nextPage = await ${pageName}.getNextPage();
                             expect(${expectedName}).toEqual(${nextPageName}.data);
                         `
+                            : expectedHasNextPage === false
+                              ? code`
+                            expect(${expectedName}).toEqual(${pageName}.data);
+                            expect(${pageName}.hasNextPage()).toBe(false);
+                        `
+                              : code`
+                            expect(${expectedName}).toEqual(${pageName}.data);
+                            `
                         : code`expect(${expectedName}).toEqual(${pageName}.data);`
                 }
                 `
@@ -2203,69 +2212,131 @@ function isPaginationResultsPathMissingInExample({
     return cursor === undefined;
 }
 
+
 /**
- * Checks if the pagination cursor/next property is missing from the example response.
- * For cursor pagination, we need the "next" property; for offset pagination, we need "hasNextPage".
- * If the cursor property is missing, we shouldn't generate hasNextPage().toBe(true) assertions
- * since there won't be a cursor to indicate a next page.
+ * Extracts a property value from a JSON object by following a property path.
+ * Used for walking response/request JSON examples using wire values.
  */
-function isPaginationCursorMissingInExample({
+function getPropertyValueFromJson(
+    json: unknown,
+    property: { propertyPath: FernIr.PropertyPathItem[] | undefined; property: { name: FernIr.NameAndWireValue } }
+): unknown {
+    const segments = [
+        ...(property.propertyPath ?? []).map((item) => item.name.originalName),
+        property.property.name.wireValue
+    ];
+
+    let value: unknown = json;
+    for (const key of segments) {
+        if (value == null || typeof value !== "object" || !(key in value)) {
+            return undefined;
+        }
+        value = (value as Record<string, unknown>)[key];
+    }
+    return value;
+}
+
+/**
+ * Extracts a request property value from example data.
+ * Handles both body properties and query parameters.
+ */
+function getRequestPropertyValueFromExample(
+    example: FernIr.ExampleEndpointCall,
+    requestProperty: FernIr.RequestProperty
+): unknown {
+    const propValue = requestProperty.property;
+    if (propValue.type === "body") {
+        // Body property - walk the request JSON
+        const requestJson = example.request?.jsonExample;
+        if (requestJson == null) {
+            return undefined;
+        }
+        const segments = [
+            ...(requestProperty.propertyPath ?? []).map((item) => item.name.originalName),
+            propValue.name.wireValue
+        ];
+        let value: unknown = requestJson;
+        for (const key of segments) {
+            if (value == null || typeof value !== "object" || !(key in value)) {
+                return undefined;
+            }
+            value = (value as Record<string, unknown>)[key];
+        }
+        return value;
+    } else if (propValue.type === "query") {
+        // Query parameter - find matching query param in example
+        const queryParam = example.queryParameters.find(
+            (qp) => qp.name.wireValue === propValue.name.wireValue
+        );
+        return queryParam?.value.jsonExample;
+    }
+    return undefined;
+}
+
+/**
+ * Calculates the expected hasNextPage() value based on pagination type and example data,
+ * mirroring the SDK's actual pagination heuristic logic.
+ *
+ * For cursor pagination: hasNextPage = next != null && next !== ""
+ * For offset pagination:
+ *   - If explicit hasNextPage response property exists: use that value, falling back to base check
+ *   - If step is defined: results.length >= Math.floor(step ?? default)
+ *   - Fallback: results.length > 0
+ *
+ * Returns undefined if the value cannot be determined from the example data.
+ */
+function calculateExpectedHasNextPage({
     example,
-    endpoint
+    endpoint,
+    pagination
 }: {
     example: FernIr.ExampleEndpointCall;
     endpoint: FernIr.HttpEndpoint;
-}): boolean {
-    const pagination = endpoint.pagination;
-    if (pagination == null) {
-        return true;
-    }
-
+    pagination: FernIr.Pagination.Cursor | FernIr.Pagination.Offset;
+}): boolean | undefined {
     const responseJson = getResponseBodyJsonExample(example.response);
     if (responseJson == null) {
-        return true;
+        return undefined;
     }
 
-    let cursorProperty;
     switch (pagination.type) {
-        case "cursor":
-            cursorProperty = pagination.next;
-            break;
-        case "offset":
-            cursorProperty = pagination.hasNextPage;
-            if (cursorProperty == null) {
-                return false;
+        case "cursor": {
+            const nextValue = getPropertyValueFromJson(responseJson, pagination.next);
+            if (nextValue === undefined) {
+                return undefined;
             }
-            break;
-        case "custom":
-        case "uri":
-        case "path":
-            return false;
-        default:
-            assertNever(pagination);
-    }
-
-    if (cursorProperty == null) {
-        return true;
-    }
-
-    // Build the path segments using wire values for JSON walking
-    // JSON examples from IR are always in wire format (snake_case), so we must
-    // always use wire values to walk the JSON regardless of retainOriginalCasing
-    // or includeSerdeLayer settings (those affect generated code, not example JSON)
-    const segments = [
-        ...(cursorProperty.propertyPath ?? []).map((item) => item.name.originalName),
-        cursorProperty.property.name.wireValue
-    ];
-
-    let cursor: unknown = responseJson;
-    for (const key of segments) {
-        if (cursor == null || typeof cursor !== "object" || !(key in cursor)) {
-            return true;
+            // SDK logic: response.next != null && !(typeof response.next === "string" && response.next === "")
+            const isNonNull = nextValue != null;
+            const isEmptyString = typeof nextValue === "string" && nextValue === "";
+            return isNonNull && !isEmptyString;
         }
-        cursor = (cursor as Record<string, unknown>)[key];
-    }
+        case "offset": {
+            // Check for explicit hasNextPage response property first
+            if (pagination.hasNextPage != null) {
+                const hasNextPageValue = getPropertyValueFromJson(responseJson, pagination.hasNextPage);
+                if (hasNextPageValue != null && typeof hasNextPageValue === "boolean") {
+                    return hasNextPageValue;
+                }
+                // Fall through to base check if hasNextPage property is missing/null
+            }
 
-    // If the leaf is explicitly undefined or null, treat it as "missing"
-    return cursor === undefined || cursor === null;
+            // Get results array length
+            const resultsValue = getPropertyValueFromJson(responseJson, pagination.results);
+            const resultsLength = Array.isArray(resultsValue) ? resultsValue.length : 0;
+
+            // If step is defined: results.length >= Math.floor(step ?? default)
+            if (pagination.step != null) {
+                const stepValue = getRequestPropertyValueFromExample(example, pagination.step);
+                if (stepValue != null && typeof stepValue === "number") {
+                    return resultsLength >= Math.floor(stepValue);
+                }
+                // If step value can't be extracted, fall back to results.length > 0
+            }
+
+            // Fallback: results.length > 0
+            return resultsLength > 0;
+        }
+        default:
+            return undefined;
+    }
 }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.52.3
+  changelogEntry:
+    - summary: |
+        Fix wire test generator to dynamically calculate the expected `hasNextPage()` value
+        based on pagination type and example data, instead of hardcoding `true` for all
+        pagination tests. For cursor pagination, `hasNextPage` is true when the next cursor
+        is non-null and non-empty. For offset pagination, it checks `results.length >= step`
+        (or falls back to `results.length > 0`). This prevents test failures when mock
+        responses represent a last page with no more results.
+      type: fix
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 3.52.2
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/pagination/no-custom-config/snippet.json
+++ b/seed/ts-sdk/pagination/no-custom-config/snippet.json
@@ -190,6 +190,18 @@
         },
         {
             "id": {
+                "path": "/users/top-level-cursor",
+                "method": "POST",
+                "identifier_override": "endpoint_users.listWithTopLevelBodyCursorPagination"
+            },
+            "snippet": {
+                "type": "typescript",
+                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithTopLevelBodyCursorPagination({\n    cursor: \"last_cursor\",\n    filter: \"active\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithTopLevelBodyCursorPagination({\n    cursor: \"last_cursor\",\n    filter: \"active\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
+            },
+            "example_identifier": "LastPage"
+        },
+        {
+            "id": {
                 "path": "/users",
                 "method": "GET",
                 "identifier_override": "endpoint_users.listWithOffsetPagination"

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -256,6 +256,12 @@ export class UsersClient {
      *         cursor: "initial_cursor",
      *         filter: "active"
      *     })
+     *
+     * @example
+     *     await client.users.listWithTopLevelBodyCursorPagination({
+     *         cursor: "last_cursor",
+     *         filter: "active"
+     *     })
      */
     public async listWithTopLevelBodyCursorPagination(
         request: SeedPagination.ListUsersTopLevelBodyCursorPaginationRequest = {},

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/requests/ListUsersTopLevelBodyCursorPaginationRequest.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/requests/ListUsersTopLevelBodyCursorPaginationRequest.ts
@@ -6,6 +6,12 @@
  *         cursor: "initial_cursor",
  *         filter: "active"
  *     }
+ *
+ * @example
+ *     {
+ *         cursor: "last_cursor",
+ *         filter: "active"
+ *     }
  */
 export interface ListUsersTopLevelBodyCursorPaginationRequest {
     /**

--- a/seed/ts-sdk/pagination/no-custom-config/tests/wire/users.test.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/wire/users.test.ts
@@ -160,7 +160,7 @@ describe("UsersClient", () => {
         expect(expected.data).toEqual(nextPage.data);
     });
 
-    test("listWithTopLevelBodyCursorPagination", async () => {
+    test("listWithTopLevelBodyCursorPagination (1)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
         const rawRequestBody = { cursor: "initial_cursor", filter: "active" };
@@ -202,6 +202,37 @@ describe("UsersClient", () => {
         expect(page.hasNextPage()).toBe(true);
         const nextPage = await page.getNextPage();
         expect(expected.data).toEqual(nextPage.data);
+    });
+
+    test("listWithTopLevelBodyCursorPagination (2)", async () => {
+        const server = mockServerPool.createServer();
+        const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
+        const rawRequestBody = { cursor: "last_cursor", filter: "active" };
+        const rawResponseBody = { data: [{ name: "Charlie", id: 3 }] };
+        server
+            .mockEndpoint()
+            .post("/users/top-level-cursor")
+            .jsonBody(rawRequestBody, { ignoredFields: ["cursor"] })
+            .respondWith()
+            .statusCode(200)
+            .jsonBody(rawResponseBody)
+            .build();
+
+        const expected = {
+            data: [
+                {
+                    name: "Charlie",
+                    id: 3,
+                },
+            ],
+        };
+        const page = await client.users.listWithTopLevelBodyCursorPagination({
+            cursor: "last_cursor",
+            filter: "active",
+        });
+
+        expect(expected.data).toEqual(page.data);
+        expect(page.hasNextPage()).toBe(false);
     });
 
     test("listWithOffsetPagination", async () => {
@@ -731,7 +762,7 @@ describe("UsersClient", () => {
             total_count: 0,
         };
         server
-            .mockEndpoint({ once: false })
+            .mockEndpoint()
             .get("/users/optional-data")
             .respondWith()
             .statusCode(200)

--- a/seed/ts-sdk/pagination/page-index-semantics/snippet.json
+++ b/seed/ts-sdk/pagination/page-index-semantics/snippet.json
@@ -190,6 +190,18 @@
         },
         {
             "id": {
+                "path": "/users/top-level-cursor",
+                "method": "POST",
+                "identifier_override": "endpoint_users.listWithTopLevelBodyCursorPagination"
+            },
+            "snippet": {
+                "type": "typescript",
+                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithTopLevelBodyCursorPagination({\n    cursor: \"last_cursor\",\n    filter: \"active\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithTopLevelBodyCursorPagination({\n    cursor: \"last_cursor\",\n    filter: \"active\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
+            },
+            "example_identifier": "LastPage"
+        },
+        {
+            "id": {
                 "path": "/users",
                 "method": "GET",
                 "identifier_override": "endpoint_users.listWithOffsetPagination"

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
@@ -256,6 +256,12 @@ export class UsersClient {
      *         cursor: "initial_cursor",
      *         filter: "active"
      *     })
+     *
+     * @example
+     *     await client.users.listWithTopLevelBodyCursorPagination({
+     *         cursor: "last_cursor",
+     *         filter: "active"
+     *     })
      */
     public async listWithTopLevelBodyCursorPagination(
         request: SeedPagination.ListUsersTopLevelBodyCursorPaginationRequest = {},

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/requests/ListUsersTopLevelBodyCursorPaginationRequest.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/requests/ListUsersTopLevelBodyCursorPaginationRequest.ts
@@ -6,6 +6,12 @@
  *         cursor: "initial_cursor",
  *         filter: "active"
  *     }
+ *
+ * @example
+ *     {
+ *         cursor: "last_cursor",
+ *         filter: "active"
+ *     }
  */
 export interface ListUsersTopLevelBodyCursorPaginationRequest {
     /**

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/wire/users.test.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/wire/users.test.ts
@@ -160,7 +160,7 @@ describe("UsersClient", () => {
         expect(expected.data).toEqual(nextPage.data);
     });
 
-    test("listWithTopLevelBodyCursorPagination", async () => {
+    test("listWithTopLevelBodyCursorPagination (1)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
         const rawRequestBody = { cursor: "initial_cursor", filter: "active" };
@@ -202,6 +202,37 @@ describe("UsersClient", () => {
         expect(page.hasNextPage()).toBe(true);
         const nextPage = await page.getNextPage();
         expect(expected.data).toEqual(nextPage.data);
+    });
+
+    test("listWithTopLevelBodyCursorPagination (2)", async () => {
+        const server = mockServerPool.createServer();
+        const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
+        const rawRequestBody = { cursor: "last_cursor", filter: "active" };
+        const rawResponseBody = { data: [{ name: "Charlie", id: 3 }] };
+        server
+            .mockEndpoint()
+            .post("/users/top-level-cursor")
+            .jsonBody(rawRequestBody, { ignoredFields: ["cursor"] })
+            .respondWith()
+            .statusCode(200)
+            .jsonBody(rawResponseBody)
+            .build();
+
+        const expected = {
+            data: [
+                {
+                    name: "Charlie",
+                    id: 3,
+                },
+            ],
+        };
+        const page = await client.users.listWithTopLevelBodyCursorPagination({
+            cursor: "last_cursor",
+            filter: "active",
+        });
+
+        expect(expected.data).toEqual(page.data);
+        expect(page.hasNextPage()).toBe(false);
     });
 
     test("listWithOffsetPagination", async () => {
@@ -731,7 +762,7 @@ describe("UsersClient", () => {
             total_count: 0,
         };
         server
-            .mockEndpoint({ once: false })
+            .mockEndpoint()
             .get("/users/optional-data")
             .respondWith()
             .statusCode(200)

--- a/test-definitions/fern/apis/pagination/definition/users.yml
+++ b/test-definitions/fern/apis/pagination/definition/users.yml
@@ -197,6 +197,17 @@ service:
                   id: 1
                 - name: "Bob"
                   id: 2
+        - name: LastPage
+          docs: Last page of results where there is no next cursor
+          request:
+            cursor: "last_cursor"
+            filter: "active"
+          response:
+            body:
+              next_cursor: null
+              data:
+                - name: "Charlie"
+                  id: 3
 
     listWithOffsetPagination:
       pagination:


### PR DESCRIPTION
## Description

Refs: Slack thread from Tanmay Singh regarding test failures when mock responses contain fewer items than the requested limit.

The wire test generator previously hardcoded `expect(page.hasNextPage()).toBe(true)` for all pagination tests. The SDK's actual pagination logic uses heuristics (e.g., `results.length >= step` for offset, `next != null` for cursor), so tests would fail when the mock response represented a last page. This PR makes the test generator mirror the SDK's actual logic to calculate the expected value dynamically.

[Link to Devin run](https://app.devin.ai/sessions/bad16b3ed86a47cd8003fae3a8c75d35)
Requested by: @Swimburger

## Changes Made

- **Replaced `isPaginationCursorMissingInExample`** with `calculateExpectedHasNextPage` in `TestGenerator.ts`, which returns `true`, `false`, or `undefined` (when indeterminate) based on pagination type:
  - **Cursor pagination**: `true` when `next` property is non-null and non-empty string
  - **Offset pagination**: checks explicit `hasNextPage` response property first, then `results.length >= step`, falls back to `results.length > 0`
- **Added helper functions**: `getPropertyValueFromJson` and `getRequestPropertyValueFromExample` to walk response/request JSON examples using IR property paths
- **Updated test assertion generation**: three branches now — `toBe(true)` + `getNextPage()`, `toBe(false)` (no `getNextPage()`), or data-only assertion (when indeterminate)
- **Added `LastPage` test example** to `listWithTopLevelBodyCursorPagination` endpoint with `next_cursor: null` to exercise the `hasNextPage=false` path
- **Regenerated seed fixtures** — both `no-custom-config` and `page-index-semantics` now include the new test case asserting `expect(page.hasNextPage()).toBe(false)`
- **Bumped version** to 3.52.4 in `versions.yml`
- [ ] Updated README.md generator (not applicable)

## Testing

- [x] Seed tests pass for `pagination` fixture (both `no-custom-config` and `page-index-semantics`)
- [x] Generated tests correctly assert `expect(page.hasNextPage()).toBe(false)` for the new LastPage example
- [x] Existing pagination tests unchanged (still assert `toBe(true)` where expected)
- [x] `listWithOptionalData` test no longer uses `{ once: false }` since its empty-data response correctly yields `hasNextPage=false`
- [x] TypeScript compilation passes

## Review Checklist

> **Most important items for reviewers:**

1. **Heuristic fidelity**: Verify that `calculateExpectedHasNextPage` accurately mirrors the SDK's actual pagination logic in `GeneratedThrowingEndpointResponse.ts`. A mismatch would produce tests that pass generation but fail at runtime.
2. **Property path traversal**: `getPropertyValueFromJson` uses `originalName` for intermediate path segments but `wireValue` for the leaf. Confirm this matches how IR JSON examples are structured.
3. **Loss of `assertNever`**: The old `isPaginationCursorMissingInExample` used `assertNever(pagination)` in the default branch. The new `calculateExpectedHasNextPage` only handles `cursor` and `offset` types, returning `undefined` for others (`custom`, `uri`, `path`). This is intentional since those types don't generate page objects, but the compile-time exhaustiveness check is lost.
4. **Undefined handling**: When `expectedHasNextPage` is `undefined` (can't determine from example data), the test omits the `hasNextPage()` assertion entirely. This is a safe fallback but reduces test coverage for those cases.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->