### PR TITLE
chore(typescript): add versions.yml entry for backport tag publish fix

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.52.8
+  changelogEntry:
+    - summary: |
+        Update generated CI workflow to publish older patch versions with `--tag backport`
+        instead of the default `latest` tag. When publishing a version older than the current
+        `latest` on npm (e.g. v1.3.2 after v1.4.0), the publish step now compares against
+        npm's current `latest` using `semver` and uses `--tag backport` to avoid moving the
+        `latest` pointer backwards.
+      type: fix
+  createdAt: "2026-02-28"
+  irVersion: 65
+
 - version: 3.52.7
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Adds the missing `versions.yml` changelog entry for the backport tag publish fix merged in #13025.

Refs #13025

## Changes Made

- Added version `3.52.8` entry to `generators/typescript/sdk/versions.yml` with a `fix` changelog entry describing the backport tag publish behavior

## Human Review Checklist

- [ ] Version `3.52.8` is the correct next patch after `3.52.7`
- [ ] `irVersion: 65` matches the current IR version used by recent entries
- [ ] Changelog summary accurately reflects the change from #13025

## Testing

No code changes — changelog entry only.

---

Link to Devin run: https://app.devin.ai/sessions/f636a769ca3840deb39382509195093d
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
