### PR TITLE
feat(cli): add --github-mode and --github-branch flags to override generators.yml

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -45,7 +45,7 @@ import { listDocsPreview } from "./commands/docs-preview/listDocsPreview.js";
 import { downgrade } from "./commands/downgrade/downgrade.js";
 import { generateOpenAPIForWorkspaces } from "./commands/export/generateOpenAPIForWorkspaces.js";
 import { formatWorkspaces } from "./commands/format/formatWorkspaces.js";
-import { GenerationMode, generateAPIWorkspaces } from "./commands/generate/generateAPIWorkspaces.js";
+import { GenerationMode, GithubMode, generateAPIWorkspaces } from "./commands/generate/generateAPIWorkspaces.js";
 import { generateDocsWorkspace } from "./commands/generate/generateDocsWorkspace.js";
 import { generateDynamicIrForWorkspaces } from "./commands/generate-dynamic-ir/generateDynamicIrForWorkspaces.js";
 import { generateFdrApiDefinitionForWorkspaces } from "./commands/generate-fdr/generateFdrApiDefinitionForWorkspaces.js";
@@ -692,6 +692,17 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     default: true,
                     hidden: true,
                     description: "Run replay after generation (use --no-replay to skip)"
+                })
+                .option("github-mode", {
+                    type: "string",
+                    choices: Object.values(GithubMode),
+                    description:
+                        "Override the github.mode for all generators in the group (push, pull-request, or release)"
+                })
+                .option("github-branch", {
+                    type: "string",
+                    description:
+                        "Override the github.branch for all generators in the group (only valid with push mode)"
                 }),
         async (argv) => {
             if (argv.api != null && argv.docs != null) {
@@ -729,6 +740,9 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
             if (argv.output != null && argv.docs != null) {
                 return cliContext.failWithoutThrowing("The --output flag is not supported for docs generation.");
             }
+            if (argv.githubBranch != null && argv.githubMode != null && argv.githubMode !== "push") {
+                return cliContext.failWithoutThrowing("--github-branch is only valid with --github-mode push.");
+            }
             const correctedGeneratorFilter =
                 argv.generator != null ? warnAndCorrectIncorrectDockerOrg(argv.generator, cliContext) : undefined;
             if (argv.api != null) {
@@ -753,7 +767,9 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     fernignorePath: argv.fernignore,
                     dynamicIrOnly: argv["dynamic-ir-only"],
                     outputDir: argv.output,
-                    noReplay: !argv.replay
+                    noReplay: !argv.replay,
+                    githubMode: argv.githubMode as GithubMode | undefined,
+                    githubBranch: argv.githubBranch
                 });
             }
             if (argv.docs != null) {
@@ -807,7 +823,9 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 fernignorePath: argv.fernignore,
                 dynamicIrOnly: argv["dynamic-ir-only"],
                 outputDir: argv.output,
-                noReplay: !argv.replay
+                noReplay: !argv.replay,
+                githubMode: argv.githubMode as GithubMode | undefined,
+                githubBranch: argv.githubBranch
             });
         }
     );

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -389,7 +389,7 @@ function applyGithubOverrides(
                     case "push":
                         return FernFiddle.GithubOutputModeV2.push({
                             ...cfg,
-                            branch: githubBranch ?? cfg.branch
+                            branch: githubBranch
                         });
                     case "pullRequest":
                         return FernFiddle.GithubOutputModeV2.pullRequest({

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -371,7 +371,7 @@ function applyGithubOverrides(
                     case "push":
                         return FernFiddle.GithubOutputModeV2.push({
                             ...base,
-                            branch: githubBranch
+                            branch: githubBranch ?? cfg.branch
                         });
                     case "pullRequest":
                         return FernFiddle.GithubOutputModeV2.pullRequest({
@@ -389,7 +389,7 @@ function applyGithubOverrides(
                     case "push":
                         return FernFiddle.GithubOutputModeV2.push({
                             ...cfg,
-                            branch: githubBranch
+                            branch: githubBranch ?? cfg.branch
                         });
                     case "pullRequest":
                         return FernFiddle.GithubOutputModeV2.pullRequest({

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -5,7 +5,7 @@ import {
     GENERATORS_CONFIGURATION_FILENAME,
     generatorsYml
 } from "@fern-api/configuration-loader";
-import { ContainerRunner } from "@fern-api/core-utils";
+import { assertNever, ContainerRunner, visitDiscriminatedUnion } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { runLocalGenerationForWorkspace } from "@fern-api/local-workspace-runner";
 import { runRemoteGenerationForAPIWorkspace } from "@fern-api/remote-workspace-runner";
@@ -14,7 +14,7 @@ import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 
 import { GROUP_CLI_OPTION } from "../../constants.js";
-import { GenerationMode } from "./generateAPIWorkspaces.js";
+import { GenerationMode, GithubMode } from "./generateAPIWorkspaces.js";
 
 export async function generateWorkspace({
     organization,
@@ -35,7 +35,9 @@ export async function generateWorkspace({
     lfsOverride,
     fernignorePath,
     dynamicIrOnly,
-    noReplay
+    noReplay,
+    githubMode,
+    githubBranch
 }: {
     organization: string;
     workspace: AbstractAPIWorkspace<unknown>;
@@ -56,6 +58,8 @@ export async function generateWorkspace({
     fernignorePath: string | undefined;
     dynamicIrOnly: boolean;
     noReplay: boolean;
+    githubMode: GithubMode | undefined;
+    githubBranch: string | undefined;
 }): Promise<void> {
     if (workspace.generatorsConfiguration == null) {
         context.logger.warn("This workspaces has no generators.yml");
@@ -115,6 +119,11 @@ export async function generateWorkspace({
             // Apply lfs-override if specified
             if (lfsOverride != null) {
                 group = applyLfsOverride(group, lfsOverride, context);
+            }
+
+            // Apply github overrides if specified
+            if (githubMode != null || githubBranch != null) {
+                group = applyGithubOverrides(group, githubMode, githubBranch, context);
             }
 
             if (resolvedGroupNames.length > 1) {
@@ -288,4 +297,121 @@ function getLanguageFromGeneratorName(generatorName: string): string {
     }
     // If we can't determine the language, use the generator name itself
     return generatorName.replace(/[^a-zA-Z0-9]/g, "-").toLowerCase();
+}
+
+/**
+ * Maps a GithubMode enum value to the discriminated union type used by FernFiddle.GithubOutputModeV2.
+ */
+type GithubOutputType = "push" | "pullRequest" | "commitAndRelease";
+
+function githubModeToOutputType(mode: GithubMode): GithubOutputType {
+    switch (mode) {
+        case "push":
+            return "push";
+        case "pull-request":
+            return "pullRequest";
+        case "release":
+            return "commitAndRelease";
+        default:
+            assertNever(mode);
+    }
+}
+
+function applyGithubOverrides(
+    group: generatorsYml.GeneratorGroup,
+    githubMode: GithubMode | undefined,
+    githubBranch: string | undefined,
+    context: TaskContext
+): generatorsYml.GeneratorGroup {
+    const modifiedGenerators: generatorsYml.GeneratorInvocation[] = [];
+
+    for (const generator of group.generators) {
+        if (generator.outputMode.type !== "githubV2") {
+            modifiedGenerators.push(generator);
+            continue;
+        }
+
+        const currentGithubConfig = generator.outputMode.githubV2;
+        const targetType: GithubOutputType =
+            githubMode != null ? githubModeToOutputType(githubMode) : currentGithubConfig.type;
+
+        if (githubBranch != null && targetType !== "push") {
+            return context.failAndThrow(
+                `--github-branch is only valid with 'push' mode. Generator '${generator.name}' would use mode '${targetType}'. ` +
+                    `Pass --github-mode push to use --github-branch.`
+            );
+        }
+
+        const newGithubConfig = visitDiscriminatedUnion(
+            currentGithubConfig,
+            "type"
+        )._visit<FernFiddle.GithubOutputModeV2>({
+            push: (cfg) => {
+                const { branch: _branch, ...base } = cfg;
+                switch (targetType) {
+                    case "push":
+                        return FernFiddle.GithubOutputModeV2.push({
+                            ...base,
+                            branch: githubBranch ?? cfg.branch
+                        });
+                    case "pullRequest":
+                        return FernFiddle.GithubOutputModeV2.pullRequest({
+                            ...base,
+                            reviewers: undefined
+                        });
+                    case "commitAndRelease":
+                        return FernFiddle.GithubOutputModeV2.commitAndRelease(base);
+                    default:
+                        assertNever(targetType);
+                }
+            },
+            pullRequest: (cfg) => {
+                const { reviewers: _reviewers, ...base } = cfg;
+                switch (targetType) {
+                    case "push":
+                        return FernFiddle.GithubOutputModeV2.push({
+                            ...base,
+                            branch: githubBranch
+                        });
+                    case "pullRequest":
+                        return FernFiddle.GithubOutputModeV2.pullRequest({
+                            ...base,
+                            reviewers: cfg.reviewers
+                        });
+                    case "commitAndRelease":
+                        return FernFiddle.GithubOutputModeV2.commitAndRelease(base);
+                    default:
+                        assertNever(targetType);
+                }
+            },
+            commitAndRelease: (cfg) => {
+                switch (targetType) {
+                    case "push":
+                        return FernFiddle.GithubOutputModeV2.push({
+                            ...cfg,
+                            branch: githubBranch
+                        });
+                    case "pullRequest":
+                        return FernFiddle.GithubOutputModeV2.pullRequest({
+                            ...cfg,
+                            reviewers: undefined
+                        });
+                    case "commitAndRelease":
+                        return FernFiddle.GithubOutputModeV2.commitAndRelease(cfg);
+                    default:
+                        assertNever(targetType);
+                }
+            }
+        });
+
+        modifiedGenerators.push({
+            ...generator,
+            outputMode: FernFiddle.OutputMode.githubV2(newGithubConfig)
+        });
+    }
+
+    return {
+        ...group,
+        generators: modifiedGenerators
+    };
 }

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -16,6 +16,14 @@ export const GenerationMode = {
 
 export type GenerationMode = Values<typeof GenerationMode>;
 
+export const GithubMode = {
+    Push: "push",
+    PullRequest: "pull-request",
+    Release: "release"
+} as const;
+
+export type GithubMode = Values<typeof GithubMode>;
+
 export async function generateAPIWorkspaces({
     project,
     cliContext,
@@ -34,7 +42,9 @@ export async function generateAPIWorkspaces({
     fernignorePath,
     dynamicIrOnly,
     outputDir,
-    noReplay
+    noReplay,
+    githubMode,
+    githubBranch
 }: {
     project: Project;
     cliContext: CliContext;
@@ -54,6 +64,8 @@ export async function generateAPIWorkspaces({
     dynamicIrOnly: boolean;
     outputDir: string | undefined;
     noReplay: boolean;
+    githubMode: GithubMode | undefined;
+    githubBranch: string | undefined;
 }): Promise<void> {
     let token: FernToken | undefined = undefined;
 
@@ -150,7 +162,9 @@ export async function generateAPIWorkspaces({
                     lfsOverride,
                     fernignorePath,
                     dynamicIrOnly,
-                    noReplay
+                    noReplay,
+                    githubMode,
+                    githubBranch
                 });
             });
         })

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.96.0
+  changelogEntry:
+    - summary: |
+        Add `--github-mode` and `--github-branch` flags to `fern generate` to
+        override the `github.mode` and `github.branch` settings in
+        `generators.yml` without editing the file. `--github-mode` accepts
+        `push`, `pull-request`, or `release`. `--github-branch` overrides the
+        target branch and is only valid with `push` mode.
+      type: feat
+  createdAt: "2026-02-28"
+  irVersion: 65
+
 - version: 3.95.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Closes #10511

Adds `--github-mode` and `--github-branch` CLI flags to `fern generate`, allowing users to override the `github.mode` and `github.branch` settings in `generators.yml` without editing the file directly.

**Requested by**: Niels Swimberghe (@Swimburger)
**Link to Devin run**: https://app.devin.ai/sessions/3b2c9a5cfd53404fad7205c8d0999bd0

## Changes Made

- Defined `GithubMode` const enum (`push`, `pull-request`, `release`) in `generateAPIWorkspaces.ts`, following the existing `GenerationMode` pattern
- Added `--github-mode` and `--github-branch` CLI options to the `generate` command in `cli.ts`
- Added early validation: `--github-branch` with a non-push `--github-mode` fails immediately
- Threaded `githubMode`/`githubBranch` through `generateAPIWorkspaces` → `generateWorkspace`
- Implemented `applyGithubOverrides()` which transforms the `GithubOutputModeV2` discriminated union using `visitDiscriminatedUnion` from `@fern-api/core-utils` and object spread for property copying
- Added `githubModeToOutputType()` helper with `assertNever` for exhaustive switching on the `GithubMode` type
- Added CLI version 3.96.0 to `versions.yml`

## Human Review Checklist

1. **Verify all 9 mode transitions produce valid configs** — the `applyGithubOverrides` function handles 3 source modes × 3 target modes. Confirm the property mapping is correct for each (e.g. `branch` and `reviewers` are handled appropriately when converting between push/pullRequest/commitAndRelease).
2. **Non-githubV2 generators are silently skipped** — generators using other output modes (e.g., `downloadFiles`, `publish`) are passed through unchanged when `--github-mode`/`--github-branch` are specified. Consider whether a warning would be helpful.
3. **`branch` fallback behavior** — when switching to push mode without `--github-branch`, we fall back to `cfg.branch` from the source config. For `pullRequest` and `commitAndRelease` source types, verify that `cfg.branch` is a valid field on those types (if not, it will be `undefined`, which may need downstream handling).
4. **Type cast** — `argv.githubMode as GithubMode | undefined` in `cli.ts` relies on yargs `choices` enforcement; this matches existing patterns like `argv.runner as ContainerRunner`.

## Testing

- [x] Biome lint/format passes on all changed files
- [x] TypeScript compilation of CLI package succeeds (pre-existing errors in unrelated packages)
- [x] Local build verified: `--github-mode` and `--github-branch` appear in `fern generate --help`
- [ ] Unit tests added/updated
- [ ] Manual end-to-end testing with actual generators.yml
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->