### PR TITLE
fix(typescript): merge additional query parameters into websocket URL

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.52.9
+  changelogEntry:
+    - summary: |
+        Fix WebSocket URL construction when the base URL already contains query parameters.
+        Previously, additional query parameters were always appended with `?`, which produced
+        an invalid URL (e.g., `wss://host/path?existing=1?new=2`). The fix now checks for an
+        existing query string and uses `&` as the separator when one is already present.
+      type: fix
+  createdAt: "2026-03-02"
+  irVersion: 65
+
 - version: 3.52.8
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/websocket/ws.ts
+++ b/generators/typescript/utils/core-utilities/src/core/websocket/ws.ts
@@ -383,7 +383,8 @@ export class ReconnectingWebSocket {
                 if (this._queryParameters && Object.keys(this._queryParameters).length > 0) {
                     const queryString = toQueryString(this._queryParameters, { arrayFormat: "repeat" });
                     if (queryString) {
-                        url = `${url}?${queryString}`;
+                        const separator = url.includes("?") ? "&" : "?";
+                        url = `${url}${separator}${queryString}`;
                     }
                 }
                 this._ws = new WebSocket(url, this._protocols, options);

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/websocket/ws.ts
@@ -383,7 +383,8 @@ export class ReconnectingWebSocket {
                 if (this._queryParameters && Object.keys(this._queryParameters).length > 0) {
                     const queryString = toQueryString(this._queryParameters, { arrayFormat: "repeat" });
                     if (queryString) {
-                        url = `${url}?${queryString}`;
+                        const separator = url.includes("?") ? "&" : "?";
+                        url = `${url}${separator}${queryString}`;
                     }
                 }
                 this._ws = new WebSocket(url, this._protocols, options);

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/websocket/ws.ts
@@ -383,7 +383,8 @@ export class ReconnectingWebSocket {
                 if (this._queryParameters && Object.keys(this._queryParameters).length > 0) {
                     const queryString = toQueryString(this._queryParameters, { arrayFormat: "repeat" });
                     if (queryString) {
-                        url = `${url}?${queryString}`;
+                        const separator = url.includes("?") ? "&" : "?";
+                        url = `${url}${separator}${queryString}`;
                     }
                 }
                 this._ws = new WebSocket(url, this._protocols, options);

--- a/seed/ts-sdk/websocket/no-serde/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/websocket/ws.ts
@@ -383,7 +383,8 @@ export class ReconnectingWebSocket {
                 if (this._queryParameters && Object.keys(this._queryParameters).length > 0) {
                     const queryString = toQueryString(this._queryParameters, { arrayFormat: "repeat" });
                     if (queryString) {
-                        url = `${url}?${queryString}`;
+                        const separator = url.includes("?") ? "&" : "?";
+                        url = `${url}${separator}${queryString}`;
                     }
                 }
                 this._ws = new WebSocket(url, this._protocols, options);

--- a/seed/ts-sdk/websocket/serde/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/websocket/ws.ts
@@ -383,7 +383,8 @@ export class ReconnectingWebSocket {
                 if (this._queryParameters && Object.keys(this._queryParameters).length > 0) {
                     const queryString = toQueryString(this._queryParameters, { arrayFormat: "repeat" });
                     if (queryString) {
-                        url = `${url}?${queryString}`;
+                        const separator = url.includes("?") ? "&" : "?";
+                        url = `${url}${separator}${queryString}`;
                     }
                 }
                 this._ws = new WebSocket(url, this._protocols, options);


### PR DESCRIPTION
## Description

Linear ticket: Closes [FER-8395](https://linear.app/buildwithfern/issue/FER-8395/deepgram-merge-additional-query-parameters-into-websocket-url)

Fixes WebSocket URL construction in `ReconnectingWebSocket._connect()` when the base URL already contains query parameters. Previously, query parameters were always appended with `?`, producing invalid URLs like `wss://host/path?existing=1?new=2`. The fix detects an existing query string and uses `&` as the separator.

[Link to Devin Session](https://app.devin.ai/sessions/6cce1711bce543a39bfe750ee10aac01)
Requested by: @Swimburger

## Changes Made

- Fix `_connect()` in `ws.ts` to check for existing `?` in the URL before appending query parameters, using `&` when a query string is already present
- Updated all 4 seed test copies of `ws.ts` with the same fix
- Added version `3.52.9` changelog entry in `generators/typescript/sdk/versions.yml`

## Review Checklist

- [ ] Verify `url.includes("?")` is a sufficient heuristic (vs. proper URL parsing) — edge cases like `?` in URL fragments are unlikely for WebSocket URLs but worth considering
- [ ] Confirm this addresses the intended scope of FER-8395 — note that v3.45.0 already added `queryParams` to `ConnectArgs`; this PR fixes the URL separator logic in the runtime

## Testing

- [ ] Unit tests added/updated — **none added**; the fix is in runtime code (`ws.ts`) that is copied as-is into generated SDKs
- [ ] Manual testing completed — not directly testable without a WebSocket server with query-parameterized base URLs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
