### PR TITLE
chore(internal): add secrets backup jobs to infisical-testing workflow

### DIFF
--- a/.github/workflows/infisical-testing.yml
+++ b/.github/workflows/infisical-testing.yml
@@ -1,7 +1,5 @@
 name: Infisical-testing
 
-#THIS WORKFLOW IS ONLY TO BE USED FOR TESTING
-
 on:
   workflow_dispatch:
 
@@ -19,3 +17,178 @@ jobs:
             echo "::error::Only repository admins can run this workflow. ${{ github.actor }} has '$PERMISSION' permission."
             exit 1
           fi
+
+  backup-repo-secrets:
+    needs: check-admin
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
+          aws-region: "us-east-1"
+
+      - name: Build secrets backup
+        env:
+          _BK_FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          _BK_FERN_API_DOCKERHUB_PASSWORD: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
+          _BK_TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          _BK_FERN_ORG_TOKEN_DEV: ${{ secrets.FERN_ORG_TOKEN_DEV }}
+          _BK_AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          _BK_AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+          _BK_FERN_NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+          _BK_POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          _BK_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          _BK_PR_BOT_GH_PAT: ${{ secrets.PR_BOT_GH_PAT }}
+          _BK_FERN_SUPPORT_GH_ACTIONS_PAT: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
+          _BK_ACTIONS_PAT: ${{ secrets.ACTIONS_PAT }}
+          _BK_FERN_GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
+          _BK_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          _BK_SEED_GITHUB_TOKEN: ${{ secrets.SEED_GITHUB_TOKEN }}
+          _BK_DEVIN_AI_PR_BOT_SLACK_TOKEN: ${{ secrets.DEVIN_AI_PR_BOT_SLACK_TOKEN }}
+          _BK_FERN_FERN_TOKEN: ${{ secrets.FERN_FERN_TOKEN }}
+          _BK_TEST_REMOTE_LOCAL_GITHUB_TOKEN: ${{ secrets.TEST_REMOTE_LOCAL_GITHUB_TOKEN }}
+        run: |
+          python3 << 'EOF'
+          import os, json
+
+          prefix = "_BK_"
+          secrets = {}
+          for key, value in sorted(os.environ.items()):
+              if key.startswith(prefix):
+                  secrets[key[len(prefix):]] = value
+
+          with open("secrets.json", "w") as f:
+              json.dump(secrets, f, indent=2, sort_keys=True)
+
+          print(f"Backed up {len(secrets)} repo-level secrets")
+          EOF
+
+      - name: Encrypt secrets file
+        run: |
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 100000 \
+            -in secrets.json \
+            -out secrets.json.enc \
+            -pass pass:"${{ secrets.BACKUP_ENCRYPTION_KEY }}"
+
+      - name: Upload to S3
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H%M%SZ")
+          aws s3 cp secrets.json.enc \
+            "s3://fern-backups/github-secrets/fern/repo-secrets-${TIMESTAMP}.json.enc" \
+            --sse AES256
+          echo "Uploaded to s3://fern-backups/github-secrets/fern/repo-secrets-${TIMESTAMP}.json.enc"
+
+      - name: Clean up
+        if: always()
+        run: rm -f secrets.json secrets.json.enc
+
+  backup-fern-dev:
+    needs: check-admin
+    runs-on: ubuntu-latest
+    environment: Fern Dev
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
+          aws-region: "us-east-1"
+
+      - name: Build Fern Dev secrets backup
+        env:
+          _BK_FERN_ORG_TOKEN_DEV: ${{ secrets.FERN_ORG_TOKEN_DEV }}
+          _BK_AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          _BK_AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+        run: |
+          python3 << 'EOF'
+          import os, json
+
+          prefix = "_BK_"
+          secrets = {}
+          for key, value in sorted(os.environ.items()):
+              if key.startswith(prefix):
+                  secrets[key[len(prefix):]] = value
+
+          with open("secrets.json", "w") as f:
+              json.dump(secrets, f, indent=2, sort_keys=True)
+
+          print(f"Backed up {len(secrets)} Fern Dev environment secrets")
+          EOF
+
+      - name: Encrypt secrets file
+        run: |
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 100000 \
+            -in secrets.json \
+            -out secrets.json.enc \
+            -pass pass:"${{ secrets.BACKUP_ENCRYPTION_KEY }}"
+
+      - name: Upload to S3
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H%M%SZ")
+          aws s3 cp secrets.json.enc \
+            "s3://fern-backups/github-secrets/fern/fern-dev-secrets-${TIMESTAMP}.json.enc" \
+            --sse AES256
+          echo "Uploaded to s3://fern-backups/github-secrets/fern/fern-dev-secrets-${TIMESTAMP}.json.enc"
+
+      - name: Clean up
+        if: always()
+        run: rm -f secrets.json secrets.json.enc
+
+  backup-fern-prod:
+    needs: check-admin
+    runs-on: ubuntu-latest
+    environment: Fern Prod
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
+          aws-region: "us-east-1"
+
+      - name: Build Fern Prod secrets backup
+        env:
+          _BK_AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          _BK_AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+        run: |
+          python3 << 'EOF'
+          import os, json
+
+          prefix = "_BK_"
+          secrets = {}
+          for key, value in sorted(os.environ.items()):
+              if key.startswith(prefix):
+                  secrets[key[len(prefix):]] = value
+
+          with open("secrets.json", "w") as f:
+              json.dump(secrets, f, indent=2, sort_keys=True)
+
+          print(f"Backed up {len(secrets)} Fern Prod environment secrets")
+          EOF
+
+      - name: Encrypt secrets file
+        run: |
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 100000 \
+            -in secrets.json \
+            -out secrets.json.enc \
+            -pass pass:"${{ secrets.BACKUP_ENCRYPTION_KEY }}"
+
+      - name: Upload to S3
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H%M%SZ")
+          aws s3 cp secrets.json.enc \
+            "s3://fern-backups/github-secrets/fern/fern-prod-secrets-${TIMESTAMP}.json.enc" \
+            --sse AES256
+          echo "Uploaded to s3://fern-backups/github-secrets/fern/fern-prod-secrets-${TIMESTAMP}.json.enc"
+
+      - name: Clean up
+        if: always()
+        run: rm -f secrets.json secrets.json.enc


### PR DESCRIPTION
## Description

Refs [fern-platform#6953](https://github.com/fern-api/fern-platform/pull/6953), [engineering-docs#33](https://github.com/fern-api/engineering-docs/pull/33)

Adds backup jobs to the existing `infisical-testing.yml` workflow to safely export all GitHub Actions secrets (repo-level and per-environment) to encrypted files in S3, in preparation for migrating to Infisical for centralized secrets management.

## Changes Made

- Added 3 parallel backup jobs to `.github/workflows/infisical-testing.yml`, gated behind the existing `check-admin` job:

| Job | Scope | S3 Key Pattern | Secret Count |
|---|---|---|---|
| `backup-repo-secrets` | Repo-level secrets | `fern/repo-secrets-<ts>.json.enc` | 18 |
| `backup-fern-dev` | `Fern Dev` environment | `fern/fern-dev-secrets-<ts>.json.enc` | 3 |
| `backup-fern-prod` | `Fern Prod` environment | `fern/fern-prod-secrets-<ts>.json.enc` | 2 |

- Each job: authenticates via OIDC (`github-ci` role) → collects secrets as `_BK_`-prefixed env vars → serializes to JSON with Python → encrypts with AES-256-CBC → uploads to `s3://fern-backups/github-secrets/fern/` → cleans up plaintext
- S3 paths include `fern/` to separate from fern-platform backups
- Removed the `#THIS WORKFLOW IS ONLY TO BE USED FOR TESTING` comment since the workflow now has real functionality

To decrypt: `openssl enc -d -aes-256-cbc -pbkdf2 -iter 100000 -in <file>.json.enc -out secrets.json -pass pass:"<BACKUP_ENCRYPTION_KEY>"`

## Testing

- [ ] Cannot be tested until merged and triggered via `workflow_dispatch`
- [ ] Pattern mirrors the already-tested [fern-platform#6953](https://github.com/fern-api/fern-platform/pull/6953)

**Prerequisites before first run:**
1. Create a `BACKUP_ENCRYPTION_KEY` repo secret in GitHub
2. Confirm the `github-ci` IAM role has `s3:PutObject` on the `fern-backups` bucket

## Human Review Checklist

- [ ] **Repo-level secrets (18 entries):** Cross-check the `_BK_*` env var names in `backup-repo-secrets` against the actual secrets in GitHub repo Settings. Secrets that exist in GitHub but are missing from the list will silently produce empty strings — they won't error, but they won't be backed up.
- [ ] **Fern Dev secrets (3) and Fern Prod secrets (2):** These were inferred from `environment:` declarations in `ci.yml` and `publish-cli.yml`. Verify against the actual environment configurations — there may be additional overrides not referenced in code.
- [ ] **IAM role ARN** (`arn:aws:iam::985111089818:role/github-ci`): Confirm this is the correct account and role, and that it has `s3:PutObject` on `fern-backups`.
- [ ] **`BACKUP_ENCRYPTION_KEY`:** Confirm creating this new repo secret is acceptable.

---

[Link to Devin run](https://app.devin.ai/sessions/4ae673e03464474c98afd1b645221b27) | Requested by @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
