### PR TITLE
fix(cli): improve subpackage error messages during docs generation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.91.2
+  changelogEntry:
+    - summary: |
+        Improve subpackage error messages during docs generation. The error
+        `Subpackage undefined not found in <uuid>` now includes the parent
+        package name, the API section title, and lists available subpackages
+        to help quickly identify and fix configuration issues.
+      type: fix
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 3.91.1
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
+++ b/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
@@ -23,7 +23,11 @@ import { ChangelogNodeConverter } from "./ChangelogNodeConverter.js";
 import { NodeIdGenerator } from "./NodeIdGenerator.js";
 import { convertPlaygroundSettings } from "./utils/convertPlaygroundSettings.js";
 import { enrichApiPackageChild } from "./utils/enrichApiPackageChild.js";
-import { cannotFindSubpackageByLocatorError, packageReuseError, subpackageNotFoundError } from "./utils/errorMessages.js";
+import {
+    cannotFindSubpackageByLocatorError,
+    packageReuseError,
+    subpackageNotFoundError
+} from "./utils/errorMessages.js";
 import { isSubpackage } from "./utils/isSubpackage.js";
 import { mergeAndFilterChildren } from "./utils/mergeAndFilterChildren.js";
 import { mergeEndpointPairs } from "./utils/mergeEndpointPairs.js";
@@ -1037,9 +1041,7 @@ export class ApiReferenceNodeConverter {
 
             const subpackage = this.#holder.getSubpackageByIdOrLocator(subpackageId);
             if (subpackage == null) {
-                const parentPackageName = isSubpackage(pkg)
-                    ? (pkg.displayName ?? pkg.name)
-                    : this.apiSection.title;
+                const parentPackageName = isSubpackage(pkg) ? (pkg.displayName ?? pkg.name) : this.apiSection.title;
                 this.taskContext.logger.error(
                     subpackageNotFoundError({
                         subpackageId,

--- a/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
+++ b/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
@@ -23,7 +23,7 @@ import { ChangelogNodeConverter } from "./ChangelogNodeConverter.js";
 import { NodeIdGenerator } from "./NodeIdGenerator.js";
 import { convertPlaygroundSettings } from "./utils/convertPlaygroundSettings.js";
 import { enrichApiPackageChild } from "./utils/enrichApiPackageChild.js";
-import { cannotFindSubpackageByLocatorError, packageReuseError } from "./utils/errorMessages.js";
+import { cannotFindSubpackageByLocatorError, packageReuseError, subpackageNotFoundError } from "./utils/errorMessages.js";
 import { isSubpackage } from "./utils/isSubpackage.js";
 import { mergeAndFilterChildren } from "./utils/mergeAndFilterChildren.js";
 import { mergeEndpointPairs } from "./utils/mergeEndpointPairs.js";
@@ -1037,10 +1037,17 @@ export class ApiReferenceNodeConverter {
 
             const subpackage = this.#holder.getSubpackageByIdOrLocator(subpackageId);
             if (subpackage == null) {
-                // I'm not clear on how this line is reachable.
-                // If the pkg.subpackages are subpackageIds, and not locators, doesn't that imply they've already been
-                // resolved to an existing subpackage?
-                this.taskContext.logger.error(`Subpackage ${subpackageId} not found in ${this.apiDefinitionId}`);
+                const parentPackageName = isSubpackage(pkg)
+                    ? (pkg.displayName ?? pkg.name)
+                    : this.apiSection.title;
+                this.taskContext.logger.error(
+                    subpackageNotFoundError({
+                        subpackageId,
+                        parentPackageName,
+                        apiSectionTitle: this.apiSection.title,
+                        availableSubpackages: this.#holder.subpackageLocators
+                    })
+                );
                 return;
             }
 

--- a/packages/cli/docs-resolver/src/utils/errorMessages.ts
+++ b/packages/cli/docs-resolver/src/utils/errorMessages.ts
@@ -32,6 +32,31 @@ export function packageReuseError(name: string): string {
     return `API section ${name} is specified multiple times, however will be only rendered once.`;
 }
 
+export function subpackageNotFoundError({
+    subpackageId,
+    parentPackageName,
+    apiSectionTitle,
+    availableSubpackages
+}: {
+    subpackageId: string | undefined;
+    parentPackageName: string;
+    apiSectionTitle: string;
+    availableSubpackages: Iterable<string>;
+}): string {
+    const subpackageLabel = subpackageId != null ? `"${subpackageId}"` : "(undefined)";
+    let msg = `Subpackage ${subpackageLabel} not found in package "${parentPackageName}" while generating docs for API section "${apiSectionTitle}".`;
+    const available = Array.from(availableSubpackages);
+    if (available.length > 0) {
+        const displayedSubpackages = available.slice(0, 10);
+        msg += ` Available subpackages: [${displayedSubpackages.join(", ")}]`;
+        if (available.length > 10) {
+            msg += ` ... and ${available.length - 10} more`;
+        }
+        msg += ".";
+    }
+    return msg;
+}
+
 export function normalizeLocatorString(s: string): string {
     return s.toLowerCase().replace(/[^a-z0-9]/g, "");
 }


### PR DESCRIPTION
## Description

Closes https://github.com/fern-api/fern/issues/6276

The error `Subpackage undefined not found in <uuid>` during docs generation was unhelpful — it didn't indicate which package, version, or API section was involved. This PR improves the error message to include actionable context.

[Link to Devin run](https://app.devin.ai/sessions/e6d793e66fbf46f2b51867b00c20c460) | Requested by: @Swimburger

## Changes Made

- Added `subpackageNotFoundError()` helper in `errorMessages.ts` that produces messages like:
  ```
  Subpackage "foo" not found in package "Users" while generating docs for API section "My API". Available subpackages: [auth, billing, users, ...]
  ```
- When `subpackageId` is `undefined` (the original bug's scenario), the message now shows `(undefined)` explicitly instead of printing the misleading literal string `undefined`
- Replaced the raw string interpolation in `ApiReferenceNodeConverter.ts` with the new helper, passing parent package name, API section title, and available subpackage locators (capped at 10 to avoid overwhelming output)
- Added CLI `versions.yml` entry for 3.91.2
- [ ] Updated README.md generator (not applicable)

## Human Review Checklist

- [ ] The `subpackageLocators` getter returns locator strings (e.g. `auth.users`, `auth/users`), not raw subpackage IDs. Verify these are the most useful values to show users in the error — users configure packages by locator in `docs.yml`, so this seems correct
- [ ] Only the CLI-side error (`ApiReferenceNodeConverter.ts`) is improved. The same unhelpful pattern exists in `fern-platform`'s `ApiReferenceNavigationConverter.ts` (lines 325, 479) — left as-is since it's a separate repo
- [ ] The old comment ("I'm not clear on how this line is reachable") was removed — the error is now actionable regardless of how it's triggered
- [ ] No unit tests added (consistent with the existing `cannotFindSubpackageByLocatorError` which also has no dedicated tests)

## Testing

- [x] TypeScript type check passes (pre-existing errors only, none in changed files)
- [x] Biome formatting check passes
- [x] All relevant CI checks pass (`test-ete` failures are unrelated timeouts in `v2/generate.test.ts`)
- [ ] No unit tests added
- [ ] Manual testing not performed — error path requires a misconfigured `docs.yml` with an invalid subpackage reference