### PR TITLE
chore(internal): cut FDR logs

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.91.3
+  changelogEntry:
+    - summary: |
+        Remove noisy debug logs from IR version compatibility checking.
+      type: chore
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 3.91.2
   changelogEntry:
     - summary: |

--- a/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
+++ b/packages/cli/yaml/generators-validator/src/rules/compatible-ir-versions/compatible-ir-versions.ts
@@ -38,23 +38,12 @@ export const CompatibleIrVersionsRule: Rule = {
                     const fdr = createFdrGeneratorsSdkService({ token: undefined });
 
                     // Pull the CLI release to get the IR version
-                    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-                    console.debug(`[FDR] compatible-ir-versions: checking CLI release for version=${cliVersion}`);
                     const cliRelease = await fdr.generators.cli.getCliRelease(cliVersion);
                     // Again, this is to allow for offline usage, and other transient errors
                     if (!cliRelease.ok) {
-                        // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-                        console.debug(
-                            `[FDR] compatible-ir-versions: getCliRelease failed for ${cliVersion}`,
-                            cliRelease
-                        );
                         return [];
                     }
                     const cliIrVersion = cliRelease.body.irVersion;
-                    // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-                    console.debug(
-                        `[FDR] compatible-ir-versions: CLI version=${cliVersion} has irVersion=${cliIrVersion}`
-                    );
 
                     // Pull the generator release to get the IR version
                     let invocationIrVersion: number;
@@ -70,18 +59,10 @@ export const CompatibleIrVersionsRule: Rule = {
                             name: addDefaultDockerOrgIfNotPresent(invocation.name)
                         };
                         const maybeIrVersion = await getIrVersionForGenerator(normalizedInvocation);
-                        // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-                        console.debug(
-                            `[FDR] compatible-ir-versions: irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version} = ${maybeIrVersion}`
-                        );
 
                         // The above returns undefined if we can't get the IR version, so we'll just return an empty array
                         // Again, this is to allow for offline usage, and other transient errors
                         if (maybeIrVersion == null) {
-                            // biome-ignore lint/suspicious/noConsole: intentional debug logging for FDR registry diagnostics
-                            console.debug(
-                                `[FDR] compatible-ir-versions: could not resolve irVersion for ${normalizedInvocation.name}@${normalizedInvocation.version}, skipping validation`
-                            );
                             return [];
                         }
 


### PR DESCRIPTION
Cutting these logs:
```
[FDR] compatible-ir-versions: checking CLI release for version=3.91.2
[FDR] compatible-ir-versions: CLI version=3.91.2 has irVersion=65
[FDR] compatible-ir-versions: irVersion for fernapi/fern-typescript-sdk@3.52.4 = 65
```
