### PR TITLE
fix(generator-cli): use StringWriter for reliable README and reference generation

### DIFF
--- a/packages/generator-cli/src/api/generate-readme.ts
+++ b/packages/generator-cli/src/api/generate-readme.ts
@@ -1,4 +1,3 @@
-import { Writable } from "node:stream";
 import type fs from "fs";
 
 import type { FernGeneratorCli } from "../configuration/sdk/index.js";
@@ -31,24 +30,10 @@ export interface GenerateReadmeParams {
 export async function generateReadme(params: GenerateReadmeParams): Promise<string> {
     const { originalReadmeContent, readmeConfig } = params;
 
-    const content: string[] = [];
-
-    const sink = new Writable({
-        write(chunk, _encoding, callback) {
-            if (typeof chunk === "string") {
-                content.push(chunk);
-            } else {
-                content.push(Buffer.from(chunk).toString("utf8"));
-            }
-            callback();
-        }
-    });
-
-    await generateReadmeToStream({
-        originalReadmeContent,
+    const generator = new ReadmeGenerator({
+        readmeParser: new ReadmeParser(),
         readmeConfig,
-        outputStream: sink as fs.WriteStream
+        originalReadme: originalReadmeContent
     });
-
-    return content.join("");
+    return generator.generateReadmeToString();
 }

--- a/packages/generator-cli/src/api/generate-reference.ts
+++ b/packages/generator-cli/src/api/generate-reference.ts
@@ -1,4 +1,3 @@
-import { Writable } from "node:stream";
 import type fs from "fs";
 
 import type { FernGeneratorCli } from "../configuration/sdk/index.js";
@@ -26,22 +25,6 @@ export interface GenerateReferenceParams {
 export async function generateReference(params: GenerateReferenceParams): Promise<string> {
     const { referenceConfig } = params;
 
-    const content: string[] = [];
-    const sink = new Writable({
-        write(chunk, _encoding, callback) {
-            if (typeof chunk === "string") {
-                content.push(chunk);
-            } else {
-                content.push(Buffer.from(chunk).toString("utf8"));
-            }
-            callback();
-        }
-    });
-
-    await generateReferenceToStream({
-        referenceConfig,
-        outputStream: sink as fs.WriteStream
-    });
-
-    return content.join("");
+    const generator = new ReferenceGenerator({ referenceConfig });
+    return generator.generateToString();
 }

--- a/packages/generator-cli/src/readme/ReadmeGenerator.ts
+++ b/packages/generator-cli/src/readme/ReadmeGenerator.ts
@@ -55,6 +55,21 @@ export class ReadmeGenerator {
         await writer.end();
     }
 
+    public async generateReadmeToString(): Promise<string> {
+        const blocks = await this.generateBlocks();
+        const mergedBlocks = await this.mergeBlocks({ blocks });
+
+        const writer = new StringWriter();
+        await this.writeHeader({ writer });
+        await this.writeTableOfContents({ writer, blocks: mergedBlocks });
+        await this.writeBlocks({
+            writer,
+            blocks: mergedBlocks
+        });
+        await writer.end();
+        return writer.toString();
+    }
+
     private async generateBlocks(): Promise<Block[]> {
         const blocks: Block[] = [];
 

--- a/packages/generator-cli/src/readme/ReadmeGenerator.ts
+++ b/packages/generator-cli/src/readme/ReadmeGenerator.ts
@@ -42,32 +42,28 @@ export class ReadmeGenerator {
     }
 
     public async generateReadme({ output }: { output: fs.WriteStream | NodeJS.Process["stdout"] }): Promise<void> {
-        const blocks = await this.generateBlocks();
-        const mergedBlocks = await this.mergeBlocks({ blocks });
-
         const writer = new StreamWriter(output);
-        await this.writeHeader({ writer });
-        await this.writeTableOfContents({ writer, blocks: mergedBlocks });
-        await this.writeBlocks({
-            writer,
-            blocks: mergedBlocks
-        });
+        await this.writeReadmeContent({ writer });
         await writer.end();
     }
 
     public async generateReadmeToString(): Promise<string> {
+        const writer = new StringWriter();
+        await this.writeReadmeContent({ writer });
+        await writer.end();
+        return writer.toString();
+    }
+
+    private async writeReadmeContent({ writer }: { writer: Writer }): Promise<void> {
         const blocks = await this.generateBlocks();
         const mergedBlocks = await this.mergeBlocks({ blocks });
 
-        const writer = new StringWriter();
         await this.writeHeader({ writer });
         await this.writeTableOfContents({ writer, blocks: mergedBlocks });
         await this.writeBlocks({
             writer,
             blocks: mergedBlocks
         });
-        await writer.end();
-        return writer.toString();
     }
 
     private async generateBlocks(): Promise<Block[]> {

--- a/packages/generator-cli/src/reference/ReferenceGenerator.ts
+++ b/packages/generator-cli/src/reference/ReferenceGenerator.ts
@@ -37,6 +37,23 @@ export class ReferenceGenerator {
         await writer.end();
     }
 
+    public async generateToString(): Promise<string> {
+        const writer = new StringWriter();
+        await writer.writeLine("# Reference");
+
+        if (this.referenceConfig.rootSection != null) {
+            await this.writeRootSection({
+                section: this.referenceConfig.rootSection,
+                writer
+            });
+        }
+        for (const section of this.referenceConfig.sections) {
+            await this.writeSection({ section, writer });
+        }
+        await writer.end();
+        return writer.toString();
+    }
+
     private async writeRootSection({
         section,
         writer

--- a/packages/generator-cli/src/reference/ReferenceGenerator.ts
+++ b/packages/generator-cli/src/reference/ReferenceGenerator.ts
@@ -23,22 +23,18 @@ export class ReferenceGenerator {
 
     public async generate({ output }: { output: fs.WriteStream | NodeJS.Process["stdout"] }): Promise<void> {
         const writer = new StreamWriter(output);
-        await writer.writeLine("# Reference");
-
-        if (this.referenceConfig.rootSection != null) {
-            await this.writeRootSection({
-                section: this.referenceConfig.rootSection,
-                writer
-            });
-        }
-        for (const section of this.referenceConfig.sections) {
-            await this.writeSection({ section, writer });
-        }
+        await this.writeReferenceContent({ writer });
         await writer.end();
     }
 
     public async generateToString(): Promise<string> {
         const writer = new StringWriter();
+        await this.writeReferenceContent({ writer });
+        await writer.end();
+        return writer.toString();
+    }
+
+    private async writeReferenceContent({ writer }: { writer: Writer }): Promise<void> {
         await writer.writeLine("# Reference");
 
         if (this.referenceConfig.rootSection != null) {
@@ -50,8 +46,6 @@ export class ReferenceGenerator {
         for (const section of this.referenceConfig.sections) {
             await this.writeSection({ section, writer });
         }
-        await writer.end();
-        return writer.toString();
     }
 
     private async writeRootSection({


### PR DESCRIPTION
## Description

Refs: Reported by @Swimburger — some generators no longer consistently generate READMEs since the migration to the generator-cli JS API (commit 34067a9).

[Link to Devin Session](https://app.devin.ai/sessions/5cef9ea268b04a5ea345f60712f1d1f8)

The `generateReadme()` and `generateReference()` JS API functions created a Node.js `Writable` stream and cast it as `fs.WriteStream` to collect output into a string. However, `StreamWriter` checks `instanceof fs.WriteStream`, which is **always false** for the `Writable`, so it falls into the stdout code path — which doesn't use write callbacks and calls `stream.write("")` instead of `stream.end()` to "end" the stream. This is a fragile pattern that can lead to inconsistent results.

This PR bypasses the stream machinery entirely when only a string result is needed, using `StringWriter` (a simple in-memory string accumulator) instead.

## Changes Made

- Added `generateReadmeToString()` method to `ReadmeGenerator` that uses `StringWriter` directly
- Added `generateToString()` method to `ReferenceGenerator` that uses `StringWriter` directly
- Updated `generateReadme()` and `generateReference()` API functions to use the new string-based methods
- Removed unused `Writable` imports from both API files
- Stream-based `generateReadmeToStream()` / `generateReferenceToStream()` are preserved for the CLI subprocess path (which uses real `fs.WriteStream` / `process.stdout`)

## Human Review Checklist

- [ ] **Code duplication**: `generateReadmeToString()` duplicates logic from `generateReadme()` (stream version). Consider whether they should share a common helper that accepts a `Writer` to reduce divergence risk.
- [x] **Root cause**: The intermittent failure wasn't reproducible locally in seed tests, so the fix is defensive. Confirm the analysis of the `instanceof` mismatch is sound.

## Testing

- [x] Lint passes (`pnpm run check`)
- [x] Seed tests pass for `ts-sdk` (examples fixture) and `python-sdk` (examples fixture) with no diff in generated output
- [ ] Unit tests added/updated — no new tests; existing seed snapshot tests cover this path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
