### PR TITLE
fix(internal): one-liner for path x-fern-server-names

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
@@ -44,7 +44,7 @@ export function convertHttpOperation({
     streamTerminator?: string;
     source: Source;
 }): EndpointWithExample[] {
-    const { document, operation, path, method, baseBreadcrumbs } = operationContext;
+    const { document, operation, path, method, baseBreadcrumbs, pathItem } = operationContext;
 
     const idempotent = getExtension<boolean>(operation, FernOpenAPIExtension.IDEMPOTENT);
     const requestNameOverride = getExtension<string>(operation, [
@@ -343,7 +343,7 @@ export function convertHttpOperation({
         servers:
             serverName != null
                 ? [{ name: serverName, url: undefined, audiences: undefined }]
-                : (operation.servers ?? []).map((server) =>
+                : (operation.servers ?? pathItem.servers ?? []).map((server) =>
                       convertServer(server, { groupMultiApiEnvironments: context.options.groupMultiApiEnvironments })
                   ),
         description: operation.description,

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -6,6 +6,9 @@
         it validates the exact definition used for generation (with generator-specific
         settings like `detectGlobalHeaders` and auth overrides applied).
       type: fix
+    - summary: |
+        Fix path-level `servers` with `x-fern-server-name` being ignored in OpenAPI 3.0 specs.
+      type: fix
   createdAt: "2026-02-27"
   irVersion: 65
 


### PR DESCRIPTION
## Description
`x-fern-server-name` was ignored on the OAS 3.0 parser for certain situations:
```
servers:
    - url: https://api.example.com
      x-fern-server-name: Production
    - url: https://agent.example.com
      x-fern-server-name: Agent
  paths:
    /v1/agent/models:
      servers:
        - url: https://agent.example.com
          x-fern-server-name: Agent
      get:
        operationId: listModels
        responses:
          "200":
            description: OK

  The path-level servers override on /v1/agent/models tells the SDK that this endpoint should use the Agent
  server (https://agent.example.com), not the default Production server. Before this fix, the override was
  silently ignored.
  ```

## Changes Made
One-liner to `openapi-ir-parser`.

## Testing
Fixes Deepgram.
- [X] Unit tests added/updated
- [X] Manual testing completed
