### PR TITLE
fix(python): restore generator-cli in Python SDK Dockerfile

### DIFF
--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -46,6 +46,8 @@ COPY ./generators/python/sdk/features.yml /assets/features.yml
 COPY ./generators/python/tests /assets/tests
 COPY ./generators/python/src ./src
 
+RUN npm install -f -g @fern-api/generator-cli@0.6.4
+
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.61.2
+  changelogEntry:
+    - summary: |
+        Restore generator-cli installation in Docker image. The Python SDK generator
+        uses generator-cli as a subprocess for README and reference generation, so it
+        must be pre-installed in the Docker image.
+      type: fix
+  createdAt: "2026-02-27"
+  irVersion: 65
+
 - version: 4.61.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs #12705

PR #12705 migrated all JS/TS generators to use the `@fern-api/generator-cli` JS API directly (bundled via esbuild) and removed `generator-cli` from **all** Dockerfiles. However, the Python SDK generator is written in Python — not JS — and has its own `GeneratorCli` class (`generators/python/src/fern_python/generator_cli/generator_cli.py`) that spawns `generator-cli` as a **subprocess** for README.md and reference.md generation. Removing it from the Python Dockerfile broke that generation path.

This PR restores the `generator-cli` installation in the Python SDK Dockerfile at version 0.6.4 (the version now in the pnpm catalog after #12705).

Link to Devin run: https://app.devin.ai/sessions/954147587dde4c49a92dfe54bf922220
Requested by: @Swimburger

## Changes Made

- Restored `RUN npm install -f -g @fern-api/generator-cli@0.6.4` in `generators/python/sdk/Dockerfile`
- Added version 4.61.2 changelog entry in `generators/python/sdk/versions.yml`

## Review Checklist

- [ ] Verify `generator-cli@0.6.4` CLI interface is backward-compatible with the Python generator's subprocess calls (previously used 0.5.3). The Python code invokes `generator-cli generate readme --config <file>` and `generator-cli generate-reference --config <file>` — confirm these commands still work in 0.6.4.
- [ ] Note: FastAPI and Pydantic Python generators are **not** affected — they don't use `generator-cli`.
- [ ] Note: The Python generator's `_install()` also runs `npm install -f -g @fern-api/generator-cli` at runtime (unpinned). With the Dockerfile pre-install, this is a no-op, but the runtime fallback now installs `latest` rather than a pinned version if the Dockerfile line is ever removed again.

## Testing

- [ ] Manual testing not completed (Dockerfile change — needs Docker build to verify)
- [ ] No unit tests added (infrastructure-only change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/12988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
