### PR TITLE
fix(typescript): deduplicate @example JSDoc blocks in request wrapper and type declarations

### DIFF
--- a/generators/typescript/model/type-generator/src/AbstractGeneratedType.ts
+++ b/generators/typescript/model/type-generator/src/AbstractGeneratedType.ts
@@ -77,7 +77,7 @@ export abstract class AbstractGeneratedType<Shape, Context extends BaseContext> 
             groups.push(this.docs);
         }
         for (const example of this.examples) {
-            const exampleStr =
+            let exampleStr =
                 "@example\n" +
                 getTextOfTsNode(
                     this.buildExample(example.shape, context, {
@@ -87,7 +87,11 @@ export abstract class AbstractGeneratedType<Shape, Context extends BaseContext> 
                         isForResponse: opts?.isForResponse
                     })
                 );
-            groups.push(exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`));
+            exampleStr = exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`);
+            // Only add if it doesn't already exist
+            if (!groups.includes(exampleStr)) {
+                groups.push(exampleStr);
+            }
         }
         if (groups.length === 0) {
             return undefined;

--- a/generators/typescript/model/type-generator/src/AbstractGeneratedType.ts
+++ b/generators/typescript/model/type-generator/src/AbstractGeneratedType.ts
@@ -1,5 +1,5 @@
 import { FernIr } from "@fern-fern/ir-sdk";
-import { GetReferenceOpts, getTextOfTsNode, Reference } from "@fern-typescript/commons";
+import { deduplicateExamples, GetReferenceOpts, getTextOfTsNode, Reference } from "@fern-typescript/commons";
 import { BaseContext, BaseGeneratedType } from "@fern-typescript/contexts";
 import { ModuleDeclarationStructure, StatementStructures, ts, WriterFunction } from "ts-morph";
 
@@ -76,8 +76,8 @@ export abstract class AbstractGeneratedType<Shape, Context extends BaseContext> 
         if (this.docs) {
             groups.push(this.docs);
         }
-        for (const example of this.examples) {
-            let exampleStr =
+        const allExamples = this.examples.map((example) => {
+            const exampleStr =
                 "@example\n" +
                 getTextOfTsNode(
                     this.buildExample(example.shape, context, {
@@ -87,12 +87,9 @@ export abstract class AbstractGeneratedType<Shape, Context extends BaseContext> 
                         isForResponse: opts?.isForResponse
                     })
                 );
-            exampleStr = exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`);
-            // Only add if it doesn't already exist
-            if (!groups.includes(exampleStr)) {
-                groups.push(exampleStr);
-            }
-        }
+            return exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`);
+        });
+        groups.push(...deduplicateExamples(allExamples));
         if (groups.length === 0) {
             return undefined;
         }

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/GeneratedDefaultEndpointImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/GeneratedDefaultEndpointImplementation.ts
@@ -1,5 +1,5 @@
 import { FernIr } from "@fern-fern/ir-sdk";
-import { Fetcher, GetReferenceOpts, getExampleEndpointCalls } from "@fern-typescript/commons";
+import { deduplicateExamples, Fetcher, GetReferenceOpts, getExampleEndpointCalls } from "@fern-typescript/commons";
 import { EndpointSampleCode, GeneratedEndpointImplementation, SdkContext } from "@fern-typescript/contexts";
 import { ts } from "ts-morph";
 import { GeneratedEndpointRequest } from "../../endpoint-request/GeneratedEndpointRequest.js";
@@ -156,7 +156,7 @@ export class GeneratedDefaultEndpointImplementation implements GeneratedEndpoint
             groups.push(exceptions.join("\n"));
         }
 
-        const examples: string[] = [];
+        const allExamples: string[] = [];
         for (const example of getExampleEndpointCalls(this.endpoint)) {
             const generatedExample = this.getExample({
                 context,
@@ -169,14 +169,12 @@ export class GeneratedDefaultEndpointImplementation implements GeneratedEndpoint
             }
             let exampleStr = "@example\n" + EndpointSampleCode.convertToString(generatedExample);
             exampleStr = exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`);
-            // Only add if it doesn't already exist
-            if (!examples.includes(exampleStr)) {
-                examples.push(exampleStr);
-            }
+            allExamples.push(exampleStr);
         }
-        if (examples.length > 0) {
+        const uniqueExamples = deduplicateExamples(allExamples);
+        if (uniqueExamples.length > 0) {
             // Each example is its own group.
-            groups.push(...examples);
+            groups.push(...uniqueExamples);
         }
 
         return groups.join("\n\n");

--- a/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
@@ -310,20 +310,24 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
     }
 
     private getDocs(context: SdkContext): string | undefined {
-        const examples = getExampleEndpointCalls(this.endpoint);
-        if (examples.length === 0) {
+        const exampleCalls = getExampleEndpointCalls(this.endpoint);
+        if (exampleCalls.length === 0) {
             return undefined;
         }
 
-        return examples
-            .map((example) => {
-                const generatedExample = this.generateExample(example);
-                const exampleStr =
-                    "@example\n" +
-                    getTextOfTsNode(generatedExample.build(context, { isForComment: true, isForRequest: true }));
-                return exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`);
-            })
-            .join("\n\n");
+        const uniqueExamples: string[] = [];
+        for (const example of exampleCalls) {
+            const generatedExample = this.generateExample(example);
+            let exampleStr =
+                "@example\n" +
+                getTextOfTsNode(generatedExample.build(context, { isForComment: true, isForRequest: true }));
+            exampleStr = exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`);
+            // Only add if it doesn't already exist
+            if (!uniqueExamples.includes(exampleStr)) {
+                uniqueExamples.push(exampleStr);
+            }
+        }
+        return uniqueExamples.join("\n\n");
     }
 
     private getInlineProperty(

--- a/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
@@ -1,6 +1,7 @@
 import { noop, SetRequired } from "@fern-api/core-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 import {
+    deduplicateExamples,
     generateInlinePropertiesModule,
     getExampleEndpointCalls,
     getPropertyKey,
@@ -315,19 +316,14 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
             return undefined;
         }
 
-        const uniqueExamples: string[] = [];
-        for (const example of exampleCalls) {
+        const allExamples = exampleCalls.map((example) => {
             const generatedExample = this.generateExample(example);
-            let exampleStr =
+            const exampleStr =
                 "@example\n" +
                 getTextOfTsNode(generatedExample.build(context, { isForComment: true, isForRequest: true }));
-            exampleStr = exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`);
-            // Only add if it doesn't already exist
-            if (!uniqueExamples.includes(exampleStr)) {
-                uniqueExamples.push(exampleStr);
-            }
-        }
-        return uniqueExamples.join("\n\n");
+            return exampleStr.replaceAll("\n", `\n${EXAMPLE_PREFIX}`);
+        });
+        return deduplicateExamples(allExamples).join("\n\n");
     }
 
     private getInlineProperty(

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.52.9
+  changelogEntry:
+    - summary: |
+        Deduplicate `@example` JSDoc blocks in request wrapper and type declaration
+        comments. When multiple examples produce identical output, only the first is
+        kept. The endpoint method docs already had this deduplication; this fix extends
+        it to request wrappers and type declarations.
+      type: fix
+  createdAt: "2026-03-02"
+  irVersion: 65
+
 - version: 3.52.8
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/codegen-utils/__test__/deduplicateExamples.test.ts
+++ b/generators/typescript/utils/commons/src/codegen-utils/__test__/deduplicateExamples.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { deduplicateExamples } from "../deduplicateExamples.js";
+
+describe("deduplicateExamples", () => {
+    it("returns empty array for empty input", () => {
+        expect(deduplicateExamples([])).toEqual([]);
+    });
+
+    it("returns single example unchanged", () => {
+        const examples = ["@example\n    {\n        page: 1\n    }"];
+        expect(deduplicateExamples(examples)).toEqual(examples);
+    });
+
+    it("removes duplicate examples", () => {
+        const example = "@example\n    {\n        page: 1\n    }";
+        expect(deduplicateExamples([example, example, example])).toEqual([example]);
+    });
+
+    it("preserves order of first occurrences", () => {
+        const example1 = "@example\n    {\n        page: 1\n    }";
+        const example2 = "@example\n    {\n        page: 2\n    }";
+        expect(deduplicateExamples([example1, example2, example1])).toEqual([example1, example2]);
+    });
+
+    it("keeps distinct examples", () => {
+        const example1 = "@example\n    {\n        awayModeEnabled: true\n    }";
+        const example2 = "@example\n    {\n        awayModeEnabled: false\n    }";
+        expect(deduplicateExamples([example1, example2])).toEqual([example1, example2]);
+    });
+
+    it("treats whitespace differences as distinct", () => {
+        const example1 = "@example\n    { page: 1 }";
+        const example2 = "@example\n    {  page: 1 }";
+        expect(deduplicateExamples([example1, example2])).toEqual([example1, example2]);
+    });
+
+    it("handles multiline examples with exact duplicates", () => {
+        const example =
+            "@example\n" +
+            "    {\n" +
+            "        awayModeEnabled: true,\n" +
+            "        awayModeReassign: true\n" +
+            "    }";
+        expect(deduplicateExamples([example, example, example])).toEqual([example]);
+    });
+});

--- a/generators/typescript/utils/commons/src/codegen-utils/deduplicateExamples.ts
+++ b/generators/typescript/utils/commons/src/codegen-utils/deduplicateExamples.ts
@@ -1,0 +1,13 @@
+/**
+ * Deduplicates example strings by keeping only the first occurrence of each unique string.
+ * This prevents identical @example JSDoc blocks from appearing multiple times in generated code.
+ */
+export function deduplicateExamples(examples: string[]): string[] {
+    const unique: string[] = [];
+    for (const example of examples) {
+        if (!unique.includes(example)) {
+            unique.push(example);
+        }
+    }
+    return unique;
+}

--- a/generators/typescript/utils/commons/src/index.ts
+++ b/generators/typescript/utils/commons/src/index.ts
@@ -4,6 +4,7 @@ export {
     createNumericLiteralSafe,
     createNumericLiteralSafeTypeNode
 } from "./codegen-utils/createNumericLiteralSafe.js";
+export { deduplicateExamples } from "./codegen-utils/deduplicateExamples.js";
 export { generateInlineAliasModule, generateInlinePropertiesModule } from "./codegen-utils/generateInlineModule.js";
 export { getExampleEndpointCalls, getExampleEndpointCallsForTests } from "./codegen-utils/getExampleEndpointCalls.js";
 export {

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/requests/ListUsersOptionalDataRequest.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/requests/ListUsersOptionalDataRequest.ts
@@ -5,11 +5,6 @@
  *     {
  *         page: 1
  *     }
- *
- * @example
- *     {
- *         page: 1
- *     }
  */
 export interface ListUsersOptionalDataRequest {
     /** Defaults to first page */

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/requests/ListUsersOptionalDataRequest.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/requests/ListUsersOptionalDataRequest.ts
@@ -5,11 +5,6 @@
  *     {
  *         page: 1
  *     }
- *
- * @example
- *     {
- *         page: 1
- *     }
  */
 export interface ListUsersOptionalDataRequest {
     /** Defaults to first page */


### PR DESCRIPTION
## Description

Closes [FER-2406](https://linear.app/buildwithfern/issue/FER-2406/typescript-duplicate-request-examples)

The endpoint method docs (`GeneratedDefaultEndpointImplementation.getDocs()`) already deduplicated `@example` JSDoc blocks, but the same fix was missing from two other code paths that generate examples. This caused duplicate identical `@example` blocks in request wrapper and type declaration JSDoc comments.

## Changes Made

- **Extracted `deduplicateExamples` utility** (`generators/typescript/utils/commons/src/codegen-utils/deduplicateExamples.ts`): Shared function that filters duplicate example strings by keeping only the first occurrence. Exported from `@fern-typescript/commons`.
- **Refactored all three `getDocs` call sites** to use the shared utility instead of inline dedup logic:
  - `GeneratedDefaultEndpointImplementation.getDocs()` — replaced inline `includes` check
  - `GeneratedRequestWrapperImpl.getDocs()` — added dedup (was previously missing entirely)
  - `AbstractGeneratedType.getDocs()` — added dedup (was previously missing entirely)
- Added **unit tests** (`deduplicateExamples.test.ts`) with 7 test cases covering empty input, single example, duplicates, ordering preservation, distinct examples, whitespace sensitivity, and multiline duplicates.
- Added version `3.52.9` changelog entry in `generators/typescript/sdk/versions.yml`.
- Updated seed snapshots for `pagination/no-custom-config` and `pagination/page-index-semantics` — duplicate `@example` blocks removed from `ListUsersOptionalDataRequest.ts`.

## Human Review Checklist

- [ ] The `deduplicateExamples` utility uses `Array.includes()` for O(n²) comparison — this is fine given the small number of examples per endpoint, but worth noting.
- [ ] `GeneratedDefaultEndpointImplementation` was already working — the refactor to use the shared utility should be behaviorally identical. The `for` loop still skips `null` examples before collecting into `allExamples`, then dedup runs on the collected array.
- [ ] In `AbstractGeneratedType`, the previous inline dedup checked against the `groups` array (which also contains `this.docs`). The new code deduplicates examples in a separate `allExamples` array before pushing to `groups`. This is slightly different but strictly better — docs strings can't realistically collide with `@example` blocks.

## Testing

- [x] Unit tests added (`deduplicateExamples.test.ts` — 7 tests, all passing)
- [x] Seed tests run locally and pass (`pnpm seed:local test --generator ts-sdk --fixture pagination`)
- [x] Seed snapshot diffs confirm duplicate `@example` blocks are correctly removed
- [x] Biome lint passes on all changed files
- [x] TypeScript compilation passes

[Link to Devin Session](https://app.devin.ai/sessions/cfcc94d21d1740ec8ac455347265ad73)
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
