### PR TITLE
feat(cli): add `fern list-generators` command

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -67,6 +67,7 @@ import { upgrade } from "./commands/upgrade/upgrade.js";
 import { validateDocsBrokenLinks } from "./commands/validate/validateDocsBrokenLinks.js";
 import { validateWorkspaces } from "./commands/validate/validateWorkspaces.js";
 import { writeDefinitionForWorkspaces } from "./commands/write-definition/writeDefinitionForWorkspaces.js";
+import { listAvailableGenerators } from "./commands/list-generators/listAvailableGenerators.js";
 import { writeDocsDefinitionForProject } from "./commands/write-docs-definition/writeDocsDefinitionForProject.js";
 import { writeTranslationForProject } from "./commands/write-translation/writeTranslationForProject.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
@@ -231,6 +232,7 @@ async function tryRunCli(cliContext: CliContext) {
     addExportCommand(cli, cliContext);
     addReplayCommand(cli, cliContext);
     addBetaCommand(cli, cliContext);
+    addListGeneratorsCommand(cli, cliContext);
 
     // CLI V2 Sanctioned Commands
     addGetOrganizationCommand(cli, cliContext);
@@ -1983,6 +1985,56 @@ function addBetaCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                 cliContext.logger.error("CLI v2 failed:", String(error));
                 cliContext.failWithoutThrowing();
             }
+        }
+    );
+}
+
+function addListGeneratorsCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
+    cli.command(
+        "list-generators",
+        "List all available Fern generators from the registry",
+        (yargs) =>
+            yargs
+                .option("language", {
+                    string: true,
+                    alias: "l",
+                    description:
+                        "Filter by programming language (e.g., python, typescript, java, go, csharp, ruby, php, swift, rust)"
+                })
+                .option("type", {
+                    string: true,
+                    alias: "t",
+                    description: "Filter by generator type (sdk, model, server, other)"
+                })
+                .option("format", {
+                    string: true,
+                    alias: "f",
+                    choices: ["table", "json", "yaml"] as const,
+                    default: "table" as const,
+                    description: "Output format (table, json, yaml)"
+                })
+                .option("output", {
+                    string: true,
+                    alias: "o",
+                    description: "Write output to a file instead of stdout"
+                }),
+        async (argv) => {
+            await cliContext.instrumentPostHogEvent({
+                command: "fern list-generators",
+                properties: {
+                    language: argv.language,
+                    type: argv.type,
+                    format: argv.format,
+                    outputLocation: argv.output
+                }
+            });
+            await listAvailableGenerators({
+                cliContext,
+                languageFilter: argv.language,
+                typeFilter: argv.type,
+                format: argv.format,
+                outputLocation: argv.output
+            });
         }
     );
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -55,6 +55,7 @@ import { generateOpenAPIIrForWorkspaces } from "./commands/generate-openapi-ir/g
 import { compareOpenAPISpecs } from "./commands/generate-overrides/compareOpenAPISpecs.js";
 import { writeOverridesForWorkspaces } from "./commands/generate-overrides/writeOverridesForWorkspaces.js";
 import { generateJsonschemaForWorkspaces } from "./commands/jsonschema/generateJsonschemaForWorkspace.js";
+import { listAvailableGenerators } from "./commands/list-generators/listAvailableGenerators.js";
 import { mockServer } from "./commands/mock/mockServer.js";
 import { registerWorkspacesV1 } from "./commands/register/registerWorkspacesV1.js";
 import { registerWorkspacesV2 } from "./commands/register/registerWorkspacesV2.js";
@@ -67,7 +68,6 @@ import { upgrade } from "./commands/upgrade/upgrade.js";
 import { validateDocsBrokenLinks } from "./commands/validate/validateDocsBrokenLinks.js";
 import { validateWorkspaces } from "./commands/validate/validateWorkspaces.js";
 import { writeDefinitionForWorkspaces } from "./commands/write-definition/writeDefinitionForWorkspaces.js";
-import { listAvailableGenerators } from "./commands/list-generators/listAvailableGenerators.js";
 import { writeDocsDefinitionForProject } from "./commands/write-docs-definition/writeDocsDefinitionForProject.js";
 import { writeTranslationForProject } from "./commands/write-translation/writeTranslationForProject.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";

--- a/packages/cli/cli/src/commands/list-generators/listAvailableGenerators.ts
+++ b/packages/cli/cli/src/commands/list-generators/listAvailableGenerators.ts
@@ -1,0 +1,138 @@
+import { FernRegistryClient as GeneratorsClient } from "@fern-fern/generators-sdk";
+import { GeneratorLanguage } from "@fern-fern/generators-sdk/api/resources/generators";
+import { writeFile } from "fs/promises";
+import yaml from "js-yaml";
+
+import { CliContext } from "../../cli-context/CliContext.js";
+
+interface GeneratorRow {
+    id: string;
+    name: string;
+    type: string;
+    language: string;
+    dockerImage: string;
+}
+
+export async function listAvailableGenerators({
+    cliContext,
+    languageFilter,
+    typeFilter,
+    format,
+    outputLocation
+}: {
+    cliContext: CliContext;
+    languageFilter: string | undefined;
+    typeFilter: string | undefined;
+    format: "table" | "json" | "yaml";
+    outputLocation: string | undefined;
+}): Promise<void> {
+    const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
+    const client = new GeneratorsClient({
+        environment: fdrOrigin
+    });
+
+    cliContext.logger.debug(`Fetching available generators from ${fdrOrigin}...`);
+
+    const response = await client.generators.listGenerators();
+    if (!response.ok) {
+        cliContext.failAndThrow("Failed to fetch generators from the registry. Please check your network connection.");
+        return;
+    }
+
+    let generators = response.body;
+
+    // Filter by language
+    if (languageFilter != null) {
+        const normalizedLanguage = languageFilter.toLowerCase();
+        const validLanguages = Object.values(GeneratorLanguage);
+        if (!validLanguages.includes(normalizedLanguage as GeneratorLanguage)) {
+            cliContext.failAndThrow(
+                `Invalid language "${languageFilter}". Valid languages are: ${validLanguages.join(", ")}`
+            );
+            return;
+        }
+        generators = generators.filter(
+            (g) => g.generatorLanguage != null && g.generatorLanguage === normalizedLanguage
+        );
+    }
+
+    // Filter by type
+    if (typeFilter != null) {
+        const normalizedType = typeFilter.toLowerCase();
+        const validTypes = ["sdk", "model", "server", "other"];
+        if (!validTypes.includes(normalizedType)) {
+            cliContext.failAndThrow(
+                `Invalid type "${typeFilter}". Valid types are: ${validTypes.join(", ")}`
+            );
+            return;
+        }
+        generators = generators.filter((g) => g.generatorType.type === normalizedType);
+    }
+
+    if (generators.length === 0) {
+        cliContext.logger.info("No generators found matching the specified filters.");
+        return;
+    }
+
+    const rows: GeneratorRow[] = generators.map((g) => ({
+        id: g.id,
+        name: g.displayName,
+        type: g.generatorType.type,
+        language: g.generatorLanguage ?? "n/a",
+        dockerImage: g.dockerImage
+    }));
+
+    // Sort by language then by type for consistent output
+    rows.sort((a, b) => {
+        const langCompare = a.language.localeCompare(b.language);
+        if (langCompare !== 0) {
+            return langCompare;
+        }
+        return a.type.localeCompare(b.type);
+    });
+
+    let output: string;
+    switch (format) {
+        case "json":
+            output = JSON.stringify(rows, null, 2);
+            break;
+        case "yaml":
+            output = yaml.dump(rows);
+            break;
+        case "table":
+        default:
+            output = formatTable(rows);
+            break;
+    }
+
+    if (outputLocation != null) {
+        try {
+            await writeFile(outputLocation, output);
+            cliContext.logger.info(`Generator list written to ${outputLocation}`);
+        } catch (error) {
+            cliContext.failAndThrow(`Could not write file to the specified location: ${outputLocation}`, error);
+        }
+    } else {
+        process.stdout.write(output + "\n");
+    }
+}
+
+function formatTable(rows: GeneratorRow[]): string {
+    const headers = ["ID", "Name", "Type", "Language", "Docker Image"];
+    const keys: (keyof GeneratorRow)[] = ["id", "name", "type", "language", "dockerImage"];
+
+    // Calculate column widths
+    const widths = headers.map((header, i) => {
+        const key = keys[i];
+        if (key == null) {
+            return header.length;
+        }
+        return Math.max(header.length, ...rows.map((row) => String(row[key]).length));
+    });
+
+    const separator = widths.map((w) => "-".repeat(w)).join(" | ");
+    const headerRow = headers.map((h, i) => h.padEnd(widths[i] ?? h.length)).join(" | ");
+    const dataRows = rows.map((row) => keys.map((key, i) => String(row[key]).padEnd(widths[i] ?? 0)).join(" | "));
+
+    return [headerRow, separator, ...dataRows].join("\n");
+}

--- a/packages/cli/cli/src/commands/list-generators/listAvailableGenerators.ts
+++ b/packages/cli/cli/src/commands/list-generators/listAvailableGenerators.ts
@@ -61,9 +61,7 @@ export async function listAvailableGenerators({
         const normalizedType = typeFilter.toLowerCase();
         const validTypes = ["sdk", "model", "server", "other"];
         if (!validTypes.includes(normalizedType)) {
-            cliContext.failAndThrow(
-                `Invalid type "${typeFilter}". Valid types are: ${validTypes.join(", ")}`
-            );
+            cliContext.failAndThrow(`Invalid type "${typeFilter}". Valid types are: ${validTypes.join(", ")}`);
             return;
         }
         generators = generators.filter((g) => g.generatorType.type === normalizedType);

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.96.0
+  changelogEntry:
+    - summary: |
+        Add `fern list-generators` command that fetches and displays all available
+        generators from the Fern registry. Supports filtering by `--language` and
+        `--type`, output in `--format` table/json/yaml, and writing to a file with
+        `--output`.
+      type: feat
+  createdAt: "2026-02-28"
+  irVersion: 65
+
 - version: 3.95.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/8602

Adds a new `fern list-generators` command that fetches and displays all available generators from the Fern registry, helping users discover generators without browsing documentation.

Link to Devin run: https://app.devin.ai/sessions/e7d15aef2011428bb873988179fe29d6
Requested by: @Swimburger

## Changes Made

- New file `packages/cli/cli/src/commands/list-generators/listAvailableGenerators.ts` implementing the command logic:
  - Calls `client.generators.listGenerators()` from `@fern-fern/generators-sdk`
  - Supports `--language` / `--type` filters with validation
  - Supports `--format` (table/json/yaml) and `--output` (file path) options
  - Table formatter with dynamic column widths
  - Results sorted by language then type for consistent output
- Registered `addListGeneratorsCommand` in `cli.ts`
- Added changelog entry (v3.96.0) in `versions.yml`

## Important Review Notes

1. **No "Version" column**: The issue's expected output includes a Version column, but the `Generator` type from the SDK only exposes `id`, `displayName`, `generatorType`, `generatorLanguage`, and `dockerImage`. Reviewer should confirm this is acceptable or if a separate `getLatestGeneratorRelease` call per generator is needed (which would add N API calls).
2. **Hardcoded valid types**: The type filter validates against `["sdk", "model", "server", "other"]` rather than deriving from `GeneratorType` discriminants. If new types are added to the SDK, this list would need manual updating.
3. **Registry data quirk**: `csharp-model` is returned from the registry with type `sdk` rather than `model` — this is a data issue upstream, not in this PR.

## Manual Testing

Tested locally against the live registry with `FERN_NO_VERSION_REDIRECTION=true`:

**`fern list-generators`** (default table output):
```
ID           | Name               | Type   | Language   | Docker Image
------------ | ------------------ | ------ | ---------- | -------------------------------
csharp-sdk   | C# SDK             | sdk    | csharp     | fernapi/fern-csharp-sdk
go-sdk       | Go SDK             | sdk    | go         | fernapi/fern-go-sdk
java-sdk     | Java SDK           | sdk    | java       | fernapi/fern-java-sdk
python-sdk   | Python SDK         | sdk    | python     | fernapi/fern-python-sdk
...
```

**`fern list-generators --language python`** — correctly filters to Python generators only.

**`fern list-generators --type sdk --format json`** — correctly outputs JSON with only SDK-type generators.

## Testing

- [x] Biome lint/format passing
- [x] Manual testing completed (table, json, --language, --type filters all verified)
- [ ] Unit tests added/updated