### PR TITLE
feat(cli): add retry logic for rate-limited 429 responses when creating remote generation jobs

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.95.7
+  changelogEntry:
+    - summary: |
+        Add retry logic for rate-limited (429) responses when creating remote
+        generation jobs. The CLI now respects the `retryAfter` value from the
+        server and retries up to 3 times before failing, preventing transient
+        rate limit errors from breaking SDK generation.
+      type: fix
+  createdAt: "2026-02-28"
+  irVersion: 65
+
 - version: 3.95.6
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -73,6 +73,9 @@ export async function createAndStartJob({
     return job;
 }
 
+const MAX_RATE_LIMIT_RETRIES = 3;
+const DEFAULT_RETRY_AFTER_SECONDS = 10;
+
 async function createJob({
     projectConfig,
     workspace,
@@ -108,23 +111,37 @@ async function createJob({
         publishMetadata: generatorInvocation.publishMetadata
     };
 
-    const createResponse = await remoteGenerationService.remoteGen.createJobV3({
-        apiName: workspace.definition.rootApiFile.contents.name,
-        version,
-        organizationName: organization,
-        generators: [generatorConfig],
-        uploadToS3: shouldUploadToS3({
-            outputMode: generatorInvocation.outputMode,
-            generatorInvocation,
-            absolutePathToPreview,
-            shouldLogS3Url
-        }),
-        whitelabel,
-        preview: absolutePathToPreview != null,
-        fernignoreContents
-    });
+    for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
+        const createResponse = await remoteGenerationService.remoteGen.createJobV3({
+            apiName: workspace.definition.rootApiFile.contents.name,
+            version,
+            organizationName: organization,
+            generators: [generatorConfig],
+            uploadToS3: shouldUploadToS3({
+                outputMode: generatorInvocation.outputMode,
+                generatorInvocation,
+                absolutePathToPreview,
+                shouldLogS3Url
+            }),
+            whitelabel,
+            preview: absolutePathToPreview != null,
+            fernignoreContents
+        });
 
-    if (!createResponse.ok) {
+        if (createResponse.ok) {
+            return createResponse.body;
+        }
+
+        // Check for rate limiting (429) before handling other errors
+        const rateLimitRetryAfter = extractRateLimitRetryAfter(createResponse.error as unknown as Fetcher.Error);
+        if (rateLimitRetryAfter != null && attempt < MAX_RATE_LIMIT_RETRIES) {
+            context.logger.info(
+                `Rate limited creating job. Retrying in ${rateLimitRetryAfter}s (attempt ${attempt + 1}/${MAX_RATE_LIMIT_RETRIES})...`
+            );
+            await delay(rateLimitRetryAfter * 1000);
+            continue;
+        }
+
         return convertCreateJobError(createResponse.error as unknown as Fetcher.Error)._visit({
             illegalApiNameError: () => {
                 return context.failAndThrow("API name is invalid: " + workspace.definition.rootApiFile.contents.name);
@@ -180,7 +197,10 @@ async function createJob({
         });
     }
 
-    return createResponse.body;
+    // This should be unreachable, but TypeScript needs it for exhaustiveness
+    return context.failAndThrow(
+        "Failed to create job after multiple retries. Please try again or contact support@buildwithfern.com for assistance."
+    );
 }
 
 async function writeFernDefinition({
@@ -278,6 +298,23 @@ async function startJob({
         context.logger.debug(`POST ${url} failed with ${JSON.stringify(error)}`);
         context.failAndThrow("Failed to start job", errorBody);
     }
+}
+
+/**
+ * Extracts the retryAfter value (in seconds) from a rate limit error response.
+ * Returns undefined if the error is not a rate limit error.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: allow explicit any
+function extractRateLimitRetryAfter(error: any): number | undefined {
+    if (error?.content?.reason === "status-code" && error.content.statusCode === 429) {
+        const retryAfter = error.content.body?.content?.retryAfter;
+        return typeof retryAfter === "number" ? retryAfter : DEFAULT_RETRY_AFTER_SECONDS;
+    }
+    return undefined;
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // Fiddle is on the old version of error serialization. Until we upgrade the


### PR DESCRIPTION
## Description

Refs: https://github.com/fern-api/fern/actions/runs/22508623450/job/65244374797?pr=13005

The `test-ete` CI job was failing because the `createJobV3` call to Fiddle returned a `429 RateLimitExceeded` response with a `retryAfter` hint, but the CLI had no retry logic — it fell through to the `_other` error handler and immediately failed.

Link to Devin run: https://app.devin.ai/sessions/d4c6d8033a1d4595b1927b282dd476fe
Requested by: @davidkonigsberg

## Changes Made

- Wrapped the `createJobV3` API call in `createJob()` with a retry loop (up to 3 retries, 4 total attempts)
- Added `extractRateLimitRetryAfter()` to detect 429 responses and extract the server-provided `retryAfter` value from the error shape `{content: {reason: "status-code", statusCode: 429, body: {content: {retryAfter: N}}}}`
- Falls back to a default of 10 seconds if `retryAfter` is not a number
- Logs an info message on each retry so users can see the delay
- Added `versions.yml` entry (3.95.7)

## Human Review Checklist

- [x] Verify `extractRateLimitRetryAfter` error shape matches actual Fiddle 429 responses (the shape was taken directly from [CI logs](https://github.com/fern-api/fern/actions/runs/22508623450/job/65244374797?pr=13005), but worth confirming it's stable)
- [x] Confirm retry count (3 retries / 4 total attempts) and default backoff (10s) are reasonable
- [ ] No unit tests were added for the retry logic — consider whether this is acceptable given the fix addresses a real CI failure

## Testing

- [x] Manual testing: Not applicable (requires hitting actual rate limits in production)
- [ ] Unit tests: None added (retry logic is integration-level and hard to unit test without mocking the entire Fiddle SDK)
- [x] CI will validate the fix by running the previously-failing `test-ete` job