### PR TITLE
fix(cli): detect duplicate auth header parameters in fern check and fix authHeaders Set construction

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -93,14 +93,16 @@ export function generateIr({
     );
     const security: GlobalSecurity | undefined = openApi.security?.filter((requirement) => requirement != null);
     const authHeaders = new Set(
-        ...Object.entries(securitySchemes).map(([_, securityScheme]) => {
-            if (securityScheme.type === "basic" || securityScheme.type === "bearer") {
-                return "Authorization";
-            } else if (securityScheme.type === "header") {
-                return securityScheme.headerName;
-            }
-            return null;
-        })
+        Object.entries(securitySchemes)
+            .map(([_, securityScheme]) => {
+                if (securityScheme.type === "basic" || securityScheme.type === "bearer") {
+                    return "Authorization";
+                } else if (securityScheme.type === "header") {
+                    return securityScheme.headerName;
+                }
+                return null;
+            })
+            .filter((header): header is string => header != null)
     );
     const variables = getVariableDefinitions(openApi, options.preserveSchemaIds);
     const globalHeaders = getGlobalHeaders(openApi);

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -95,7 +95,11 @@ export function generateIr({
     const authHeaders = new Set(
         Object.entries(securitySchemes)
             .map(([_, securityScheme]) => {
-                if (securityScheme.type === "basic" || securityScheme.type === "bearer" || securityScheme.type === "oauth") {
+                if (
+                    securityScheme.type === "basic" ||
+                    securityScheme.type === "bearer" ||
+                    securityScheme.type === "oauth"
+                ) {
                     return "Authorization";
                 } else if (securityScheme.type === "header") {
                     return securityScheme.headerName;

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -95,7 +95,7 @@ export function generateIr({
     const authHeaders = new Set(
         Object.entries(securitySchemes)
             .map(([_, securityScheme]) => {
-                if (securityScheme.type === "basic" || securityScheme.type === "bearer") {
+                if (securityScheme.type === "basic" || securityScheme.type === "bearer" || securityScheme.type === "oauth") {
                     return "Authorization";
                 } else if (securityScheme.type === "header") {
                     return securityScheme.headerName;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/hathora.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/hathora.json
@@ -3550,23 +3550,7 @@
           }
         }
       ],
-      "headers": [
-        {
-          "name": "Authorization",
-          "schema": {
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "CreatePrivateLobbyDeprecatedRequestAuthorization",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        }
-      ],
+      "headers": [],
       "generatedRequestName": "CreatePrivateLobbyDeprecatedRequest",
       "response": {
         "description": "Ok",
@@ -3745,18 +3729,7 @@
             }
           ],
           "queryParameters": [],
-          "headers": [
-            {
-              "name": "Authorization",
-              "value": {
-                "value": {
-                  "value": "Authorization",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            }
-          ],
+          "headers": [],
           "response": {
             "value": {
               "value": {
@@ -3843,23 +3816,7 @@
           }
         }
       ],
-      "headers": [
-        {
-          "name": "Authorization",
-          "schema": {
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "CreatePublicLobbyDeprecatedRequestAuthorization",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        }
-      ],
+      "headers": [],
       "generatedRequestName": "CreatePublicLobbyDeprecatedRequest",
       "response": {
         "description": "Ok",
@@ -4038,18 +3995,7 @@
             }
           ],
           "queryParameters": [],
-          "headers": [
-            {
-              "name": "Authorization",
-              "value": {
-                "value": {
-                  "value": "Authorization",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            }
-          ],
+          "headers": [],
           "response": {
             "value": {
               "value": {
@@ -4136,23 +4082,7 @@
           }
         }
       ],
-      "headers": [
-        {
-          "name": "Authorization",
-          "schema": {
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "ListActivePublicLobbiesDeprecatedRequestAuthorization",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        }
-      ],
+      "headers": [],
       "generatedRequestName": "ListActivePublicLobbiesDeprecatedRequest",
       "response": {
         "description": "Ok",
@@ -4255,18 +4185,7 @@
             }
           ],
           "queryParameters": [],
-          "headers": [
-            {
-              "name": "Authorization",
-              "value": {
-                "value": {
-                  "value": "Authorization",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            }
-          ],
+          "headers": [],
           "response": {
             "value": {
               "value": [
@@ -4420,23 +4339,7 @@
           }
         }
       ],
-      "headers": [
-        {
-          "name": "Authorization",
-          "schema": {
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "CreatePrivateLobbyRequestAuthorization",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        }
-      ],
+      "headers": [],
       "generatedRequestName": "CreatePrivateLobbyRequest",
       "request": {
         "schema": {
@@ -4679,18 +4582,7 @@
             }
           ],
           "queryParameters": [],
-          "headers": [
-            {
-              "name": "Authorization",
-              "value": {
-                "value": {
-                  "value": "Authorization",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            }
-          ],
+          "headers": [],
           "request": {
             "properties": {
               "initialConfig": {
@@ -4869,23 +4761,7 @@
           }
         }
       ],
-      "headers": [
-        {
-          "name": "Authorization",
-          "schema": {
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "CreatePublicLobbyRequestAuthorization",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        }
-      ],
+      "headers": [],
       "generatedRequestName": "CreatePublicLobbyRequest",
       "request": {
         "schema": {
@@ -5128,18 +5004,7 @@
             }
           ],
           "queryParameters": [],
-          "headers": [
-            {
-              "name": "Authorization",
-              "value": {
-                "value": {
-                  "value": "Authorization",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            }
-          ],
+          "headers": [],
           "request": {
             "properties": {
               "initialConfig": {
@@ -5318,23 +5183,7 @@
           }
         }
       ],
-      "headers": [
-        {
-          "name": "Authorization",
-          "schema": {
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "CreateLocalLobbyRequestAuthorization",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        }
-      ],
+      "headers": [],
       "generatedRequestName": "CreateLocalLobbyRequest",
       "request": {
         "schema": {
@@ -5577,18 +5426,7 @@
             }
           ],
           "queryParameters": [],
-          "headers": [
-            {
-              "name": "Authorization",
-              "value": {
-                "value": {
-                  "value": "Authorization",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            }
-          ],
+          "headers": [],
           "request": {
             "properties": {
               "initialConfig": {
@@ -5767,23 +5605,7 @@
           }
         }
       ],
-      "headers": [
-        {
-          "name": "Authorization",
-          "schema": {
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "CreateLobbyRequestAuthorization",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        }
-      ],
+      "headers": [],
       "generatedRequestName": "CreateLobbyRequest",
       "request": {
         "schema": {
@@ -6057,18 +5879,7 @@
             }
           ],
           "queryParameters": [],
-          "headers": [
-            {
-              "name": "Authorization",
-              "value": {
-                "value": {
-                  "value": "Authorization",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            }
-          ],
+          "headers": [],
           "request": {
             "properties": {
               "visibility": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/hathora.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/hathora.json
@@ -2507,7 +2507,6 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2554,7 +2553,6 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2598,7 +2596,6 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2688,7 +2685,6 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers: {}
           response:
             body: string
     CreatePublicLobbyDeprecated:
@@ -2719,7 +2715,6 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers: {}
           response:
             body: string
     ListActivePublicLobbiesDeprecated:
@@ -2747,7 +2742,6 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers: {}
           response:
             body:
               - state:
@@ -2787,7 +2781,6 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2860,7 +2853,6 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -2931,7 +2923,6 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -3002,7 +2993,6 @@ service:
               ],
               "examples": [
                 {
-                  "headers": {},
                   "path-parameters": {
                     "appId": "appId",
                   },
@@ -3283,7 +3273,6 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers: {}
           request:
             initialConfig:
               key: value
@@ -3331,7 +3320,6 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers: {}
           request:
             initialConfig:
               key: value
@@ -3379,7 +3367,6 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers: {}
           request:
             initialConfig:
               key: value
@@ -3427,7 +3414,6 @@ service:
       examples:
         - path-parameters:
             appId: appId
-          headers: {}
           request:
             visibility: public
             initialConfig:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildGlobalHeaders.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildGlobalHeaders.ts
@@ -27,7 +27,7 @@ class HeaderWithCount {
 /* 75% of endpoints must have header present, for it to be considered a global header*/
 const GLOBAL_HEADER_PERCENTAGE_THRESHOLD = 0.75;
 
-const HEADERS_TO_IGNORE = new Set(...["authorization"]);
+const HEADERS_TO_IGNORE = new Set(["authorization"]);
 
 export function buildGlobalHeaders(context: OpenApiIrConverterContext): void {
     if (context.globalHeaderOverrides != null) {

--- a/packages/cli/api-importers/openapi/openapi-ir/src/utils/isSchemaEqual.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir/src/utils/isSchemaEqual.ts
@@ -31,8 +31,8 @@ function isPrimitiveSchemaValueEqual(a: PrimitiveSchemaValue, b: PrimitiveSchema
 }
 
 function areEnumValuesEqual(a: EnumValue[], b: EnumValue[]): boolean {
-    const aSet = new Set(...a.map((enumValue) => enumValue.value));
-    const bSet = new Set(...b.map((enumValue) => enumValue.value));
+    const aSet = new Set(a.map((enumValue) => enumValue.value));
+    const bSet = new Set(b.map((enumValue) => enumValue.value));
     return isEqual(aSet, bSet);
 }
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -9,11 +9,12 @@
         error. Now a warning is emitted during validation.
       type: fix
     - summary: |
-        Fix incorrect construction of the auth-header filter set in the v1
-        OpenAPI parser. `new Set(...array)` was used instead of
-        `new Set(array)`, which caused the set to contain individual characters
-        instead of full header names, so duplicate Authorization headers from
-        path parameters were never filtered out.
+        Fix incorrect construction of Sets using `new Set(...array)` instead of
+        `new Set(array)` in three places: the auth-header filter in the v1
+        OpenAPI parser (`generateIr.ts`), the headers-to-ignore set in
+        `buildGlobalHeaders.ts`, and enum value comparison in
+        `isSchemaEqual.ts`. The spread caused Sets to contain individual
+        characters instead of full strings.
       type: fix
   createdAt: "2026-03-01"
   irVersion: 65

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,23 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.95.7
+  changelogEntry:
+    - summary: |
+        Fix `fern check` not detecting when an OpenAPI spec declares an explicit
+        header parameter (e.g. `Authorization`) that conflicts with a header
+        already implied by a security scheme (e.g. Bearer token auth). Previously
+        `fern check` silently passed and generation would fail with a confusing
+        error. Now a warning is emitted during validation.
+      type: fix
+    - summary: |
+        Fix incorrect construction of the auth-header filter set in the v1
+        OpenAPI parser. `new Set(...array)` was used instead of
+        `new Set(array)`, which caused the set to contain individual characters
+        instead of full header names, so duplicate Authorization headers from
+        path parameters were never filtered out.
+      type: fix
+  createdAt: "2026-03-01"
+  irVersion: 65
+
 - version: 3.95.6
   changelogEntry:
     - summary: |

--- a/packages/cli/workspace/oss-validator/src/getAllRules.ts
+++ b/packages/cli/workspace/oss-validator/src/getAllRules.ts
@@ -1,7 +1,8 @@
 import { Rule } from "./Rule.js";
+import { NoDuplicateAuthHeaderParametersRule } from "./rules/no-duplicate-auth-header-parameters/index.js";
 import { NoDuplicateOverridesRule } from "./rules/no-duplicate-overrides/index.js";
 import { NoSchemaTitleCollisionsRule } from "./rules/no-schema-title-collisions/index.js";
 
 export function getAllRules(): Rule[] {
-    return [NoDuplicateOverridesRule, NoSchemaTitleCollisionsRule];
+    return [NoDuplicateAuthHeaderParametersRule, NoDuplicateOverridesRule, NoSchemaTitleCollisionsRule];
 }

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-auth-header-parameters/index.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-auth-header-parameters/index.ts
@@ -1,0 +1,1 @@
+export { NoDuplicateAuthHeaderParametersRule } from "./no-duplicate-auth-header-parameters.js";

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-auth-header-parameters/no-duplicate-auth-header-parameters.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-auth-header-parameters/no-duplicate-auth-header-parameters.ts
@@ -1,0 +1,190 @@
+import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
+import { relative } from "@fern-api/fs-utils";
+import { convertOpenAPIV2ToV3, loadOpenAPI } from "@fern-api/lazy-fern-workspace";
+import { readFile } from "fs/promises";
+
+import { Rule } from "../../Rule.js";
+import { ValidationViolation } from "../../ValidationViolation.js";
+
+/**
+ * Validates that OpenAPI specs don't define header parameters that conflict
+ * with headers implied by security schemes.
+ *
+ * For example, if a spec has a Bearer Token security scheme (which implies
+ * an Authorization header), and also declares an explicit "Authorization"
+ * header parameter on a path, this rule will emit a warning.
+ *
+ * See: https://github.com/fern-api/fern/issues/6908
+ */
+export const NoDuplicateAuthHeaderParametersRule: Rule = {
+    name: "no-duplicate-auth-header-parameters",
+    run: async ({ workspace, specs, context }) => {
+        const violations: ValidationViolation[] = [];
+
+        for (const spec of specs) {
+            if (spec.type !== "openapi") {
+                continue;
+            }
+
+            const contents = (await readFile(spec.absoluteFilepath)).toString();
+
+            if (!contents.includes("openapi") && !contents.includes("swagger")) {
+                continue;
+            }
+
+            const openAPI = await loadOpenAPI({
+                absolutePathToOpenAPI: spec.absoluteFilepath,
+                context,
+                absolutePathToOpenAPIOverrides: spec.absoluteFilepathToOverrides,
+                absolutePathToOpenAPIOverlays: spec.absoluteFilepathToOverlays
+            });
+
+            const apiToValidate = isOpenAPIV2(openAPI) ? await convertOpenAPIV2ToV3(openAPI) : openAPI;
+
+            const authHeaderNames = getAuthHeaderNames(apiToValidate);
+            if (authHeaderNames.size === 0) {
+                continue;
+            }
+
+            const relativeFilepath = relative(workspace.absoluteFilePath, spec.source.file);
+
+            for (const [path, pathItem] of Object.entries(apiToValidate.paths ?? {})) {
+                if (pathItem == null) {
+                    continue;
+                }
+
+                const pathItemObj = pathItem as Record<string, unknown>;
+
+                // Check path-level parameters
+                const pathLevelParams = pathItemObj.parameters;
+                if (Array.isArray(pathLevelParams)) {
+                    for (const param of pathLevelParams) {
+                        const resolved = resolveParam(param, apiToValidate);
+                        if (resolved != null && isDuplicateAuthHeader(resolved, authHeaderNames)) {
+                            violations.push({
+                                name: "no-duplicate-auth-header-parameters",
+                                severity: "warning",
+                                relativeFilepath,
+                                nodePath: ["paths", path, "parameters"],
+                                message: `Header parameter '${resolved.name}' conflicts with the '${resolved.name}' header already defined by a security scheme. This parameter will be ignored during SDK generation.`
+                            });
+                        }
+                    }
+                }
+
+                // Check operation-level parameters
+                for (const method of ["get", "put", "post", "delete", "options", "head", "patch", "trace"]) {
+                    const operation = pathItemObj[method] as { parameters?: unknown[] } | undefined;
+                    if (operation?.parameters == null) {
+                        continue;
+                    }
+
+                    for (const param of operation.parameters) {
+                        const resolved = resolveParam(param, apiToValidate);
+                        if (resolved != null && isDuplicateAuthHeader(resolved, authHeaderNames)) {
+                            violations.push({
+                                name: "no-duplicate-auth-header-parameters",
+                                severity: "warning",
+                                relativeFilepath,
+                                nodePath: ["paths", path, method],
+                                message: `Header parameter '${resolved.name}' conflicts with the '${resolved.name}' header already defined by a security scheme. This parameter will be ignored during SDK generation.`
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        return violations;
+    }
+};
+
+interface ResolvedParam {
+    in: string;
+    name: string;
+}
+
+/**
+ * Collects the set of header names (lowercased) implied by security schemes in the spec.
+ */
+function getAuthHeaderNames(
+    // biome-ignore lint/suspicious/noExplicitAny: OpenAPI document type
+    api: any
+): Set<string> {
+    const headerNames = new Set<string>();
+    const securitySchemes = api.components?.securitySchemes as Record<string, Record<string, unknown>> | undefined;
+
+    if (securitySchemes == null) {
+        return headerNames;
+    }
+
+    for (const scheme of Object.values(securitySchemes)) {
+        if (typeof scheme !== "object" || scheme == null) {
+            continue;
+        }
+
+        // Skip unresolved $ref
+        if (typeof scheme.$ref === "string") {
+            continue;
+        }
+
+        const type = scheme.type as string | undefined;
+
+        if (type === "http") {
+            // http schemes (basic, bearer, digest, etc.) use the Authorization header
+            headerNames.add("authorization");
+        } else if (type === "apiKey" && scheme.in === "header") {
+            const name = scheme.name as string | undefined;
+            if (name != null) {
+                headerNames.add(name.toLowerCase());
+            }
+        } else if (type === "oauth2" || type === "openIdConnect") {
+            // OAuth2 and OpenID Connect also use the Authorization header
+            headerNames.add("authorization");
+        }
+    }
+
+    return headerNames;
+}
+
+/**
+ * Resolves a parameter, handling $ref if needed.
+ */
+function resolveParam(
+    param: unknown,
+    // biome-ignore lint/suspicious/noExplicitAny: OpenAPI document type
+    api: any
+): ResolvedParam | undefined {
+    if (typeof param !== "object" || param == null) {
+        return undefined;
+    }
+
+    const paramObj = param as Record<string, unknown>;
+
+    // Handle $ref
+    if (typeof paramObj.$ref === "string") {
+        const refPath = paramObj.$ref;
+        if (refPath.startsWith("#/components/parameters/")) {
+            const paramName = refPath.substring("#/components/parameters/".length);
+            const components = api.components as { parameters?: Record<string, unknown> } | undefined;
+            const resolved = components?.parameters?.[paramName];
+            if (resolved != null) {
+                return resolveParam(resolved, api);
+            }
+        }
+        return undefined;
+    }
+
+    if (typeof paramObj.in === "string" && typeof paramObj.name === "string") {
+        return { in: paramObj.in, name: paramObj.name };
+    }
+
+    return undefined;
+}
+
+/**
+ * Checks if a resolved parameter is a header that conflicts with auth headers.
+ */
+function isDuplicateAuthHeader(param: ResolvedParam, authHeaderNames: Set<string>): boolean {
+    return param.in === "header" && authHeaderNames.has(param.name.toLowerCase());
+}

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-auth-header-parameters/no-duplicate-auth-header-parameters.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-auth-header-parameters/no-duplicate-auth-header-parameters.ts
@@ -153,7 +153,8 @@ function getAuthHeaderNames(
 function resolveParam(
     param: unknown,
     // biome-ignore lint/suspicious/noExplicitAny: OpenAPI document type
-    api: any
+    api: any,
+    visited: Set<string> = new Set()
 ): ResolvedParam | undefined {
     if (typeof param !== "object" || param == null) {
         return undefined;
@@ -164,12 +165,16 @@ function resolveParam(
     // Handle $ref
     if (typeof paramObj.$ref === "string") {
         const refPath = paramObj.$ref;
+        if (visited.has(refPath)) {
+            return undefined; // Circular reference detected
+        }
         if (refPath.startsWith("#/components/parameters/")) {
             const paramName = refPath.substring("#/components/parameters/".length);
             const components = api.components as { parameters?: Record<string, unknown> } | undefined;
             const resolved = components?.parameters?.[paramName];
             if (resolved != null) {
-                return resolveParam(resolved, api);
+                visited.add(refPath);
+                return resolveParam(resolved, api, visited);
             }
         }
         return undefined;


### PR DESCRIPTION
## Description

Closes https://github.com/fern-api/fern/issues/6908

Fixes `fern check` silently passing when an OpenAPI spec declares an explicit header parameter (e.g. `Authorization`) that conflicts with a header already implied by a security scheme (e.g. Bearer token auth). Previously generation would fail with a confusing error; now a warning is surfaced during validation.

Also fixes the same `new Set(...array)` spread bug in two additional locations discovered during review.

[Link to Devin run](https://app.devin.ai/sessions/fd4f501a6dea470698a2e4988f06c52f) | Requested by: @Swimburger

## Changes Made

### 1. Fix broken `authHeaders` Set construction in v1 OpenAPI parser
In `generateIr.ts`, the auth-header filter set was constructed as `new Set(...array)`. Because `Set()` takes a single iterable argument, `new Set("Authorization")` created a set of **individual characters** (`{'A','u','t','h',...}`) instead of the string `"Authorization"`. This meant the duplicate-header check in `convertParameters.ts` (`!context.authHeaders.has(resolvedParameter.name)`) **never matched**, so conflicting Authorization headers from path parameters were never filtered out.

**Fix:** Removed the spread operator, added `.filter()` to strip nulls, and added `oauth` to the security scheme type check (alongside `basic` and `bearer`) so OAuth2 security schemes also correctly contribute the `Authorization` header to the filter set.

### 2. Fix same `new Set(...array)` spread bug in two more locations
- **`buildGlobalHeaders.ts`**: `HEADERS_TO_IGNORE` was `new Set(...["authorization"])`, creating a set of single characters. This meant `authorization` headers were never filtered during global header detection. Fixed to `new Set(["authorization"])`.
- **`isSchemaEqual.ts`**: `areEnumValuesEqual` used `new Set(...a.map(...))`, which only iterated the first enum value as a string of characters. Fixed to `new Set(a.map(...))` on both lines.

### 3. New OSS validation rule: `no-duplicate-auth-header-parameters`
Adds a new `fern check` validation rule that warns when header parameters on paths/operations conflict with headers implied by security schemes (`http`, `apiKey` in header, `oauth2`, `openIdConnect`). Follows the same structure as existing rules (`no-duplicate-overrides`, `no-schema-title-collisions`). Includes circular `$ref` protection in parameter resolution.

### 4. Updated hathora snapshots
The Set fix now correctly filters out duplicate Authorization headers in the hathora fixture, which previously leaked through. Snapshot diffs confirm the fix is working: `Authorization` headers that duplicate the security scheme are no longer emitted in the OpenAPI IR.

### 5. Changelog entry for v3.95.7

- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [x] Existing snapshot tests updated (hathora fixture — both `openapi-ir` and `openapi` snapshots)
- [x] Manual type-checking confirmed changes compile (pre-existing type errors in oss-validator are unrelated)
- [x] All CI checks passing (47 pass, 27 skipping, 0 fail)
- [ ] Unit tests for the new validation rule (not added — existing rules in the same package have `__test__` directories; consider adding)

## Human Review Checklist

- **Two type systems for security schemes**: The internal `SecurityScheme` type in the v1 parser uses `"oauth"` while the OpenAPI spec uses `"oauth2"`. The `authHeaders` Set in `generateIr.ts` checks the internal type (`"oauth"`), while the new validation rule checks the OpenAPI type (`"oauth2"`). Confirm these are correct for their respective contexts.
- **Set fix correctness**: Verify the `new Set(array)` vs `new Set(...array)` fix across all three locations — this is a well-known JS footgun but worth a second look.
- **Pre-existing `isObjectEqual` bug**: Devin Review flagged that `isObjectEqual` in `isSchemaEqual.ts` uses `Object.entries` on an array (producing index keys like `"0"`, `"1"` instead of property names), causing object equality to always return `false`. This is a **pre-existing bug not fixed in this PR** — left for a separate change to keep scope focused.
- **Snapshot diffs**: The hathora snapshot changes (~200 lines removed) all show duplicate `Authorization` headers being correctly filtered out. Worth confirming no headers were removed that shouldn't have been.
- **Warning severity**: The new rule uses `"warning"` (not `"error"`), meaning `fern check` will still pass but `fern check --strict` will fail. Is this the desired behavior, or should this be an error?
- **No unit tests for new rule**: The new validation rule doesn't have dedicated tests. The existing rules in the same package do have `__test__` directories. Should tests be added?
- **`any` types**: The new rule uses `any` with `biome-ignore` for the OpenAPI document type since `openapi-types` is not a dependency of the oss-validator package. This matches the pattern used by existing rules.