### PR TITLE
chore(ci): fail seed CI if git-tracked files differ after seed generation

### DIFF
--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -103,6 +103,27 @@ runs:
       run: |
         echo "end_time=$EPOCHSECONDS" >> $GITHUB_OUTPUT
 
+    # Fail CI if seed produced changes to any git-tracked files (excluding known non-deterministic paths like .mock and lock files)
+    - name: Ensure no pending git changes
+      if: always() && !cancelled()
+      shell: bash
+      run: |
+        # Parse JSON array and build exclude arguments
+        JSON_INPUT='${{ inputs.determinism-exclude-paths }}'
+        EXCLUDE_ARGS=()
+        for EXCLUDE_PATTERN in $(echo "${JSON_INPUT}" | jq -c -r '.[]'); do
+          EXCLUDE_ARGS+=(":(exclude)${EXCLUDE_PATTERN}")
+        done
+
+        if ! git --no-pager diff --exit-code --quiet -- "${EXCLUDE_ARGS[@]}"; then
+          echo "::error::Seed generation produced changes to git-tracked files. Please run seed locally and commit the changes."
+          echo "Showing first 200 lines of diff:"
+          git --no-pager diff -- "${EXCLUDE_ARGS[@]}" | head -200 || true
+          exit 1
+        else
+          echo "No pending git changes after seed generation."
+        fi
+
     # Run after seed is built, do this separately so we can keep seed time collection limited to seed generation
     # Note: tests failing can be a cause of this reporting as non-deterministic
     - name: Verify Determinism

--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -111,9 +111,9 @@ runs:
         # Parse JSON array and build exclude arguments
         JSON_INPUT='${{ inputs.determinism-exclude-paths }}'
         EXCLUDE_ARGS=()
-        for EXCLUDE_PATTERN in $(echo "${JSON_INPUT}" | jq -c -r '.[]'); do
+        while IFS= read -r EXCLUDE_PATTERN; do
           EXCLUDE_ARGS+=(":(exclude)${EXCLUDE_PATTERN}")
-        done
+        done < <(echo "${JSON_INPUT}" | jq -c -r '.[]')
 
         if ! git --no-pager diff --exit-code --quiet -- "${EXCLUDE_ARGS[@]}"; then
           echo "::error::Seed generation produced changes to git-tracked files. Please run seed locally and commit the changes."


### PR DESCRIPTION
## Description

Previously, seed CI (`seed.yml`) did not verify that running seed produced no changes to git-tracked files. The existing `verify-determinism` step only ran during metrics-collection runs (`collect-metrics == 'true'`), not on regular PR checks. This meant a PR could pass seed CI even if it had uncommitted seed snapshot changes.

This adds an "Ensure no pending git changes" step to the `run-seed-process` composite action that runs on **every** seed CI run and fails if `git diff` detects any modified tracked files (excluding known non-deterministic paths like `.mock` and lock files via the existing `determinism-exclude-paths` input).

Refs https://app.devin.ai/sessions/1534523d96f84b02a00485f7c6664926
Requested by: @Swimburger

## Changes Made

- Added a new `Ensure no pending git changes` step to `.github/actions/run-seed-process/action.yaml`
- Reuses the existing `determinism-exclude-paths` input for consistent exclusion of `.mock` dirs, lock files, etc.
- Outputs first 200 lines of diff on failure for debugging

## Updates since last revision

- Fixed word-splitting bug in exclude-path parsing: switched from `for ... in $(...)` to `while IFS= read -r` loop to correctly handle patterns containing spaces (addressed Graphite review comment)

## Human Review Checklist

- [ ] **`always()` condition**: The step runs even if seed generation itself failed. If seed fails partway through, partial file changes could trigger a secondary "pending changes" error. Is this acceptable or should it be gated on the seed step succeeding?
- [ ] **Exclude paths coverage**: Are the current `determinism-exclude-paths` defaults (`seed/*/.mock/*`) and per-generator overrides (e.g. `Gemfile.lock`, `poetry.lock`) sufficient, or are there other non-deterministic files that need exclusion?
- [ ] **Overlap with `verify-determinism`**: The new step and the existing `verify-determinism` action now check the same thing, but `verify-determinism` only records a metric (doesn't fail) and only runs for metric-collection runs. Worth considering whether to consolidate.

## Testing

- [ ] No unit tests — this is a CI workflow change that will be validated when seed CI runs on PRs that touch seed/generator files