### PR TITLE
fix(seed): stream script runner output based on shouldStreamOutput flag

### DIFF
--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -240,12 +240,13 @@ export class ContainerScriptRunner extends ScriptRunner {
         }
 
         // Now actually run the test script
+        const streamOutput = this.shouldStreamOutput();
         const command = await loggingExeca(
             taskContext.logger,
             this.runner,
             ["exec", containerId, "/bin/sh", "-c", `chmod +x /${workDir}/test.sh && /${workDir}/test.sh`],
             {
-                doNotPipeOutput: true,
+                doNotPipeOutput: !streamOutput,
                 reject: false
             }
         );
@@ -255,6 +256,9 @@ export class ContainerScriptRunner extends ScriptRunner {
             taskContext.logger.error(command.stderr);
             return { type: "failure", message: command.stdout };
         } else {
+            if (!streamOutput && command.stdout) {
+                taskContext.logger.debug(command.stdout);
+            }
             return { type: "success" };
         }
     }

--- a/packages/seed/src/commands/test/script-runner/LocalScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/LocalScriptRunner.ts
@@ -165,9 +165,10 @@ export class LocalScriptRunner extends ScriptRunner {
             return { type: "failure", message: chmodCommand.stdout };
         }
 
+        const streamOutput = this.shouldStreamOutput();
         const command = await loggingExeca(taskContext.logger, "/bin/sh", [scriptFile.path], {
             cwd: outputDir,
-            doNotPipeOutput: true,
+            doNotPipeOutput: !streamOutput,
             reject: false
         });
 
@@ -177,6 +178,9 @@ export class LocalScriptRunner extends ScriptRunner {
             taskContext.logger.error(command.stderr);
             return { type: "failure", message: command.stdout };
         } else {
+            if (!streamOutput && command.stdout) {
+                taskContext.logger.debug(command.stdout);
+            }
             return { type: "success" };
         }
     }


### PR DESCRIPTION
## Description
Linear ticket: Closes
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

Script runners previously always suppressed output from test scripts (`doNotPipeOutput: true`), meaning stdout was silently discarded even on success. This PR wires up the existing `shouldStreamOutput()` method (which returns `true` when log level is `debug` or `trace`) so that script output is streamed live at higher verbosity levels, and captured and logged at `debug` level on success at lower verbosity levels.

## Changes Made
- `LocalScriptRunner`: respect `shouldStreamOutput()` when running test scripts; log stdout at debug level on success when not streaming
- `ContainerScriptRunner`: same fix for the container-based script execution path
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed — run `pnpm seed test --generator <generator> --fixture <fixture>` with and without `--log-level debug` to verify output streaming behavior
