### PR TITLE
fix(cli): optimize throwaway git ops to avoid commit signing prompts

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.95.5
+  changelogEntry:
+    - summary: |
+        Optimize throwaway git operations in LocalTaskHandler to avoid triggering
+        commit signing prompts (e.g. Touch ID on macOS). Internal git commits used
+        for .fernignore resolution now disable GPG/SSH signing, skip hooks, and
+        inline user config to reduce spawned git processes.
+      type: fix
+  createdAt: "2026-02-28"
+  irVersion: 65
+
 - version: 3.95.4
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -312,15 +312,6 @@ export class LocalTaskHandler {
         // to prevent accidental deletion when README generation fails silently.
         const pathsToPreserve = await this.getPathsToPreserve(fernIgnorePaths);
 
-        const response = await this.runGitCommand(["config", "--list"], this.absolutePathToLocalOutput);
-        if (!response.includes("user.name")) {
-            await this.runGitCommand(["config", "user.name", "fern-api"], this.absolutePathToLocalOutput);
-            await this.runGitCommand(
-                ["config", "user.email", "info@buildwithfern.com"],
-                this.absolutePathToLocalOutput
-            );
-        }
-
         // Stage deletions `git rm -rf .`
         await this.runGitCommand(["rm", "-rf", "."], this.absolutePathToLocalOutput);
 
@@ -352,16 +343,28 @@ export class LocalTaskHandler {
         // Copy files from local output to tmp directory
         await cp(this.absolutePathToLocalOutput, tmpOutputResolutionDir, { recursive: true });
 
-        // In tmp directory initialize a `.git` directory
+        // Initialize a throwaway git repo in the temp directory. This is only used to
+        // leverage git's file-tracking for resolving .fernignore paths. We inline the
+        // user config, disable commit signing, and skip hooks to avoid prompts (e.g.
+        // Touch ID on macOS) and unnecessary overhead.
         await this.runGitCommand(["init"], tmpOutputResolutionDir);
         await this.runGitCommand(["add", "."], tmpOutputResolutionDir);
-
-        const response = await this.runGitCommand(["config", "--list"], tmpOutputResolutionDir);
-        if (!response.includes("user.name")) {
-            await this.runGitCommand(["config", "user.name", "fern-api"], tmpOutputResolutionDir);
-            await this.runGitCommand(["config", "user.email", "info@buildwithfern.com"], tmpOutputResolutionDir);
-        }
-        await this.runGitCommand(["commit", "--allow-empty", "-m", '"init"'], tmpOutputResolutionDir);
+        await this.runGitCommand(
+            [
+                "-c",
+                "user.name=fern",
+                "-c",
+                "user.email=hey@buildwithfern.com",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--allow-empty",
+                "--no-verify",
+                "-m",
+                "init"
+            ],
+            tmpOutputResolutionDir
+        );
 
         // Stage deletions `git rm -rf .`
         await this.runGitCommand(["rm", "-rf", "."], tmpOutputResolutionDir);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -317,12 +317,6 @@ async function downloadFilesWithFernIgnoreInExistingRepo({
     const absolutePathToFernignore = join(absolutePathToLocalOutput, RelativeFilePath.of(FERNIGNORE_FILENAME));
     const fernIgnorePaths = await getFernIgnorePaths({ absolutePathToFernignore });
 
-    const gitConfigResponse = await runGitCommand(["config", "--list"], absolutePathToLocalOutput, context);
-    if (!gitConfigResponse.includes("user.name")) {
-        await runGitCommand(["config", "user.name", "fern-api"], absolutePathToLocalOutput, context);
-        await runGitCommand(["config", "user.email", "info@buildwithfern.com"], absolutePathToLocalOutput, context);
-    }
-
     await runGitCommand(["rm", "-rf", "."], absolutePathToLocalOutput, context);
 
     await downloadAndExtractZipToDirectory({ s3PreSignedReadUrl, outputPath: absolutePathToLocalOutput });
@@ -349,15 +343,29 @@ async function downloadFilesWithFernIgnoreInTempRepo({
 
     await cp(absolutePathToLocalOutput, tmpOutputResolutionDir, { recursive: true });
 
+    // Initialize a throwaway git repo in the temp directory. This is only used to
+    // leverage git's file-tracking for resolving .fernignore paths. We inline the
+    // user config, disable commit signing, and skip hooks to avoid prompts (e.g.
+    // Touch ID on macOS) and unnecessary overhead.
     await runGitCommand(["init"], tmpOutputResolutionDir, context);
     await runGitCommand(["add", "."], tmpOutputResolutionDir, context);
-
-    const gitConfigResponse = await runGitCommand(["config", "--list"], tmpOutputResolutionDir, context);
-    if (!gitConfigResponse.includes("user.name")) {
-        await runGitCommand(["config", "user.name", "fern-api"], tmpOutputResolutionDir, context);
-        await runGitCommand(["config", "user.email", "info@buildwithfern.com"], tmpOutputResolutionDir, context);
-    }
-    await runGitCommand(["commit", "--allow-empty", "-m", '"init"'], tmpOutputResolutionDir, context);
+    await runGitCommand(
+        [
+            "-c",
+            "user.name=fern",
+            "-c",
+            "user.email=hey@buildwithfern.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--allow-empty",
+            "--no-verify",
+            "-m",
+            "init"
+        ],
+        tmpOutputResolutionDir,
+        context
+    );
 
     await runGitCommand(["rm", "-rf", "."], tmpOutputResolutionDir, context);
 


### PR DESCRIPTION
## Description

When running `fern generate` with `.fernignore` resolution, the CLI creates throwaway git repos in temp directories. These internal `git commit` calls inherit the user's global git config, which can trigger commit signing prompts (e.g. Touch ID on macOS with `commit.gpgsign=true`), blocking the process.

This affected both local and remote generation paths.

Requested by: @Swimburger
[Link to Devin run](https://app.devin.ai/sessions/526f8813b77847919e0aef16066d4a88)

## Changes Made

### `LocalTaskHandler.ts`

**`copyGeneratedFilesWithFernIgnoreInTempRepo`**:
- Replaced 4 separate git process spawns (`config --list`, `config user.name`, `config user.email`, `commit`) with a single `git commit` call that inlines config via `-c` flags
- Added `-c commit.gpgsign=false` to disable GPG/SSH signing on the throwaway commit
- Added `--no-verify` to skip git hooks (unnecessary in temp dirs)

**`copyGeneratedFilesWithFernIgnoreInExistingRepo`**:
- Removed unnecessary `git config --list` check and `git config user.name/email` calls (3 process spawns). This method only runs `git rm`, `git add`, `git reset`, `git clean`, `git restore` — none of which require `user.name`/`user.email`.

### `RemoteTaskHandler.ts`

**`downloadFilesWithFernIgnoreInTempRepo`**:
- Same optimization as LocalTaskHandler: replaced config check + config set + commit (4 spawns) with a single commit using `-c` flags, `--no-verify`, and `commit.gpgsign=false`.

**`downloadFilesWithFernIgnoreInExistingRepo`**:
- Same as LocalTaskHandler: removed unnecessary `git config` calls (3 spawns) since this method makes no commits.

## Human Review Checklist
- [ ] Verify that removing the `user.name`/`user.email` config from both `*WithFernIgnoreInExistingRepo` methods is safe — no git operations in those methods require author identity (no commits are made)
- [ ] Confirm the `-c` flag approach for passing config to the commit command works as expected across git versions
- [ ] Check that `--no-verify` in freshly `git init`-ed temp dirs has no unintended side effects (there should be no hooks to skip, but global `core.hooksPath` could theoretically point somewhere)

## Testing
- [ ] Linting passes (biome check)
- [ ] Cannot test Touch ID prompt resolution in CI — requires macOS with commit signing enabled