### PR TITLE
fix(cli): suppress repeated Download output in fern docs dev for cached dependencies

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.91.2
+  changelogEntry:
+    - summary: |
+        Fix `fern docs dev` repeatedly printing `Download @fern/registry` and
+        `Download ../fern-definition` on every hot-reload. Cached and local
+        dependencies are now loaded silently instead of spawning a visible
+        interactive task each time.
+      type: fix
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 3.91.1
   changelogEntry:
     - summary: |

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/loadDependency.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/loadDependency.ts
@@ -104,7 +104,11 @@ export async function loadDependency({
             );
         } else {
             context.logger.debug(`Loading cached dependency ${stringifyDependency(dependency)}`);
-            await loadTask(context);
+            try {
+                await loadTask(context);
+            } catch (error) {
+                context.failWithoutThrowing(undefined, error);
+            }
         }
     }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/loadDependency.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/loadDependency.ts
@@ -68,33 +68,44 @@ export async function loadDependency({
             dependencyName
         };
     } else {
-        await context.runInteractiveTask(
-            { name: `Download ${stringifyDependency(dependency)}` },
-            async (contextForDependency) => {
-                switch (dependency.type) {
-                    case "version":
-                        definition = await validateVersionedDependencyAndGetDefinition({
-                            context: contextForDependency,
-                            dependency,
-                            cliVersion,
-                            settings,
-                            loadAPIWorkspace
-                        });
-                        return;
-                    case "local":
-                        definition = await validateLocalDependencyAndGetDefinition({
-                            context: contextForDependency,
-                            dependency,
-                            cliVersion,
-                            settings,
-                            loadAPIWorkspace
-                        });
-                        return;
-                    default:
-                        assertNever(dependency);
-                }
+        const needsDownload = await isDependencyDownloadRequired(dependency);
+
+        const loadTask = async (contextForDependency: TaskContext) => {
+            switch (dependency.type) {
+                case "version":
+                    definition = await validateVersionedDependencyAndGetDefinition({
+                        context: contextForDependency,
+                        dependency,
+                        cliVersion,
+                        settings,
+                        loadAPIWorkspace
+                    });
+                    return;
+                case "local":
+                    definition = await validateLocalDependencyAndGetDefinition({
+                        context: contextForDependency,
+                        dependency,
+                        cliVersion,
+                        settings,
+                        loadAPIWorkspace
+                    });
+                    return;
+                default:
+                    assertNever(dependency);
             }
-        );
+        };
+
+        if (needsDownload) {
+            await context.runInteractiveTask(
+                { name: `Download ${stringifyDependency(dependency)}` },
+                async (contextForDependency) => {
+                    await loadTask(contextForDependency);
+                }
+            );
+        } else {
+            context.logger.debug(`Loading cached dependency ${stringifyDependency(dependency)}`);
+            await loadTask(context);
+        }
     }
 
     if (definition != null) {
@@ -108,6 +119,31 @@ const DEPENDENCIES_FOLDER_NAME = "dependencies";
 const DEFINITION_FOLDER_NAME = "definition";
 const METADATA_RESPONSE_FILENAME = "metadata.json";
 const LOCAL_STORAGE_FOLDER = process.env.LOCAL_STORAGE_FOLDER ?? ".fern";
+
+/**
+ * Checks whether a dependency needs to be downloaded from the network.
+ * Returns false for local dependencies (always on disk) and for versioned
+ * dependencies that are already cached locally, so we can skip the
+ * interactive "Download ..." task on subsequent loads / hot-reloads.
+ */
+async function isDependencyDownloadRequired(dependency: dependenciesYml.Dependency): Promise<boolean> {
+    switch (dependency.type) {
+        case "local":
+            return false;
+        case "version": {
+            const pathToDependency = getPathToLocalStorageDependency(dependency);
+            const pathToDefinition = join(pathToDependency, RelativeFilePath.of(DEPENDENCIES_FOLDER_NAME));
+            const pathToMetadata = join(pathToDependency, RelativeFilePath.of(METADATA_RESPONSE_FILENAME));
+            const [definitionExists, metadataExists] = await Promise.all([
+                doesPathExist(pathToDefinition),
+                doesPathExist(pathToMetadata)
+            ]);
+            return !definitionExists || !metadataExists;
+        }
+        default:
+            assertNever(dependency);
+    }
+}
 
 function getPathToLocalStorageDependency(dependency: dependenciesYml.VersionedDependency): AbsoluteFilePath {
     return join(


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/6112

`fern docs dev` repeatedly prints `│ ✓ Download @fern/registry` and `│ ✓ Download ../fern-definition` on every hot-reload cycle. This happens because `loadDependency` unconditionally wraps all dependency loading in `context.runInteractiveTask(...)`, which renders a visible interactive task line—even when the dependency is already cached on disk or is a local path reference.

## Changes Made

- Added `isDependencyDownloadRequired()` that checks whether a versioned dependency is already cached on disk (definition + metadata files exist) or if the dependency is local (never needs downloading)
- When no download is needed, the dependency is loaded silently via `context.logger.debug()` instead of spawning a visible interactive task
- Wrapped the cached/local path in `try/catch` with `context.failWithoutThrowing()` to match the error-containment behavior that `runInteractiveTask` previously provided
- When a real download is needed (first time), the interactive task with `Download ...` label is still shown as before
- Added changelog entry (version 3.91.2)

## Testing

- [ ] Unit tests added/updated — *not added; this is a UX/output-suppression fix that is difficult to unit test*
- [x] Manual code review completed

## Human Review Checklist

- **Duplicated cache check**: `isDependencyDownloadRequired` replicates the `doesPathExist` logic from `validateVersionedDependencyAndGetDefinition` (~line 221 in the new file). If one is changed, the other must stay in sync.
- **Parent context in cached path**: When cached, `loadTask(context)` uses the parent context directly. Sub-functions log at `info` level (e.g. "Parsing..."). Confirm this doesn't produce unwanted visible output for the caller.

---

Link to Devin run: https://app.devin.ai/sessions/06f26df18baa49d19cefb47389d12373
Requested by: @Swimburger