### PR TITLE
fix(fastapi): optional body properties in file upload requests now default to None

### DIFF
--- a/generators/python/fastapi/versions.yml
+++ b/generators/python/fastapi/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 2.1.1
+  changelogEntry:
+    - type: fix
+      summary: |
+        Optional body properties in file upload requests are now correctly treated as optional.
+        Previously, optional inline request body parameters (e.g. `optional<map<string, string>>`)
+        in file upload endpoints were generated with `fastapi.Body()` (required) instead of
+        `fastapi.Body()` with `default=None`, causing FastAPI to reject requests that omit
+        those fields.
+  createdAt: "2026-02-28"
+  irVersion: 61
+
 - version: 2.1.0
   changelogEntry:
     - type: feat

--- a/generators/python/src/fern_python/generators/fastapi/service_generator/endpoint_parameters/request/file_upload_request_endpoint_parameter.py
+++ b/generators/python/src/fern_python/generators/fastapi/service_generator/endpoint_parameters/request/file_upload_request_endpoint_parameter.py
@@ -1,3 +1,4 @@
+import typing
 from typing import List, Optional
 
 from ....context import FastApiGeneratorContext
@@ -80,6 +81,16 @@ class FileUploadRequestBodyParameter(EndpointParameter):
         return self._context.fastapi_params.Body(
             variable_name=self._parameter_name(), wire_value=self._request_property.name.wire_value
         )
+
+    def get_python_default(self) -> "typing.Optional[AST.Expression]":
+        value_type = self._request_property.value_type.get_as_union()
+        is_optional = value_type.type == "container" and (
+            value_type.container.get_as_union().type == "optional"
+            or value_type.container.get_as_union().type == "nullable"
+        )
+        if is_optional:
+            return AST.Expression(AST.TypeHint.none())
+        return None
 
 
 class FileUploadRequestEndpointParameters:

--- a/seed/fastapi/file-upload/resources/service/service/service.py
+++ b/seed/fastapi/file-upload/resources/service/service/service.py
@@ -163,7 +163,7 @@ class AbstractServiceService(AbstractFernService):
                 new_parameters.append(parameter.replace(default=fastapi.Depends(cls)))
             elif parameter_name == "maybe_string":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "integer":
                 new_parameters.append(
@@ -187,11 +187,11 @@ class AbstractServiceService(AbstractFernService):
                 )
             elif parameter_name == "maybe_integer":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "optional_list_of_strings":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "list_of_objects":
                 new_parameters.append(
@@ -199,15 +199,15 @@ class AbstractServiceService(AbstractFernService):
                 )
             elif parameter_name == "optional_metadata":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "optional_object_type":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "optional_id":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "alias_object":
                 new_parameters.append(
@@ -441,7 +441,7 @@ class AbstractServiceService(AbstractFernService):
                 )
             elif parameter_name == "foo_bar":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             else:
                 new_parameters.append(parameter)
@@ -529,7 +529,7 @@ class AbstractServiceService(AbstractFernService):
                 new_parameters.append(parameter.replace(default=fastapi.Depends(cls)))
             elif parameter_name == "maybe_string":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "integer":
                 new_parameters.append(
@@ -553,11 +553,11 @@ class AbstractServiceService(AbstractFernService):
                 )
             elif parameter_name == "maybe_integer":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "optional_list_of_strings":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "list_of_objects":
                 new_parameters.append(
@@ -565,15 +565,15 @@ class AbstractServiceService(AbstractFernService):
                 )
             elif parameter_name == "optional_metadata":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "optional_object_type":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "optional_id":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "list_of_objects_with_optionals":
                 new_parameters.append(
@@ -633,7 +633,7 @@ class AbstractServiceService(AbstractFernService):
                 )
             elif parameter_name == "request":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             else:
                 new_parameters.append(parameter)
@@ -719,7 +719,7 @@ class AbstractServiceService(AbstractFernService):
                 )
             elif parameter_name == "json":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             else:
                 new_parameters.append(parameter)
@@ -798,15 +798,15 @@ class AbstractServiceService(AbstractFernService):
                 )
             elif parameter_name == "model_type":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "open_enum":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             elif parameter_name == "maybe_name":
                 new_parameters.append(
-                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()])
+                    parameter.replace(annotation=typing.Annotated[resolved_annotation, fastapi.Body()], default=None)
                 )
             else:
                 new_parameters.append(parameter)


### PR DESCRIPTION
## Description

Closes https://github.com/fern-api/fern/issues/6982

Optional inline request body parameters in file upload endpoints were incorrectly treated as required by FastAPI. For example, a field defined as `optional<map<string, string>>` in a file upload request would generate `fastapi.Body()` (required) instead of including `default=None`, causing FastAPI to reject requests that omit those fields.

## Changes Made

- Added `get_python_default()` override to `FileUploadRequestBodyParameter` that checks if the property's `value_type` is an optional/nullable container and returns `None` as the default. This mirrors the existing pattern in `QueryEndpointParameter` and `HeaderEndpointParameter`.
- Updated seed test output for `file-upload` fixture to reflect the fix.
- Added changelog entry in `generators/python/fastapi/versions.yml` (v2.1.1).

## Review Checklist

- [ ] Verify the `get_python_default()` logic in `file_upload_request_endpoint_parameter.py` matches the pattern in `query_endpoint_parameter.py` and `header_endpoint_parameter.py`
- [ ] Confirm only optional body params got `default=None` in the seed output — required params like `integer`, `list_of_objects`, `foo`, `bar` should remain unchanged

## Testing

- [x] `pnpm seed:local test --generator fastapi --fixture file-upload` passes
- [x] `pnpm seed:local test --generator fastapi --fixture file-upload-openapi` passes (no changes, as expected)
- [x] Pre-commit hooks pass (`poetry run pre-commit run -a`)

---

[Link to Devin run](https://app.devin.ai/sessions/9b4d6bac790c426b8936e74d4debea30) | Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
