### PR TITLE
chore(ci): add hello-world rerun-seed-tests workflow for testing

### DIFF
--- a/.github/workflows/rerun-seed-tests.yml
+++ b/.github/workflows/rerun-seed-tests.yml
@@ -1,0 +1,17 @@
+name: Rerun Failed Seed PR Tests
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  pull-requests: read
+  checks: read
+
+jobs:
+  rerun-failed-seed-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Hello world
+        run: echo "Hello world - workflow trigger is working!"


### PR DESCRIPTION
## Description

Adds a stub `rerun-seed-tests.yml` workflow with a hello-world job so the `workflow_dispatch` trigger can be tested from `main` before merging the full implementation in #13020.

[Link to Devin run](https://app.devin.ai/sessions/7b1e4ea814434e2eb597ea647b71c549)
Requested by: @davidkonigsberg

## Changes Made

- Added `.github/workflows/rerun-seed-tests.yml` with a manual-only trigger (`workflow_dispatch`) and a single hello-world step
- Permissions are pre-configured for the full workflow (`actions: write`, `pull-requests: read`, `checks: read`) — these are harmless in the stub but ready for the follow-up

## Context

This is a **temporary stepping stone**. Once merged and the trigger is verified via the Actions tab, #13020 should be merged on top to replace this with the real logic (scans open seed PRs, checks approval + failure count, and re-runs failed CI jobs).

## Testing

- [ ] After merge, trigger manually from Actions → "Rerun Failed Seed PR Tests" → "Run workflow" and confirm the job prints "Hello world"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
