### PR TITLE
fix(python): re-add generator-cli to Docker image for README/reference generation

### DIFF
--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -46,6 +46,8 @@ COPY ./generators/python/sdk/features.yml /assets/features.yml
 COPY ./generators/python/tests /assets/tests
 COPY ./generators/python/src ./src
 
+RUN npm install -f -g @fern-api/generator-cli@0.5.3
+
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.61.2
+  changelogEntry:
+    - summary: |
+        Re-add `@fern-api/generator-cli` to Python SDK Docker image. The CLI was inadvertently
+        removed in 4.60.1 when JS-based generators migrated to using the generator-cli JS API
+        directly. The Python generator still relies on the CLI binary via subprocess for
+        README.md and reference.md generation.
+      type: fix
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 4.61.1
   changelogEntry:
     - summary: |

--- a/seed/python-sdk/examples/readme/README.md
+++ b/seed/python-sdk/examples/readme/README.md
@@ -1,0 +1,231 @@
+# CustomName Python Library
+
+![](https://www.fernapi.com)
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Seed%2FPython)
+[![pypi](https://img.shields.io/pypi/v/fern_examples)](https://pypi.python.org/pypi/fern_examples)
+
+This is a test introduction
+split across multiple lines.
+
+
+## Table of Contents
+
+- [Documentation](#documentation)
+- [Installation](#installation)
+- [Reference](#reference)
+- [Base Readme Custom Section](#base-readme-custom-section)
+- [Override Section](#override-section)
+- [Generator Invocation Custom Section](#generator-invocation-custom-section)
+- [Usage](#usage)
+- [Async Client](#async-client)
+- [Exception Handling](#exception-handling)
+- [Advanced](#advanced)
+  - [Access Raw Response Data](#access-raw-response-data)
+  - [Retries](#retries)
+  - [Timeouts](#timeouts)
+  - [Custom Client](#custom-client)
+
+## Documentation
+
+API reference documentation is available [here](https://www.docs.fernapi.com).
+
+## Installation
+
+```sh
+pip install fern_examples
+```
+
+## Reference
+
+A full reference for this library is available [here](./reference.md).
+
+## Base Readme Custom Section
+
+Base Readme Custom Content for fern_examples
+
+## Override Section
+
+Override Content
+
+## Generator Invocation Custom Section
+
+Generator Invocation Custom Content for fern_examples
+
+## Usage
+
+Instantiate and use the client with the following:
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.service.create_movie(
+    id="movie-c06a4ad7",
+    prequel="movie-cv9b914f",
+    title="The Boy and the Heron",
+    from_="Hayao Miyazaki",
+    rating=8.0,
+    tag="tag-wf9as23d",
+    metadata={
+        "actors": ["Christian Bale", "Florence Pugh", "Willem Dafoe"],
+        "releaseDate": "2023-12-08",
+        "ratings": {"rottenTomatoes": 97, "imdb": 7.6},
+    },
+    revenue=1000000,
+)
+```
+
+## Async Client
+
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
+
+```python
+import asyncio
+
+from seed import AsyncSeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = AsyncSeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+
+
+async def main() -> None:
+    await client.service.get_movie(
+        movie_id="movie-c06a4ad7",
+    )
+
+
+asyncio.run(main())
+```
+
+```python
+import asyncio
+
+from seed import AsyncSeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = AsyncSeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+
+
+async def main() -> None:
+    await client.service.create_movie(
+        id="movie-c06a4ad7",
+        prequel="movie-cv9b914f",
+        title="The Boy and the Heron",
+        from_="Hayao Miyazaki",
+        rating=8.0,
+        tag="tag-wf9as23d",
+        metadata={
+            "actors": ["Christian Bale", "Florence Pugh", "Willem Dafoe"],
+            "releaseDate": "2023-12-08",
+            "ratings": {"rottenTomatoes": 97, "imdb": 7.6},
+        },
+        revenue=1000000,
+    )
+
+
+asyncio.run(main())
+```
+
+## Exception Handling
+
+When the API returns a non-success status code (4xx or 5xx response), a subclass of the following error
+will be thrown.
+
+```python
+from seed.core.api_error import ApiError
+
+try:
+    client.service.create_movie(...)
+except ApiError as e:
+    print(e.status_code)
+    print(e.body)
+```
+
+## Advanced
+
+### Access Raw Response Data
+
+The SDK provides access to raw response data, including headers, through the `.with_raw_response` property.
+The `.with_raw_response` property returns a "raw" client that can be used to access the `.headers` and `.data` attributes.
+
+```python
+from seed import SeedExamples
+
+client = SeedExamples(
+    ...,
+)
+response = client.service.with_raw_response.create_movie(...)
+print(response.headers)  # access the response headers
+print(response.status_code)  # access the response status code
+print(response.data)  # access the underlying object
+```
+
+### Retries
+
+The SDK is instrumented with automatic retries with exponential backoff. A request will be retried as long
+as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
+retry limit (default: 2).
+
+A request is deemed retryable when any of the following HTTP status codes is returned:
+
+- [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+- [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+- [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+
+Use the `max_retries` request option to configure this behavior.
+
+```python
+client.service.create_movie(..., request_options={
+    "max_retries": 1
+})
+```
+
+### Timeouts
+
+The SDK defaults to a 60 second timeout. You can configure this with a timeout option at the client or request level.
+
+```python
+
+from seed import SeedExamples
+
+client = SeedExamples(
+    ...,
+    timeout=20.0,
+)
+
+
+# Override timeout for a specific method
+client.service.create_movie(..., request_options={
+    "timeout_in_seconds": 1
+})
+```
+
+### Custom Client
+
+You can override the `httpx` client to customize it for your use-case. Some common use-cases include support for proxies
+and transports.
+
+```python
+import httpx
+from seed import SeedExamples
+
+client = SeedExamples(
+    ...,
+    httpx_client=httpx.Client(
+        proxy="http://my.test.proxy.example.com",
+        transport=httpx.HTTPTransport(local_address="0.0.0.0"),
+    ),
+)
+```
+

--- a/seed/python-sdk/examples/readme/reference.md
+++ b/seed/python-sdk/examples/readme/reference.md
@@ -1,0 +1,1076 @@
+# Reference
+<details><summary><code>client.<a href="src/seed/client.py">echo</a>(...) -&gt; AsyncHttpResponse[str]</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.echo(
+    request="Hello world!\\n\\nwith\\n\\tnewlines",
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**request:** `str` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.<a href="src/seed/client.py">create_type</a>(...) -&gt; AsyncHttpResponse[Identifier]</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.create_type(
+    request="primitive",
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**request:** `Type` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+## File Notification Service
+<details><summary><code>client.file.notification.service.<a href="src/seed/file/notification/service/client.py">get_exception</a>(...) -&gt; AsyncHttpResponse[Exception]</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.file.notification.service.get_exception(
+    notification_id="notification-hsy129x",
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**notification_id:** `str` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+## File Service
+<details><summary><code>client.file.service.<a href="src/seed/file/service/client.py">get_file</a>(...) -&gt; AsyncHttpResponse[File]</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+This endpoint returns a file by its name.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.file.service.get_file(
+    filename="file.txt",
+    x_file_api_version="0.0.2",
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**filename:** `str` — This is a filename
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**x_file_api_version:** `str` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+## Health Service
+<details><summary><code>client.health.service.<a href="src/seed/health/service/client.py">check</a>(...) -&gt; AsyncHttpResponse[None]</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+This endpoint checks the health of a resource.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.health.service.check(
+    id="id-3tey93i",
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**id:** `str` — The id to check
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.health.service.<a href="src/seed/health/service/client.py">ping</a>() -&gt; AsyncHttpResponse[bool]</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+This endpoint checks the health of the service.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.health.service.ping()
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+## Service
+<details><summary><code>client.service.<a href="src/seed/service/client.py">get_movie</a>(...) -&gt; AsyncHttpResponse[Movie]</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.service.get_movie(
+    movie_id="movie-c06a4ad7",
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**movie_id:** `MovieId` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.service.<a href="src/seed/service/client.py">create_movie</a>(...) -&gt; AsyncHttpResponse[MovieId]</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.service.create_movie(
+    id="movie-c06a4ad7",
+    prequel="movie-cv9b914f",
+    title="The Boy and the Heron",
+    from_="Hayao Miyazaki",
+    rating=8.0,
+    tag="tag-wf9as23d",
+    metadata={
+        "actors": ["Christian Bale", "Florence Pugh", "Willem Dafoe"],
+        "releaseDate": "2023-12-08",
+        "ratings": {"rottenTomatoes": 97, "imdb": 7.6},
+    },
+    revenue=1000000,
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**id:** `MovieId` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**title:** `str` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**from_:** `str` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**rating:** `float` — The rating scale is one to five stars
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**tag:** `Tag` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**metadata:** `typing.Dict[str, typing.Any]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**revenue:** `int` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**prequel:** `typing.Optional[MovieId]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**book:** `typing.Optional[str]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.service.<a href="src/seed/service/client.py">get_metadata</a>(...) -&gt; AsyncHttpResponse[Metadata]</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.service.get_metadata(
+    x_api_version="0.0.1",
+    shallow=False,
+    tag="development",
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**x_api_version:** `str` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**shallow:** `typing.Optional[bool]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**tag:** `typing.Optional[typing.Union[str, typing.Sequence[str]]]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.service.<a href="src/seed/service/client.py">create_big_entity</a>(...) -&gt; AsyncHttpResponse[Response]</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+import datetime
+import uuid
+
+from seed import SeedExamples
+from seed.commons.types import Data_String, EventInfo_Metadata, Metadata
+from seed.environment import SeedExamplesEnvironment
+from seed.types import (
+    Actor,
+    Directory,
+    Entity,
+    Exception_Generic,
+    ExtendedMovie,
+    File,
+    Metadata_Html,
+    Migration,
+    Moment,
+    Node,
+    Test_And,
+    Tree,
+)
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.service.create_big_entity(
+    cast_member=Actor(
+        name="name",
+        id="id",
+    ),
+    extended_movie=ExtendedMovie(
+        cast=["cast", "cast"],
+        id="id",
+        prequel="prequel",
+        title="title",
+        from_="from",
+        rating=1.1,
+        tag="tag",
+        book="book",
+        metadata={"metadata": {"key": "value"}},
+        revenue=1000000,
+    ),
+    entity=Entity(
+        type="primitive",
+        name="name",
+    ),
+    metadata=Metadata_Html(value="metadata"),
+    common_metadata=Metadata(
+        id="id",
+        data={"data": "data"},
+        json_string="jsonString",
+    ),
+    event_info=EventInfo_Metadata(
+        id="id",
+        data={"data": "data"},
+        json_string="jsonString",
+    ),
+    data=Data_String(value="data"),
+    migration=Migration(
+        name="name",
+        status="RUNNING",
+    ),
+    exception=Exception_Generic(
+        exception_type="exceptionType",
+        exception_message="exceptionMessage",
+        exception_stacktrace="exceptionStacktrace",
+    ),
+    test=Test_And(value=True),
+    node=Node(
+        name="name",
+        nodes=[
+            Node(
+                name="name",
+                nodes=[
+                    Node(
+                        name="name",
+                    ),
+                    Node(
+                        name="name",
+                    ),
+                ],
+                trees=[
+                    Tree(
+                        nodes=[],
+                    ),
+                    Tree(
+                        nodes=[],
+                    ),
+                ],
+            ),
+            Node(
+                name="name",
+                nodes=[
+                    Node(
+                        name="name",
+                    ),
+                    Node(
+                        name="name",
+                    ),
+                ],
+                trees=[
+                    Tree(
+                        nodes=[],
+                    ),
+                    Tree(
+                        nodes=[],
+                    ),
+                ],
+            ),
+        ],
+        trees=[
+            Tree(
+                nodes=[
+                    Node(
+                        name="name",
+                        nodes=[],
+                        trees=[],
+                    ),
+                    Node(
+                        name="name",
+                        nodes=[],
+                        trees=[],
+                    ),
+                ],
+            ),
+            Tree(
+                nodes=[
+                    Node(
+                        name="name",
+                        nodes=[],
+                        trees=[],
+                    ),
+                    Node(
+                        name="name",
+                        nodes=[],
+                        trees=[],
+                    ),
+                ],
+            ),
+        ],
+    ),
+    directory=Directory(
+        name="name",
+        files=[
+            File(
+                name="name",
+                contents="contents",
+            ),
+            File(
+                name="name",
+                contents="contents",
+            ),
+        ],
+        directories=[
+            Directory(
+                name="name",
+                files=[
+                    File(
+                        name="name",
+                        contents="contents",
+                    ),
+                    File(
+                        name="name",
+                        contents="contents",
+                    ),
+                ],
+                directories=[
+                    Directory(
+                        name="name",
+                    ),
+                    Directory(
+                        name="name",
+                    ),
+                ],
+            ),
+            Directory(
+                name="name",
+                files=[
+                    File(
+                        name="name",
+                        contents="contents",
+                    ),
+                    File(
+                        name="name",
+                        contents="contents",
+                    ),
+                ],
+                directories=[
+                    Directory(
+                        name="name",
+                    ),
+                    Directory(
+                        name="name",
+                    ),
+                ],
+            ),
+        ],
+    ),
+    moment=Moment(
+        id=uuid.UUID(
+            "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+        ),
+        date=datetime.date.fromisoformat(
+            "2023-01-15",
+        ),
+        datetime=datetime.datetime.fromisoformat(
+            "2024-01-15 09:30:00+00:00",
+        ),
+    ),
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**cast_member:** `typing.Optional[CastMember]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**extended_movie:** `typing.Optional[ExtendedMovie]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**entity:** `typing.Optional[Entity]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**metadata:** `typing.Optional[Metadata]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**common_metadata:** `typing.Optional[Metadata]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**event_info:** `typing.Optional[EventInfo]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**data:** `typing.Optional[Data]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**migration:** `typing.Optional[Migration]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**exception:** `typing.Optional[Exception]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**test:** `typing.Optional[Test]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**node:** `typing.Optional[Node]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**directory:** `typing.Optional[Directory]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**moment:** `typing.Optional[Moment]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.service.<a href="src/seed/service/client.py">refresh_token</a>(...) -&gt; AsyncHttpResponse[None]</code></summary>
+<dl>
+<dd>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+from seed import SeedExamples
+from seed.environment import SeedExamplesEnvironment
+from seed.types import RefreshTokenRequest
+
+client = SeedExamples(
+    token="YOUR_TOKEN",
+    environment=SeedExamplesEnvironment.PRODUCTION,
+)
+client.service.refresh_token(
+    request=RefreshTokenRequest(
+        ttl=420,
+    ),
+)
+
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**request:** `typing.Optional[RefreshTokenRequest]` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request_options:** `typing.Optional[RequestOptions]` — Request-specific configuration.
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+


### PR DESCRIPTION
## Description

Refs: Reported by @iamnamananand996
Link to Devin run: https://app.devin.ai/sessions/46a7bc90cd564e59a93592c524bb967b

The Python SDK generator stopped producing `README.md` (and `reference.md`) after commit 34067a9b222 (#12705) removed `@fern-api/generator-cli` from all generator Dockerfiles. That commit migrated JS/TS generators to use the generator-cli JS API directly, but the **Python generator still invokes the CLI binary via subprocess** (`GeneratorCli._run_command`). With the binary missing and `skip_install=True`, the subprocess call fails — and the exception is silently caught at `DEBUG` log level in `sdk_generator.py`, so generation appears to succeed but produces no README.

## Changes Made

- Re-add `RUN npm install -f -g @fern-api/generator-cli@0.5.3` to `generators/python/sdk/Dockerfile` (restoring the line removed in #12705)
- Add version `4.61.2` changelog entry in `generators/python/sdk/versions.yml`
- Update seed snapshots for `examples:readme` fixture — `README.md` now contains 231 lines of generated SDK documentation (was previously empty/0 bytes), and `reference.md` (1076 lines) is now included

## Human Review Checklist

- [ ] **Version pin**: Is `@fern-api/generator-cli@0.5.3` still the correct version to use? The `generators/base/package.json` references `"@fern-api/generator-cli": "catalog:"` — verify the catalog version matches or is compatible.
- [ ] **Silent failure pattern**: The `try/except` in `sdk_generator.py:344-361` swallows the README generation error at DEBUG level. Consider whether this should be promoted to WARN so future breakages are more visible.
- [ ] **Long-term**: The Python generator is now the only generator still relying on the CLI binary via subprocess. Consider a follow-up to migrate Python to a native approach (e.g., Python bindings or calling the JS API via the Node runtime already in the image).
- [ ] **Other fixtures**: Other seed fixtures (`examples:no-custom-config`, `imdb`, etc.) also have empty `README.md` files. Only the `examples:readme` snapshot was regenerated in this PR. The remaining snapshots will update when those fixtures are next run.

## Testing

- [x] Built Docker image locally from the fixed Dockerfile and ran `pnpm seed:local test --generator python-sdk --fixture examples:readme` (Docker mode, not `--local`) — **1/1 test cases passed**
- [x] Verified `README.md` went from 0 bytes to 5895 bytes with proper content (package name, installation, usage examples, custom sections, API reference link)
- [x] Verified `reference.md` was generated (15475 bytes) with full API reference documentation
- [ ] No unit test changes (not applicable for Dockerfile changes)

![Seed test passing](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJlbWFpbHw2OGYxMzJkZDE0YzE2ODY1NTc1OTBmMDQiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfc2JkaXJzeHp5eHRjdHphai83YjEzOWYxZC1iOWU5LTQwNWEtOThlMy01ZTAxOWNlYzIxYzQiLCJpYXQiOjE3NzIyMjQwODUsImV4cCI6MTc3MjgyODg4NX0.MFV4ADIlR5_WfjcrI4PdfABK8RSboZ8qC70-IRKYQh4)
![Generated README.md content](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJlbWFpbHw2OGYxMzJkZDE0YzE2ODY1NTc1OTBmMDQiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfc2JkaXJzeHp5eHRjdHphai9kZjg3NmJhYi0yNTc3LTRiM2ItOWFkZS1jYTNkMzAyZDBiZWQiLCJpYXQiOjE3NzIyMjQwODUsImV4cCI6MTc3MjgyODg4NX0.OERzeXpqISNCzelCuTiofkiQa823-ceNRiuCZa0yHrM)