### PR TITLE
chore(ci): add workflow to rerun failed tests on seed PRs

### DIFF
--- a/.github/workflows/rerun-seed-tests.yml
+++ b/.github/workflows/rerun-seed-tests.yml
@@ -11,9 +11,6 @@ permissions:
   pull-requests: read
   checks: read
 
-env:
-  DO_NOT_TRACK: "1"
-
 jobs:
   rerun-failed-seed-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/rerun-seed-tests.yml
+++ b/.github/workflows/rerun-seed-tests.yml
@@ -28,7 +28,7 @@ jobs:
           MAX_FAILURES=3
 
           echo "Fetching open PRs with 'seed' label..."
-          PRS=$(gh pr list --label seed --state open --json number,headRefSha --jq '.[] | "\(.number) \(.headRefSha)"')
+          PRS=$(gh pr list --label seed --state open --json number,headRefOid --jq '.[] | "\(.number) \(.headRefOid)"')
 
           if [ -z "$PRS" ]; then
             echo "No open PRs with 'seed' label found."
@@ -49,8 +49,8 @@ jobs:
             fi
             echo "PR #${PR_NUMBER}: Has ${APPROVAL_COUNT} approval(s)."
 
-            # Get all check runs for the head SHA
-            CHECK_RUNS_JSON=$(gh api "repos/{owner}/{repo}/commits/${HEAD_SHA}/check-runs" --paginate --jq '.check_runs')
+            # Get all check runs for the head SHA (flatten paginated arrays)
+            CHECK_RUNS_JSON=$(gh api "repos/{owner}/{repo}/commits/${HEAD_SHA}/check-runs" --paginate --jq '.check_runs[]' | jq -s '.')
 
             # Check if all check runs are completed (none pending/in_progress)
             INCOMPLETE_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status != "completed")] | length')
@@ -71,15 +71,13 @@ jobs:
             echo "PR #${PR_NUMBER}: ${FAILED_COUNT} failed check(s), within acceptable range."
 
             # Get the workflow run IDs for the failed checks
-            # Each check run belongs to a check suite, which corresponds to a workflow run
             FAILED_CHECK_NAMES=$(echo "$FAILED_CHECKS" | jq -r '.[].name')
             echo "Failed checks: ${FAILED_CHECK_NAMES}"
 
-            # Get all workflow runs for this head SHA to find failed ones
-            # We need to find the run_id for re-running
-            WORKFLOW_RUNS=$(gh api "repos/{owner}/{repo}/actions/runs?head_sha=${HEAD_SHA}&status=completed" --paginate --jq '.workflow_runs')
+            # Get all workflow runs for this head SHA to find failed ones (flatten paginated arrays)
+            WORKFLOW_RUNS=$(gh api "repos/{owner}/{repo}/actions/runs?head_sha=${HEAD_SHA}&status=completed" --paginate --jq '.workflow_runs[]' | jq -s '.')
 
-            # Find runs that have failed jobs matching our failed checks
+            # Find runs that have failed jobs
             RERUN_RUN_IDS=$(echo "$WORKFLOW_RUNS" | jq -r '[.[] | select(.conclusion == "failure")] | .[].id' | sort -u)
 
             if [ -z "$RERUN_RUN_IDS" ]; then

--- a/.github/workflows/rerun-seed-tests.yml
+++ b/.github/workflows/rerun-seed-tests.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   rerun-failed-seed-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Find and rerun failed seed PR tests
         env:
@@ -101,6 +101,10 @@ jobs:
               else
                 echo "PR #${PR_NUMBER}: Failed to trigger rerun for run ${RUN_ID}."
               fi
+
+              # Wait 1 minute between re-runs to avoid rate limiting
+              echo "Waiting 60 seconds before next rerun..."
+              sleep 60
             done
           done
 

--- a/.github/workflows/rerun-seed-tests.yml
+++ b/.github/workflows/rerun-seed-tests.yml
@@ -1,0 +1,113 @@
+name: Rerun Failed Seed PR Tests
+
+on:
+  schedule:
+    # Run every 2 hours
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  pull-requests: read
+  checks: read
+
+env:
+  DO_NOT_TRACK: "1"
+
+jobs:
+  rerun-failed-seed-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Find and rerun failed seed PR tests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          MAX_RERUN_ATTEMPTS=3
+          MIN_FAILURES=1
+          MAX_FAILURES=3
+
+          echo "Fetching open PRs with 'seed' label..."
+          PRS=$(gh pr list --label seed --state open --json number,headRefSha --jq '.[] | "\(.number) \(.headRefSha)"')
+
+          if [ -z "$PRS" ]; then
+            echo "No open PRs with 'seed' label found."
+            exit 0
+          fi
+
+          echo "$PRS" | while read -r PR_NUMBER HEAD_SHA; do
+            echo ""
+            echo "=========================================="
+            echo "Processing PR #${PR_NUMBER} (SHA: ${HEAD_SHA})"
+            echo "=========================================="
+
+            # Check if PR is approved
+            APPROVAL_COUNT=$(gh pr view "$PR_NUMBER" --json reviews --jq '[.reviews[] | select(.state == "APPROVED")] | length')
+            if [ "$APPROVAL_COUNT" -eq 0 ]; then
+              echo "PR #${PR_NUMBER}: Not approved, skipping."
+              continue
+            fi
+            echo "PR #${PR_NUMBER}: Has ${APPROVAL_COUNT} approval(s)."
+
+            # Get all check runs for the head SHA
+            CHECK_RUNS_JSON=$(gh api "repos/{owner}/{repo}/commits/${HEAD_SHA}/check-runs" --paginate --jq '.check_runs')
+
+            # Check if all check runs are completed (none pending/in_progress)
+            INCOMPLETE_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status != "completed")] | length')
+            if [ "$INCOMPLETE_COUNT" -gt 0 ]; then
+              echo "PR #${PR_NUMBER}: ${INCOMPLETE_COUNT} check(s) still running, skipping."
+              continue
+            fi
+            echo "PR #${PR_NUMBER}: All checks completed."
+
+            # Count failed check runs (conclusion is 'failure')
+            FAILED_CHECKS=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.conclusion == "failure")]')
+            FAILED_COUNT=$(echo "$FAILED_CHECKS" | jq 'length')
+
+            if [ "$FAILED_COUNT" -lt "$MIN_FAILURES" ] || [ "$FAILED_COUNT" -gt "$MAX_FAILURES" ]; then
+              echo "PR #${PR_NUMBER}: ${FAILED_COUNT} failed check(s), outside range [${MIN_FAILURES}, ${MAX_FAILURES}]. Skipping."
+              continue
+            fi
+            echo "PR #${PR_NUMBER}: ${FAILED_COUNT} failed check(s), within acceptable range."
+
+            # Get the workflow run IDs for the failed checks
+            # Each check run belongs to a check suite, which corresponds to a workflow run
+            FAILED_CHECK_NAMES=$(echo "$FAILED_CHECKS" | jq -r '.[].name')
+            echo "Failed checks: ${FAILED_CHECK_NAMES}"
+
+            # Get all workflow runs for this head SHA to find failed ones
+            # We need to find the run_id for re-running
+            WORKFLOW_RUNS=$(gh api "repos/{owner}/{repo}/actions/runs?head_sha=${HEAD_SHA}&status=completed" --paginate --jq '.workflow_runs')
+
+            # Find runs that have failed jobs matching our failed checks
+            RERUN_RUN_IDS=$(echo "$WORKFLOW_RUNS" | jq -r '[.[] | select(.conclusion == "failure")] | .[].id' | sort -u)
+
+            if [ -z "$RERUN_RUN_IDS" ]; then
+              echo "PR #${PR_NUMBER}: No failed workflow runs found to rerun."
+              continue
+            fi
+
+            for RUN_ID in $RERUN_RUN_IDS; do
+              # Check the run attempt count
+              RUN_ATTEMPT=$(gh api "repos/{owner}/{repo}/actions/runs/${RUN_ID}" --jq '.run_attempt')
+              echo "PR #${PR_NUMBER}: Workflow run ${RUN_ID} is on attempt ${RUN_ATTEMPT}."
+
+              if [ "$RUN_ATTEMPT" -ge "$MAX_RERUN_ATTEMPTS" ]; then
+                echo "PR #${PR_NUMBER}: Run ${RUN_ID} already at attempt ${RUN_ATTEMPT} (>= ${MAX_RERUN_ATTEMPTS}), skipping rerun."
+                continue
+              fi
+
+              echo "PR #${PR_NUMBER}: Re-running failed jobs for workflow run ${RUN_ID}..."
+              if gh run rerun "$RUN_ID" --failed; then
+                echo "PR #${PR_NUMBER}: Successfully triggered rerun for run ${RUN_ID}."
+              else
+                echo "PR #${PR_NUMBER}: Failed to trigger rerun for run ${RUN_ID}."
+              fi
+            done
+          done
+
+          echo ""
+          echo "Done processing all seed PRs."


### PR DESCRIPTION
## Description

Replaces the hello-world stub (merged in #13021) with the full implementation of a GitHub Actions workflow that automatically finds open seed PRs with a small number of transient test failures and re-runs them. This addresses cases like [#13008](https://github.com/fern-api/fern/pull/13008) where `test-ete` fails due to rate limiting or other transient issues, blocking auto-merge of seed update PRs.

[Link to Devin run](https://app.devin.ai/sessions/7b1e4ea814434e2eb597ea647b71c549)
Requested by: @davidkonigsberg

## Changes Made

- Replaced the hello-world stub in `.github/workflows/rerun-seed-tests.yml` with the full workflow logic:
  - Adds a `schedule` trigger (every 2 hours via cron) alongside the existing `workflow_dispatch`
  - Finds all open PRs labeled `seed`
  - For each PR, checks: (1) PR is approved, (2) all CI checks are completed, (3) exactly 1–3 checks failed
  - For qualifying PRs, re-runs failed jobs on workflow runs that have been attempted fewer than 3 times
  - Waits 60 seconds between each rerun trigger to avoid rate limiting
- Uses only `gh` CLI and GitHub API calls — no checkout or build steps needed
- Job timeout set to 30 minutes to accommodate sleep delays between reruns

## Updates Since Last Revision

- Added 60-second sleep between each rerun trigger to avoid rate limiting
- Bumped job `timeout-minutes` from 10 → 30 to accommodate the added sleep delays
- (Previous) Fixed `headRefSha` → `headRefOid` (correct field name for `gh pr list --json`)
- (Previous) Fixed pagination: paginated API responses now use `--jq '.check_runs[]' | jq -s '.'` to properly flatten multi-page results into a single array

## Testing

- [ ] Manual testing completed (trigger via Actions → "Rerun Failed Seed PR Tests" → "Run workflow" on `main` and verify it processes seed PRs correctly)

## Human Review Checklist

- **Rate-limit sleep placement**: The `sleep 60` runs after every rerun trigger including the last one in each PR's loop, adding an unnecessary wait at the end. This is harmless but worth noting.
- **Subshell error propagation**: The `while read` loop runs in a subshell (due to pipe from `echo "$PRS"`). If a command inside the loop fails unexpectedly, it won't cause the outer script to fail despite `set -e`. Verify this is acceptable behavior or consider using a `for` loop with process substitution instead.
- **Permissions**: Confirm `actions: write` on `GITHUB_TOKEN` is sufficient for `gh run rerun`. The existing `rerun.yml` workflow uses `github.token` similarly.
- **Failure thresholds**: The 1–3 failure range and max 3 attempts cap — verify these match the desired policy.
- **Schedule frequency**: Every 2 hours (`0 */2 * * *`) — confirm this is appropriate.
- **Timeout adequacy**: 30 minutes should be sufficient for processing several PRs with 60s sleeps, but could be tight if many seed PRs qualify simultaneously.