### PR TITLE
feat(cli): allow underscores in `x-fern-sdk-group-name` values

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-sdk-group-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-sdk-group-name.json
@@ -93,6 +93,85 @@
         "file": "../openapi.yml",
         "type": "openapi"
       }
+    },
+    {
+      "audiences": [],
+      "tags": [],
+      "sdkName": {
+        "groupName": [
+          "v1",
+          "_internal",
+          "pets"
+        ],
+        "methodName": "list"
+      },
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ListPetsRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "value": {
+            "generatedName": "ListPetsResponseItem",
+            "schema": "Pet",
+            "source": {
+              "file": "../openapi.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          },
+          "generatedName": "ListPetsResponse",
+          "groupName": [],
+          "type": "array"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "description": "This endpoint uses underscore-prefixed group name",
+      "authed": false,
+      "method": "GET",
+      "path": "/v1/_internal/pets",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": [
+                {
+                  "properties": {
+                    "name": {
+                      "value": {
+                        "value": "name",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
     }
   ],
   "webhooks": [],
@@ -120,6 +199,41 @@
           "person"
         ],
         "type": "primitive"
+      },
+      "Pet": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "petName",
+            "key": "name",
+            "schema": {
+              "generatedName": "PetName",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "PetName",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "Pet",
+        "groupName": [
+          "_internal"
+        ],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
       },
       "User": {
         "allOf": [],

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-sdk-group-name.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-sdk-group-name.json
@@ -37,6 +37,30 @@
       openapi: ../openapi.yml
 ",
     },
+    "_internal.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "Pet": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "name": "optional<string>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  Pet:
+    properties:
+      name: optional<string>
+    source:
+      openapi: ../openapi.yml
+",
+    },
     "auth/user.yml": {
       "absoluteFilepath": "/DUMMY_PATH",
       "contents": {
@@ -171,6 +195,72 @@ types:
       associatedPersons: optional<list<root.Person>>
     source:
       openapi: ../openapi.yml
+",
+    },
+    "v1/_internal/pets.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "imports": {
+          "internal": "../../_internal.yml",
+        },
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "list": {
+              "auth": undefined,
+              "docs": "This endpoint uses underscore-prefixed group name",
+              "examples": [
+                {
+                  "response": {
+                    "body": [
+                      {
+                        "name": "name",
+                      },
+                    ],
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/v1/_internal/pets",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "list<internal.Pet>",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+      },
+      "rawContents": "imports:
+  internal: ../../_internal.yml
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    list:
+      path: /v1/_internal/pets
+      method: GET
+      docs: This endpoint uses underscore-prefixed group name
+      source:
+        openapi: ../openapi.yml
+      response:
+        docs: Success
+        type: list<internal.Pet>
+        status-code: 200
+      examples:
+        - response:
+            body:
+              - name: name
+  source:
+    openapi: ../openapi.yml
 ",
     },
   },

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-sdk-group-name/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-sdk-group-name/openapi.yml
@@ -15,6 +15,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/User"
+  /v1/_internal/pets:
+    get:
+      description: This endpoint uses underscore-prefixed group name
+      x-fern-sdk-group-name: ["v1", "_internal", "pets"]
+      x-fern-sdk-method-name: list
+      responses:
+        "200":
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
 
 components:
   schemas:
@@ -26,6 +40,13 @@ components:
       # Test nested group names
       x-fern-sdk-group-name: ["ids", "person"]
       type: string
+    Pet:
+      # Test underscore-prefixed group name on schema
+      x-fern-sdk-group-name: ["_internal"]
+      type: object
+      properties:
+        name:
+          type: string
     User:
       description: This user object should be in user.yml
       x-fern-sdk-group-name: user

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/convertSdkGroupName.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/convertSdkGroupName.ts
@@ -4,6 +4,22 @@ import { EndpointSdkName, SdkGroupName } from "@fern-api/openapi-ir";
 import { join, RelativeFilePath } from "@fern-api/path-utils";
 import { camelCase } from "lodash-es";
 
+/**
+ * Wraps camelCase to preserve leading/trailing underscores that lodash strips.
+ * E.g. "_internal" -> "_internal" instead of "internal"
+ */
+function camelCasePreservingUnderscores(name: string): string {
+    const leadingMatch = name.match(/^(_+)/);
+    const trailingMatch = name.match(/(_+)$/);
+    const leading = leadingMatch?.[1] ?? "";
+    const trailing = trailingMatch?.[1] ?? "";
+    if (leading === "" && trailing === "") {
+        return camelCase(name);
+    }
+    const core = name.slice(leading.length, name.length - trailing.length || undefined);
+    return `${leading}${camelCase(core)}${trailing}`;
+}
+
 function cleanSdkGroupName(groupName: SdkGroupName): SdkGroupName {
     const maybeNamespace = groupName.find((group) => typeof group === "object" && group.type === "namespace");
     const noNamespace = groupName.filter((group) => typeof group === "string" || group.type !== "namespace");
@@ -18,12 +34,12 @@ export function convertSdkGroupNameToFileWithoutExtension(groupName: SdkGroupNam
     const fileNames: string[] = [];
     for (const [index, group] of cleanedGroupName.entries()) {
         if (typeof group === "string") {
-            fileNames.push(camelCase(group));
+            fileNames.push(camelCasePreservingUnderscores(group));
         } else if (typeof group === "object") {
             switch (group.type) {
                 case "namespace": {
                     if (index < cleanedGroupName.length - 1) {
-                        fileNames.push(camelCase(group.name));
+                        fileNames.push(camelCasePreservingUnderscores(group.name));
                     } else {
                         // For the last namespace, make it a true namespace (ie. a directory with it's contents in the root package marker)
                         fileNames.push(...[group.name, FERN_PACKAGE_MARKER_FILENAME_NO_EXTENSION]);

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/convertSdkGroupName.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/convertSdkGroupName.ts
@@ -16,6 +16,9 @@ function camelCasePreservingUnderscores(name: string): string {
     if (leading === "" && trailing === "") {
         return camelCase(name);
     }
+    if (leading.length + trailing.length >= name.length) {
+        return name;
+    }
     const core = name.slice(leading.length, name.length - trailing.length || undefined);
     return `${leading}${camelCase(core)}${trailing}`;
 }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.96.0
+  changelogEntry:
+    - summary: |
+        Allow underscores in `x-fern-sdk-group-name` values. Previously, leading
+        underscores (e.g. `_internal`) were stripped by lodash's `camelCase`,
+        making it impossible to use underscore-prefixed group names for marking
+        private/internal modules. Both the OpenAPI-to-Fern file name conversion
+        and the IR casings generator now preserve leading and trailing underscores.
+      type: feat
+  createdAt: "2026-02-28"
+  irVersion: 65
+
 - version: 3.95.6
   changelogEntry:
     - summary: |

--- a/packages/commons/casings-generator/src/CasingsGenerator.ts
+++ b/packages/commons/casings-generator/src/CasingsGenerator.ts
@@ -39,42 +39,48 @@ export function constructCasingsGenerator({
             let camelCaseName = withUnderscorePreservation(name, camelCase);
             let pascalCaseName = upperFirst(camelCaseName);
             let snakeCaseName = withUnderscorePreservation(name, snakeCase);
+            const { leading: nameLeading, trailing: nameTrailing } = extractUnderscoreAffixes(name);
             const camelCaseWords = words(camelCaseName);
             if (smartCasing) {
                 if (
                     !hasAdjacentCommonInitialisms(camelCaseWords) &&
                     (generationLanguage == null || CAPITALIZE_INITIALISM.includes(generationLanguage))
                 ) {
-                    camelCaseName = camelCaseWords
-                        .map((word, index) => {
-                            if (index > 0) {
-                                const pluralInitialism = maybeGetPluralInitialism(word);
-                                if (pluralInitialism != null) {
-                                    return pluralInitialism;
-                                }
-                                if (isCommonInitialism(word)) {
-                                    return word.toUpperCase();
-                                }
-                            }
-                            return word;
-                        })
-                        .join("");
-                    pascalCaseName = upperFirst(
+                    camelCaseName =
+                        nameLeading +
                         camelCaseWords
                             .map((word, index) => {
-                                const pluralInitialism = maybeGetPluralInitialism(word);
-                                if (pluralInitialism != null) {
-                                    return pluralInitialism;
-                                }
-                                if (isCommonInitialism(word)) {
-                                    return word.toUpperCase();
-                                }
-                                if (index === 0) {
-                                    return upperFirst(word);
+                                if (index > 0) {
+                                    const pluralInitialism = maybeGetPluralInitialism(word);
+                                    if (pluralInitialism != null) {
+                                        return pluralInitialism;
+                                    }
+                                    if (isCommonInitialism(word)) {
+                                        return word.toUpperCase();
+                                    }
                                 }
                                 return word;
                             })
-                            .join("")
+                            .join("") +
+                        nameTrailing;
+                    pascalCaseName = upperFirst(
+                        nameLeading +
+                            camelCaseWords
+                                .map((word, index) => {
+                                    const pluralInitialism = maybeGetPluralInitialism(word);
+                                    if (pluralInitialism != null) {
+                                        return pluralInitialism;
+                                    }
+                                    if (isCommonInitialism(word)) {
+                                        return word.toUpperCase();
+                                    }
+                                    if (index === 0) {
+                                        return upperFirst(word);
+                                    }
+                                    return word;
+                                })
+                                .join("") +
+                            nameTrailing
                     );
                 }
 
@@ -250,6 +256,9 @@ function extractUnderscoreAffixes(name: string): { leading: string; trailing: st
     const trailingMatch = name.match(/(_+)$/);
     const leading = leadingMatch?.[1] ?? "";
     const trailing = trailingMatch?.[1] ?? "";
+    if (leading.length + trailing.length >= name.length) {
+        return { leading: name, trailing: "", core: "" };
+    }
     const core = name.slice(leading.length, name.length - trailing.length || undefined);
     return { leading, trailing, core };
 }

--- a/packages/commons/casings-generator/src/CasingsGenerator.ts
+++ b/packages/commons/casings-generator/src/CasingsGenerator.ts
@@ -36,9 +36,9 @@ export function constructCasingsGenerator({
                 })
             });
 
-            let camelCaseName = camelCase(name);
+            let camelCaseName = withUnderscorePreservation(name, camelCase);
             let pascalCaseName = upperFirst(camelCaseName);
-            let snakeCaseName = snakeCase(name);
+            let snakeCaseName = withUnderscorePreservation(name, snakeCase);
             const camelCaseWords = words(camelCaseName);
             if (smartCasing) {
                 if (
@@ -81,10 +81,12 @@ export function constructCasingsGenerator({
                 // In smartCasing, manage numbers next to letters differently:
                 // _.snakeCase("v2") = "v_2"
                 // smartCasing("v2") = "v2", other examples: "test2This2 2v22" => "test2this2_2v22", "applicationV1" => "application_v1"
-                snakeCaseName = name
-                    .split(" ")
-                    .map((part) => part.split(/(\d+)/).map(snakeCase).join(""))
-                    .join("_");
+                snakeCaseName = withUnderscorePreservation(name, (n) =>
+                    n
+                        .split(" ")
+                        .map((part) => part.split(/(\d+)/).map(snakeCase).join(""))
+                        .join("_")
+                );
             }
 
             return {
@@ -236,4 +238,29 @@ function preprocessName(name: string): string {
         (result, [pattern, replacement]) => result.replace(pattern, replacement),
         name
     );
+}
+
+/**
+ * Extracts leading and trailing underscores from a string.
+ * Lodash's camelCase/snakeCase strip these, but they are meaningful
+ * (e.g. _internal marks private/protected modules in Python, Ruby, JS).
+ */
+function extractUnderscoreAffixes(name: string): { leading: string; trailing: string; core: string } {
+    const leadingMatch = name.match(/^(_+)/);
+    const trailingMatch = name.match(/(_+)$/);
+    const leading = leadingMatch?.[1] ?? "";
+    const trailing = trailingMatch?.[1] ?? "";
+    const core = name.slice(leading.length, name.length - trailing.length || undefined);
+    return { leading, trailing, core };
+}
+
+/**
+ * Wraps a casing function to preserve leading and trailing underscores.
+ */
+function withUnderscorePreservation(name: string, casingFn: (s: string) => string): string {
+    const { leading, trailing, core } = extractUnderscoreAffixes(name);
+    if (leading === "" && trailing === "") {
+        return casingFn(name);
+    }
+    return `${leading}${casingFn(core)}${trailing}`;
 }

--- a/packages/commons/casings-generator/src/CasingsGenerator.ts
+++ b/packages/commons/casings-generator/src/CasingsGenerator.ts
@@ -104,9 +104,7 @@ export function constructCasingsGenerator({
                         .split(" ")
                         .map((part) => part.split(/(\d+)/).map(snakeCase).join(""))
                         .join("_");
-                snakeCaseName = preserve
-                    ? withUnderscorePreservation(name, smartSnakeFn)
-                    : smartSnakeFn(name);
+                snakeCaseName = preserve ? withUnderscorePreservation(name, smartSnakeFn) : smartSnakeFn(name);
             }
 
             return {

--- a/packages/commons/casings-generator/src/CasingsGenerator.ts
+++ b/packages/commons/casings-generator/src/CasingsGenerator.ts
@@ -6,11 +6,14 @@ import { camelCase, snakeCase, upperFirst, words } from "lodash-es";
 import { RESERVED_KEYWORDS } from "./reserved.js";
 
 export interface CasingsGenerator {
-    generateName(name: string, opts?: { casingOverrides?: RawSchemas.CasingOverridesSchema }): Name;
+    generateName(
+        name: string,
+        opts?: { casingOverrides?: RawSchemas.CasingOverridesSchema; preserveUnderscores?: boolean }
+    ): Name;
     generateNameAndWireValue(args: {
         name: string;
         wireValue: string;
-        opts?: { casingOverrides?: RawSchemas.CasingOverridesSchema };
+        opts?: { casingOverrides?: RawSchemas.CasingOverridesSchema; preserveUnderscores?: boolean };
     }): NameAndWireValue;
 }
 
@@ -36,10 +39,19 @@ export function constructCasingsGenerator({
                 })
             });
 
-            let camelCaseName = withUnderscorePreservation(name, camelCase);
-            let pascalCaseName = upperFirst(camelCaseName);
-            let snakeCaseName = withUnderscorePreservation(name, snakeCase);
-            const { leading: nameLeading, trailing: nameTrailing } = extractUnderscoreAffixes(name);
+            const preserve = opts?.preserveUnderscores === true;
+            const applyCasing = preserve
+                ? (n: string, fn: (s: string) => string) => withUnderscorePreservation(n, fn)
+                : (_n: string, fn: (s: string) => string) => fn(_n);
+
+            let camelCaseName = applyCasing(name, camelCase);
+            let pascalCaseName = preserve
+                ? withUnderscorePreservation(name, (n) => upperFirst(camelCase(n)))
+                : upperFirst(camelCaseName);
+            let snakeCaseName = applyCasing(name, snakeCase);
+            const { leading: nameLeading, trailing: nameTrailing } = preserve
+                ? extractUnderscoreAffixes(name)
+                : { leading: "", trailing: "" };
             const camelCaseWords = words(camelCaseName);
             if (smartCasing) {
                 if (
@@ -87,12 +99,14 @@ export function constructCasingsGenerator({
                 // In smartCasing, manage numbers next to letters differently:
                 // _.snakeCase("v2") = "v_2"
                 // smartCasing("v2") = "v2", other examples: "test2This2 2v22" => "test2this2_2v22", "applicationV1" => "application_v1"
-                snakeCaseName = withUnderscorePreservation(name, (n) =>
+                const smartSnakeFn = (n: string) =>
                     n
                         .split(" ")
                         .map((part) => part.split(/(\d+)/).map(snakeCase).join(""))
-                        .join("_")
-                );
+                        .join("_");
+                snakeCaseName = preserve
+                    ? withUnderscorePreservation(name, smartSnakeFn)
+                    : smartSnakeFn(name);
             }
 
             return {

--- a/packages/commons/casings-generator/src/__test__/CasingsGenerator.test.ts
+++ b/packages/commons/casings-generator/src/__test__/CasingsGenerator.test.ts
@@ -1,0 +1,234 @@
+import { constructCasingsGenerator } from "../CasingsGenerator.js";
+
+describe("CasingsGenerator underscore preservation", () => {
+    describe("without smartCasing", () => {
+        const generator = constructCasingsGenerator({
+            generationLanguage: undefined,
+            keywords: undefined,
+            smartCasing: false
+        });
+
+        it("preserves single leading underscore", () => {
+            const result = generator.generateName("_internal");
+            expect(result.camelCase.unsafeName).toBe("_internal");
+            expect(result.snakeCase.unsafeName).toBe("_internal");
+            expect(result.pascalCase.unsafeName).toBe("_internal");
+            expect(result.screamingSnakeCase.unsafeName).toBe("_INTERNAL");
+        });
+
+        it("preserves double leading underscores", () => {
+            const result = generator.generateName("__private");
+            expect(result.camelCase.unsafeName).toBe("__private");
+            expect(result.snakeCase.unsafeName).toBe("__private");
+            expect(result.pascalCase.unsafeName).toBe("__private");
+            expect(result.screamingSnakeCase.unsafeName).toBe("__PRIVATE");
+        });
+
+        it("preserves trailing underscore", () => {
+            const result = generator.generateName("reserved_");
+            expect(result.camelCase.unsafeName).toBe("reserved_");
+            expect(result.snakeCase.unsafeName).toBe("reserved_");
+            expect(result.pascalCase.unsafeName).toBe("Reserved_");
+            expect(result.screamingSnakeCase.unsafeName).toBe("RESERVED_");
+        });
+
+        it("preserves both leading and trailing underscores", () => {
+            const result = generator.generateName("_both_");
+            expect(result.camelCase.unsafeName).toBe("_both_");
+            expect(result.snakeCase.unsafeName).toBe("_both_");
+            expect(result.pascalCase.unsafeName).toBe("_both_");
+            expect(result.screamingSnakeCase.unsafeName).toBe("_BOTH_");
+        });
+
+        it("handles all-underscore input without doubling", () => {
+            const result = generator.generateName("_");
+            expect(result.camelCase.unsafeName).toBe("_");
+            expect(result.snakeCase.unsafeName).toBe("_");
+        });
+
+        it("handles double underscore input without quadrupling", () => {
+            const result = generator.generateName("__");
+            expect(result.camelCase.unsafeName).toBe("__");
+            expect(result.snakeCase.unsafeName).toBe("__");
+        });
+
+        it("does not affect names without underscores", () => {
+            const result = generator.generateName("normalName");
+            expect(result.camelCase.unsafeName).toBe("normalName");
+            expect(result.snakeCase.unsafeName).toBe("normal_name");
+            expect(result.pascalCase.unsafeName).toBe("NormalName");
+        });
+
+        it("handles multi-word underscore-prefixed names", () => {
+            const result = generator.generateName("_internal_api");
+            expect(result.camelCase.unsafeName).toBe("_internalApi");
+            expect(result.snakeCase.unsafeName).toBe("_internal_api");
+            expect(result.pascalCase.unsafeName).toBe("_internalApi");
+        });
+
+        it("preserves original name", () => {
+            const result = generator.generateName("_internal");
+            expect(result.originalName).toBe("_internal");
+        });
+    });
+
+    describe("with smartCasing and Go language (initialism capitalization)", () => {
+        const generator = constructCasingsGenerator({
+            generationLanguage: "go",
+            keywords: undefined,
+            smartCasing: true
+        });
+
+        it("preserves leading underscore with smartCasing for camelCase", () => {
+            const result = generator.generateName("_internal");
+            expect(result.camelCase.unsafeName).toBe("_internal");
+        });
+
+        it("preserves leading underscore with smartCasing for pascalCase", () => {
+            const result = generator.generateName("_internal");
+            // upperFirst("_internal") = "_Internal" since _ is not a letter
+            expect(result.pascalCase.unsafeName).toBe("_Internal");
+        });
+
+        it("preserves leading underscore with smartCasing for snakeCase", () => {
+            const result = generator.generateName("_internal");
+            expect(result.snakeCase.unsafeName).toBe("_internal");
+        });
+
+        it("preserves underscore with initialism in smartCasing", () => {
+            const result = generator.generateName("_httpClient");
+            // words("_httpClient") = ["http", "Client"]; "http" is at index 0 so not uppercased
+            expect(result.camelCase.unsafeName).toBe("_httpClient");
+            expect(result.snakeCase.unsafeName).toBe("_http_client");
+        });
+
+        it("handles underscore-prefixed name with API initialism", () => {
+            const result = generator.generateName("_apiKey");
+            // words("_apiKey") = ["api", "Key"]; "api" is at index 0 so not uppercased
+            expect(result.camelCase.unsafeName).toBe("_apiKey");
+            expect(result.snakeCase.unsafeName).toBe("_api_key");
+        });
+
+        it("uppercases initialism not at index 0 with underscore prefix", () => {
+            const result = generator.generateName("_getHttpResponse");
+            // words("_getHttpResponse") = ["get", "Http", "Response"]; "Http" at index 1 is uppercased
+            expect(result.camelCase.unsafeName).toBe("_getHTTPResponse");
+            expect(result.snakeCase.unsafeName).toBe("_get_http_response");
+        });
+
+        it("does not affect normal names in smartCasing", () => {
+            const result = generator.generateName("normalName");
+            expect(result.camelCase.unsafeName).toBe("normalName");
+            expect(result.snakeCase.unsafeName).toBe("normal_name");
+            expect(result.pascalCase.unsafeName).toBe("NormalName");
+        });
+    });
+
+    describe("with smartCasing and Ruby language", () => {
+        const generator = constructCasingsGenerator({
+            generationLanguage: "ruby",
+            keywords: undefined,
+            smartCasing: true
+        });
+
+        it("preserves leading underscore with Ruby smartCasing", () => {
+            const result = generator.generateName("_internal");
+            expect(result.camelCase.unsafeName).toBe("_internal");
+            expect(result.snakeCase.unsafeName).toBe("_internal");
+        });
+    });
+
+    describe("with smartCasing and undefined language (default)", () => {
+        const generator = constructCasingsGenerator({
+            generationLanguage: undefined,
+            keywords: undefined,
+            smartCasing: true
+        });
+
+        it("preserves leading underscore with default smartCasing", () => {
+            const result = generator.generateName("_internal");
+            expect(result.camelCase.unsafeName).toBe("_internal");
+            expect(result.snakeCase.unsafeName).toBe("_internal");
+            // upperFirst("_internal") = "_Internal" since _ is not a letter
+            expect(result.pascalCase.unsafeName).toBe("_Internal");
+        });
+    });
+
+    describe("with smartCasing and Python language (no initialism capitalization)", () => {
+        const generator = constructCasingsGenerator({
+            generationLanguage: "python",
+            keywords: undefined,
+            smartCasing: true
+        });
+
+        it("preserves leading underscore without initialism capitalization", () => {
+            const result = generator.generateName("_internal");
+            expect(result.camelCase.unsafeName).toBe("_internal");
+            expect(result.snakeCase.unsafeName).toBe("_internal");
+        });
+
+        it("preserves leading underscore for multi-word names", () => {
+            const result = generator.generateName("_internal_api");
+            expect(result.camelCase.unsafeName).toBe("_internalApi");
+            expect(result.snakeCase.unsafeName).toBe("_internal_api");
+        });
+    });
+
+    describe("backward compatibility - names without underscores unchanged", () => {
+        const generatorNoSmart = constructCasingsGenerator({
+            generationLanguage: undefined,
+            keywords: undefined,
+            smartCasing: false
+        });
+
+        const generatorSmart = constructCasingsGenerator({
+            generationLanguage: "go",
+            keywords: undefined,
+            smartCasing: true
+        });
+
+        const testCases = ["hello", "helloWorld", "hello_world", "HelloWorld", "HELLO_WORLD", "v2", "httpApi"];
+
+        for (const name of testCases) {
+            it(`"${name}" is unaffected without smartCasing`, () => {
+                const result = generatorNoSmart.generateName(name);
+                // Just verify it doesn't throw and produces non-empty results
+                expect(result.camelCase.unsafeName).toBeTruthy();
+                expect(result.snakeCase.unsafeName).toBeTruthy();
+                expect(result.pascalCase.unsafeName).toBeTruthy();
+            });
+
+            it(`"${name}" is unaffected with smartCasing`, () => {
+                const result = generatorSmart.generateName(name);
+                expect(result.camelCase.unsafeName).toBeTruthy();
+                expect(result.snakeCase.unsafeName).toBeTruthy();
+                expect(result.pascalCase.unsafeName).toBeTruthy();
+            });
+        }
+    });
+
+    describe("edge cases", () => {
+        const generator = constructCasingsGenerator({
+            generationLanguage: undefined,
+            keywords: undefined,
+            smartCasing: false
+        });
+
+        it("handles underscore in middle of name (not leading/trailing)", () => {
+            const result = generator.generateName("hello_world");
+            expect(result.camelCase.unsafeName).toBe("helloWorld");
+            expect(result.snakeCase.unsafeName).toBe("hello_world");
+        });
+
+        it("handles name with spaces and leading underscore", () => {
+            const result = generator.generateName("_hello world");
+            expect(result.camelCase.unsafeName).toBe("_helloWorld");
+            expect(result.snakeCase.unsafeName).toBe("_hello_world");
+        });
+
+        it("preserves originalName exactly as input", () => {
+            const result = generator.generateName("_Internal_API_");
+            expect(result.originalName).toBe("_Internal_API_");
+        });
+    });
+});

--- a/packages/commons/casings-generator/src/__test__/CasingsGenerator.test.ts
+++ b/packages/commons/casings-generator/src/__test__/CasingsGenerator.test.ts
@@ -1,55 +1,18 @@
 import { constructCasingsGenerator } from "../CasingsGenerator.js";
 
-describe("CasingsGenerator underscore preservation", () => {
-    describe("without smartCasing", () => {
+describe("CasingsGenerator underscore preservation with preserveUnderscores option", () => {
+    describe("without preserveUnderscores (default behavior - underscores stripped by lodash)", () => {
         const generator = constructCasingsGenerator({
             generationLanguage: undefined,
             keywords: undefined,
             smartCasing: false
         });
 
-        it("preserves single leading underscore", () => {
+        it("strips leading underscore by default", () => {
             const result = generator.generateName("_internal");
-            expect(result.camelCase.unsafeName).toBe("_internal");
-            expect(result.snakeCase.unsafeName).toBe("_internal");
-            expect(result.pascalCase.unsafeName).toBe("_internal");
-            expect(result.screamingSnakeCase.unsafeName).toBe("_INTERNAL");
-        });
-
-        it("preserves double leading underscores", () => {
-            const result = generator.generateName("__private");
-            expect(result.camelCase.unsafeName).toBe("__private");
-            expect(result.snakeCase.unsafeName).toBe("__private");
-            expect(result.pascalCase.unsafeName).toBe("__private");
-            expect(result.screamingSnakeCase.unsafeName).toBe("__PRIVATE");
-        });
-
-        it("preserves trailing underscore", () => {
-            const result = generator.generateName("reserved_");
-            expect(result.camelCase.unsafeName).toBe("reserved_");
-            expect(result.snakeCase.unsafeName).toBe("reserved_");
-            expect(result.pascalCase.unsafeName).toBe("Reserved_");
-            expect(result.screamingSnakeCase.unsafeName).toBe("RESERVED_");
-        });
-
-        it("preserves both leading and trailing underscores", () => {
-            const result = generator.generateName("_both_");
-            expect(result.camelCase.unsafeName).toBe("_both_");
-            expect(result.snakeCase.unsafeName).toBe("_both_");
-            expect(result.pascalCase.unsafeName).toBe("_both_");
-            expect(result.screamingSnakeCase.unsafeName).toBe("_BOTH_");
-        });
-
-        it("handles all-underscore input without doubling", () => {
-            const result = generator.generateName("_");
-            expect(result.camelCase.unsafeName).toBe("_");
-            expect(result.snakeCase.unsafeName).toBe("_");
-        });
-
-        it("handles double underscore input without quadrupling", () => {
-            const result = generator.generateName("__");
-            expect(result.camelCase.unsafeName).toBe("__");
-            expect(result.snakeCase.unsafeName).toBe("__");
+            expect(result.camelCase.unsafeName).toBe("internal");
+            expect(result.snakeCase.unsafeName).toBe("internal");
+            expect(result.pascalCase.unsafeName).toBe("Internal");
         });
 
         it("does not affect names without underscores", () => {
@@ -59,20 +22,84 @@ describe("CasingsGenerator underscore preservation", () => {
             expect(result.pascalCase.unsafeName).toBe("NormalName");
         });
 
-        it("handles multi-word underscore-prefixed names", () => {
-            const result = generator.generateName("_internal_api");
-            expect(result.camelCase.unsafeName).toBe("_internalApi");
-            expect(result.snakeCase.unsafeName).toBe("_internal_api");
-            expect(result.pascalCase.unsafeName).toBe("_internalApi");
-        });
-
-        it("preserves original name", () => {
+        it("preserves originalName exactly as input", () => {
             const result = generator.generateName("_internal");
             expect(result.originalName).toBe("_internal");
         });
     });
 
-    describe("with smartCasing and Go language (initialism capitalization)", () => {
+    describe("with preserveUnderscores: true (no smartCasing)", () => {
+        const generator = constructCasingsGenerator({
+            generationLanguage: undefined,
+            keywords: undefined,
+            smartCasing: false
+        });
+
+        it("preserves single leading underscore", () => {
+            const result = generator.generateName("_internal", { preserveUnderscores: true });
+            expect(result.camelCase.unsafeName).toBe("_internal");
+            expect(result.snakeCase.unsafeName).toBe("_internal");
+            expect(result.pascalCase.unsafeName).toBe("_Internal");
+            expect(result.screamingSnakeCase.unsafeName).toBe("_INTERNAL");
+        });
+
+        it("preserves double leading underscores", () => {
+            const result = generator.generateName("__private", { preserveUnderscores: true });
+            expect(result.camelCase.unsafeName).toBe("__private");
+            expect(result.snakeCase.unsafeName).toBe("__private");
+            expect(result.pascalCase.unsafeName).toBe("__Private");
+            expect(result.screamingSnakeCase.unsafeName).toBe("__PRIVATE");
+        });
+
+        it("preserves trailing underscore", () => {
+            const result = generator.generateName("reserved_", { preserveUnderscores: true });
+            expect(result.camelCase.unsafeName).toBe("reserved_");
+            expect(result.snakeCase.unsafeName).toBe("reserved_");
+            expect(result.pascalCase.unsafeName).toBe("Reserved_");
+            expect(result.screamingSnakeCase.unsafeName).toBe("RESERVED_");
+        });
+
+        it("preserves both leading and trailing underscores", () => {
+            const result = generator.generateName("_both_", { preserveUnderscores: true });
+            expect(result.camelCase.unsafeName).toBe("_both_");
+            expect(result.snakeCase.unsafeName).toBe("_both_");
+            expect(result.pascalCase.unsafeName).toBe("_Both_");
+            expect(result.screamingSnakeCase.unsafeName).toBe("_BOTH_");
+        });
+
+        it("handles all-underscore input without doubling", () => {
+            const result = generator.generateName("_", { preserveUnderscores: true });
+            expect(result.camelCase.unsafeName).toBe("_");
+            expect(result.snakeCase.unsafeName).toBe("_");
+        });
+
+        it("handles double underscore input without quadrupling", () => {
+            const result = generator.generateName("__", { preserveUnderscores: true });
+            expect(result.camelCase.unsafeName).toBe("__");
+            expect(result.snakeCase.unsafeName).toBe("__");
+        });
+
+        it("does not affect names without underscores", () => {
+            const result = generator.generateName("normalName", { preserveUnderscores: true });
+            expect(result.camelCase.unsafeName).toBe("normalName");
+            expect(result.snakeCase.unsafeName).toBe("normal_name");
+            expect(result.pascalCase.unsafeName).toBe("NormalName");
+        });
+
+        it("handles multi-word underscore-prefixed names", () => {
+            const result = generator.generateName("_internal_api", { preserveUnderscores: true });
+            expect(result.camelCase.unsafeName).toBe("_internalApi");
+            expect(result.snakeCase.unsafeName).toBe("_internal_api");
+            expect(result.pascalCase.unsafeName).toBe("_InternalApi");
+        });
+
+        it("preserves original name", () => {
+            const result = generator.generateName("_internal", { preserveUnderscores: true });
+            expect(result.originalName).toBe("_internal");
+        });
+    });
+
+    describe("with preserveUnderscores: true and smartCasing + Go (initialism capitalization)", () => {
         const generator = constructCasingsGenerator({
             generationLanguage: "go",
             keywords: undefined,
@@ -80,51 +107,47 @@ describe("CasingsGenerator underscore preservation", () => {
         });
 
         it("preserves leading underscore with smartCasing for camelCase", () => {
-            const result = generator.generateName("_internal");
+            const result = generator.generateName("_internal", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_internal");
         });
 
         it("preserves leading underscore with smartCasing for pascalCase", () => {
-            const result = generator.generateName("_internal");
-            // upperFirst("_internal") = "_Internal" since _ is not a letter
+            const result = generator.generateName("_internal", { preserveUnderscores: true });
             expect(result.pascalCase.unsafeName).toBe("_Internal");
         });
 
         it("preserves leading underscore with smartCasing for snakeCase", () => {
-            const result = generator.generateName("_internal");
+            const result = generator.generateName("_internal", { preserveUnderscores: true });
             expect(result.snakeCase.unsafeName).toBe("_internal");
         });
 
         it("preserves underscore with initialism in smartCasing", () => {
-            const result = generator.generateName("_httpClient");
-            // words("_httpClient") = ["http", "Client"]; "http" is at index 0 so not uppercased
+            const result = generator.generateName("_httpClient", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_httpClient");
             expect(result.snakeCase.unsafeName).toBe("_http_client");
         });
 
         it("handles underscore-prefixed name with API initialism", () => {
-            const result = generator.generateName("_apiKey");
-            // words("_apiKey") = ["api", "Key"]; "api" is at index 0 so not uppercased
+            const result = generator.generateName("_apiKey", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_apiKey");
             expect(result.snakeCase.unsafeName).toBe("_api_key");
         });
 
         it("uppercases initialism not at index 0 with underscore prefix", () => {
-            const result = generator.generateName("_getHttpResponse");
-            // words("_getHttpResponse") = ["get", "Http", "Response"]; "Http" at index 1 is uppercased
+            const result = generator.generateName("_getHttpResponse", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_getHTTPResponse");
             expect(result.snakeCase.unsafeName).toBe("_get_http_response");
         });
 
         it("does not affect normal names in smartCasing", () => {
-            const result = generator.generateName("normalName");
+            const result = generator.generateName("normalName", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("normalName");
             expect(result.snakeCase.unsafeName).toBe("normal_name");
             expect(result.pascalCase.unsafeName).toBe("NormalName");
         });
     });
 
-    describe("with smartCasing and Ruby language", () => {
+    describe("with preserveUnderscores: true and smartCasing + Ruby", () => {
         const generator = constructCasingsGenerator({
             generationLanguage: "ruby",
             keywords: undefined,
@@ -132,13 +155,13 @@ describe("CasingsGenerator underscore preservation", () => {
         });
 
         it("preserves leading underscore with Ruby smartCasing", () => {
-            const result = generator.generateName("_internal");
+            const result = generator.generateName("_internal", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_internal");
             expect(result.snakeCase.unsafeName).toBe("_internal");
         });
     });
 
-    describe("with smartCasing and undefined language (default)", () => {
+    describe("with preserveUnderscores: true and smartCasing + undefined language (default)", () => {
         const generator = constructCasingsGenerator({
             generationLanguage: undefined,
             keywords: undefined,
@@ -146,15 +169,14 @@ describe("CasingsGenerator underscore preservation", () => {
         });
 
         it("preserves leading underscore with default smartCasing", () => {
-            const result = generator.generateName("_internal");
+            const result = generator.generateName("_internal", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_internal");
             expect(result.snakeCase.unsafeName).toBe("_internal");
-            // upperFirst("_internal") = "_Internal" since _ is not a letter
             expect(result.pascalCase.unsafeName).toBe("_Internal");
         });
     });
 
-    describe("with smartCasing and Python language (no initialism capitalization)", () => {
+    describe("with preserveUnderscores: true and smartCasing + Python (no initialism capitalization)", () => {
         const generator = constructCasingsGenerator({
             generationLanguage: "python",
             keywords: undefined,
@@ -162,13 +184,13 @@ describe("CasingsGenerator underscore preservation", () => {
         });
 
         it("preserves leading underscore without initialism capitalization", () => {
-            const result = generator.generateName("_internal");
+            const result = generator.generateName("_internal", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_internal");
             expect(result.snakeCase.unsafeName).toBe("_internal");
         });
 
         it("preserves leading underscore for multi-word names", () => {
-            const result = generator.generateName("_internal_api");
+            const result = generator.generateName("_internal_api", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_internalApi");
             expect(result.snakeCase.unsafeName).toBe("_internal_api");
         });
@@ -192,7 +214,6 @@ describe("CasingsGenerator underscore preservation", () => {
         for (const name of testCases) {
             it(`"${name}" is unaffected without smartCasing`, () => {
                 const result = generatorNoSmart.generateName(name);
-                // Just verify it doesn't throw and produces non-empty results
                 expect(result.camelCase.unsafeName).toBeTruthy();
                 expect(result.snakeCase.unsafeName).toBeTruthy();
                 expect(result.pascalCase.unsafeName).toBeTruthy();
@@ -215,19 +236,19 @@ describe("CasingsGenerator underscore preservation", () => {
         });
 
         it("handles underscore in middle of name (not leading/trailing)", () => {
-            const result = generator.generateName("hello_world");
+            const result = generator.generateName("hello_world", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("helloWorld");
             expect(result.snakeCase.unsafeName).toBe("hello_world");
         });
 
         it("handles name with spaces and leading underscore", () => {
-            const result = generator.generateName("_hello world");
+            const result = generator.generateName("_hello world", { preserveUnderscores: true });
             expect(result.camelCase.unsafeName).toBe("_helloWorld");
             expect(result.snakeCase.unsafeName).toBe("_hello_world");
         });
 
         it("preserves originalName exactly as input", () => {
-            const result = generator.generateName("_Internal_API_");
+            const result = generator.generateName("_Internal_API_", { preserveUnderscores: true });
             expect(result.originalName).toBe("_Internal_API_");
         });
     });

--- a/packages/commons/casings-generator/tsconfig.json
+++ b/packages/commons/casings-generator/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@fern-api/configs/tsconfig/main.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["vitest/globals"]
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## Description

Closes https://github.com/fern-api/fern/issues/6580

Lodash's `camelCase()` and `snakeCase()` strip leading/trailing underscores (e.g. `_internal` → `internal`), making it impossible to use underscore-prefixed SDK group names like `["v1", "_internal", "pets"]` for marking private/internal modules — a common convention in Python, Ruby, and JavaScript.

## Changes Made

- **`convertSdkGroupName.ts`**: Added `camelCasePreservingUnderscores()` helper so that group name → file path conversion preserves underscores (e.g. `_internal` → `_internal.yml` instead of `internal.yml`). Includes overlap guard for all-underscore input.
- **`CasingsGenerator.ts`**: Added `extractUnderscoreAffixes()` and `withUnderscorePreservation()` helpers. Added **opt-in** `preserveUnderscores` flag to `generateName()` / `generateNameAndWireValue()`. When `preserveUnderscores: true` is passed, all `camelCase`/`snakeCase`/`pascalCase`/`screamingSnakeCase` outputs preserve leading/trailing underscores. Without the flag, behavior is unchanged (underscores stripped by lodash as before). The smartCasing branch (Go/Ruby initialism capitalization) also respects the flag.
- **`CasingsGenerator.test.ts`**: Added 40 unit tests covering: default behavior (underscores stripped), opt-in preservation for all casing variants, smartCasing with Go/Ruby/Python/undefined language, initialism capitalization with underscores, backward compatibility for names without underscores, and edge cases (all-underscore input, middle underscores, spaces with underscores).
- Updated the `x-fern-sdk-group-name` test fixture with underscore-prefixed group name cases and regenerated snapshots.
- Added `versions.yml` entry (3.96.0).

## Testing

- [x] 40 unit tests added for `CasingsGenerator` underscore preservation (all passing)
- [x] 259 snapshot tests passing (openapi-ir + openapi-ir-to-fern)
- [x] Biome/lint/compile/all CI checks passing

## ⚠️ Human review checklist


1. **Scope of underscore preservation** — The `preserveUnderscores` flag on `CasingsGenerator` is opt-in and currently not called by any production code in this PR. The actual fix that makes `x-fern-sdk-group-name` work is in `convertSdkGroupName.ts` which has its own `camelCasePreservingUnderscores()` helper for file path generation. The `CasingsGenerator` flag provides infrastructure for future use when IR Name objects need underscore preservation. Verify this is the intended design.
2. **PascalCase for underscore-prefixed names** — When `preserveUnderscores: true`, `upperFirst("_internal")` produces `"_Internal"` (capitalizes the first letter after the underscore). Verify this is acceptable behavior for generated SDKs across all languages.
3. **Duplicate logic** — The underscore-preservation pattern is implemented separately in both `CasingsGenerator.ts` and `convertSdkGroupName.ts` rather than shared via a utility. Consider whether this should be extracted.

---

[Link to Devin run](https://app.devin.ai/sessions/1a59c02182d548d89556fe22396c29e3) | Requested by: @Swimburger