### PR TITLE
chore(cli): formalizes output of fern check --json to a schema.json

### DIFF
--- a/fern-check-result.schema.json
+++ b/fern-check-result.schema.json
@@ -1,0 +1,133 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/CheckJsonResult",
+    "definitions": {
+        "CheckJsonResult": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "success": {
+                    "type": "boolean"
+                },
+                "results": {
+                    "$ref": "#/definitions/CheckResults"
+                }
+            },
+            "required": [
+                "success",
+                "results"
+            ],
+            "title": "Check Result"
+        },
+        "CheckResults": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apis": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CheckJsonViolation"
+                    }
+                },
+                "docs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CheckJsonViolation"
+                    }
+                },
+                "sdks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CheckJsonViolation"
+                    }
+                }
+            },
+            "title": "Check Results"
+        },
+        "CheckJsonViolation": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "api": {
+                    "type": "string"
+                },
+                "severity": {
+                    "$ref": "#/definitions/ViolationSeverity"
+                },
+                "rule": {
+                    "$ref": "#/definitions/ValidationRuleName"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "severity",
+                "rule",
+                "message"
+            ],
+            "title": "Check Violation"
+        },
+        "ValidationRuleName": {
+            "type": "string",
+            "enum": [
+                "content-type-only-for-multipart",
+                "exploded-form-data-is-array",
+                "import-file-exists",
+                "matching-environment-urls",
+                "no-circular-imports",
+                "no-complex-query-params",
+                "no-conflicting-endpoint-parameters",
+                "no-conflicting-endpoint-paths",
+                "no-conflicting-request-wrapper-properties",
+                "no-duplicate-declarations",
+                "no-duplicate-enum-values",
+                "no-duplicate-example-names",
+                "no-duplicate-field-names",
+                "no-error-status-code-conflict",
+                "no-extensions-with-file-upload",
+                "no-get-request-body",
+                "no-missing-auth",
+                "no-missing-error-discriminant",
+                "no-missing-request-name",
+                "no-object-single-property-key",
+                "no-response-property",
+                "no-undefined-error-reference",
+                "no-undefined-example-reference",
+                "no-undefined-path-parameters",
+                "no-undefined-type-reference",
+                "no-undefined-variable-reference",
+                "no-unused-generic",
+                "only-object-extensions",
+                "valid-base-path",
+                "valid-default-environment",
+                "valid-endpoint-path",
+                "valid-example-endpoint-call",
+                "valid-example-error",
+                "valid-example-type",
+                "valid-field-names",
+                "valid-generic",
+                "valid-navigation",
+                "valid-oauth",
+                "valid-pagination",
+                "valid-path-parameters-configuration",
+                "valid-service-urls",
+                "valid-stream-condition",
+                "valid-type-name",
+                "valid-type-reference-with-default-and-validation",
+                "valid-version",
+                "valid-webhook-signature"
+            ],
+            "title": "Validation Rule Name"
+        },
+        "ViolationSeverity": {
+            "type": "string",
+            "enum": [
+                "fatal",
+                "error",
+                "warning"
+            ],
+            "title": "Violation Severity"
+        }
+    }
+}

--- a/fern-check-result.schema.json
+++ b/fern-check-result.schema.json
@@ -26,25 +26,25 @@
                 "apis": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CheckJsonViolation"
+                        "$ref": "#/definitions/ApiCheckJsonViolation"
                     }
                 },
                 "docs": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CheckJsonViolation"
+                        "$ref": "#/definitions/DocsCheckJsonViolation"
                     }
                 },
                 "sdks": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/CheckJsonViolation"
+                        "$ref": "#/definitions/ApiCheckJsonViolation"
                     }
                 }
             },
             "title": "Check Results"
         },
-        "CheckJsonViolation": {
+        "ApiCheckJsonViolation": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -55,7 +55,7 @@
                     "$ref": "#/definitions/ViolationSeverity"
                 },
                 "rule": {
-                    "$ref": "#/definitions/ValidationRuleName"
+                    "$ref": "#/definitions/ApiValidationRuleName"
                 },
                 "message": {
                     "type": "string"
@@ -66,9 +66,30 @@
                 "rule",
                 "message"
             ],
-            "title": "Check Violation"
+            "title": "API Check Violation"
         },
-        "ValidationRuleName": {
+        "DocsCheckJsonViolation": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "severity": {
+                    "$ref": "#/definitions/ViolationSeverity"
+                },
+                "rule": {
+                    "$ref": "#/definitions/DocsValidationRuleName"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "severity",
+                "rule",
+                "message"
+            ],
+            "title": "Docs Check Violation"
+        },
+        "ApiValidationRuleName": {
             "type": "string",
             "enum": [
                 "content-type-only-for-multipart",
@@ -118,7 +139,32 @@
                 "valid-version",
                 "valid-webhook-signature"
             ],
-            "title": "Validation Rule Name"
+            "title": "API Validation Rule Name"
+        },
+        "DocsValidationRuleName": {
+            "type": "string",
+            "enum": [
+                "accent-color-contrast",
+                "all-roles-must-be-declared",
+                "filepaths-exist",
+                "no-circular-redirects",
+                "no-non-component-refs",
+                "no-openapi-v2-in-docs",
+                "only-versioned-navigation",
+                "tab-with-href",
+                "valid-docs-endpoints",
+                "valid-file-types",
+                "valid-frontmatter",
+                "valid-instance-url",
+                "valid-local-references",
+                "valid-markdown",
+                "valid-markdown-file-references",
+                "valid-markdown-links",
+                "valid-openapi-examples",
+                "validate-product-file",
+                "validate-version-file"
+            ],
+            "title": "Docs Validation Rule Name"
         },
         "ViolationSeverity": {
             "type": "string",

--- a/packages/cli/cli/src/commands/validate/buildCheckJsonResult.ts
+++ b/packages/cli/cli/src/commands/validate/buildCheckJsonResult.ts
@@ -1,18 +1,24 @@
 import { ApiValidationResult, DocsValidationResult } from "./printCheckReport.js";
 
-export interface CheckJsonViolation {
+export interface ApiCheckJsonViolation {
     api?: string;
     severity: string;
-    rule?: string;
+    rule: string;
+    message: string;
+}
+
+export interface DocsCheckJsonViolation {
+    severity: string;
+    rule: string;
     message: string;
 }
 
 export interface CheckJsonResult {
     success: boolean;
     results: {
-        apis?: CheckJsonViolation[];
-        docs?: CheckJsonViolation[];
-        sdks?: CheckJsonViolation[];
+        apis?: ApiCheckJsonViolation[];
+        docs?: DocsCheckJsonViolation[];
+        sdks?: ApiCheckJsonViolation[];
     };
 }
 
@@ -27,34 +33,29 @@ export function buildCheckJsonResult({
     hasErrors: boolean;
     showApiNames: boolean;
 }): CheckJsonResult {
-    const apis: CheckJsonViolation[] = [];
+    const apis: ApiCheckJsonViolation[] = [];
     for (const apiResult of apiResults) {
         for (const violation of apiResult.violations) {
-            const entry: CheckJsonViolation = {
+            const entry: ApiCheckJsonViolation = {
                 severity: violation.severity,
+                rule: violation.name,
                 message: violation.message
             };
             if (showApiNames) {
                 entry.api = apiResult.apiName;
             }
-            if (violation.name != null) {
-                entry.rule = violation.name;
-            }
             apis.push(entry);
         }
     }
 
-    const docs: CheckJsonViolation[] = [];
+    const docs: DocsCheckJsonViolation[] = [];
     if (docsResult != null) {
         for (const violation of docsResult.violations) {
-            const entry: CheckJsonViolation = {
+            docs.push({
                 severity: violation.severity,
+                rule: violation.name,
                 message: violation.message
-            };
-            if (violation.name != null) {
-                entry.rule = violation.name;
-            }
-            docs.push(entry);
+            });
         }
     }
 

--- a/packages/cli/fern-definition/validator/src/ValidationViolation.ts
+++ b/packages/cli/fern-definition/validator/src/ValidationViolation.ts
@@ -2,7 +2,7 @@ import { NodePath } from "@fern-api/fern-definition-schema";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 
 export interface ValidationViolation {
-    name?: string;
+    name: string;
     severity: "fatal" | "error" | "warning";
     relativeFilepath: RelativeFilePath;
     nodePath: NodePath;

--- a/packages/cli/yaml/docs-validator/src/ValidationViolation.ts
+++ b/packages/cli/yaml/docs-validator/src/ValidationViolation.ts
@@ -2,7 +2,7 @@ import { NodePath } from "@fern-api/fern-definition-schema";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 
 export interface ValidationViolation {
-    name?: string;
+    name: string;
     severity: "fatal" | "error" | "warning";
     relativeFilepath: RelativeFilePath;
     nodePath: NodePath;

--- a/packages/cli/yaml/docs-validator/src/createDocsConfigFileAstVisitorForRules.ts
+++ b/packages/cli/yaml/docs-validator/src/createDocsConfigFileAstVisitorForRules.ts
@@ -11,10 +11,12 @@ import { ValidationViolation } from "./ValidationViolation.js";
 export function createDocsConfigFileAstVisitorForRules({
     relativeFilepath,
     allRuleVisitors,
+    ruleNames,
     addViolations
 }: {
     relativeFilepath: RelativeFilePath;
     allRuleVisitors: RuleVisitor<DocsConfigFileAstNodeTypes>[];
+    ruleNames: string[];
     addViolations: (newViolations: ValidationViolation[]) => void;
 }): DocsConfigFileAstVisitor {
     function createAstNodeVisitor<K extends keyof DocsConfigFileAstNodeTypes>(
@@ -24,20 +26,22 @@ export function createDocsConfigFileAstVisitorForRules({
             node: DocsConfigFileAstNodeTypes[K],
             nodePath: NodePath
         ) => {
-            for (const ruleVisitors of allRuleVisitors) {
-                const visitFromRule = ruleVisitors[nodeType];
-                if (visitFromRule != null) {
-                    const ruleViolations = await visitFromRule(node);
-                    addViolations(
-                        ruleViolations.map((violation) => ({
-                            name: violation.name,
-                            severity: violation.severity,
-                            relativeFilepath: violation.relativeFilepath ?? RelativeFilePath.of(""),
-                            nodePath,
-                            message: violation.message
-                        }))
-                    );
-                }
+                for (let i = 0; i < allRuleVisitors.length; i++) {
+                    const ruleVisitors = allRuleVisitors[i];
+                    const ruleName = ruleNames[i];
+                    const visitFromRule = ruleVisitors?.[nodeType];
+                    if (visitFromRule != null) {
+                        const ruleViolations = await visitFromRule(node);
+                        addViolations(
+                            ruleViolations.map((violation) => ({
+                                name: violation.name ?? ruleName ?? "unknown",
+                                severity: violation.severity,
+                                relativeFilepath: violation.relativeFilepath ?? RelativeFilePath.of(""),
+                                nodePath,
+                                message: violation.message
+                            }))
+                        );
+                    }
             }
         };
 

--- a/packages/cli/yaml/docs-validator/src/createDocsConfigFileAstVisitorForRules.ts
+++ b/packages/cli/yaml/docs-validator/src/createDocsConfigFileAstVisitorForRules.ts
@@ -26,22 +26,22 @@ export function createDocsConfigFileAstVisitorForRules({
             node: DocsConfigFileAstNodeTypes[K],
             nodePath: NodePath
         ) => {
-                for (let i = 0; i < allRuleVisitors.length; i++) {
-                    const ruleVisitors = allRuleVisitors[i];
-                    const ruleName = ruleNames[i];
-                    const visitFromRule = ruleVisitors?.[nodeType];
-                    if (visitFromRule != null) {
-                        const ruleViolations = await visitFromRule(node);
-                        addViolations(
-                            ruleViolations.map((violation) => ({
-                                name: violation.name ?? ruleName ?? "unknown",
-                                severity: violation.severity,
-                                relativeFilepath: violation.relativeFilepath ?? RelativeFilePath.of(""),
-                                nodePath,
-                                message: violation.message
-                            }))
-                        );
-                    }
+            for (let i = 0; i < allRuleVisitors.length; i++) {
+                const ruleVisitors = allRuleVisitors[i];
+                const ruleName = ruleNames[i];
+                const visitFromRule = ruleVisitors?.[nodeType];
+                if (visitFromRule != null) {
+                    const ruleViolations = await visitFromRule(node);
+                    addViolations(
+                        ruleViolations.map((violation) => ({
+                            name: violation.name ?? ruleName ?? "unknown",
+                            severity: violation.severity,
+                            relativeFilepath: violation.relativeFilepath ?? RelativeFilePath.of(""),
+                            nodePath,
+                            message: violation.message
+                        }))
+                    );
+                }
             }
         };
 

--- a/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
+++ b/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
@@ -56,6 +56,7 @@ export async function runRulesOnDocsWorkspace({
     const astVisitor = createDocsConfigFileAstVisitorForRules({
         relativeFilepath: RelativeFilePath.of(DOCS_CONFIGURATION_FILENAME),
         allRuleVisitors,
+        ruleNames: rules.map((rule) => rule.name),
         addViolations: (newViolations: ValidationViolation[]) => {
             violations.push(...newViolations);
         }


### PR DESCRIPTION
## Description

Refs: https://app.devin.ai/sessions/00111074e604464982c512dd8a08f9e0
Requested by: @aditya-arolkar-swe

Formalizes the output of `fern check --json` into a JSON Schema (draft-07) and separates violation types for APIs vs Docs, each with their own strict rule name enums.

## Changes Made

- Added `fern-check-result.schema.json` following the same conventions as `fern-versions-yml.schema.json` (`$ref`-based definitions, `additionalProperties: false`, `required` arrays, `title` fields)
- Split the single `CheckJsonViolation` into **`ApiCheckJsonViolation`** (with optional `api` field) and **`DocsCheckJsonViolation`** (docs-only fields), each referencing their own rule name enum
- Made `ValidationViolation.name` required (`string` instead of `string | undefined`) in both `fern-definition-validator` and `docs-validator`
- Made `rule` always required in the JSON output (no more conditional `if (violation.name != null)` checks)
- Added rule name fallback in `createDocsConfigFileAstVisitorForRules`: violations that don't set a `name` now inherit the parent rule's name (`violation.name ?? ruleName ?? "unknown"`)

### Schema structure

| Definition | Maps to | Notes |
|---|---|---|
| `CheckJsonResult` | Top-level output | `success` (bool) + `results` |
| `CheckResults` | `results` object | Optional `apis`, `docs`, `sdks` arrays |
| `ApiCheckJsonViolation` | API/SDK violation | `severity`, `rule` (required, from `ApiValidationRuleName`), `message`, `api` (optional) |
| `DocsCheckJsonViolation` | Docs violation | `severity`, `rule` (required, from `DocsValidationRuleName`), `message` |
| `ApiValidationRuleName` | 46 API rule names | Strict enum from `packages/cli/fern-definition/validator/src/rules/` |
| `DocsValidationRuleName` | 19 docs rule names | Strict enum from `packages/cli/yaml/docs-validator/src/rules/` |
| `ViolationSeverity` | `"fatal" \| "error" \| "warning"` | Shared by both violation types |

- [ ] Updated README.md generator (if applicable)

## Maintenance note

- When a new API validation rule is added to `packages/cli/fern-definition/validator/src/rules/`, its name should also be added to the `ApiValidationRuleName` enum in `fern-check-result.schema.json`.
- When a new docs validation rule is added to `packages/cli/yaml/docs-validator/src/rules/`, its name should also be added to the `DocsValidationRuleName` enum in `fern-check-result.schema.json`.

## Human review checklist

- [ ] Verify the `ApiValidationRuleName` enum (46 entries) and `DocsValidationRuleName` enum (19 entries) in the schema match the complete set of rules in their respective `src/rules/` directories
- [ ] Confirm the `RuleViolation.name` in `docs-validator/src/Rule.ts` is intentionally still optional — the mapping layer in `createDocsConfigFileAstVisitorForRules` fills in the rule name as fallback via `violation.name ?? ruleName ?? "unknown"`
- [ ] Verify that the index-based parallel iteration of `allRuleVisitors[i]` / `ruleNames[i]` is safe (both arrays are derived from the same `rules` array in `validateDocsWorkspace.ts`)

## Testing

- [x] All CI checks pass (compile, lint, biome, test, test-ete, depcheck, etc.)
- [ ] Verify the schema validates a sample `fern check --json` output correctly
- [ ] Verify the schema rejects invalid severity values and unknown rule names