### PR TITLE
fix(python): fix positional_single_property_constructors breaking pydantic response deserialization

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.61.1
+  changelogEntry:
+    - summary: |
+        Fix `positional_single_property_constructors` breaking pydantic response deserialization.
+        The custom `__init__` now uses `@typing.overload` with a permissive `*args, **kwargs` runtime
+        signature, so pydantic can pass alias-keyed data freely during deserialization while still
+        allowing positional construction like `Wrapper("value")`.
+      type: fix
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 4.61.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
+++ b/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
@@ -367,23 +367,51 @@ class PydanticModel:
 
         single_field = required_non_discriminator_fields[0]
 
-        # Generate the __init__ method body
+        # Generate the __init__ method body using *args/**kwargs to be compatible with
+        # pydantic's internal deserialization. When pydantic deserializes a response from JSON,
+        # it may call __init__(**data) where data uses alias keys (e.g. "ticketReference")
+        # rather than the Python field name (e.g. "ticket_reference"). A required positional
+        # parameter would cause a TypeError in that case. Using *args/**kwargs with overloads
+        # preserves the positional construction API while allowing pydantic to pass data freely.
         def write_init_body(writer: AST.NodeWriter) -> None:
-            writer.write(f"super().__init__({single_field.name}={single_field.name}, **kwargs)")
+            writer.write_line("if args:")
+            with writer.indent():
+                writer.write_line(f"super().__init__({single_field.name}=args[0], **kwargs)")
+            writer.write_line("else:")
+            with writer.indent():
+                writer.write("super().__init__(**kwargs)")
+
+        # Overload 1: positional construction - e.g. Isin("US0378331005")
+        overload_positional = AST.FunctionSignature(
+            parameters=[
+                AST.FunctionParameter(
+                    name=single_field.name,
+                    type_hint=single_field.type_hint,
+                ),
+            ],
+            return_type=AST.TypeHint.none(),
+        )
+
+        # Overload 2: keyword construction - e.g. Isin(isin="US0378331005")
+        overload_keyword = AST.FunctionSignature(
+            named_parameters=[
+                AST.NamedFunctionParameter(
+                    name=single_field.name,
+                    type_hint=single_field.type_hint,
+                ),
+            ],
+            return_type=AST.TypeHint.none(),
+        )
 
         init_declaration = AST.FunctionDeclaration(
             name="__init__",
             signature=AST.FunctionSignature(
-                parameters=[
-                    AST.FunctionParameter(
-                        name=single_field.name,
-                        type_hint=single_field.type_hint,
-                    ),
-                ],
+                include_args=True,
                 include_kwargs=True,
                 return_type=AST.TypeHint.none(),
             ),
             body=AST.CodeWriter(write_init_body),
+            overloads=[overload_positional, overload_keyword],
         )
 
         self._class_declaration.add_method(declaration=init_declaration)

--- a/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
+++ b/generators/python/src/fern_python/pydantic_codegen/pydantic_model.py
@@ -376,6 +376,7 @@ class PydanticModel:
         def write_init_body(writer: AST.NodeWriter) -> None:
             writer.write_line("if args:")
             with writer.indent():
+                writer.write_line(f"kwargs.pop('{single_field.name}', None)")
                 writer.write_line(f"super().__init__({single_field.name}=args[0], **kwargs)")
             writer.write_line("else:")
             with writer.indent():

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/cusip.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/cusip.py
@@ -9,8 +9,17 @@ from ..core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 class Cusip(UniversalBaseModel):
     cusip: str
 
-    def __init__(self, cusip: str, **kwargs: typing.Any) -> None:
-        super().__init__(cusip=cusip, **kwargs)
+    @typing.overload
+    def __init__(self, cusip: str) -> None: ...
+
+    @typing.overload
+    def __init__(self, *, cusip: str) -> None: ...
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        if args:
+            super().__init__(cusip=args[0], **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/cusip.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/cusip.py
@@ -17,6 +17,7 @@ class Cusip(UniversalBaseModel):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         if args:
+            kwargs.pop('cusip', None)
             super().__init__(cusip=args[0], **kwargs)
         else:
             super().__init__(**kwargs)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/isin.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/isin.py
@@ -9,8 +9,17 @@ from ..core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 class Isin(UniversalBaseModel):
     isin: str
 
-    def __init__(self, isin: str, **kwargs: typing.Any) -> None:
-        super().__init__(isin=isin, **kwargs)
+    @typing.overload
+    def __init__(self, isin: str) -> None: ...
+
+    @typing.overload
+    def __init__(self, *, isin: str) -> None: ...
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        if args:
+            super().__init__(isin=args[0], **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/isin.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/isin.py
@@ -17,6 +17,7 @@ class Isin(UniversalBaseModel):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         if args:
+            kwargs.pop('isin', None)
             super().__init__(isin=args[0], **kwargs)
         else:
             super().__init__(**kwargs)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/isin_with_discriminator.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/isin_with_discriminator.py
@@ -10,8 +10,17 @@ class IsinWithDiscriminator(UniversalBaseModel):
     isin: str
     type: typing.Literal["ISIN"] = "ISIN"
 
-    def __init__(self, isin: str, **kwargs: typing.Any) -> None:
-        super().__init__(isin=isin, **kwargs)
+    @typing.overload
+    def __init__(self, isin: str) -> None: ...
+
+    @typing.overload
+    def __init__(self, *, isin: str) -> None: ...
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        if args:
+            super().__init__(isin=args[0], **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/isin_with_discriminator.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/isin_with_discriminator.py
@@ -18,6 +18,7 @@ class IsinWithDiscriminator(UniversalBaseModel):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         if args:
+            kwargs.pop('isin', None)
             super().__init__(isin=args[0], **kwargs)
         else:
             super().__init__(**kwargs)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/one_required_one_optional.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/one_required_one_optional.py
@@ -10,8 +10,17 @@ class OneRequiredOneOptional(UniversalBaseModel):
     required_field: str
     optional_field: typing.Optional[str] = None
 
-    def __init__(self, required_field: str, **kwargs: typing.Any) -> None:
-        super().__init__(required_field=required_field, **kwargs)
+    @typing.overload
+    def __init__(self, required_field: str) -> None: ...
+
+    @typing.overload
+    def __init__(self, *, required_field: str) -> None: ...
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        if args:
+            super().__init__(required_field=args[0], **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/one_required_one_optional.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/one_required_one_optional.py
@@ -18,6 +18,7 @@ class OneRequiredOneOptional(UniversalBaseModel):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         if args:
+            kwargs.pop('required_field', None)
             super().__init__(required_field=args[0], **kwargs)
         else:
             super().__init__(**kwargs)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/quantity.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/quantity.py
@@ -18,6 +18,7 @@ class Quantity(UniversalBaseModel):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         if args:
+            kwargs.pop('quantity', None)
             super().__init__(quantity=args[0], **kwargs)
         else:
             super().__init__(**kwargs)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/quantity.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/quantity.py
@@ -10,8 +10,17 @@ class Quantity(UniversalBaseModel):
     quantity: float
     type: typing.Literal["QUANTITY"] = "QUANTITY"
 
-    def __init__(self, quantity: float, **kwargs: typing.Any) -> None:
-        super().__init__(quantity=quantity, **kwargs)
+    @typing.overload
+    def __init__(self, quantity: float) -> None: ...
+
+    @typing.overload
+    def __init__(self, *, quantity: float) -> None: ...
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        if args:
+            super().__init__(quantity=args[0], **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/taker_party.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/taker_party.py
@@ -10,8 +10,17 @@ from .trader import Trader
 class TakerParty(UniversalBaseModel):
     trader: Trader
 
-    def __init__(self, trader: Trader, **kwargs: typing.Any) -> None:
-        super().__init__(trader=trader, **kwargs)
+    @typing.overload
+    def __init__(self, trader: Trader) -> None: ...
+
+    @typing.overload
+    def __init__(self, *, trader: Trader) -> None: ...
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        if args:
+            super().__init__(trader=args[0], **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/taker_party.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/taker_party.py
@@ -18,6 +18,7 @@ class TakerParty(UniversalBaseModel):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         if args:
+            kwargs.pop('trader', None)
             super().__init__(trader=args[0], **kwargs)
         else:
             super().__init__(**kwargs)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/trader.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/trader.py
@@ -17,6 +17,7 @@ class Trader(UniversalBaseModel):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         if args:
+            kwargs.pop('uuid_', None)
             super().__init__(uuid_=args[0], **kwargs)
         else:
             super().__init__(**kwargs)

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/trader.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/types/trader.py
@@ -9,8 +9,17 @@ from ..core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 class Trader(UniversalBaseModel):
     uuid_: int
 
-    def __init__(self, uuid_: int, **kwargs: typing.Any) -> None:
-        super().__init__(uuid_=uuid_, **kwargs)
+    @typing.overload
+    def __init__(self, uuid_: int) -> None: ...
+
+    @typing.overload
+    def __init__(self, *, uuid_: int) -> None: ...
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        if args:
+            super().__init__(uuid_=args[0], **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2


### PR DESCRIPTION
## Description

Refs: [Slack thread](https://buildwithfern.slack.com/archives/C09EN84AV37/p1770830452619889) — customer report that `positional_single_property_constructors: true` causes `TypeError` on response deserialization.

Fixes the `positional_single_property_constructors` feature generating a custom `__init__` that breaks pydantic's internal response deserialization on both v1 and v2.

Link to Devin run: https://app.devin.ai/sessions/4a3d6924326b40bd9aaf675afe5355d8
Requested by: @aditya-arolkar-swe

## Root Cause

When `positional_single_property_constructors: true` is enabled, the generator emits a custom `__init__` on **all** single-property pydantic models:

```python
def __init__(self, ticket_reference: str, **kwargs):
    super().__init__(ticket_reference=ticket_reference, **kwargs)
```

When pydantic deserializes a JSON response like `{"ticketReference": "..."}`, it calls `Model(**data)` with alias keys. The custom `__init__` sees `ticketReference` in `**kwargs` but `ticket_reference` (the Python field name) is missing as a required positional parameter → `TypeError`.

## Changes Made

- **`generators/python/src/fern_python/pydantic_codegen/pydantic_model.py`**: Changed `_maybe_add_positional_init()` to generate an `__init__` that uses `@typing.overload` for IDE/type-checker support, with a permissive `*args, **kwargs` runtime signature:
  ```python
  @typing.overload
  def __init__(self, field: str) -> None: ...       # positional
  @typing.overload
  def __init__(self, *, field: str) -> None: ...     # keyword
  def __init__(self, *args, **kwargs):               # runtime: pydantic-safe
      if args:
          kwargs.pop('field', None)                  # prevent duplicate kwarg
          super().__init__(field=args[0], **kwargs)
      else:
          super().__init__(**kwargs)
  ```
- **`generators/python/sdk/versions.yml`**: Added v4.61.1 changelog entry.
- **`seed/python-sdk/python-positional-single-property/with-positional-constructors/`**: Updated 7 snapshot files to match the new generated output.

## Human Review Checklist

- [ ] **Snapshot correctness**: Snapshots were updated manually (local seed tool had a pre-existing env issue unrelated to this PR). CI seed tests passed on the first commit; verify the second commit (adding `kwargs.pop`) also passes.
- [ ] **Permissive `else` branch**: `Model()` with no args won't raise at runtime (only caught by type-checkers via overloads). This is intentional to allow pydantic's internal construction paths — confirm this tradeoff is acceptable.
- [ ] **`kwargs.pop` defensive fix**: When a positional arg is provided, `kwargs.pop(field_name, None)` silently drops a duplicate keyword to prevent `TypeError: got multiple values for keyword argument`. This is defensive; the overloads already prevent this at the type-checker level.
- [ ] **Both pydantic v1 and v2**: The fix should work for both since the `else` branch delegates entirely to `super().__init__(**kwargs)` which lets pydantic handle alias resolution.

## Testing

- [x] Pre-commit / ruff lint passes
- [x] CI seed tests passed on first commit (90/90 checks green)
- [ ] CI seed tests for second commit (added `kwargs.pop` defensive fix per Graphite review)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
