### PR TITLE
feat(openapi): include x-fern-availability in generated OpenAPI specs

### DIFF
--- a/generators/openapi/src/__test__/convertAvailability.test.ts
+++ b/generators/openapi/src/__test__/convertAvailability.test.ts
@@ -1,0 +1,26 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { describe, expect, it } from "vitest";
+
+import { convertAvailabilityStatus } from "../utils/convertAvailability.js";
+
+describe("convertAvailabilityStatus", () => {
+    it("converts IN_DEVELOPMENT to 'in-development'", () => {
+        expect(convertAvailabilityStatus(FernIr.AvailabilityStatus.InDevelopment)).toBe("in-development");
+    });
+
+    it("converts PRE_RELEASE to 'pre-release'", () => {
+        expect(convertAvailabilityStatus(FernIr.AvailabilityStatus.PreRelease)).toBe("pre-release");
+    });
+
+    it("converts GENERAL_AVAILABILITY to 'generally-available'", () => {
+        expect(convertAvailabilityStatus(FernIr.AvailabilityStatus.GeneralAvailability)).toBe("generally-available");
+    });
+
+    it("converts DEPRECATED to 'deprecated'", () => {
+        expect(convertAvailabilityStatus(FernIr.AvailabilityStatus.Deprecated)).toBe("deprecated");
+    });
+
+    it("returns undefined for unknown status", () => {
+        expect(convertAvailabilityStatus("UNKNOWN_STATUS" as FernIr.AvailabilityStatus)).toBeUndefined();
+    });
+});

--- a/generators/openapi/src/__test__/convertObjectAvailability.test.ts
+++ b/generators/openapi/src/__test__/convertObjectAvailability.test.ts
@@ -1,0 +1,115 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { describe, expect, it } from "vitest";
+
+import { convertObject } from "../converters/convertObject.js";
+
+function makeName(name: string): FernIr.NameAndWireValue {
+    return {
+        wireValue: name,
+        name: {
+            originalName: name,
+            camelCase: { unsafeName: name, safeName: name },
+            snakeCase: { unsafeName: name, safeName: name },
+            screamingSnakeCase: { unsafeName: name, safeName: name },
+            pascalCase: { unsafeName: name, safeName: name }
+        }
+    };
+}
+
+// Cast through unknown to avoid needing to construct the full visitor-equipped TypeReference
+const STRING_TYPE_REFERENCE = {
+    type: "primitive",
+    primitive: {
+        v1: "STRING",
+        v2: FernIr.PrimitiveTypeV2.string({
+            default: undefined,
+            validation: undefined
+        })
+    }
+} as unknown as FernIr.TypeReference;
+
+describe("convertObject with availability", () => {
+    it("includes x-fern-availability on properties with availability set", () => {
+        const result = convertObject({
+            docs: undefined,
+            properties: [
+                {
+                    docs: undefined,
+                    availability: {
+                        status: FernIr.AvailabilityStatus.Deprecated,
+                        message: undefined
+                    },
+                    name: makeName("deprecatedField"),
+                    valueType: STRING_TYPE_REFERENCE
+                },
+                {
+                    docs: undefined,
+                    availability: {
+                        status: FernIr.AvailabilityStatus.InDevelopment,
+                        message: undefined
+                    },
+                    name: makeName("devField"),
+                    valueType: STRING_TYPE_REFERENCE
+                },
+                {
+                    docs: undefined,
+                    name: makeName("stableField"),
+                    valueType: STRING_TYPE_REFERENCE
+                }
+            ],
+            extensions: []
+        });
+
+        // biome-ignore lint/suspicious/noExplicitAny: test assertion
+        const properties = result.properties as Record<string, any>;
+        expect(properties?.["deprecatedField"]?.["x-fern-availability"]).toBe("deprecated");
+        expect(properties?.["devField"]?.["x-fern-availability"]).toBe("in-development");
+        expect(properties?.["stableField"]?.["x-fern-availability"]).toBeUndefined();
+    });
+
+    it("includes x-fern-availability for all status types", () => {
+        const statuses: Array<{ status: FernIr.AvailabilityStatus; expected: string }> = [
+            { status: FernIr.AvailabilityStatus.InDevelopment, expected: "in-development" },
+            { status: FernIr.AvailabilityStatus.PreRelease, expected: "pre-release" },
+            { status: FernIr.AvailabilityStatus.GeneralAvailability, expected: "generally-available" },
+            { status: FernIr.AvailabilityStatus.Deprecated, expected: "deprecated" }
+        ];
+
+        for (const { status, expected } of statuses) {
+            const result = convertObject({
+                docs: undefined,
+                properties: [
+                    {
+                        docs: undefined,
+                        availability: { status, message: undefined },
+                        name: makeName("field"),
+                        valueType: STRING_TYPE_REFERENCE
+                    }
+                ],
+                extensions: []
+            });
+
+            // biome-ignore lint/suspicious/noExplicitAny: test assertion
+            const properties = result.properties as Record<string, any>;
+            expect(properties?.["field"]?.["x-fern-availability"]).toBe(expected);
+        }
+    });
+
+    it("does not include x-fern-availability when availability is not set", () => {
+        const result = convertObject({
+            docs: undefined,
+            properties: [
+                {
+                    docs: undefined,
+                    name: makeName("field"),
+                    valueType: STRING_TYPE_REFERENCE
+                }
+            ],
+            extensions: []
+        });
+
+        // biome-ignore lint/suspicious/noExplicitAny: test assertion
+        const properties = result.properties as Record<string, any>;
+        expect(properties?.["field"]?.["x-fern-availability"]).toBeUndefined();
+    });
+});

--- a/generators/openapi/src/convertToOpenApi.ts
+++ b/generators/openapi/src/convertToOpenApi.ts
@@ -4,6 +4,7 @@ import { OpenAPIV3 } from "openapi-types";
 import { convertServices } from "./converters/servicesConverter.js";
 import { convertType } from "./converters/typeConverter.js";
 import { constructEndpointSecurity, constructSecuritySchemes } from "./security.js";
+import { convertAvailabilityStatus } from "./utils/convertAvailability.js";
 import { Mode } from "./writeOpenApi.js";
 
 export function convertToOpenApi({
@@ -21,10 +22,17 @@ export function convertToOpenApi({
     Object.values(ir.types).forEach((typeDeclaration) => {
         // convert type to open api schema
         const convertedType = convertType(typeDeclaration, ir);
-        schemas[convertedType.schemaName] = {
+        const schema: Record<string, unknown> = {
             title: convertedType.schemaName,
             ...convertedType.openApiSchema
         };
+        if (typeDeclaration.availability != null) {
+            const availabilityValue = convertAvailabilityStatus(typeDeclaration.availability.status);
+            if (availabilityValue != null) {
+                schema["x-fern-availability"] = availabilityValue;
+            }
+        }
+        schemas[convertedType.schemaName] = schema as OpenAPIV3.SchemaObject;
         // populates typesByName map
         typesByName[getDeclaredTypeNameKey(typeDeclaration.name)] = typeDeclaration;
     });

--- a/generators/openapi/src/converters/convertObject.ts
+++ b/generators/openapi/src/converters/convertObject.ts
@@ -1,10 +1,12 @@
 import { FernIr } from "@fern-fern/ir-sdk";
 import { OpenAPIV3 } from "openapi-types";
 
+import { convertAvailabilityStatus } from "../utils/convertAvailability.js";
 import { convertTypeReference, getReferenceFromDeclaredTypeName, OpenApiComponentSchema } from "./typeConverter.js";
 
 export interface ObjectProperty {
     docs: string | undefined;
+    availability?: FernIr.Availability;
     name: FernIr.NameAndWireValue;
     valueType: FernIr.TypeReference;
     example?: FernIr.ExampleObjectProperty | FernIr.ExampleInlinedRequestBodyProperty;
@@ -36,11 +38,20 @@ export function convertObject({
             example = objectProperty.example.value.jsonExample;
         }
 
-        convertedProperties[objectProperty.name.wireValue] = {
+        const propertySchema: Record<string, unknown> = {
             ...convertedObjectProperty,
             description: objectProperty.docs ?? undefined,
             example
         };
+
+        if (objectProperty.availability != null) {
+            const availabilityValue = convertAvailabilityStatus(objectProperty.availability.status);
+            if (availabilityValue != null) {
+                propertySchema["x-fern-availability"] = availabilityValue;
+            }
+        }
+
+        convertedProperties[objectProperty.name.wireValue] = propertySchema as OpenApiComponentSchema;
         const isOptionalProperty =
             objectProperty.valueType.type === "container" && objectProperty.valueType.container.type === "optional";
         if (!isOptionalProperty) {

--- a/generators/openapi/src/converters/servicesConverter.ts
+++ b/generators/openapi/src/converters/servicesConverter.ts
@@ -5,6 +5,7 @@ import { OpenAPIV3 } from "openapi-types";
 import urlJoin from "url-join";
 
 import { getDeclaredTypeNameKey, getErrorTypeNameKey } from "../convertToOpenApi.js";
+import { convertAvailabilityStatus } from "../utils/convertAvailability.js";
 import { Mode } from "../writeOpenApi.js";
 import { convertObject } from "./convertObject.js";
 import { convertTypeReference, OpenApiComponentSchema } from "./typeConverter.js";
@@ -149,6 +150,13 @@ function convertHttpEndpoint({
         summary: httpEndpoint.displayName ?? undefined
     };
 
+    if (httpEndpoint.availability != null) {
+        const availabilityValue = convertAvailabilityStatus(httpEndpoint.availability.status);
+        if (availabilityValue != null) {
+            (operationObject as unknown as Record<string, unknown>)["x-fern-availability"] = availabilityValue;
+        }
+    }
+
     if (httpEndpoint.baseUrl != null) {
         const baseUrlId = httpEndpoint.baseUrl;
         if (environments?.environments.type !== "multipleBaseUrls") {
@@ -246,6 +254,11 @@ function convertRequestBody({
                         }
                         return {
                             docs: property.docs ?? undefined,
+                            availability:
+                                "availability" in property
+                                    ? (property as unknown as { availability: FernIr.Availability | undefined })
+                                          .availability
+                                    : undefined,
                             name: property.name,
                             valueType: property.valueType,
                             example: exampleProperty
@@ -634,6 +647,13 @@ function convertQueryParameter({
             : convertTypeReference(queryParameter.valueType)
     };
 
+    if (queryParameter.availability != null) {
+        const availabilityValue = convertAvailabilityStatus(queryParameter.availability.status);
+        if (availabilityValue != null) {
+            (convertedParameter as unknown as Record<string, unknown>)["x-fern-availability"] = availabilityValue;
+        }
+    }
+
     const openapiExamples: OpenAPIV3.ParameterObject["examples"] = {};
     for (const example of examples) {
         const queryParameterExample = example.queryParameters.find(
@@ -678,6 +698,13 @@ function convertHeader({
         required: isTypeReferenceRequired({ typeReference: httpHeader.valueType, typesByName }),
         schema: convertTypeReference(httpHeader.valueType)
     };
+
+    if (httpHeader.availability != null) {
+        const availabilityValue = convertAvailabilityStatus(httpHeader.availability.status);
+        if (availabilityValue != null) {
+            (convertedParameter as unknown as Record<string, unknown>)["x-fern-availability"] = availabilityValue;
+        }
+    }
 
     const openapiExamples: OpenAPIV3.ParameterObject["examples"] = {};
     for (const example of examples) {

--- a/generators/openapi/src/converters/typeConverter.ts
+++ b/generators/openapi/src/converters/typeConverter.ts
@@ -67,6 +67,7 @@ export function convertType(
                     }
                     return {
                         docs: property.docs ?? undefined,
+                        availability: property.availability ?? undefined,
                         name: property.name,
                         valueType: property.valueType,
                         example: exampleProperty

--- a/generators/openapi/src/utils/convertAvailability.ts
+++ b/generators/openapi/src/utils/convertAvailability.ts
@@ -1,0 +1,14 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+
+/**
+ * Converts an IR AvailabilityStatus to the corresponding x-fern-availability string value.
+ */
+export function convertAvailabilityStatus(status: FernIr.AvailabilityStatus): string | undefined {
+    return FernIr.AvailabilityStatus._visit<string | undefined>(status, {
+        inDevelopment: () => "in-development",
+        preRelease: () => "pre-release",
+        generalAvailability: () => "generally-available",
+        deprecated: () => "deprecated",
+        _other: () => undefined
+    });
+}

--- a/generators/openapi/versions.yml
+++ b/generators/openapi/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
-- version: 0.2.1
+- version: 0.3.0
   createdAt: "2026-02-27"
   changelogEntry:
     - type: feat

--- a/generators/openapi/versions.yml
+++ b/generators/openapi/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
+- version: 0.2.1
+  createdAt: "2026-02-27"
+  changelogEntry:
+    - type: feat
+      summary: |
+        The OpenAPI generator now includes `x-fern-availability` extensions in the generated OpenAPI spec
+        for endpoints, query parameters, headers, object properties, and type declarations.
+  irVersion: 53
+
 - version: 0.2.0
   createdAt: "2026-02-10"
   changelogEntry:

--- a/seed/openapi/imdb/custom-filename/imdb.yaml
+++ b/seed/openapi/imdb/custom-filename/imdb.yaml
@@ -17,6 +17,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MovieId'
+      x-fern-availability: pre-release
       requestBody:
         required: true
         content:
@@ -47,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MovieId'
+      x-fern-availability: deprecated
 components:
   schemas:
     MovieId:
@@ -64,10 +66,12 @@ components:
           type: number
           format: double
           description: The rating scale is one to five stars
+          x-fern-availability: deprecated
       required:
         - id
         - title
         - rating
+      x-fern-availability: generally-available
     CreateMovieRequest:
       title: CreateMovieRequest
       type: object

--- a/seed/openapi/imdb/custom-overrides/openapi.yml
+++ b/seed/openapi/imdb/custom-overrides/openapi.yml
@@ -18,6 +18,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MovieId'
+      x-fern-availability: pre-release
       requestBody:
         required: true
         content:
@@ -48,6 +49,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MovieId'
+      x-fern-availability: deprecated
 components:
   schemas:
     MovieId:
@@ -65,10 +67,12 @@ components:
           type: number
           format: double
           description: The rating scale is one to five stars
+          x-fern-availability: deprecated
       required:
         - id
         - title
         - rating
+      x-fern-availability: generally-available
     CreateMovieRequest:
       title: CreateMovieRequest
       type: object

--- a/seed/openapi/imdb/json-format/openapi.json
+++ b/seed/openapi/imdb/json-format/openapi.json
@@ -25,6 +25,7 @@
             }
           }
         },
+        "x-fern-availability": "pre-release",
         "requestBody": {
           "required": true,
           "content": {
@@ -74,7 +75,8 @@
               }
             }
           }
-        }
+        },
+        "x-fern-availability": "deprecated"
       }
     }
   },
@@ -97,14 +99,16 @@
           "rating": {
             "type": "number",
             "format": "double",
-            "description": "The rating scale is one to five stars"
+            "description": "The rating scale is one to five stars",
+            "x-fern-availability": "deprecated"
           }
         },
         "required": [
           "id",
           "title",
           "rating"
-        ]
+        ],
+        "x-fern-availability": "generally-available"
       },
       "CreateMovieRequest": {
         "title": "CreateMovieRequest",

--- a/seed/openapi/imdb/no-custom-config/openapi.yml
+++ b/seed/openapi/imdb/no-custom-config/openapi.yml
@@ -17,6 +17,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MovieId'
+      x-fern-availability: pre-release
       requestBody:
         required: true
         content:
@@ -47,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MovieId'
+      x-fern-availability: deprecated
 components:
   schemas:
     MovieId:
@@ -64,10 +66,12 @@ components:
           type: number
           format: double
           description: The rating scale is one to five stars
+          x-fern-availability: deprecated
       required:
         - id
         - title
         - rating
+      x-fern-availability: generally-available
     CreateMovieRequest:
       title: CreateMovieRequest
       type: object

--- a/seed/openapi/imdb/override/openapi.yml
+++ b/seed/openapi/imdb/override/openapi.yml
@@ -17,6 +17,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MovieId'
+      x-fern-availability: pre-release
       requestBody:
         required: true
         content:
@@ -47,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MovieId'
+      x-fern-availability: deprecated
 components:
   schemas:
     MovieId:
@@ -63,10 +65,12 @@ components:
           type: number
           format: double
           description: The rating scale is one to five stars
+          x-fern-availability: deprecated
       required:
         - id
         - title
         - rating
+      x-fern-availability: generally-available
     CreateMovieRequest:
       title: CreateMovieRequest
       type: object

--- a/seed/openapi/seed.yml
+++ b/seed/openapi/seed.yml
@@ -13,6 +13,11 @@ test:
   docker:
     image: fernapi/fern-openapi:latest
     command: pnpm turbo run dockerTagLatest --filter @fern-api/openapi-generator
+  local:
+    workingDirectory: generators/openapi
+    buildCommand:
+      - pnpm turbo run dist:cli --filter @fern-api/openapi-generator
+    runCommand: node --enable-source-maps dist/cli.cjs openapi {CONFIG_PATH}
 generatorType: Documentation
 defaultOutputMode: local_files
 fixtures:
@@ -46,4 +51,4 @@ fixtures:
             schemas: 
               Operand: 
                 type: null     
-      outputFolder: custom-overrides  
+      outputFolder: custom-overrides      

--- a/test-definitions/fern/apis/imdb/definition/imdb.yml
+++ b/test-definitions/fern/apis/imdb/definition/imdb.yml
@@ -2,12 +2,14 @@ types:
   MovieId: string
 
   Movie:
+    availability: generally-available
     properties:
       id: MovieId
       title: string
       rating:
         type: double
         docs: The rating scale is one to five stars
+        availability: deprecated
 
   CreateMovieRequest:
     properties:
@@ -26,6 +28,7 @@ service:
       response:
         type: MovieId
         status-code: 201
+      availability: pre-release
 
     getMovie:
       method: GET
@@ -33,6 +36,7 @@ service:
       path-parameters:
         movieId: MovieId
       response: Movie
+      availability: deprecated
       errors:
         - MovieDoesNotExistError
 


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/6142

The OpenAPI generator was completely ignoring the `availability` field from the Fern IR when generating OpenAPI specs. This PR adds `x-fern-availability` extension output so that availability information (e.g., `in-development`, `deprecated`) roundtrips through the OpenAPI generator.

[Link to Devin run](https://app.devin.ai/sessions/cede71e04e214e7e99aeaac51dbf70ef) | Requested by: @Swimburger

## Changes Made

- **New utility** (`generators/openapi/src/utils/convertAvailability.ts`): Maps IR `AvailabilityStatus` → `x-fern-availability` string values (`in-development`, `pre-release`, `generally-available`, `deprecated`)
- **Endpoints** (`servicesConverter.ts`): Emits `x-fern-availability` on `OperationObject` when endpoint has availability set
- **Query parameters & headers** (`servicesConverter.ts`): Emits `x-fern-availability` on `ParameterObject` for query params and headers
- **Inlined request body properties** (`servicesConverter.ts`): Passes availability through to `ObjectProperty` with a runtime `"availability" in property` check (the installed IR SDK v53.9.0 doesn't expose this field in its types)
- **Object properties** (`convertObject.ts`, `typeConverter.ts`): Emits `x-fern-availability` on individual schema properties
- **Type declarations** (`convertToOpenApi.ts`): Emits `x-fern-availability` on top-level component schemas
- **Version bump** to `0.3.0` in `generators/openapi/versions.yml`
- **Unit tests** (`convertAvailability.test.ts`): 5 tests covering all availability status mappings including unknown status
- **Integration tests** (`convertObjectAvailability.test.ts`): 3 tests verifying `x-fern-availability` is correctly emitted (or omitted) on object properties via `convertObject`
- **Seed snapshot updates**: Added availability annotations (`pre-release`, `deprecated`, `generally-available`) to `imdb` test fixture and updated all 5 imdb seed snapshots to verify `x-fern-availability` in generated output
- **Local seed test config** added to `seed/openapi/seed.yml` for running seed tests natively
- [ ] Updated README.md generator (if applicable) — N/A

## Updates since last revision

- Fixed changelog validation: bumped version from `0.2.1` → `0.3.0` (a `feat` changelog entry requires a minor version bump, not a patch bump)
- Added unit tests for `convertAvailabilityStatus` (all 4 status values + unknown)
- Added integration tests for `convertObject` verifying `x-fern-availability` on object properties
- Added availability annotations to the `imdb` test definition (`Movie` type: `generally-available`, `rating` property: `deprecated`, `createMovie` endpoint: `pre-release`, `getMovie` endpoint: `deprecated`)
- Updated all 5 imdb seed snapshots (`no-custom-config`, `override`, `custom-overrides`, `custom-filename`, `json-format`) with `x-fern-availability` extensions
- Added `local` test config to `seed/openapi/seed.yml`

## Important — Human Review Checklist

- [ ] **Verify `as unknown as Record<string, unknown>` casts**: Multiple places cast OpenAPI typed objects to set the `x-fern-availability` extension key. Confirm these survive YAML/JSON serialization correctly and don't silently drop the extension. (Seed snapshots confirm this works, but worth a glance.)
- [ ] **Review `"availability" in property` runtime check** (`servicesConverter.ts` L257): This is a workaround for the installed `@fern-fern/ir-sdk@53.9.0` not having `availability` on `InlinedRequestBodyProperty`. Should be cleaned up when the IR SDK dependency is bumped.
- [ ] **Not covered**: Enum value-level availability, service-level availability. Consider whether these warrant follow-up work.
- [ ] **Test coverage**: Unit tests cover the utility function and object property conversion. Seed snapshots verify end-to-end output for endpoints, types, and properties. No explicit tests for query params/headers availability (though the code path is identical to properties).

## Testing

- [x] TypeScript type check passes (`pnpm tsc --noEmit`)
- [x] Biome lint/format passes
- [x] All OpenAPI seed tests pass (5/5 imdb fixtures green)
- [x] Changelog validation passes
- [x] Unit tests added/updated — 8 new tests (5 for `convertAvailabilityStatus`, 3 for `convertObject` with availability)
- [x] Seed snapshots updated — all 5 imdb fixtures now include `x-fern-availability` in generated output
- [ ] Manual testing completed — not tested end-to-end with a real Fern definition outside of seed tests